### PR TITLE
[codex] Re-review PN existing candidates

### DIFF
--- a/genes/human/BCAP31/BCAP31-ai-review.yaml
+++ b/genes/human/BCAP31/BCAP31-ai-review.yaml
@@ -891,6 +891,29 @@ existing_annotations:
       supporting_text: "BAP31 associates with the N terminus of one of its newly synthesized
         client proteins, the DeltaF508 mutant of CFTR, and promotes its retrotranslocation
         from the ER and degradation by the cytoplasmic 26S proteasome system"
+- term:
+    id: GO:0036503
+    label: ERAD pathway
+  evidence_type: IGI
+  original_reference_id: PMID:18555783
+  review:
+    summary: >-
+      NEW annotation capturing BCAP31's direct participation in ER-associated
+      degradation. The Sec61/Derlin-1 study showed BCAP31 binds a misfolded ERAD
+      substrate (CFTRDeltaF508) and promotes its retrotranslocation and
+      proteasomal degradation.
+    action: NEW
+    reason: >-
+      The PN suggestion to add ERAD pathway stands up biologically. BCAP31 is not
+      just an upstream ER-stress factor; it directly facilitates substrate
+      retrotranslocation within the ERAD machinery. This direct pathway term is
+      more appropriate than representing the function only with positive-regulation
+      child terms.
+    supported_by:
+    - reference_id: PMID:18555783
+      supporting_text: "BAP31 associates with the N terminus of one of its newly synthesized
+        client proteins, the DeltaF508 mutant of CFTR, and promotes its retrotranslocation
+        from the ER and degradation by the cytoplasmic 26S proteasome system"
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with 

--- a/genes/human/EDF1/EDF1-ai-review.yaml
+++ b/genes/human/EDF1/EDF1-ai-review.yaml
@@ -686,6 +686,30 @@ existing_annotations:
         - reference_id: PMID:12040021
           supporting_text: Multiprotein bridging factor-1 (MBF-1) is a cofactor 
             for nuclear receptors that regulate lipid metabolism.
+  - term:
+      id: GO:0006515
+      label: protein quality control for misfolded or incompletely synthesized proteins
+    evidence_type: IEA
+    original_reference_id: file:human/EDF1/EDF1-deep-research-openai.md
+    review:
+      summary: >-
+        NEW annotation for EDF1's ribosome-surveillance role. EDF1 is recruited
+        to collided ribosomes, where it recruits the GIGYF2-eIF4E2 translational
+        repressor complex and suppresses further initiation on defective mRNAs,
+        placing it in ribosome-associated quality control rather than bulk
+        cytoplasmic translation.
+      action: NEW
+      reason: >-
+        The PN-linked RQC suggestion stands up biologically and is more defensible
+        than broad translation/cytoplasmic translation additions. EDF1 functions
+        as a collision sensor and translational quality-control factor for stalled
+        or damaged messages.
+      supported_by:
+        - reference_id: file:human/EDF1/EDF1-deep-research-openai.md
+          supporting_text: >-
+            In other words, EDF1 helps shut down translation initiation on
+            messages that are broken or stalled, which is part of a process
+            called No-Go Decay/Ribosome Quality Control (RQC).
 references:
   - id: GO_REF:0000033
     title: Annotation inferences using phylogenetic trees
@@ -798,5 +822,9 @@ core_functions:
     description: EDF1 was identified as an mRNA-binding protein in two 
       independent proteomics studies [PMID:22658674, PMID:22681889]. This is 
       consistent with its role at collided ribosomes where structural studies 
-      show it contacts mRNA.
+      show it contacts mRNA and recruits the GIGYF2-eIF4E2 complex to enforce
+      ribosome-associated quality control on stalled messages.
+    directly_involved_in:
+      - id: GO:0006515
+        label: protein quality control for misfolded or incompletely synthesized proteins
 status: COMPLETE

