### PR TITLE
Add GO:0160308 obsolescence note and OXPHOS figure

### DIFF
--- a/genes/human/SDHA/SDHA-ai-review.yaml
+++ b/genes/human/SDHA/SDHA-ai-review.yaml
@@ -1260,6 +1260,13 @@ existing_annotations:
         fumarate; the FAD cofactor serves as the immediate electron acceptor. This
         term
         fills a gap where the current annotations only capture the complex-level activity.
+        Note: GO:0160308 (succinate dehydrogenase (FAD) activity; RHEA:30343) is a more
+        specific child term that explicitly names FAD as the acceptor (FAD + succinate + H+
+        = fumarate + FADH2). This may be more precise for SDHA since FAD is the actual
+        cofactor. However, GO:0160308 is under consideration for obsolescence. If retained,
+        it would be the preferred term over GO:0000104. The three SDH activity terms form
+        a specificity series: GO:0000104 (generic acceptor, RHEA:16357) > GO:0160308
+        (FAD, RHEA:30343) and GO:0008177 (quinone, EC:1.3.5.1, RHEA:40523).
       supported_by:
         - reference_id: PMID:7550341
           supporting_text: >-

--- a/projects/OXPHOS.md
+++ b/projects/OXPHOS.md
@@ -12,6 +12,12 @@ OXPHOS is responsible for ~90% of cellular ATP production and is unique in requi
 coordinated expression from both nuclear and mitochondrial genomes: 13 subunits are
 mtDNA-encoded, while ~80 structural subunits and dozens of assembly factors are nuclear-encoded.
 
+![TCA cycle and OXPHOS coordination](https://media.springernature.com/lw1200/springer-static/image/art%3A10.1038%2Fs41467-019-13668-3/MediaObjects/41467_2019_13668_Fig3_HTML.png)
+*Fig. 3 from Martínez-Reyes & Chandel (2020) [PMID:31911585](https://pubmed.ncbi.nlm.nih.gov/31911585/).
+The TCA cycle and OXPHOS are tightly coordinated. Complex II (SDH) uniquely bridges both
+pathways: the succinate → fumarate reaction (TCA step 6) simultaneously feeds electrons
+into the ETC via FAD → FADH₂ → Fe-S → ubiquinone.*
+
 ## Model Species
 
 **Primary: Homo sapiens (human)**


### PR DESCRIPTION
## Summary
- **SDHA review**: Added note documenting the three SDH activity GO terms and their RHEA/EC cross-references (GO:0000104 generic RHEA:16357, GO:0160308 FAD-specific RHEA:30343, GO:0008177 quinone EC:1.3.5.1 RHEA:40523), noting GO:0160308 is under consideration for obsolescence
- **OXPHOS project**: Added Martínez-Reyes & Chandel 2020 (PMID:31911585) Fig. 3 illustrating TCA/OXPHOS coordination via Complex II

## Test plan
- [ ] Validate SDHA review: `just validate human SDHA`
- [ ] Confirm figure renders in project page

🤖 Generated with [Claude Code](https://claude.com/claude-code)