### PR TITLE
[codex] Add prokaryotic immunity term prediction layer

### DIFF
--- a/projects/DEFENSE_GO_WRAPPER.md
+++ b/projects/DEFENSE_GO_WRAPPER.md
@@ -1,0 +1,123 @@
+# Defense GO Wrapper
+
+## Overview
+
+This project adds a small in-repo translation layer between prokaryotic defense-family prediction
+and AIGR/GO curation output.
+
+The immediate goal is not to annotate defense genes automatically end-to-end. The goal is to make
+family-level predictions usable in review by:
+
+- assigning stable internal family IDs
+- normalizing family labels and aliases
+- attaching explicit GO mapping policy per family
+- separating families that are safe to map automatically from families that still require curator review
+
+This keeps the prediction pipeline and the GO policy layer decoupled, while still making the two
+compose cleanly.
+
+## Why This Exists
+
+The predictor can often say that something is `CRISPR-Cas`, `restriction-modification`, `CBASS`,
+`Thoeris`, or `abortive infection`, but those labels are not yet a good direct input to GO curation.
+
+There are three different problems mixed together if we do not separate the layers:
+
+1. Family recognition
+2. Stable family identity and synonym handling
+3. GO translation policy
+
+Those should not live as ad hoc conditionals inside the predictor.
+
+This project creates an extraction-ready wrapper in `src/ai_gene_review/defense_go/` that owns the
+second and third layers.
+
+## Design
+
+The wrapper currently consists of:
+
+- `src/ai_gene_review/defense_go/models.py`
+  Typed models for defense families, incoming family predictions, and GO mapping suggestions
+- `src/ai_gene_review/defense_go/registry.yaml`
+  Versioned source-of-truth registry for stable family IDs, aliases, GO mappings, and review notes
+- `src/ai_gene_review/defense_go/registry.py`
+  Loader and resolver for the registry
+- `tests/test_defense_go.py`
+  Focused tests for alias resolution, automatic mappings, unmapped families, and registry safety
+
+The wrapper API is intentionally narrow:
+
+- predictor emits a family label plus optional confidence
+- wrapper resolves that to a stable family record
+- wrapper returns either:
+  - automatic GO suggestions, or
+  - review-only notes saying why automatic mapping is not yet allowed
+
+## Initial Stable Family IDs
+
+The first registry version includes:
+
+- `DEFENSE_FAMILY:CRISPR_CAS`
+- `DEFENSE_FAMILY:RESTRICTION_MODIFICATION`
+- `DEFENSE_FAMILY:ABORTIVE_INFECTION`
+- `DEFENSE_FAMILY:CBASS`
+- `DEFENSE_FAMILY:THOERIS`
+
+The ID layer is the important part. It gives us a stable target that later tools can consume
+without depending on whatever exact family string the predictor or external database emitted.
+
+## Initial GO Policy
+
+The current registry is intentionally conservative.
+
+Families with automatic GO mappings:
+
+- `DEFENSE_FAMILY:CRISPR_CAS`
+  Maps to `GO:0099048` `CRISPR-cas system`
+- `DEFENSE_FAMILY:RESTRICTION_MODIFICATION`
+  Maps to `GO:0009307` `DNA restriction-modification system`
+
+Families currently left unmapped at the automatic layer:
+
+- `DEFENSE_FAMILY:ABORTIVE_INFECTION`
+- `DEFENSE_FAMILY:CBASS`
+- `DEFENSE_FAMILY:THOERIS`
+
+These remain review-only because the family labels are currently too broad to support reliable,
+family-wide automatic GO assignment in this repo.
+
+## Integration Plan
+
+This project does not yet wire the wrapper into the prokaryotic immunity predictor branch. That is
+intentional.
+
+The intended integration path is:
+
+1. Predictor emits normalized family calls and confidence
+2. `ai_gene_review.defense_go.wrap_prediction(...)` resolves them to stable IDs and mapping policy
+3. AIGR export code turns automatic mappings into review-ready term suggestions
+4. Review-only families remain visible to curators with explicit notes instead of silent omission
+
+Keeping those steps separate makes later extraction into a standalone repo possible, but does not
+force that split now.
+
+## Status
+
+Completed in this unit:
+
+- Added the `defense_go` package
+- Added the first versioned registry
+- Added alias resolution and conflict detection
+- Added targeted tests
+
+Deferred:
+
+- integration into the prokaryotic immunity prediction pipeline branch
+- export of wrapper output into `PredictionReview` YAML
+- expansion of the registry to more defense families and GO policies
+- support for evidence-code policy and provenance payloads
+
+## Validation
+
+- `uv run ruff check src/ai_gene_review/defense_go tests/test_defense_go.py`
+- `uv run pytest tests/test_defense_go.py`

