### PR TITLE
feat: upgrade linkml-term-validator to 0.4.0rc2 (2.5x speedup + ND annotations fix)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
   "playwright>=1.56.0",
   "rapidfuzz>=3.14.3",
   "scipy>=1.16.1",
-  "linkml-term-validator",
+  "linkml-term-validator>=0.4.0rc2",
   "linkml-data-qc>=0.1.0",
   "linkml-reference-validator==0.2.0rc1",
 ]

--- a/src/ai_gene_review/schema/gene_review.yaml
+++ b/src/ai_gene_review/schema/gene_review.yaml
@@ -1417,13 +1417,14 @@ enums:
           Weaker than located_in or part_of.
 
   GOTermEnum:
-    description: A term in the GO ontology
+    description: A term in the GO ontology (including roots, to allow ND annotations)
     reachable_from:
       source_nodes:
         - GO:0003674
         - GO:0008150
         - GO:0005575
       is_direct: false
+      include_self: true
       relationship_types:
         - rdfs:subClassOf
   

--- a/uv.lock
+++ b/uv.lock
@@ -114,7 +114,7 @@ requires-dist = [
     { name = "linkml-data-qc", specifier = ">=0.1.0" },
     { name = "linkml-reference-validator", specifier = "==0.2.0rc1" },
     { name = "linkml-runtime", specifier = ">=1.9.4" },
-    { name = "linkml-term-validator" },
+    { name = "linkml-term-validator", specifier = ">=0.4.0rc2" },
     { name = "lxml", specifier = ">=6.0.1" },
     { name = "markdown", specifier = ">=3.8.2" },
     { name = "matplotlib", specifier = ">=3.10.5" },
@@ -2437,7 +2437,7 @@ wheels = [
 
 [[package]]
 name = "linkml-term-validator"
-version = "0.1.1"
+version = "0.4.0rc2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "linkml" },
@@ -2447,9 +2447,9 @@ dependencies = [
     { name = "ruamel-yaml" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/fd/76d4fb7ba602a56f03fba88df8365f3e9e2adfcbbff4f6a912cb8f3d3ac6/linkml_term_validator-0.1.1.tar.gz", hash = "sha256:726688dbab5082d84d41bf28a0a130890f5f0ddc14d4910a6ac97f89c5fba4b9", size = 373882 }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/ee/d7b84cd19b1b7af20efe5c56d795ee09843a69ba53efd60870a123c63788/linkml_term_validator-0.4.0rc2.tar.gz", hash = "sha256:de226e88a2bc2a3307b1cb93d5d8b5938ce47eb406d161ea8a7ce272472e2aa2", size = 390745 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/47/057ac0c228c9c3e400b0488455e41a8eabd4ff4ac40c6facc57f656e55df/linkml_term_validator-0.1.1-py3-none-any.whl", hash = "sha256:1a4cfc2841472614885e659ed65cba63ec8ae8c4bf5dc0e1709b062a91fa2bb9", size = 34312 },
+    { url = "https://files.pythonhosted.org/packages/53/1b/8320922ce80d186517b0f1cfbd42d270718c2f503f6b7d313360949e833d/linkml_term_validator-0.4.0rc2-py3-none-any.whl", hash = "sha256:6b0448024d6d527de0110287957c3743f542f465217815f0fe6122ab46c65005", size = 41897 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Upgrades `linkml-term-validator` from 0.1.1 to 0.4.0rc2, which adds persistent enum-expansion caching (linkml/linkml-term-validator#22). This provides a ~2.5x speedup on warm validation runs and paves the way for much faster `validate-all`.

Also adds `include_self: true` to `GOTermEnum` in the schema to allow root GO terms (GO:0003674, GO:0008150, GO:0005575) in ND (No Data) annotations, which the new validator correctly flags but we want to permit.

## Changes

1. **Schema: `include_self: true` for GOTermEnum**
   - `GOTermEnum` uses `reachable_from` with GO roots as `source_nodes`
   - `reachable_from` excludes source_nodes by default, so roots themselves weren't in the enum
   - The new validator (0.4.0rc2) correctly enforces this binding on `existing_annotations.term.id`, flagging legitimate ND annotations like:
     ```yaml
     term:
       id: GO:0003674
       label: molecular_function
     evidence_type: ND
     original_reference_id: GO_REF:0000015
     ```
   - Setting `include_self: true` includes the roots, so ND annotations are now accepted

2. **Dependency: `linkml-term-validator>=0.4.0rc2`**
   - Previously unversioned; now requires the release with enum caching
   - Populates `cache/enums/` with CSV files hashed by enum definition
   - ~2.5x speedup on repeated validation (14.8s → 6.0s/file cold→warm)

## Verification

Ran clean same-sample comparison between 0.1.1 and 0.4.0rc2:

| Sample size | 0.1.1 errors | 0.4.0rc2 errors | Diff |
|---|---|---|---|
| 20 files | 9 | 9 | identical |
| 50 files | 33 | 33 | identical |

No regressions detected. The only behavioral change (GOTermEnum enforcement on ND annotations) is addressed by the schema fix.

## Performance

- Cold run (first time): ~14.8s/file (enum cache being built)
- Warm run: ~6.0s/file (cache hits) — **2.5x speedup**
- Cache files: `cache/enums/*.csv` (5 enums × hashed definition)
- Cache is automatically invalidated when enum definition changes

## Test plan

- [x] Sample 20-file diff: identical error sets
- [x] Sample 50-file diff: identical error sets  
- [x] SDHA, che-2, tlcd4b validate (previously failed on new version, now pass)
- [ ] Full `just validate-all` benchmark for speedup measurement
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)