--- a/projects/PROTEOSTASIS.md
+++ b/projects/PROTEOSTASIS.md
@@ -302,6 +302,47 @@ These are especially useful for AIGR because the papers themselves signal uncert
 - `TTC28`: PN places it as an HSP70-HSP90 joint cochaperone, but the current AIGR review treats it as a mitotic scaffold
 - `MEX3B`: RING-family UPS placement may be real but needs distinction between family membership and core proteostasis role
 
+### Existing-review rereview examples
+
+On the `83`-gene existing-review queue, the useful distinction was not just the
+pipeline label but whether the PN-projected term was actually a better GO
+assertion than the current AIGR review. In practice,
+`more_specific_than_existing_goa` is a projection label, not a guarantee that
+the PN term remains the most specific biologically defensible choice after
+manual rereview.
+
+- `BCAP31` (`more_specific_than_existing_goa`): accepted `GO:0036503 ERAD pathway`.
+  This is a good positive-control case where the PN mapping is exact and the
+  biology holds up. The current review already supported direct ERAD
+  participation, and the rereview added the pathway term because BCAP31 helps
+  handle retrotranslocation of ERAD substrates rather than only acting in a
+  looser ER-stress or regulatory context.
+- `EDF1` (`new_to_goa`): PN suggested `GO:0002181 cytoplasmic translation`,
+  `GO:0006412 translation`, and `GO:0006515 protein quality control for
+  misfolded or incompletely synthesized proteins`. Only `GO:0006515` survived
+  conservative rereview. The broad translation terms were not added because the
+  best-supported biology is collided-ribosome surveillance and
+  ribosome-associated quality control rather than generic translation.
+- `TOMM20` (`more_specific_than_existing_goa` in the queue): rejected. The PN
+  mitochondrial mapping propagates the group-level `Protein import` bucket to
+  `GO:0017038 protein import`, but the current AIGR review already uses the
+  route-specific mitochondrial import term `GO:0030150 protein import into
+  mitochondrial matrix`. At the gene-review level, the PN suggestion was
+  broader rather than more specific.
+- `HSPA8` (`more_specific_than_existing_goa` in the queue): rejected. The PN
+  `GO:0035973 aggrephagy` projection comes from a selective-autophagy-receptor
+  path, whereas the current review already captures HSPA8's direct and much
+  better supported CMA biology with `GO:0061684 chaperone-mediated autophagy`
+  and `GO:0061740 protein targeting to lysosome involved in chaperone-mediated
+  autophagy`. HSPA8 clearly participates in proteostasis and aggregate handling,
+  but that did not justify promoting it to aggrephagy here.
+- `RAB7A` (`more_specific_than_existing_goa` in the queue): rejected on
+  conservative rereview. PN projected `GO:0061909 autophagosome-lysosome
+  fusion`, but the local evidence base is mixed, and mammalian knockout work
+  supports a stronger role in post-fusion autolysosome maturation than in the
+  fusion step itself. That was not strong enough to add the more specific term
+  to the human review.
+
 ## Priority Review Targets
 
 See [priority_genes.tsv](PROTEOSTASIS/priority_genes.tsv).


### PR DESCRIPTION
## Summary

This PR records the conservative rereview of PN-projected additions for existing human gene reviews.

## What changed

- added `GO:0036503 ERAD pathway` to `BCAP31` where the PN-specific ERAD suggestion held up biologically
- added `GO:0006515 protein quality control for misfolded or incompletely synthesized proteins` to `EDF1` and aligned the core-function summary with EDF1's ribosome-quality-control role
- added a new section to `projects/PROTEOSTASIS.md` documenting concrete rereview examples from the 83-gene queue, including accepted and rejected cases

## Why

The PN pipeline label `more_specific_than_existing_goa` was useful as a triage signal, but several projected terms did not remain the most specific or best-scoped GO assertion after manual review. The doc update now makes that distinction explicit.

## Notes

- delegated conservative spot rereviews for `TOMM20`, `HSPA8`, and `RAB7A`; all three stayed as no-change cases
- left projected PN terms unadded where the current review was already more specific or where the biological support stayed mixed

## Validation

- `just validate human BCAP31`
- `just validate human EDF1`