--- a/projects/PROKARYOTIC_IMMUNITY_TERM_PREDICTION.md
+++ b/projects/PROKARYOTIC_IMMUNITY_TERM_PREDICTION.md
@@ -1,40 +1,45 @@
-# Defense GO Wrapper
+# Prokaryotic Immunity Term Prediction
 
 ## Overview
 
-This project adds a small in-repo translation layer between prokaryotic defense-family prediction
-and AIGR/GO curation output.
+This project is about increasing automation for predicting precise biology-first GO terms for
+prokaryotic immunity systems.
 
-The immediate goal is not to annotate defense genes automatically end-to-end. The goal is to make
-family-level predictions usable in review by:
+The immediate unit here does not try to solve end-to-end annotation. It adds the missing translation
+layer between broad defense-system calls and review-ready term suggestions. In practice, the current
+source being translated is family-level output from the prokaryotic immunity predictor, which emits
+calls such as `CRISPR-Cas`, `restriction-modification`, `CBASS`, `Thoeris`, and `abortive infection`.
+
+The goal is to make those outputs usable for precise review by:
 
 - assigning stable internal family IDs
 - normalizing family labels and aliases
 - attaching explicit GO mapping policy per family
 - separating families that are safe to map automatically from families that still require curator review
 
-This keeps the prediction pipeline and the GO policy layer decoupled, while still making the two
-compose cleanly.
+This keeps immunity-term prediction centered on the biology while still allowing multiple upstream
+tools or predictors to plug into the same GO policy layer later.
 
 ## Why This Exists
 
-The predictor can often say that something is `CRISPR-Cas`, `restriction-modification`, `CBASS`,
-`Thoeris`, or `abortive infection`, but those labels are not yet a good direct input to GO curation.
+The current predictor can often say that something belongs to a broad defense family, but broad
+family labels are not yet a good direct input to GO curation.
 
 There are three different problems mixed together if we do not separate the layers:
 
 1. Family recognition
-2. Stable family identity and synonym handling
-3. GO translation policy
+2. Stable immunity-system identity and synonym handling
+3. Precise term-prediction policy
 
-Those should not live as ad hoc conditionals inside the predictor.
+Those should not live as ad hoc conditionals inside one particular predictor or one particular
+database parser.
 
-This project creates an extraction-ready wrapper in `src/ai_gene_review/defense_go/` that owns the
-second and third layers.
+This project creates an extraction-ready translation layer in `src/ai_gene_review/defense_go/` that
+owns the second and third layers.
 
 ## Design
 
-The wrapper currently consists of:
+The current term-prediction layer consists of:
 
 - `src/ai_gene_review/defense_go/models.py`
   Typed models for defense families, incoming family predictions, and GO mapping suggestions
@@ -45,13 +50,17 @@ The wrapper currently consists of:
 - `tests/test_defense_go.py`
   Focused tests for alias resolution, automatic mappings, unmapped families, and registry safety
 
-The wrapper API is intentionally narrow:
+The API is intentionally narrow:
 
-- predictor emits a family label plus optional confidence
-- wrapper resolves that to a stable family record
-- wrapper returns either:
+- an upstream tool emits a family label plus optional confidence
+- the translation layer resolves that to a stable family record
+- it returns either:
   - automatic GO suggestions, or
   - review-only notes saying why automatic mapping is not yet allowed
+
+Today, the intended upstream source is the prokaryotic immunity predictor branch. Later, the same
+layer could absorb outputs from DefenseFinder, PADLOC, CasFinder, or additional learned models
+without changing the downstream GO policy interface.
 
 ## Initial Stable Family IDs
 
