### PR TITLE
Gitignore cache lock files and generated dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,6 @@ rules/rules-export.csv
 publications-not-cached/
 projects/TRANSCRIPTION_FACTORS/deeptfactor-validation/
 reports/validation-all.tsv
+cache/enums/
+cache/go/go/
+cache/**/*.lock


### PR DESCRIPTION
## Summary
- Gitignore `cache/**/*.lock`, `cache/enums/`, `cache/go/go/`
- Prevents stale lock files and generated cache dirs from showing in status
- Scoped to cache/ to avoid affecting `uv.lock` files

## Test plan
- [x] Verified `uv.lock` files still tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)