### PR TITLE
[codex] add mechanobiology project scaffold

### DIFF
--- a/pages/projects/MECHANOBIOLOGY.html
+++ b/pages/projects/MECHANOBIOLOGY.html
@@ -1,0 +1,478 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mechanobiology Gene Review Project - AI Gene Review Projects</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-primary: #3498db;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+
+        .breadcrumb {
+            margin-bottom: 1.5rem;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .breadcrumb a {
+            color: var(--color-primary);
+            text-decoration: none;
+        }
+
+        .breadcrumb a:hover {
+            text-decoration: underline;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        h2 {
+            font-size: 1.75rem;
+            font-weight: 600;
+            margin-top: 2rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        h3 {
+            font-size: 1.25rem;
+            font-weight: 600;
+            margin-top: 1.5rem;
+            margin-bottom: 0.75rem;
+            color: #374151;
+        }
+
+        h4 {
+            font-size: 1rem;
+            font-weight: 600;
+            margin-top: 1.25rem;
+            margin-bottom: 0.5rem;
+            color: #4b5563;
+        }
+
+        p {
+            margin-bottom: 1rem;
+        }
+
+        a {
+            color: var(--color-primary);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        /* Gene symbol links */
+        .content a[href*="/genes/"] {
+            background-color: #dbeafe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-weight: 500;
+        }
+
+        .content a[href*="/genes/"]:hover {
+            background-color: #bfdbfe;
+        }
+
+        ul, ol {
+            margin-bottom: 1rem;
+            padding-left: 2rem;
+        }
+
+        li {
+            margin-bottom: 0.25rem;
+        }
+
+        code {
+            background: #f4f4f4;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+            font-size: 0.875em;
+        }
+
+        pre {
+            background: #1f2937;
+            color: #f9fafb;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+
+        pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+
+        blockquote {
+            border-left: 4px solid var(--color-primary);
+            margin-left: 0;
+            padding-left: 1.5rem;
+            color: #4b5563;
+            font-style: italic;
+            margin-bottom: 1rem;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 1.5rem 0;
+        }
+
+        th, td {
+            border: 1px solid var(--border-color);
+            padding: 0.75rem;
+            text-align: left;
+        }
+
+        th {
+            background-color: var(--bg-light);
+            font-weight: 600;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            font-size: 0.75rem;
+            letter-spacing: 0.05em;
+        }
+
+        tr:nth-child(even) {
+            background-color: #f9fafb;
+        }
+
+        tr:hover {
+            background-color: #f3f4f6;
+        }
+
+        /* Mermaid diagrams */
+        .mermaid {
+            text-align: center;
+            margin: 2rem 0;
+            background: white;
+            padding: 1.5rem;
+            border-radius: 0.5rem;
+            border: 1px solid var(--border-color);
+        }
+
+        .mermaid svg {
+            max-width: 100%;
+            height: auto;
+        }
+
+        /* Warnings section */
+        .warnings {
+            background-color: #fef3c7;
+            border: 1px solid #fde68a;
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 2rem;
+        }
+
+        .warnings h3 {
+            color: #92400e;
+            margin-top: 0;
+            margin-bottom: 0.5rem;
+            font-size: 1rem;
+        }
+
+        .warnings ul {
+            margin-bottom: 0;
+            color: #78350f;
+        }
+
+        /* Task lists (checkboxes) */
+        li input[type="checkbox"] {
+            margin-right: 0.5rem;
+        }
+
+        /* Status badges */
+        .badge {
+            display: inline-block;
+            padding: 0.25rem 0.625rem;
+            border-radius: 9999px;
+            font-size: 0.75rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .badge-success {
+            background-color: #d1fae5;
+            color: #065f46;
+        }
+
+        .badge-warning {
+            background-color: #fef3c7;
+            color: #92400e;
+        }
+
+        .badge-info {
+            background-color: #dbeafe;
+            color: #1e40af;
+        }
+
+        /* Content wrapper */
+        .content {
+            margin-bottom: 2rem;
+        }
+
+        /* Footer */
+        footer {
+            margin-top: 3rem;
+            padding-top: 1.5rem;
+            border-top: 1px solid var(--border-color);
+            color: var(--text-muted);
+            font-size: 0.875rem;
+            text-align: center;
+        }
+
+        footer small {
+            display: block;
+        }
+    </style>
+    <!-- Mermaid.js for diagram rendering -->
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+    <script>
+        mermaid.initialize({
+            startOnLoad: true,
+            theme: 'default',
+            themeVariables: {
+                primaryColor: '#3498db',
+                primaryTextColor: '#fff',
+                primaryBorderColor: '#2c3e50',
+                lineColor: '#333',
+                secondaryColor: '#ecf0f1',
+                tertiaryColor: '#f39c12'
+            },
+            flowchart: {
+                htmlLabels: true,
+                curve: 'basis'
+            }
+        });
+    </script>
+</head>
+<body>
+    <nav class="breadcrumb">
+        <a href="../index.html">Home</a> &raquo;
+        <a href="index.html">Projects</a> &raquo;
+        Mechanobiology Gene Review Project
+    </nav>
+
+    <header class="header">
+        <h1>Mechanobiology Gene Review Project</h1>
+        
+    </header>
+
+    
+
+    <div class="content">
+        <h1 id="mechanobiology-gene-review-project">Mechanobiology Gene Review Project</h1>
+<h2 id="scope">Scope</h2>
+<p>This project reviews genes whose core function is to sense mechanical cues, transmit force-dependent signals, or reshape the mechanical microenvironment in ways that drive reproducible biological outcomes.</p>
+<p>This scaffold was informed by <a href="https://github.com/cmungall/stuff/issues/671">cmungall/stuff#671</a>, but the project stays deliberately narrower and more practical than the grant-style framing in that issue:<br />
+- focus on reviewable genes, evidence-backed mechanisms, and curation outputs<br />
+- use disease relevance to prioritize batches, not to over-claim translational impact<br />
+- treat ontology or knowledge-graph follow-up as optional downstream outputs, not the primary deliverable</p>
+<p>Operationally, each reviewed gene should be placed in a concrete chain:</p>
+<p><code>mechanical stimulus -&gt; sensor/transducer -&gt; downstream axis -&gt; phenotype/context</code></p>
+<h2 id="practical-inclusion-criteria">Practical inclusion criteria</h2>
+<p>Include genes when there is evidence for one or more of the following:<br />
+- direct sensing of membrane tension, stretch, shear, compression, or osmotic/mechano-osmotic change<br />
+- force transmission through adhesions, cortex, cytoskeleton, primary cilium, or nucleus<br />
+- robust mechanosensitive downstream signaling repeatedly tied to defined mechanical contexts<br />
+- active remodeling of ECM stiffness/compliance or tissue mechanics that is central to the gene's biological role</p>
+<p>Deprioritize genes when they are only:<br />
+- generic proliferation, migration, or stress-response genes without a defined mechanical trigger<br />
+- broad ECM structural components with no mechanotransduction-specific evidence<br />
+- one-off assay hits from poorly defined stretching/stiffness systems</p>
+<h2 id="mechanical-stimulus-space-to-capture-explicitly">Mechanical stimulus space to capture explicitly</h2>
+<ul>
+<li><strong>Matrix stiffness / compliance</strong>: soft vs stiff substrate responses, durotaxis, fibrotic stiffening</li>
+<li><strong>Fluid shear stress</strong>: endothelial flow sensing, tubular flow, ciliary flow detection</li>
+<li><strong>Tensile stretch / cyclic stretch</strong>: muscle, lung, vessel wall, epithelium</li>
+<li><strong>Compression / confinement</strong>: cartilage, tumor growth, nuclear squeezing during migration</li>
+<li><strong>Membrane tension</strong>: channel gating, blebbing, osmotic swelling, cell shape change</li>
+<li><strong>Cell crowding / packing forces</strong>: contact-dependent YAP/TAZ control, epithelial jamming</li>
+<li><strong>Topography / curvature</strong>: force-sensitive adhesion and cytoskeletal organization</li>
+</ul>
+<h2 id="candidate-mechanosensor-and-transduction-modules">Candidate mechanosensor and transduction modules</h2>
+<h3 id="1-direct-or-near-direct-mechanical-sensors">1. Direct or near-direct mechanical sensors</h3>
+<ul>
+<li><strong>PIEZO1, PIEZO2</strong>: canonical mechanically activated ion channels</li>
+<li><strong>TRPV4</strong>: osmotic and mechanical channel with recurring roles in cartilage, vasculature, and fibrosis-related signaling</li>
+<li><strong>PKD1, PKD2</strong>: flow/ciliary mechanosensation candidates with strong kidney/cilia relevance</li>
+</ul>
+<h3 id="2-adhesion-and-focal-adhesion-force-coupling">2. Adhesion and focal-adhesion force coupling</h3>
+<ul>
+<li><strong>ITGB1, ITGA5</strong>: integrin-mediated ECM force coupling</li>
+<li><strong>TLN1, VCL, PXN, ILK, PTK2/FAK1</strong>: adhesion proteins that convert load-bearing contacts into signaling outputs</li>
+</ul>
+<h3 id="3-cytoskeletal-force-transmission">3. Cytoskeletal force transmission</h3>
+<ul>
+<li><strong>RHOA, ROCK1, ROCK2</strong>: contractility and cortical tension axis</li>
+<li><strong>ACTN1, ACTN4, FLNA, MYH9, MYH10</strong>: actomyosin-linked mechanical response machinery</li>
+</ul>
+<h3 id="4-nuclear-mechanotransmission">4. Nuclear mechanotransmission</h3>
+<ul>
+<li><strong>LMNA</strong>: nuclear lamina stiffness and force buffering</li>
+<li><strong>SYNE1, SYNE2, SUN1, SUN2, EMD</strong>: LINC/nuclear-envelope components transmitting cytoskeletal force to the nucleus</li>
+</ul>
+<h3 id="5-downstream-mechanosensitive-effectors">5. Downstream mechanosensitive effectors</h3>
+<ul>
+<li><strong>YAP1, WWTR1 (TAZ), LATS1, LATS2</strong>: Hippo-linked mechanical state readout</li>
+<li><strong><a href="../../genes/human/MAPK1/MAPK1-ai-review.html">MAPK1</a>, MAPK3, MTOR, MRTFA, SRF</strong>: common downstream axes that often need careful specificity in curation</li>
+<li><strong>SMAD2, <a href="../../genes/human/SMAD3/SMAD3-ai-review.html">SMAD3</a>, TGFB1, CTGF/CCN2</strong>: stiffness/fibrosis-linked outputs that should usually be treated as downstream context, not primary sensors</li>
+</ul>
+<h3 id="6-mechanical-microenvironment-modifiers">6. Mechanical microenvironment modifiers</h3>
+<ul>
+<li><strong><a href="../../genes/human/FN1/FN1-ai-review.html">FN1</a>, LOX, COL1A1, <a href="../../genes/human/SPARC/SPARC-ai-review.html">SPARC</a>, <a href="../../genes/human/DCN/DCN-ai-review.html">DCN</a></strong>: ECM regulators that can change tissue stiffness and feed back onto mechanosensing</li>
+<li>These belong in scope only when the mechanical consequence is central, not merely because they are ECM genes</li>
+</ul>
+<h2 id="suggested-first-review-batches">Suggested first review batches</h2>
+<h3 id="batch-a-canonical-direct-mechanosensors">Batch A: canonical direct mechanosensors</h3>
+<ul>
+<li>PIEZO1</li>
+<li>PIEZO2</li>
+<li>TRPV4</li>
+<li>PKD1</li>
+<li>PKD2</li>
+</ul>
+<h3 id="batch-b-integrin-adhesome-force-transduction">Batch B: integrin-adhesome force transduction</h3>
+<ul>
+<li>ITGB1</li>
+<li>ITGA5</li>
+<li>TLN1</li>
+<li>VCL</li>
+<li>PTK2</li>
+<li>PXN</li>
+</ul>
+<h3 id="batch-c-nucleus-cytoskeleton-coupling">Batch C: nucleus-cytoskeleton coupling</h3>
+<ul>
+<li>LMNA</li>
+<li>SYNE1</li>
+<li>SYNE2</li>
+<li>SUN1</li>
+<li>SUN2</li>
+<li>EMD</li>
+</ul>
+<h3 id="batch-d-downstream-mechanical-state-effectors">Batch D: downstream mechanical state effectors</h3>
+<ul>
+<li>YAP1</li>
+<li>WWTR1</li>
+<li>LATS1</li>
+<li>LATS2</li>
+<li>RHOA</li>
+<li>ROCK1</li>
+<li>ROCK2</li>
+</ul>
+<h3 id="batch-e-matrix-stiffening-and-fibrosis-anchor-genes">Batch <a href="../../genes/BPT4/E/E-ai-review.html">E</a>: matrix stiffening and fibrosis anchor genes</h3>
+<ul>
+<li><a href="../../genes/human/FN1/FN1-ai-review.html">FN1</a></li>
+<li>LOX</li>
+<li><a href="../../genes/human/SPARC/SPARC-ai-review.html">SPARC</a></li>
+<li><a href="../../genes/human/DCN/DCN-ai-review.html">DCN</a></li>
+<li>TGFB1</li>
+<li>CTGF</li>
+</ul>
+<h2 id="downstream-axes-to-record-in-reviews">Downstream axes to record in reviews</h2>
+<p>When a gene is in scope, reviewers should try to capture which of these axes is actually supported:<br />
+- <strong>Ca2+ influx and ion-channel signaling</strong><br />
+- <strong>RhoA/ROCK-actomyosin contractility</strong><br />
+- <strong>Hippo/YAP/TAZ nuclear localization or transcriptional output</strong><br />
+- <strong>FAK/<a href="../../genes/mouse/Src/Src-ai-review.html">Src</a>/MAPK signaling</strong><br />
+- <strong>mTOR / growth-state coupling</strong><br />
+- <strong>TGF-beta / SMAD fibrotic remodeling</strong><br />
+- <strong>Endothelial flow programs</strong> such as KLF2/KLF4/NOS3<br />
+- <strong>Migration / invasion / EMT-like programs</strong> when clearly tied to force context</p>
+<h2 id="disease-and-tissue-anchors-for-prioritization">Disease and tissue anchors for prioritization</h2>
+<p>These are useful anchors for choosing batches, but should not become hype-driven claims:<br />
+- <strong>Fibrosis</strong>: lung, liver, heart, kidney; matrix stiffening and feed-forward myofibroblast activation<br />
+- <strong>Cancer invasion and metastasis</strong>: confinement, adhesion turnover, ECM remodeling, YAP/TAZ programs<br />
+- <strong>Cardiovascular and endothelial biology</strong>: shear stress, stretch, cardiac remodeling<br />
+- <strong>Kidney and cilia-linked mechanosensation</strong>: flow detection and tubular phenotypes<br />
+- <strong>Cartilage, bone, tendon, and muscle</strong>: load-bearing mechanobiology</p>
+<h2 id="expected-outputs">Expected outputs</h2>
+<ul>
+<li>a reviewed starter set of high-confidence mechanobiology genes in <code>genes/&lt;organism&gt;/&lt;gene&gt;/</code></li>
+<li>a project-level summary table linking stimulus, sensor/transducer class, downstream axis, and phenotype</li>
+<li>a shortlist of over-annotation patterns or recurrent GO term pain points in mechanobiology curation</li>
+<li>possible pathway-style summary pages once the first review batches stabilize</li>
+<li>optional bioinformatics sidecars only where they answer a concrete curation question</li>
+</ul>
+<h2 id="questions-to-keep-asking-during-curation">Questions to keep asking during curation</h2>
+<ul>
+<li>Is this gene a <strong>direct mechanosensor</strong>, a <strong>force-transducing component</strong>, a <strong>downstream effector</strong>, or a <strong>mechanical-context modifier</strong>?</li>
+<li>What is the actual stimulus: stiffness, shear, stretch, compression, membrane tension, osmotic change, or something more indirect?</li>
+<li>Is the evidence from a defined mechanical perturbation, or just from a generic migration/adhesion assay?</li>
+<li>Is the reported function likely cell-type or tissue specific?</li>
+<li>Are existing annotations too broad, especially around <code>cell adhesion</code>, <code>ECM organization</code>, <code>actin binding</code>, <code>response to mechanical stimulus</code>, or generic signaling terms?</li>
+<li>Does the paper support a core function, a conditional context-specific role, or only a disease-associated correlation?</li>
+</ul>
+<h2 id="guardrails">Guardrails</h2>
+<ul>
+<li>Do not treat every ECM or cytoskeletal gene as mechanobiology by default.</li>
+<li>Do not elevate downstream fibrosis or cancer markers into "mechanosensors" unless the upstream mechanical link is demonstrated.</li>
+<li>Prefer a smaller, well-argued starter set over a sprawling catch-all list.</li>
+<li>Only propose ontology or schema extensions after repeated curation pain points appear across reviewed genes.</li>
+</ul>
+<h2 id="how-issue-671-influenced-this-framing">How issue #671 influenced this framing</h2>
+<p>The issue materially improved the scaffold in four ways:</p>
+<ol>
+<li>It expanded the project from a narrow ECM/stiffness idea into a fuller mechanical landscape including shear, tension, compression, membrane tension, and osmotic pressure.</li>
+<li>It surfaced a practical shortlist of mechanobiology anchor classes: Piezo channels, integrin/adhesion machinery, nuclear lamins, and YAP/TAZ-linked signaling.</li>
+<li>It pushed the framing toward explicit <code>stimulus -&gt; sensor -&gt; downstream phenotype</code> chains rather than a flat list of "mechanics-related genes."</li>
+<li>It suggested useful disease anchors and outputs, especially fibrosis, cancer invasion, and cardiovascular remodeling.</li>
+</ol>
+<p>What was intentionally <strong>not</strong> adopted from the issue as a primary goal:<br />
+- a new mechanobiology ontology<br />
+- a large AI extraction platform<br />
+- broad therapeutic-discovery claims</p>
+<p>Those may become relevant later, but the present project is first a grounded curation and synthesis effort for <code>ai-gene-review</code>.</p>
+<h2 id="source-input">Source input</h2>
+<ul>
+<li>Key ideation source: <a href="https://github.com/cmungall/stuff/issues/671">cmungall/stuff issue #671</a>, fetched 2026-04-11</li>
+</ul>
+    </div>
+
+    <footer>
+        <small>Generated from MECHANOBIOLOGY.md</small>
+        <small>AI Gene Review Project</small>
+    </footer>
+</body>
+</html>

--- a/pages/projects/index.html
+++ b/pages/projects/index.html
@@ -209,6 +209,9 @@
             <a href="ECM.html">Extracellular Matrix</a>
         </div>
         <div class="project-card">
+            <a href="MECHANOBIOLOGY.html">Mechanobiology</a>
+        </div>
+        <div class="project-card">
             <a href="ER_PHAGY.html">ER-Phagy</a>
         </div>
         <div class="project-card">

--- a/projects/MECHANOBIOLOGY.md
+++ b/projects/MECHANOBIOLOGY.md
@@ -1,0 +1,183 @@
+# Mechanobiology Gene Review Project
+
+## Scope
+
+This project reviews genes whose core function is to sense mechanical cues, transmit force-dependent signals, or reshape the mechanical microenvironment in ways that drive reproducible biological outcomes.
+
+This scaffold was informed by [cmungall/stuff#671](https://github.com/cmungall/stuff/issues/671), but the project stays deliberately narrower and more practical than the grant-style framing in that issue:
+- focus on reviewable genes, evidence-backed mechanisms, and curation outputs
+- use disease relevance to prioritize batches, not to over-claim translational impact
+- treat ontology or knowledge-graph follow-up as optional downstream outputs, not the primary deliverable
+
+Operationally, each reviewed gene should be placed in a concrete chain:
+
+`mechanical stimulus -> sensor/transducer -> downstream axis -> phenotype/context`
+
+## Practical inclusion criteria
+
+Include genes when there is evidence for one or more of the following:
+- direct sensing of membrane tension, stretch, shear, compression, or osmotic/mechano-osmotic change
+- force transmission through adhesions, cortex, cytoskeleton, primary cilium, or nucleus
+- robust mechanosensitive downstream signaling repeatedly tied to defined mechanical contexts
+- active remodeling of ECM stiffness/compliance or tissue mechanics that is central to the gene's biological role
+
+Deprioritize genes when they are only:
+- generic proliferation, migration, or stress-response genes without a defined mechanical trigger
+- broad ECM structural components with no mechanotransduction-specific evidence
+- one-off assay hits from poorly defined stretching/stiffness systems
+
+## Mechanical stimulus space to capture explicitly
+
+- **Matrix stiffness / compliance**: soft vs stiff substrate responses, durotaxis, fibrotic stiffening
+- **Fluid shear stress**: endothelial flow sensing, tubular flow, ciliary flow detection
+- **Tensile stretch / cyclic stretch**: muscle, lung, vessel wall, epithelium
+- **Compression / confinement**: cartilage, tumor growth, nuclear squeezing during migration
+- **Membrane tension**: channel gating, blebbing, osmotic swelling, cell shape change
+- **Cell crowding / packing forces**: contact-dependent YAP/TAZ control, epithelial jamming
+- **Topography / curvature**: force-sensitive adhesion and cytoskeletal organization
+
+## Candidate mechanosensor and transduction modules
+
+### 1. Direct or near-direct mechanical sensors
+
+- **PIEZO1, PIEZO2**: canonical mechanically activated ion channels
+- **TRPV4**: osmotic and mechanical channel with recurring roles in cartilage, vasculature, and fibrosis-related signaling
+- **PKD1, PKD2**: flow/ciliary mechanosensation candidates with strong kidney/cilia relevance
+
+### 2. Adhesion and focal-adhesion force coupling
+
+- **ITGB1, ITGA5**: integrin-mediated ECM force coupling
+- **TLN1, VCL, PXN, ILK, PTK2/FAK1**: adhesion proteins that convert load-bearing contacts into signaling outputs
+
+### 3. Cytoskeletal force transmission
+
+- **RHOA, ROCK1, ROCK2**: contractility and cortical tension axis
+- **ACTN1, ACTN4, FLNA, MYH9, MYH10**: actomyosin-linked mechanical response machinery
+
+### 4. Nuclear mechanotransmission
+
+- **LMNA**: nuclear lamina stiffness and force buffering
+- **SYNE1, SYNE2, SUN1, SUN2, EMD**: LINC/nuclear-envelope components transmitting cytoskeletal force to the nucleus
+
+### 5. Downstream mechanosensitive effectors
+
+- **YAP1, WWTR1 (TAZ), LATS1, LATS2**: Hippo-linked mechanical state readout
+- **MAPK1, MAPK3, MTOR, MRTFA, SRF**: common downstream axes that often need careful specificity in curation
+- **SMAD2, SMAD3, TGFB1, CTGF/CCN2**: stiffness/fibrosis-linked outputs that should usually be treated as downstream context, not primary sensors
+
+### 6. Mechanical microenvironment modifiers
+
+- **FN1, LOX, COL1A1, SPARC, DCN**: ECM regulators that can change tissue stiffness and feed back onto mechanosensing
+- These belong in scope only when the mechanical consequence is central, not merely because they are ECM genes
+
+## Suggested first review batches
+
+### Batch A: canonical direct mechanosensors
+
+- PIEZO1
+- PIEZO2
+- TRPV4
+- PKD1
+- PKD2
+
+### Batch B: integrin-adhesome force transduction
+
+- ITGB1
+- ITGA5
+- TLN1
+- VCL
+- PTK2
+- PXN
+
+### Batch C: nucleus-cytoskeleton coupling
+
+- LMNA
+- SYNE1
+- SYNE2
+- SUN1
+- SUN2
+- EMD
+
+### Batch D: downstream mechanical state effectors
+
+- YAP1
+- WWTR1
+- LATS1
+- LATS2
+- RHOA
+- ROCK1
+- ROCK2
+
+### Batch E: matrix stiffening and fibrosis anchor genes
+
+- FN1
+- LOX
+- SPARC
+- DCN
+- TGFB1
+- CTGF
+
+## Downstream axes to record in reviews
+
+When a gene is in scope, reviewers should try to capture which of these axes is actually supported:
+- **Ca2+ influx and ion-channel signaling**
+- **RhoA/ROCK-actomyosin contractility**
+- **Hippo/YAP/TAZ nuclear localization or transcriptional output**
+- **FAK/Src/MAPK signaling**
+- **mTOR / growth-state coupling**
+- **TGF-beta / SMAD fibrotic remodeling**
+- **Endothelial flow programs** such as KLF2/KLF4/NOS3
+- **Migration / invasion / EMT-like programs** when clearly tied to force context
+
+## Disease and tissue anchors for prioritization
+
+These are useful anchors for choosing batches, but should not become hype-driven claims:
+- **Fibrosis**: lung, liver, heart, kidney; matrix stiffening and feed-forward myofibroblast activation
+- **Cancer invasion and metastasis**: confinement, adhesion turnover, ECM remodeling, YAP/TAZ programs
+- **Cardiovascular and endothelial biology**: shear stress, stretch, cardiac remodeling
+- **Kidney and cilia-linked mechanosensation**: flow detection and tubular phenotypes
+- **Cartilage, bone, tendon, and muscle**: load-bearing mechanobiology
+
+## Expected outputs
+
+- a reviewed starter set of high-confidence mechanobiology genes in `genes/<organism>/<gene>/`
+- a project-level summary table linking stimulus, sensor/transducer class, downstream axis, and phenotype
+- a shortlist of over-annotation patterns or recurrent GO term pain points in mechanobiology curation
+- possible pathway-style summary pages once the first review batches stabilize
+- optional bioinformatics sidecars only where they answer a concrete curation question
+
+## Questions to keep asking during curation
+
+- Is this gene a **direct mechanosensor**, a **force-transducing component**, a **downstream effector**, or a **mechanical-context modifier**?
+- What is the actual stimulus: stiffness, shear, stretch, compression, membrane tension, osmotic change, or something more indirect?
+- Is the evidence from a defined mechanical perturbation, or just from a generic migration/adhesion assay?
+- Is the reported function likely cell-type or tissue specific?
+- Are existing annotations too broad, especially around `cell adhesion`, `ECM organization`, `actin binding`, `response to mechanical stimulus`, or generic signaling terms?
+- Does the paper support a core function, a conditional context-specific role, or only a disease-associated correlation?
+
+## Guardrails
+
+- Do not treat every ECM or cytoskeletal gene as mechanobiology by default.
+- Do not elevate downstream fibrosis or cancer markers into "mechanosensors" unless the upstream mechanical link is demonstrated.
+- Prefer a smaller, well-argued starter set over a sprawling catch-all list.
+- Only propose ontology or schema extensions after repeated curation pain points appear across reviewed genes.
+
+## How issue #671 influenced this framing
+
+The issue materially improved the scaffold in four ways:
+
+1. It expanded the project from a narrow ECM/stiffness idea into a fuller mechanical landscape including shear, tension, compression, membrane tension, and osmotic pressure.
+2. It surfaced a practical shortlist of mechanobiology anchor classes: Piezo channels, integrin/adhesion machinery, nuclear lamins, and YAP/TAZ-linked signaling.
+3. It pushed the framing toward explicit `stimulus -> sensor -> downstream phenotype` chains rather than a flat list of "mechanics-related genes."
+4. It suggested useful disease anchors and outputs, especially fibrosis, cancer invasion, and cardiovascular remodeling.
+
+What was intentionally **not** adopted from the issue as a primary goal:
+- a new mechanobiology ontology
+- a large AI extraction platform
+- broad therapeutic-discovery claims
+
+Those may become relevant later, but the present project is first a grounded curation and synthesis effort for `ai-gene-review`.
+
+## Source input
+
+- Key ideation source: [cmungall/stuff issue #671](https://github.com/cmungall/stuff/issues/671), fetched 2026-04-11


### PR DESCRIPTION
## What changed
- added `projects/MECHANOBIOLOGY.md` as a new mechanobiology project scaffold
- rendered `pages/projects/MECHANOBIOLOGY.html`
- added the Mechanobiology project card to `pages/projects/index.html`

## Why
This adds a curation-first mechanobiology entry point to the repo, using Chris's issue #671 as input for scope and candidate axes while keeping the framing practical for `ai-gene-review` rather than ontology/grant-hype driven.

## Framing choices
- expands the scaffold to cover explicit mechanical stimuli such as stiffness, shear, stretch, compression, and membrane tension
- organizes candidate genes as direct sensors, force-transduction modules, nuclear mechanotransmission, downstream effectors, and microenvironment modifiers
- keeps ontology / knowledge-graph ideas as optional future outputs rather than the primary goal

## Validation
- `uv run ai-gene-review render-projects projects/MECHANOBIOLOGY.md -o pages/projects`