@@ -88,8 +97,8 @@ family-wide automatic GO assignment in this repo.
 
 ## Integration Plan
 
-This project does not yet wire the wrapper into the prokaryotic immunity predictor branch. That is
-intentional.
+This project does not yet wire the term-prediction layer into the prokaryotic immunity predictor
+branch. That is intentional.
 
 The intended integration path is:
 
@@ -98,8 +107,8 @@ The intended integration path is:
 3. AIGR export code turns automatic mappings into review-ready term suggestions
 4. Review-only families remain visible to curators with explicit notes instead of silent omission
 
-Keeping those steps separate makes later extraction into a standalone repo possible, but does not
-force that split now.
+Keeping those steps separate makes the project biology-first while still leaving room to support
+multiple upstream predictors and databases later.
 
 ## Status
 

--- a/src/ai_gene_review/defense_go/__init__.py
+++ b/src/ai_gene_review/defense_go/__init__.py
@@ -1,0 +1,33 @@
+"""Translate prokaryotic defense-family calls into reviewable GO suggestions."""
+
+from ai_gene_review.defense_go.models import (
+    DefenseFamily,
+    DefenseFamilyPrediction,
+    GoTermMapping,
+    MappingPolicy,
+    WrappedDefensePrediction,
+)
+from ai_gene_review.defense_go.registry import (
+    DefenseGoRegistry,
+    default_registry_path,
+    load_default_registry,
+    load_registry,
+    normalize_family_query,
+    wrap_prediction,
+    wrap_predictions,
+)
+
+__all__ = [
+    "DefenseFamily",
+    "DefenseFamilyPrediction",
+    "DefenseGoRegistry",
+    "GoTermMapping",
+    "MappingPolicy",
+    "WrappedDefensePrediction",
+    "default_registry_path",
+    "load_default_registry",
+    "load_registry",
+    "normalize_family_query",
+    "wrap_prediction",
+    "wrap_predictions",
+]

--- a/src/ai_gene_review/defense_go/models.py
+++ b/src/ai_gene_review/defense_go/models.py
@@ -1,0 +1,81 @@
+"""Typed models for translating defense-family predictions into GO review inputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from ai_gene_review.datamodel.gene_review_model import Term
+
+
+class MappingPolicy(StrEnum):
+    """How aggressively the wrapper should treat a family-to-GO mapping."""
+
+    AUTOMATIC = "automatic"
+    REVIEW_ONLY = "review_only"
+
+
+@dataclass(frozen=True, slots=True)
+class GoTermMapping:
+    """A GO term suggested for a defense-family prediction."""
+
+    term: Term
+    relation: str
+    policy: MappingPolicy
+    rationale: str
+
+
+@dataclass(frozen=True, slots=True)
+class DefenseFamily:
+    """A stable, extractable representation of a defense-family concept."""
+
+    id: str
+    label: str
+    description: str
+    aliases: tuple[str, ...] = ()
+    go_terms: tuple[GoTermMapping, ...] = ()
+    review_notes: tuple[str, ...] = ()
+
+    @property
+    def automatic_terms(self) -> tuple[GoTermMapping, ...]:
+        """Return GO terms that are safe to materialize automatically."""
+        return tuple(mapping for mapping in self.go_terms if mapping.policy is MappingPolicy.AUTOMATIC)
+
+    @property
+    def review_only_terms(self) -> tuple[GoTermMapping, ...]:
+        """Return GO terms that should remain curation suggestions."""
+        return tuple(mapping for mapping in self.go_terms if mapping.policy is MappingPolicy.REVIEW_ONLY)
+
+
+@dataclass(frozen=True, slots=True)
+class DefenseFamilyPrediction:
+    """A minimal family assignment emitted by a defense predictor."""
+
+    family: str
+    confidence: float | None = None
+    source: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class WrappedDefensePrediction:
+    """A family prediction enriched with stable IDs, GO terms, and review notes."""
+
+    family: DefenseFamily
+    matched_input: str
+    confidence: float | None = None
+    source: str | None = None
+
+    @property
+    def automatic_terms(self) -> tuple[GoTermMapping, ...]:
+        """Convenience access to automatically assignable GO terms."""
+        return self.family.automatic_terms
+
+    @property
+    def review_only_terms(self) -> tuple[GoTermMapping, ...]:
+        """Convenience access to review-only GO suggestions."""
+        return self.family.review_only_terms
+
+    @property
+    def review_notes(self) -> tuple[str, ...]:
+        """Convenience access to family-level curation notes."""
+        return self.family.review_notes

--- a/src/ai_gene_review/defense_go/registry.py
+++ b/src/ai_gene_review/defense_go/registry.py
@@ -1,0 +1,161 @@
+"""Load and query the in-repo defense-family to GO registry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+from ai_gene_review.datamodel.gene_review_model import Term
+from ai_gene_review.defense_go.models import (
+    DefenseFamily,
+    DefenseFamilyPrediction,
+    GoTermMapping,
+    MappingPolicy,
+    WrappedDefensePrediction,
+)
+
+
+def default_registry_path() -> Path:
+    """Return the package-local default registry path."""
+    return Path(__file__).with_name("registry.yaml")
+
+
+def normalize_family_query(value: str) -> str:
+    """Normalize family IDs, labels, and aliases for stable lookups."""
+    return "".join(character for character in value.lower() if character.isalnum())
+
+
+@dataclass(slots=True)
+class DefenseGoRegistry:
+    """Lookup object for stable defense-family IDs and GO suggestions."""
+
+    version: str
+    families_by_id: dict[str, DefenseFamily]
+    aliases_to_id: dict[str, str]
+
+    @property
+    def families(self) -> tuple[DefenseFamily, ...]:
+        """Return all families in registry order."""
+        return tuple(self.families_by_id.values())
+
+    def get(self, family_id: str) -> DefenseFamily | None:
+        """Return a family by its canonical ID."""
+        return self.families_by_id.get(family_id)
+
+    def resolve(self, query: str) -> DefenseFamily:
+        """Resolve a family by canonical ID, label, or alias."""
+        if query in self.families_by_id:
+            return self.families_by_id[query]
+
+        normalized = normalize_family_query(query)
+        family_id = self.aliases_to_id.get(normalized)
+        if family_id is None:
+            raise KeyError(f"Unknown defense family: {query}")
+        return self.families_by_id[family_id]
+
+
+def load_registry(path: Path | None = None) -> DefenseGoRegistry:
+    """Load a defense-family registry from YAML."""
+    registry_path = path or default_registry_path()
+    payload = yaml.safe_load(registry_path.read_text(encoding="utf-8")) or {}
+    version = str(payload.get("version", "0"))
+    family_rows = payload.get("families", [])
+
+    families_by_id: dict[str, DefenseFamily] = {}
+    aliases_to_id: dict[str, str] = {}
+    for row in family_rows:
+        family = _load_family(row)
+        if family.id in families_by_id:
+            raise ValueError(f"Duplicate defense family ID: {family.id}")
+        families_by_id[family.id] = family
+        for alias in (family.id, family.label, *family.aliases):
+            _register_alias(alias, family.id, aliases_to_id)
+
+    return DefenseGoRegistry(
+        version=version,
+        families_by_id=families_by_id,
+        aliases_to_id=aliases_to_id,
+    )
+
+
+@lru_cache(maxsize=1)
+def load_default_registry() -> DefenseGoRegistry:
+    """Load and cache the package-local registry."""
+    return load_registry()
+
+
+def wrap_prediction(
+    prediction: DefenseFamilyPrediction | str,
+    registry: DefenseGoRegistry | None = None,
+) -> WrappedDefensePrediction:
+    """Resolve a family prediction into GO-aware review data."""
+    active_registry = registry or load_default_registry()
+    normalized_prediction = (
+        prediction
+        if isinstance(prediction, DefenseFamilyPrediction)
+        else DefenseFamilyPrediction(family=prediction)
+    )
+    family = active_registry.resolve(normalized_prediction.family)
+    return WrappedDefensePrediction(
+        family=family,
+        matched_input=normalized_prediction.family,
+        confidence=normalized_prediction.confidence,
+        source=normalized_prediction.source,
+    )
+
+
+def wrap_predictions(
+    predictions: Iterable[DefenseFamilyPrediction | str],
+    registry: DefenseGoRegistry | None = None,
+) -> list[WrappedDefensePrediction]:
+    """Resolve multiple family predictions into GO-aware review data."""
+    active_registry = registry or load_default_registry()
+    return [wrap_prediction(prediction, registry=active_registry) for prediction in predictions]
+
+
+def _load_family(row: dict[str, object]) -> DefenseFamily:
+    """Build a DefenseFamily from registry YAML."""
+    family_id = str(row["id"])
+    label = str(row["label"])
+    description = str(row.get("description", ""))
+    aliases = tuple(str(alias) for alias in row.get("aliases", []))
+    go_terms = tuple(_load_go_term_mapping(mapping) for mapping in row.get("go_terms", []))
+    review_notes = tuple(str(note) for note in row.get("review_notes", []))
+    return DefenseFamily(
+        id=family_id,
+        label=label,
+        description=description,
+        aliases=aliases,
+        go_terms=go_terms,
+        review_notes=review_notes,
+    )
+
+
+def _load_go_term_mapping(row: dict[str, object]) -> GoTermMapping:
+    """Build a GoTermMapping from registry YAML."""
+    term_payload = dict(row["term"])
+    term = Term(
+        id=str(term_payload["id"]),
+        label=str(term_payload["label"]),
+        ontology=str(term_payload.get("ontology", "GO")),
+    )
+    policy = MappingPolicy(str(row.get("policy", MappingPolicy.AUTOMATIC.value)))
+    return GoTermMapping(
+        term=term,
+        relation=str(row.get("relation", "involved_in")),
+        policy=policy,
+        rationale=str(row.get("rationale", "")),
+    )
+
+
+def _register_alias(alias: str, family_id: str, aliases_to_id: dict[str, str]) -> None:
+    """Register one normalized alias, rejecting cross-family collisions."""
+    normalized = normalize_family_query(alias)
+    existing = aliases_to_id.get(normalized)
+    if existing is not None and existing != family_id:
+        raise ValueError(f"Duplicate defense-family alias '{alias}' for {family_id} and {existing}")
+    aliases_to_id[normalized] = family_id

--- a/src/ai_gene_review/defense_go/registry.yaml
+++ b/src/ai_gene_review/defense_go/registry.yaml
@@ -1,0 +1,82 @@
+version: "1"
+families:
+  - id: DEFENSE_FAMILY:CRISPR_CAS
+    label: CRISPR-Cas
+    description: >
+      CRISPR-associated adaptive and interference defense systems that act on
+      foreign nucleic acids.
+    aliases:
+      - CRISPR
+      - CRISPR/Cas
+      - CRISPR cas
+    go_terms:
+      - term:
+          id: GO:0099048
+          label: CRISPR-cas system
+          ontology: GO
+        relation: involved_in
+        policy: automatic
+        rationale: >
+          A family-level CRISPR-Cas call supports review of the CRISPR-cas
+          system biological-process term.
+    review_notes:
+      - Do not infer specific Cas molecular functions from the family label alone.
+      - Use gene-level review to separate adaptation, processing, and interference proteins.
+  - id: DEFENSE_FAMILY:RESTRICTION_MODIFICATION
+    label: Restriction-modification
+    description: >
+      Restriction-modification defense systems combining sequence-specific
+      cleavage with host-protective DNA modification.
+    aliases:
+      - restriction modification
+      - restriction-modification system
+      - R-M
+      - RM
+    go_terms:
+      - term:
+          id: GO:0009307
+          label: DNA restriction-modification system
+          ontology: GO
+        relation: involved_in
+        policy: automatic
+        rationale: >
+          A restriction-modification family call supports review of the DNA
+          restriction-modification system biological-process term.
+    review_notes:
+      - Do not infer methyltransferase or endonuclease molecular function from the family label alone.
+  - id: DEFENSE_FAMILY:ABORTIVE_INFECTION
+    label: Abortive infection
+    description: >
+      Anti-phage systems that block infection through host sacrifice or severe
+      self-limiting growth arrest.
+    aliases:
+      - Abi
+      - abortive infection system
+    go_terms: []
+    review_notes:
+      - No automatic GO mapping is assigned yet because the family is mechanistically broad.
+      - Add GO terms only after the specific abortive-infection mechanism is reviewed.
+  - id: DEFENSE_FAMILY:CBASS
+    label: CBASS
+    description: >
+      Cyclic oligonucleotide-based anti-phage signaling systems with diverse
+      effectors and outputs.
+    aliases:
+      - cyclic oligonucleotide-based antiphage signaling system
+      - cyclic-oligonucleotide-based anti-phage signaling system
+    go_terms: []
+    review_notes:
+      - No automatic GO mapping is assigned yet because CBASS lacks a stable family-specific GO term policy here.
+      - Review effector class and mechanism before proposing GO terms.
+  - id: DEFENSE_FAMILY:THOERIS
+    label: Thoeris
+    description: >
+      ThsA/ThsB-like anti-phage defense systems associated with nucleotide
+      signaling and diverse downstream effectors.
+    aliases:
+      - ths
+      - thsA/thsB system
+    go_terms: []
+    review_notes:
+      - No automatic GO mapping is assigned yet because Thoeris is not represented by a stable family-specific GO term here.
+      - Review the effector architecture before assigning GO terms.

--- a/tests/test_defense_go.py
+++ b/tests/test_defense_go.py
@@ -1,0 +1,77 @@
+"""Tests for the extraction-ready defense-family to GO wrapper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ai_gene_review.defense_go import (
+    DefenseFamilyPrediction,
+    load_default_registry,
+    load_registry,
+    wrap_prediction,
+)
+
+
+def test_default_registry_exposes_stable_family_ids() -> None:
+    """The built-in registry should load the expected stable family IDs."""
+    registry = load_default_registry()
+    family_ids = {family.id for family in registry.families}
+    assert "DEFENSE_FAMILY:CRISPR_CAS" in family_ids
+    assert "DEFENSE_FAMILY:RESTRICTION_MODIFICATION" in family_ids
+    assert "DEFENSE_FAMILY:CBASS" in family_ids
+
+
+def test_registry_resolves_aliases_and_labels() -> None:
+    """Canonical labels and common aliases should resolve to the same family."""
+    registry = load_default_registry()
+    assert registry.resolve("CRISPR-Cas").id == "DEFENSE_FAMILY:CRISPR_CAS"
+    assert registry.resolve("R-M").id == "DEFENSE_FAMILY:RESTRICTION_MODIFICATION"
+    assert registry.resolve("restriction modification").id == "DEFENSE_FAMILY:RESTRICTION_MODIFICATION"
+
+
+def test_wrap_prediction_returns_automatic_go_terms_for_supported_families() -> None:
+    """Supported families should translate into automatic GO term suggestions."""
+    wrapped = wrap_prediction(
+        DefenseFamilyPrediction(
+            family="CRISPR/Cas",
+            confidence=0.94,
+            source="plm-classifier",
+        )
+    )
+    assert wrapped.family.id == "DEFENSE_FAMILY:CRISPR_CAS"
+    assert wrapped.confidence == 0.94
+    assert wrapped.source == "plm-classifier"
+    assert [mapping.term.id for mapping in wrapped.automatic_terms] == ["GO:0099048"]
+    assert not wrapped.review_only_terms
+
+
+def test_wrap_prediction_preserves_unmapped_families_for_review() -> None:
+    """Families without GO policy should still resolve cleanly for review."""
+    wrapped = wrap_prediction("CBASS")
+    assert wrapped.family.id == "DEFENSE_FAMILY:CBASS"
+    assert not wrapped.automatic_terms
+    assert any("No automatic GO mapping" in note for note in wrapped.review_notes)
+
+
+def test_load_registry_rejects_cross_family_alias_collisions(tmp_path: Path) -> None:
+    """Alias reuse across families should fail fast during registry load."""
+    registry_path = tmp_path / "registry.yaml"
+    registry_path.write_text(
+        "\n".join(
+            [
+                'version: "1"',
+                "families:",
+                "  - id: DEFENSE_FAMILY:ONE",
+                "    label: One",
+                "    aliases: [shared]",
+                "  - id: DEFENSE_FAMILY:TWO",
+                "    label: Two",
+                "    aliases: [shared]",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="Duplicate defense-family alias"):
+        load_registry(registry_path)


### PR DESCRIPTION
## Summary

Add an extraction-ready in-repo term-prediction layer for prokaryotic immunity systems.

This PR does not try to wire the entire prokaryotic immunity predictor into GO review in one step. Instead, it introduces the missing middle layer between:
- broad prokaryotic immunity system calls such as `CRISPR-Cas`, `restriction-modification`, `CBASS`, `Thoeris`, or `abortive infection`
- review-ready AIGR / GO curation objects

The new layer lives in `src/ai_gene_review/defense_go/` and owns:
- stable internal defense-family IDs
- alias and synonym resolution
- a versioned registry of family-level GO mapping policy
- explicit separation between automatic GO suggestions and review-only families

This keeps the project centered on biology and precise immunity-term prediction while avoiding hard-coded GO logic inside any one predictor.

## Current Upstream Context

The immediate upstream source for this layer is the prokaryotic immunity predictor branch, which emits broad family-level calls for defense systems. Those calls are useful biologically, but they are still too coarse to serve as direct GO curation objects.

This PR turns that broad output into a stable intermediate representation that later export code can consume. The same layer can also absorb outputs from DefenseFinder, PADLOC, CasFinder, or other learned models later.

## Why This Separate Unit Exists

There are three distinct concerns here:
1. recognizing an immunity family
2. assigning a stable immunity-system identity
3. translating that identity into precise term-prediction policy

This PR addresses only steps 2 and 3.

That is why it is on its own branch and PR. It is a coherent unit with its own tests, and it can be integrated into the predictor branch later without mixing prediction logic, database parsing, and GO policy in one diff.

## What Changed

### New package

Added `src/ai_gene_review/defense_go/` with:
- `models.py`
- `registry.py`
- `registry.yaml`
- `__init__.py`

This package exposes a narrow API that accepts a family prediction and returns a stable family record plus any GO suggestions currently allowed by policy.

### Versioned registry

Added a first registry version with stable IDs for:
- `DEFENSE_FAMILY:CRISPR_CAS`
- `DEFENSE_FAMILY:RESTRICTION_MODIFICATION`
- `DEFENSE_FAMILY:ABORTIVE_INFECTION`
- `DEFENSE_FAMILY:CBASS`
- `DEFENSE_FAMILY:THOERIS`

### Initial GO policy

Current automatic mappings are intentionally conservative:
- `CRISPR-Cas` -> `GO:0099048` `CRISPR-cas system`
- `Restriction-modification` -> `GO:0009307` `DNA restriction-modification system`

The following families remain review-only for now:
- `abortive infection`
- `CBASS`
- `Thoeris`

They still resolve to stable family IDs and carry review notes, but they do not emit automatic GO mappings yet.

### Project context

Added a project note at:
- `projects/PROKARYOTIC_IMMUNITY_TERM_PREDICTION.md`

That document now frames the work around the biological goal: more automation for predicting precise prokaryotic immunity terms. It also explains that the current wrapped source is the prokaryotic immunity predictor's broad family output, while leaving room for additional upstream tools later.

### Tests

Added focused tests for:
- alias resolution
- automatic mapping for supported families
- unmapped family behavior
- registry collision safety

## Intended Follow-On Integration

This PR deliberately stops before wiring into the immunity prediction pipeline.

The planned integration path is:
1. predictor emits normalized family calls and confidence
2. `ai_gene_review.defense_go.wrap_prediction(...)` resolves them to stable IDs and GO policy
3. export code turns automatic mappings into review-ready AIGR suggestions
4. review-only families stay visible with explicit notes instead of being silently dropped

## Validation

- `uv run ruff check src/ai_gene_review/defense_go tests/test_defense_go.py`
- `uv run pytest tests/test_defense_go.py`