### PR TITLE
Review GO annotations for 9POAL psbA (PSII D1)

### DIFF
--- a/cache/go/terms.csv
+++ b/cache/go/terms.csv
@@ -1746,6 +1746,7 @@ GO:0009751,response to salicylic acid,2026-03-22T22:38:14.237952
 GO:0009753,response to jasmonic acid,2026-03-22T22:38:14.237952
 GO:0009755,hormone-mediated signaling pathway,2026-03-22T22:38:14.237952
 GO:0009758,carbohydrate utilization,2026-03-22T22:38:14.237952
+GO:0009772,photosynthetic electron transport in photosystem II,2026-04-22T22:51:45.266494
 GO:0009785,blue light signaling pathway,2026-03-22T22:38:14.237952
 GO:0009787,regulation of abscisic acid-activated signaling pathway,2026-03-22T22:38:14.237952
 GO:0009790,embryo development,2026-03-22T22:38:14.237952
@@ -1846,6 +1847,7 @@ GO:0010218,response to far red light,2026-03-22T22:38:14.237952
 GO:0010224,response to UV-B,2026-03-22T22:38:14.237952
 GO:0010225,response to UV-C,2026-03-22T22:38:14.237952
 GO:0010228,vegetative to reproductive phase transition of meristem,2026-03-22T22:38:14.237952
+GO:0010242,oxygen evolving activity,2026-04-22T22:51:45.200169
 GO:0010243,obsolete response to organonitrogen compound,2026-03-22T22:38:14.237952
 GO:0010244,response to low fluence blue light stimulus by blue low-fluence system,2026-03-22T22:38:14.237952
 GO:0010256,endomembrane system organization,2026-03-22T22:38:14.237952
@@ -6074,7 +6076,6 @@ GO:0071561,nucleus-vacuole junction,2026-03-22T22:38:14.237952
 GO:0071564,npBAF complex,2026-03-22T22:38:14.237952
 GO:0071565,nBAF complex,2026-03-22T22:38:14.237952
 GO:0071567,deUFMylase activity,2026-04-19T19:53:21.908704
-GO:0071585,detoxification of cadmium ion,2026-04-22T22:50:28.053417
 GO:0071588,hydrogen peroxide mediated signaling pathway,2026-03-22T22:38:14.237952
 GO:0071598,neuronal ribonucleoprotein granule,2026-04-19T19:58:39.942845
 GO:0071599,otic vesicle development,2026-03-22T22:38:14.237952
@@ -6788,7 +6789,6 @@ GO:0140467,integrated stress response signaling,2026-03-22T22:38:14.237952
 GO:0140468,HRI-mediated signaling,2026-03-22T22:38:14.237952
 GO:0140469,GCN2-mediated signaling,2026-03-22T22:38:14.237952
 GO:0140481,ABC-type iron-sulfur cluster transporter activity,2026-03-22T22:38:14.237952
-GO:0140487,metal ion sequestering activity,2026-04-22T22:50:27.991813
 GO:0140488,heme receptor activity,2026-03-22T22:38:14.237952
 GO:0140494,migrasome,2026-03-22T22:38:14.237952
 GO:0140517,protein-RNA adaptor activity,2026-03-22T22:38:14.237952

--- a/genes/9POAL/psbA/psbA-ai-review.yaml
+++ b/genes/9POAL/psbA/psbA-ai-review.yaml
@@ -1,0 +1,387 @@
+id: P48183
+gene_symbol: psbA
+product_type: PROTEIN
+status: IN_PROGRESS
+taxon:
+  id: NCBITaxon:4577
+  label: Zea mays
+description: >-
+  psbA encodes the D1 protein (Photosystem II protein D1), which is the core reaction center
+  subunit of Photosystem II (PSII). D1 forms a heterodimer with D2 (PsbD) that binds P680,
+  the primary electron donor of PSII, along with pheophytin, plastoquinone QB, and a non-heme
+  iron. D1 provides most of the ligands for the Mn4-Ca-O5 cluster of the oxygen-evolving complex
+  (OEC), which catalyzes the light-driven oxidation of water to molecular oxygen. The protein
+  functions as a water:plastoquinone oxidoreductase (EC 1.10.3.9). D1 is located in the chloroplast
+  thylakoid membrane and is a multi-pass transmembrane protein with 5 transmembrane helices. It is
+  the primary target of photoinhibition damage and undergoes rapid light-dependent turnover via
+  degradation by Deg1 and FtsH proteases followed by de novo synthesis. The QB binding pocket of
+  D1 is also the target site for herbicides such as atrazine, diuron, and ioxynil. The protein is
+  C-terminally processed by CTPA protease, which is essential for assembly of the OEC. psbA is
+  chloroplast-encoded and one of the most conserved genes across all oxygenic photosynthetic
+  organisms.
+existing_annotations:
+- term:
+    id: GO:0009523
+    label: photosystem II
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: >-
+      IBA annotation placing psbA/D1 as part of the photosystem II complex, inferred by
+      phylogenetic analysis across orthologs. D1 is one of the two core reaction center
+      subunits of PSII (together with D2/PsbD). This is arguably the single most fundamental
+      annotation for this protein. UniProt states: "PSII is composed of 1 copy each of
+      membrane proteins PsbA, PsbB, PsbC, PsbD, PsbE, PsbF, PsbH, PsbI, PsbJ, PsbK, PsbL,
+      PsbM, PsbT, PsbX, PsbY, PsbZ, Psb30/Ycf12" (HAMAP-Rule:MF_01379). The IBA annotation
+      is phylogenetically well-supported and at the correct level of specificity.
+    action: ACCEPT
+    reason: >-
+      psbA/D1 is a core structural and catalytic subunit of PSII. This is the defining
+      annotation for this protein. The IBA is appropriately at the photosystem II level
+      rather than being overly specific to a sub-complex.
+    supported_by:
+      - reference_id: UniProt:P48183
+        supporting_text: "PSII is composed of 1 copy each of membrane proteins PsbA, PsbB, PsbC, PsbD, PsbE, PsbF, PsbH, PsbI, PsbJ, PsbK, PsbL, PsbM, PsbT, PsbX, PsbY, PsbZ, Psb30/Ycf12"
+      - reference_id: UniProt:P48183
+        supporting_text: "The D1/D2 (PsbA/PsbD) reaction center heterodimer binds P680, the primary electron donor of PSII as well as several subsequent electron acceptors"
+- term:
+    id: GO:0005506
+    label: iron ion binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000104
+  review:
+    summary: >-
+      IEA annotation for iron ion binding, transferred via UniRule UR000352928. D1 does
+      bind a non-heme iron atom shared with D2 at the interface of the heterodimer. UniProt
+      feature annotations show His-215 and His-272 as Fe cation binding residues with the note
+      "ligand shared with heterodimeric partner" (HAMAP-Rule:MF_01379). While accurate, this
+      is a secondary cofactor-binding property rather than a core catalytic function.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      The non-heme iron binding is real and structurally important — it bridges the D1/D2
+      heterodimer between the QA and QB quinone binding sites. However, this is a structural
+      cofactor role subsidiary to the primary catalytic function. Iron ion binding alone does
+      not adequately describe what psbA does.
+    supported_by:
+      - reference_id: UniProt:P48183
+        supporting_text: "ligand shared with heterodimeric partner [Fe cation binding at His-215 and His-272]"
+      - reference_id: UniProt:P48183
+        supporting_text: "The D1/D2 heterodimer... shares a non-heme iron and each subunit binds pheophytin, quinone, additional chlorophylls, carotenoids and lipids"
+- term:
+    id: GO:0010242
+    label: oxygen evolving activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: >-
+      IEA annotation for oxygen evolving activity (catalysis of 2 H2O = O2 + 4 H+ + 4 e-),
+      inferred from EC 1.10.3.9. D1 provides most of the ligands for the Mn4-Ca-O5 cluster
+      of the oxygen-evolving complex (OEC). UniProt feature annotations show binding of the
+      [CaMn4O5] cluster at residues Asp-170, His-189, Glu-332, His-333, Ala-342, and Ala-344
+      (HAMAP-Rule:MF_01379). The Tyr-161 residue forms the redox-active TyrZ radical
+      intermediate that directly participates in electron extraction from water.
+    action: ACCEPT
+    reason: >-
+      Oxygen evolving activity is one of the core molecular functions of psbA/D1. The D1
+      subunit provides 5 of the 7 amino acid ligands to the Mn4-Ca-O5 cluster and the
+      redox-active TyrZ (Tyr-161) that is the immediate electron donor to P680+. This is
+      a defining catalytic activity.
+    supported_by:
+      - reference_id: UniProt:P48183
+        supporting_text: "D1 provides most of the ligands for the Mn4-Ca-O5 cluster of the oxygen-evolving complex (OEC)"
+      - reference_id: UniProt:P48183
+        supporting_text: "Tyr-161 forms a radical intermediate that is referred to as redox-active TyrZ, YZ or Y-Z"
+- term:
+    id: GO:0015979
+    label: photosynthesis
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000104
+  review:
+    summary: >-
+      IEA annotation for involvement in photosynthesis, transferred via UniRule UR000352928.
+      D1 is essential for photosynthesis as the core reaction center subunit of PSII. However,
+      this is a very broad BP term. More specific terms like GO:0009772 (photosynthetic electron
+      transport in photosystem II) are already annotated and better capture the specific role.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      While accurate — D1 is absolutely essential for oxygenic photosynthesis — the term
+      GO:0015979 is very general. The more specific GO:0009772 (photosynthetic electron
+      transport in photosystem II) is already annotated and better represents the specific
+      biological process this protein participates in. This broad annotation is redundant
+      but not incorrect.
+    supported_by:
+      - reference_id: UniProt:P48183
+        supporting_text: "Photosystem II (PSII) is a light-driven water:plastoquinone oxidoreductase that uses light energy to abstract electrons from H(2)O, generating O(2) and a proton gradient subsequently used for ATP formation"
+- term:
+    id: GO:0016168
+    label: chlorophyll binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000104
+  review:
+    summary: >-
+      IEA annotation for chlorophyll binding, transferred via UniRule UR000352928. D1 binds
+      multiple chlorophyll a molecules including ChlzD1 (axial binding at His-118) and PD1
+      (axial binding at His-198), one of the pair of chlorophylls constituting the P680
+      reaction center. UniProt notes that "2 of the reaction center chlorophylls (ChlD1 and
+      ChlD2) are entirely coordinated by water" (HAMAP-Rule:MF_01379).
+    action: ACCEPT
+    reason: >-
+      Chlorophyll binding is a core molecular function of D1. The binding of PD1 chlorophyll
+      is essential for formation of the P680 reaction center, and ChlzD1 participates in
+      accessory electron transfer pathways. The structural binding sites are well-characterized.
+    supported_by:
+      - reference_id: UniProt:P48183
+        supporting_text: "chlorophyll a binding [ChlzD1] axial binding residue at His-118"
+      - reference_id: UniProt:P48183
+        supporting_text: "chlorophyll a binding [PD1] axial binding residue at His-198"
+      - reference_id: UniProt:P48183
+        supporting_text: "2 of the reaction center chlorophylls (ChlD1 and ChlD2) are entirely coordinated by water"
+- term:
+    id: GO:0016682
+    label: oxidoreductase activity, acting on diphenols and related substances as
+      donors, oxygen as acceptor
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000104
+  review:
+    summary: >-
+      IEA annotation for oxidoreductase activity corresponding to EC 1.10.3.9
+      (water:plastoquinone oxidoreductase), transferred via UniRule UR000352928. The PSII
+      complex catalyzes: 2 plastoquinone + 4 hnu + 2 H2O = 2 plastoquinol + O2. This
+      describes the overall enzymatic reaction of the PSII complex in which D1 is the
+      central catalytic subunit.
+    action: ACCEPT
+    reason: >-
+      This term captures the catalytic activity of the PSII reaction center. The catalytic
+      activity annotation at EC 1.10.3.9 is specifically assigned to the D1/D2 heterodimer
+      and is the defining enzymatic function. D1 binds the QB plastoquinone binding site
+      (Ser-264, Phe-265, His-215) where plastoquinone is reduced to plastoquinol.
+    supported_by:
+      - reference_id: UniProt:P48183
+        supporting_text: "Reaction=2 a plastoquinone + 4 hnu + 2 H2O = 2 a plastoquinol + O2; EC=1.10.3.9"
+      - reference_id: UniProt:P48183
+        supporting_text: "quinone binding [B] at Ser-264/Phe-265 and His-215"
+- term:
+    id: GO:0009055
+    label: electron transfer activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: >-
+      IEA annotation for electron transfer activity, inferred from InterPro IPR005867
+      (PSII D1) and UniRule UR000352928. D1 contains a complete electron transfer chain:
+      P680 -> pheophytin (PheoD1) -> QA (on D2) -> QB (on D1). The protein binds
+      pheophytin a at Glu-126 and plastoquinone QB at His-215/Ser-264/Phe-265. Tyr-161
+      (TyrZ) mediates electron transfer from the Mn4-Ca-O5 cluster to P680+.
+    action: ACCEPT
+    reason: >-
+      Electron transfer activity is a core molecular function of D1. The D1 subunit
+      directly participates in the photosynthetic electron transfer chain: TyrZ donates
+      electrons to P680+, and the protein provides the QB binding site where the terminal
+      electron acceptor plastoquinone is reduced. This is intrinsic to the catalytic
+      mechanism.
+    supported_by:
+      - reference_id: UniProt:P48183
+        supporting_text: "each subunit binds pheophytin, quinone, additional chlorophylls, carotenoids and lipids"
+      - reference_id: UniProt:P48183
+        supporting_text: "pheophytin a binding [D1] at Glu-126"
+- term:
+    id: GO:0009535
+    label: chloroplast thylakoid membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: >-
+      IEA annotation for localization to the chloroplast thylakoid membrane, inferred from
+      UniProtKB-SubCell SL-0058 and UniRule UR000352928. This localization is experimentally
+      confirmed in maize by Fristedt et al. (PMID:22833285), who showed by mass spectrometry
+      that D1 is present in thylakoid membranes of both bundle sheath and mesophyll
+      chloroplasts, with PSII more abundant in mesophyll cells and in grana lamellae.
+    action: ACCEPT
+    reason: >-
+      Chloroplast thylakoid membrane localization is well-established for D1 by direct
+      experimental evidence in Zea mays (PMID:22833285). D1 is a multi-pass transmembrane
+      protein with 5 transmembrane helices embedded in the thylakoid membrane.
+    supported_by:
+      - reference_id: PMID:22833285
+        supporting_text: "the photosynthetic apparatus is partitioned over two cell types called mesophyll (M) and bundle sheath (BS), which have different structure and specialization of the photosynthetic thylakoid membranes"
+      - reference_id: UniProt:P48183
+        supporting_text: "Plastid, chloroplast thylakoid membrane; Multi-pass membrane protein"
+- term:
+    id: GO:0009536
+    label: plastid
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: >-
+      IEA annotation for localization to plastid, inferred by ARBA machine learning
+      (ARBA:ARBA00027316). While technically correct — psbA is chloroplast-encoded and
+      the D1 protein resides in the chloroplast — this is a less specific term than the
+      already-annotated GO:0009535 (chloroplast thylakoid membrane), which precisely
+      captures the sub-organellar localization.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      The plastid annotation is accurate but redundant with the more specific chloroplast
+      thylakoid membrane annotation (GO:0009535). GO:0009536 (plastid) is a broad parent
+      term. Since the more precise term is already annotated, this adds no additional
+      information, but is not incorrect.
+    supported_by:
+      - reference_id: UniProt:P48183
+        supporting_text: "Plastid, chloroplast thylakoid membrane"
+- term:
+    id: GO:0009772
+    label: photosynthetic electron transport in photosystem II
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: >-
+      IEA annotation for involvement in photosynthetic electron transport in photosystem II,
+      inferred from InterPro domains IPR000484 (Photo_RC_L/M) and IPR036854 (Photo_II_D1/D2_sf).
+      D1 is the central subunit in PSII electron transport, hosting the primary electron
+      transfer chain from water oxidation through TyrZ -> P680 -> PheoD1 -> QA -> QB ->
+      plastoquinone pool. This is the most specific and accurate BP term for D1's role.
+    action: ACCEPT
+    reason: >-
+      This is the most appropriate biological process term for psbA/D1. The protein is the
+      core catalytic subunit mediating electron transfer from water to plastoquinone within
+      PSII. This term is at the right level of specificity — more informative than the broad
+      "photosynthesis" term while accurately describing the specific process.
+    supported_by:
+      - reference_id: UniProt:P48183
+        supporting_text: "Photosystem II (PSII) is a light-driven water:plastoquinone oxidoreductase that uses light energy to abstract electrons from H(2)O, generating O(2) and a proton gradient subsequently used for ATP formation"
+- term:
+    id: GO:0019684
+    label: photosynthesis, light reaction
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: >-
+      IEA annotation for involvement in photosynthesis, light reaction, inferred from
+      InterPro domains IPR000484 and IPR036854. D1 is essential for the light-dependent
+      reactions of photosynthesis as the reaction center where light energy drives charge
+      separation. However, this term is intermediate in specificity between GO:0015979
+      (photosynthesis) and GO:0009772 (photosynthetic electron transport in photosystem II).
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Accurate but partially redundant with the more specific GO:0009772 (photosynthetic
+      electron transport in photosystem II), which is already annotated. This broader term
+      adds little additional information beyond what the PSII-specific electron transport
+      term captures. Not wrong, but not the most informative annotation.
+    supported_by:
+      - reference_id: UniProt:P48183
+        supporting_text: "Photosystem II (PSII) is a light-driven water:plastoquinone oxidoreductase that uses light energy to abstract electrons from H(2)O"
+# New annotations not covered by existing GOA
+- term:
+    id: GO:0030145
+    label: manganese ion binding
+  evidence_type: IEA
+  original_reference_id: HAMAP-Rule:MF_01379
+  review:
+    summary: >-
+      D1 provides most of the amino acid ligands for the Mn4-Ca-O5 cluster of the
+      oxygen-evolving complex (OEC). UniProt feature annotations show [CaMn4O5] cluster
+      binding at residues Asp-170, His-189, Glu-332, His-333, Ala-342, and Ala-344
+      (5 of the 7 protein ligands to the cluster). Manganese binding is essential for
+      water oxidation activity and is a core molecular function not captured by existing
+      annotations.
+    action: NEW
+    reason: >-
+      The existing iron ion binding annotation captures the non-heme Fe, but the much more
+      functionally important Mn4-Ca-O5 cluster binding is not annotated. D1 provides the
+      majority of ligands to this catalytic metal center. Manganese ion binding is a core
+      molecular function that should be annotated.
+    supported_by:
+      - reference_id: UniProt:P48183
+        supporting_text: "D1 provides most of the ligands for the Mn4-Ca-O5 cluster of the oxygen-evolving complex (OEC)"
+      - reference_id: UniProt:P48183
+        supporting_text: "[CaMn4O5] cluster binding at Asp-170, His-189, Glu-332, His-333, Ala-342, Ala-344"
+- term:
+    id: GO:0048038
+    label: quinone binding
+  evidence_type: IEA
+  original_reference_id: HAMAP-Rule:MF_01379
+  review:
+    summary: >-
+      D1 provides the QB plastoquinone binding site, which is critical for PSII function.
+      UniProt feature annotations show quinone binding at His-215 and Ser-264/Phe-265
+      (HAMAP-Rule:MF_01379). The QB site is also the target of herbicides (atrazine,
+      diuron, ioxynil) that compete for plastoquinone binding. This is a functionally
+      important molecular function not captured by existing annotations.
+    action: NEW
+    reason: >-
+      Quinone (plastoquinone) binding at the QB site is one of the most functionally
+      important activities of D1 — it is essential for electron transfer from PSII to the
+      plastoquinone pool and is the binding site for major herbicide classes. This is a
+      core molecular function that should be annotated.
+    supported_by:
+      - reference_id: UniProt:P48183
+        supporting_text: "quinone binding [B] at His-215 and Ser-264/Phe-265"
+      - reference_id: UniProt:P48183
+        supporting_text: "Herbicides such as atrazine, BNT, diuron or ioxynil bind in the Q(B) binding site and block subsequent electron transfer"
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000104
+  title: Electronic Gene Ontology annotations created by transferring manual GO annotations
+    between related proteins based on shared sequence features
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:22833285
+  title: Differential phosphorylation of thylakoid proteins in mesophyll and bundle sheath
+    chloroplasts from maize plants grown under low or high light
+  findings:
+    - statement: >-
+        Direct experimental evidence for D1 localization in chloroplast thylakoid membrane
+        in Zea mays. D1 is phosphorylated in both bundle sheath and mesophyll cells.
+        PSII is more abundant in mesophyll than bundle sheath cells. D1 degradation is
+        faster in bundle sheath cells.
+- id: PMID:7666415
+  title: Complete sequence of the maize chloroplast genome
+  findings:
+    - statement: Complete nucleotide sequence of the Zea mays chloroplast genome including psbA
+- id: HAMAP-Rule:MF_01379
+  title: HAMAP rule for Photosystem II protein D1
+  findings:
+    - statement: >-
+        Comprehensive annotation rule for PSII D1 protein covering function, cofactors,
+        subunit composition, subcellular location, and post-translational modifications
+core_functions:
+# Core function 1: PSII reaction center -- water oxidation and electron transfer
+- description: >-
+    D1 is the core reaction center subunit of Photosystem II, forming a heterodimer with
+    D2 (PsbD) that binds P680, the primary electron donor. D1 provides most of the ligands
+    for the Mn4-Ca-O5 cluster of the oxygen-evolving complex (OEC), which catalyzes the
+    light-driven oxidation of water to molecular oxygen. The protein mediates the electron
+    transfer chain: water -> TyrZ (Tyr-161) -> P680 -> pheophytin -> QA -> QB (plastoquinone).
+    D1 also binds multiple chlorophyll a molecules including PD1 (part of the P680 reaction
+    center) and accessory ChlzD1. The overall catalytic reaction is water:plastoquinone
+    oxidoreductase (EC 1.10.3.9): 2 plastoquinone + 4 hnu + 2 H2O = 2 plastoquinol + O2.
+    D1 is subject to light-induced damage (photoinhibition) and undergoes rapid turnover
+    via FtsH and Deg1 proteases followed by de novo synthesis.
+  molecular_function:
+    id: GO:0010242
+    label: oxygen evolving activity
+  directly_involved_in:
+  - id: GO:0009772
+    label: photosynthetic electron transport in photosystem II
+  locations:
+  - id: GO:0009535
+    label: chloroplast thylakoid membrane
+  in_complex:
+    id: GO:0009523
+    label: photosystem II
+  supported_by:
+  - reference_id: UniProt:P48183
+    supporting_text: "Photosystem II (PSII) is a light-driven water:plastoquinone oxidoreductase that uses light energy to abstract electrons from H(2)O, generating O(2) and a proton gradient subsequently used for ATP formation"
+  - reference_id: UniProt:P48183
+    supporting_text: "D1 provides most of the ligands for the Mn4-Ca-O5 cluster of the oxygen-evolving complex (OEC)"
+  - reference_id: PMID:22833285
+    supporting_text: "the photosynthetic apparatus is partitioned over two cell types called mesophyll (M) and bundle sheath (BS), which have different structure and specialization of the photosynthetic thylakoid membranes"

--- a/genes/9POAL/psbA/psbA-deep-research-falcon.md
+++ b/genes/9POAL/psbA/psbA-deep-research-falcon.md
@@ -1,0 +1,279 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-04-22T22:44:45.210881'
+end_time: '2026-04-22T22:53:34.539772'
+duration_seconds: 529.33
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: 9POAL
+  gene_id: psbA
+  gene_symbol: psbA
+  uniprot_accession: P48183
+  protein_description: 'RecName: Full=Photosystem II protein D1 {ECO:0000255|HAMAP-Rule:MF_01379};
+    Short=PSII D1 protein {ECO:0000255|HAMAP-Rule:MF_01379}; EC=1.10.3.9 {ECO:0000255|HAMAP-Rule:MF_01379};
+    AltName: Full=32 kDa thylakoid membrane protein {ECO:0000303|Ref.1}; AltName:
+    Full=Photosystem II Q(B) protein {ECO:0000255|HAMAP-Rule:MF_01379}; Flags: Precursor;'
+  gene_info: Name=psbA {ECO:0000255|HAMAP-Rule:MF_01379};
+  organism_full: Zea mays (Maize).
+  protein_family: Belongs to the reaction center PufL/M/PsbA/D family.
+  protein_domains: D1/D2. (IPR055266); Photo_II_D1/D2_sf. (IPR036854); Photo_RC_L/M.
+    (IPR000484); Photo_RC_L/M_CS. (IPR055265); PSII_D1. (IPR005867)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 25
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P48183
+- **Protein Description:** RecName: Full=Photosystem II protein D1 {ECO:0000255|HAMAP-Rule:MF_01379}; Short=PSII D1 protein {ECO:0000255|HAMAP-Rule:MF_01379}; EC=1.10.3.9 {ECO:0000255|HAMAP-Rule:MF_01379}; AltName: Full=32 kDa thylakoid membrane protein {ECO:0000303|Ref.1}; AltName: Full=Photosystem II Q(B) protein {ECO:0000255|HAMAP-Rule:MF_01379}; Flags: Precursor;
+- **Gene Information:** Name=psbA {ECO:0000255|HAMAP-Rule:MF_01379};
+- **Organism (full):** Zea mays (Maize).
+- **Protein Family:** Belongs to the reaction center PufL/M/PsbA/D family.
+- **Key Domains:** D1/D2. (IPR055266); Photo_II_D1/D2_sf. (IPR036854); Photo_RC_L/M. (IPR000484); Photo_RC_L/M_CS. (IPR055265); PSII_D1. (IPR005867)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "psbA" matches the protein description above**
+2. **Verify the organism is correct:** Zea mays (Maize).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'psbA' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **psbA** (gene ID: psbA, UniProt: P48183) in 9POAL.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P48183
+- **Protein Description:** RecName: Full=Photosystem II protein D1 {ECO:0000255|HAMAP-Rule:MF_01379}; Short=PSII D1 protein {ECO:0000255|HAMAP-Rule:MF_01379}; EC=1.10.3.9 {ECO:0000255|HAMAP-Rule:MF_01379}; AltName: Full=32 kDa thylakoid membrane protein {ECO:0000303|Ref.1}; AltName: Full=Photosystem II Q(B) protein {ECO:0000255|HAMAP-Rule:MF_01379}; Flags: Precursor;
+- **Gene Information:** Name=psbA {ECO:0000255|HAMAP-Rule:MF_01379};
+- **Organism (full):** Zea mays (Maize).
+- **Protein Family:** Belongs to the reaction center PufL/M/PsbA/D family.
+- **Key Domains:** D1/D2. (IPR055266); Photo_II_D1/D2_sf. (IPR036854); Photo_RC_L/M. (IPR000484); Photo_RC_L/M_CS. (IPR055265); PSII_D1. (IPR005867)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "psbA" matches the protein description above**
+2. **Verify the organism is correct:** Zea mays (Maize).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'psbA' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **psbA** (gene ID: psbA, UniProt: P48183) in 9POAL.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research report: functional annotation of **psbA / Photosystem II protein D1** (UniProt **P48183**) in **Zea mays**
+
+### 0) Mandatory verification of target identity (to avoid symbol ambiguity)
+The gene symbol **psbA** is widely used across oxygenic photosynthetic lineages, but the **specific target here is Zea mays psbA encoding Photosystem II reaction-center protein D1**, consistent with UniProt accession **P48183**. Primary literature explicitly identifies **ZmpsbA as a cDNA encoding the D1 protein from maize (Zea mays L.)**, and maize chloroplast ribosome-profiling studies likewise define **psbA as encoding the D1 reaction-center protein of Photosystem II (PSII)**. (huo2016overexpressionofthe pages 2-3, chotewutmontri2018multileveleffectsof pages 1-2)
+
+### 1) Key concepts and definitions (current understanding)
+
+#### 1.1 What is PsbA/D1?
+**PsbA (D1)** is a **chloroplast-encoded, integral thylakoid-membrane core subunit of PSII**. It is described as an indispensable component of oxygenic photosynthesis and a key part of the PSII reaction center together with D2; D1 and D2 bind most redox-active cofactors required for electron transfer. (huo2016overexpressionofthe pages 1-2, huo2016overexpressionofthe pages 2-3)
+
+#### 1.2 PSII as an enzyme system and the role of D1
+A modern functional definition of PSII is a **water–plastoquinone oxidoreductase**: it uses light energy to drive charge separation, extracts electrons ultimately from water (via the oxygen-evolving complex, OEC), and reduces plastoquinone. In mechanistic terms, PSII photochemistry proceeds from **P680 → pheophytin → QA (primary plastoquinone acceptor) → QB (secondary acceptor)**. D1 is a core reaction-center subunit in which the quinone chemistry and binding pocket targeted by many inhibitors is classically localized (“32 kDa QB protein” terminology appears in the recent PSII repair review literature). (mehra2024assemblyandrepair pages 1-2, mehra2024assemblyandrepair pages 13-14)
+
+#### 1.3 Localization and membrane topology
+D1 is a **thylakoid membrane protein** whose synthesis and assembly are coordinated with thylakoid insertion. A recent light-stress review describes D1 as being inserted **co-translationally into thylakoid membranes**, with a topology including **five transmembrane helices** and an **N-terminus facing the stroma**. (khan2025adaptiveresponsesof pages 9-10)
+
+### 2) Biological processes, pathways, and mechanistic function
+
+#### 2.1 Photosynthetic electron transfer at PSII (QA/QB pathway)
+PSII electron transfer includes reduction of QA and then QB during successive turnover events; this QA/QB step is central to converting a one-electron photochemical event into plastoquinol formation. The PSII assembly/repair review explicitly situates QA and QB as sequential electron acceptors after P680 and pheophytin. (mehra2024assemblyandrepair pages 1-2)
+
+#### 2.2 Photoinhibition and why D1 is replaced
+A core concept in PSII biology is that **D1 is a primary target of light-driven oxidative damage** and therefore undergoes ongoing **damage–degradation–replacement**. In maize chloroplasts, this requirement is reflected by unusually strong regulation of psbA translation: D1 is described as the **primary target of photo-oxidative damage** and subject to a **repair cycle** where damaged D1 is degraded and replaced with newly synthesized D1; to meet this demand, D1 is among the most rapidly synthesized proteins in photosynthesizing cells. (chotewutmontri2018multileveleffectsof pages 1-2)
+
+Mechanistically, photodamage can involve both **donor-side** problems (near/OEC) and **acceptor-side** limitations (acceptor saturation leading to charge recombination), which promote formation of reactive species such as **singlet oxygen (\u00b9O2)**; acceptor-side effects can include conditions where QA becomes doubly reduced and is released, increasing damaging reactions. (lempiainenUnknownyearphotoinhibitionandregulation pages 31-35)
+
+#### 2.3 The PSII repair cycle (proteases, assembly factors, and thylakoid regions)
+A consistent view across recent synthesis is that PSII repair proceeds through partial PSII disassembly and migration within the thylakoid membrane network, followed by targeted D1 proteolysis and reassembly. One review summarizes a cycle in which **CP43 dissociates to expose D1**, **D1 is degraded** (Deg proteases implicated in primary cleavages; FtsH involved in processive degradation/remodeling), and then **new D1 is synthesized and inserted**, after which CP43 rebinds and functional PSII is restored. (mehra2024assemblyandrepair pages 6-8, mehra2024assemblyandrepair pages 13-14)
+
+A figure schematic from the 2024 PSII assembly/repair review shows the spatial organization of these events: **active PSII dimers are located in appressed thylakoid regions (grana), whereas assembly and degradation/repair steps occur in non-appressed regions (stroma lamellae/margins)**, with D1 degradation linked to FtsH (and possibly Deg) and followed by resynthesis/insertion. (mehra2024assemblyandrepair media f077a610)
+
+### 3) Regulation of psbA expression (maize-specific evidence)
+A distinctive feature of chloroplast gene regulation is that **psbA translation is strongly light responsive relative to most other chloroplast mRNAs**. In maize seedlings, **ribosome occupancy on psbA mRNA increases dramatically within minutes after illumination and returns to low occupancy within about an hour in darkness**, consistent with rapid D1 replacement needs during PSII maintenance. (chotewutmontri2018multileveleffectsof pages 1-2)
+
+### 4) Recent developments and latest research (prioritizing 2023–2024)
+
+#### 4.1 2024: PSII assembly and repair synthesis (state of the field)
+The 2024 review of PSII assembly and repair consolidates current understanding that (i) D1 is highly oxidation-prone and hence frequently replaced; (ii) D1 proteolysis is a central step in repair; and (iii) repair is organized in specialized thylakoid regions and depends on proteases and assembly factors that coordinate disassembly, replacement, and reassembly. (mehra2024assemblyandrepair pages 6-8, mehra2024assemblyandrepair media f077a610)
+
+#### 4.2 2024: PSII inhibitor discovery targeting the D1/QB pocket
+Applied mechanistic work in 2024 demonstrates continuing emphasis on the D1 pocket as a chemical target. A 2024 study investigating **brassicanate A sulfoxide** reports that it binds stably to D1 and **competes with plastoquinone at the binding pocket**, forming hydrogen bonds with **His-214 and Phe-261**, and highlights that urea/triazine inhibitors bind near **Ser-264**. Binding was supported computationally (molecular dynamics) and experimentally by **biolayer interferometry**. (wang2024potentialcandidatemolecule pages 9-10)
+
+### 5) Current applications and real-world implementations
+
+#### 5.1 Engineering stress tolerance by manipulating psbA/D1 abundance
+A transgenic application relevant to crop biotechnology is the use of maize psbA to modulate PSII performance under stress: overexpression of **ZmpsbA** in tobacco increased D1 abundance and was associated with improved drought-tolerance phenotypes, including less reduction of photosynthetic parameters such as **Fv/Fm** under drought, alongside altered antioxidant enzyme activities. (huo2016overexpressionofthe pages 2-3)
+
+#### 5.2 Herbicides and bioherbicide development targeting D1/QB
+The D1/QB pocket is a long-established herbicide target, and new natural-product-inspired candidates continue to be explored. The 2024 brassicanate A sulfoxide study explicitly positions D1 binding as a mode of action for developing photosynthesis-inhibiting herbicides (and validates binding by recombinant D1 expression plus biophysical binding assays). (wang2024potentialcandidatemolecule pages 9-10)
+
+### 6) Expert opinions and authoritative synthesis (with caveats)
+Recent review-level synthesis (2024) frames **D1 turnover as a central, energetically costly but essential maintenance strategy** that is more efficient than complete reaction-center replacement, and emphasizes the coordinated roles of proteases and assembly factors in maintaining PSII function under light stress. (mehra2024assemblyandrepair pages 6-8)
+
+Limitation: A major 2024 Plant Cell review on PSII biogenesis/maintenance was flagged as unobtainable in the retrieval process, so this report relies primarily on accessible 2024 synthesis in *Plants* and the accessible applied 2024 D1-inhibitor work; maize-specific mechanistic details beyond translation regulation were limited in the retrieved full-text set. (mehra2024assemblyandrepair pages 1-2, mehra2024assemblyandrepair pages 6-8, chotewutmontri2018multileveleffectsof pages 1-2, wang2024potentialcandidatemolecule pages 9-10)
+
+### 7) Relevant statistics and quantitative data (recent studies)
+
+* **D1 turnover under high light:** A 2024 review reports that in *Chlamydomonas*, under saturating light, **D1 half-life can be ~20 minutes**, illustrating the extreme turnover pressures that psbA translation and the repair protease network must meet in oxygenic photosynthesis. (mehra2024assemblyandrepair pages 6-8)
+
+* **D1-ligand binding affinity (herbicide candidate):** The 2024 brassicanate A sulfoxide study reports an affinity constant of **2.69 × 10−3 M** for binding to PSII D1 (measured by biolayer interferometry), supporting stable binding in the D1 pocket used for inhibitor development. (wang2024potentialcandidatemolecule pages 9-10)
+
+### 8) Summary functional annotation (for database-style use)
+
+| Category | Key points | Evidence/citations | Key references with URL and publication date |
+|---|---|---|---|
+| Identity | UniProt P48183 matches **Zea mays psbA**, encoding the **Photosystem II reaction-center D1 protein**; maize psbA/"ZmpsbA" was experimentally isolated as a cDNA encoding D1. D1 is a core PSII reaction-center subunit and historically corresponds to the 32 kDa QB/D1 protein class. | Maize-specific identification of ZmpsbA as D1 (huo2016overexpressionofthe pages 2-3); psbA encodes D1 in maize chloroplasts and D1/D2 bind most redox-active cofactors (huo2016overexpressionofthe pages 1-2); broader PSII/core-subunit mapping psbA→D1 (mehra2024assemblyandrepair pages 2-4, mehra2024assemblyandrepair pages 13-14) | Huo et al., *Frontiers in Plant Science* (Jan 2016), https://doi.org/10.3389/fpls.2015.01223; Mehra et al., *Plants* (Mar 2024), https://doi.org/10.3390/plants13060811 |
+| Localization/topology | D1 is a **chloroplast-encoded thylakoid membrane protein** inserted co-translationally into thylakoid membranes; active PSII dimers are enriched in appressed thylakoids, whereas repair/assembly steps occur in non-appressed regions. A recent review describes D1 as having **five transmembrane helices** with the **N-terminus facing the stroma**. | Chloroplast-encoded, membrane-inserted D1 in thylakoids (mehra2024assemblyandrepair pages 2-4, huo2016overexpressionofthe pages 2-3); co-translational targeting/insertion and topology (khan2025adaptiveresponsesof pages 9-10); repair/assembly localization across thylakoid domains (mehra2024assemblyandrepair pages 6-8, mehra2024assemblyandrepair media f077a610) | Khan et al., *Frontiers in Plant Science* (Mar 2025), https://doi.org/10.3389/fpls.2025.1550125; Mehra et al., *Plants* (Mar 2024), https://doi.org/10.3390/plants13060811 |
+| Core biochemical function | D1 is indispensable for oxygenic photosynthesis as part of the **PSII reaction center**. Together with D2, it binds most redox-active cofactors and supports photochemical electron transfer in PSII, which functions as a **water–plastoquinone oxidoreductase**. | D1/D2 bind redox cofactors and participate in electron transfer (huo2016overexpressionofthe pages 1-2); PSII defined as water–plastoquinone oxidoreductase and D1 as core component in assembly/repair review (mehra2024assemblyandrepair pages 1-2) | Huo et al., *Frontiers in Plant Science* (Jan 2016), https://doi.org/10.3389/fpls.2015.01223; Mehra et al., *Plants* (Mar 2024), https://doi.org/10.3390/plants13060811 |
+| Electron acceptors/cofactors | In PSII photochemistry, charge separation proceeds from **P680** to **pheophytin**, then to the primary plastoquinone acceptor **QA** and secondary acceptor **QB**. D1 is the canonical **QB/plastoquinone-binding** reaction-center subunit targeted by many PSII inhibitor herbicides; recent work identified ligand interactions involving **His-214** and **Phe-261**, while prior inhibitor classes are noted to bind near **Ser-264**. | QA/QB electron-transfer pathway in PSII review (mehra2024assemblyandrepair pages 1-2); D1 as 32 kDa QB protein and herbicide/QB-site target (mehra2024assemblyandrepair pages 13-14, wang2024potentialcandidatemolecule pages 9-10); acceptor-side photodamage context involving QA release/recombination (lempiainenUnknownyearphotoinhibitionandregulation pages 31-35) | Mehra et al., *Plants* (Mar 2024), https://doi.org/10.3390/plants13060811; Wang et al., *International Journal of Molecular Sciences* (Feb 2024), https://doi.org/10.3390/ijms25042400 |
+| PSII repair/turnover | D1 is the **primary target of photo-oxidative damage** and undergoes continuous **damage–degradation–replacement** during the PSII repair cycle. In plants/algae, repair involves PSII migration/disassembly, proteolysis by **Deg** and **FtsH** proteases, synthesis/insertion of new D1, and reassembly. Quantitative data from a 2024 review note that under saturating light in *Chlamydomonas*, D1 half-life can be **~20 min**. | Maize/light-regulated high D1 turnover and repair need (chotewutmontri2018multileveleffectsof pages 1-2); D1 photodamage and FtsH/Deg-mediated turnover (huo2016overexpressionofthe pages 1-2, mehra2024assemblyandrepair pages 6-8, mehra2024assemblyandrepair pages 13-14); localization of repair in non-appressed membranes (mehra2024assemblyandrepair media f077a610) | Chotewutmontri & Barkan, *PLOS Genetics* (Aug 2018), https://doi.org/10.1371/journal.pgen.1007555; Mehra et al., *Plants* (Mar 2024), https://doi.org/10.3390/plants13060811 |
+| Regulation of gene expression | **psbA translation is uniquely and strongly light regulated** in chloroplasts. In maize, ribosome occupancy on psbA mRNA increases within minutes in the light and declines in darkness, consistent with rapid D1 replacement needs. Reviews emphasize that transcription/translation of psbA is a major chloroplast-gene-expression response to high light and stress. | Maize ribosome profiling showing rapid, psbA-specific light response (chotewutmontri2018multileveleffectsof pages 1-2); stress/light review highlighting psbA transcription/translation importance (khan2025adaptiveresponsesof pages 9-10); recent chloroplast gene-expression review framing psbA regulation as important for crop yield/stress tolerance (khan2025adaptiveresponsesof pages 9-10) | Chotewutmontri & Barkan, *PLOS Genetics* (Aug 2018), https://doi.org/10.1371/journal.pgen.1007555; Zhang et al., *Plant Communications* (Sep 2023), https://doi.org/10.1016/j.xplc.2023.100611; Zhang et al., *Int. J. Mol. Sci.* (Aug 2020), https://doi.org/10.3390/ijms21176082 |
+| Applications/real-world | Real-world relevance centers on **crop stress tolerance** and **PSII-targeting herbicides**. Overexpressing maize psbA in tobacco increased D1 abundance and improved drought tolerance, photosynthetic performance, antioxidant enzyme activities, and Fv/Fm under stress. Separately, the D1/QB pocket is exploited for herbicide design; a 2024 study reported a PSII-inhibitor candidate with biolayer interferometry affinity of **2.69 × 10^-3 M** for D1. | Transgenic overexpression/abiotic-stress phenotype from maize psbA (huo2016overexpressionofthe pages 2-3); D1-targeted natural-product herbicide candidate and measured affinity (wang2024potentialcandidatemolecule pages 9-10) | Huo et al., *Frontiers in Plant Science* (Jan 2016), https://doi.org/10.3389/fpls.2015.01223; Wang et al., *International Journal of Molecular Sciences* (Feb 2024), https://doi.org/10.3390/ijms25042400 |
+
+
+*Table: This table summarizes the functional annotation of Zea mays psbA (UniProt P48183), covering identity, localization, core PSII function, repair dynamics, regulation, and applied relevance. It is useful as a compact evidence map anchored to available context IDs and recent authoritative literature.*
+
+**One-sentence functional summary:** In maize chloroplasts, **psbA (UniProt P48183)** encodes the PSII reaction-center **D1** thylakoid membrane protein that is essential for PSII photochemistry (QA→QB/plastoquinone reduction) and is the principal target of photodamage, maintained through a conserved PSII repair cycle involving D1 proteolysis (Deg/FtsH) and rapid light-regulated resynthesis and membrane reinsertion. (chotewutmontri2018multileveleffectsof pages 1-2, mehra2024assemblyandrepair pages 1-2, mehra2024assemblyandrepair pages 13-14, mehra2024assemblyandrepair media f077a610)
+
+### Key visual evidence
+A schematic of PSII assembly/repair localizes D1 damage, degradation, and replacement steps within the thylakoid network (grana vs non-appressed regions). (mehra2024assemblyandrepair media f077a610)
+
+### References (URLs and publication dates)
+* Mehra HS et al. **Assembly and Repair of Photosystem II in Chlamydomonas reinhardtii.** *Plants* (publication date: **Mar 2024**). https://doi.org/10.3390/plants13060811 (mehra2024assemblyandrepair pages 1-2, mehra2024assemblyandrepair pages 6-8, mehra2024assemblyandrepair pages 13-14, mehra2024assemblyandrepair media f077a610)
+* Wang Y et al. **Potential Candidate Molecule of Photosystem II Inhibitor Herbicide—Brassicanate A Sulfoxide.** *International Journal of Molecular Sciences* (publication date: **Feb 2024**). https://doi.org/10.3390/ijms25042400 (wang2024potentialcandidatemolecule pages 9-10)
+* Zhang Y et al. **Chloroplast gene expression: Recent advances and perspectives.** *Plant Communications* (publication date: **Sep 2023**). https://doi.org/10.1016/j.xplc.2023.100611 (khan2025adaptiveresponsesof pages 9-10)
+* Chotewutmontri P, Barkan A. **Multilevel effects of light on ribosome dynamics in chloroplasts program genome-wide and psbA-specific changes in translation.** *PLOS Genetics* (publication date: **Aug 2018**). https://doi.org/10.1371/journal.pgen.1007555 (chotewutmontri2018multileveleffectsof pages 1-2)
+* Huo Y et al. **Overexpression of the Maize psbA Gene Enhances Drought Tolerance…** *Frontiers in Plant Science* (publication date: **Jan 2016**). https://doi.org/10.3389/fpls.2015.01223 (huo2016overexpressionofthe pages 2-3, huo2016overexpressionofthe pages 1-2)
+
+
+References
+
+1. (huo2016overexpressionofthe pages 2-3): Yongjin Huo, Meiping Wang, Yangyang Wei, and Zongliang Xia. Overexpression of the maize psba gene enhances drought tolerance through regulating antioxidant system, photosynthetic capability, and stress defense gene expression in tobacco. Frontiers in Plant Science, Jan 2016. URL: https://doi.org/10.3389/fpls.2015.01223, doi:10.3389/fpls.2015.01223. This article has 126 citations.
+
+2. (chotewutmontri2018multileveleffectsof pages 1-2): Prakitchai Chotewutmontri and Alice Barkan. Multilevel effects of light on ribosome dynamics in chloroplasts program genome-wide and psba-specific changes in translation. PLOS Genetics, 14:e1007555, Aug 2018. URL: https://doi.org/10.1371/journal.pgen.1007555, doi:10.1371/journal.pgen.1007555. This article has 96 citations and is from a domain leading peer-reviewed journal.
+
+3. (huo2016overexpressionofthe pages 1-2): Yongjin Huo, Meiping Wang, Yangyang Wei, and Zongliang Xia. Overexpression of the maize psba gene enhances drought tolerance through regulating antioxidant system, photosynthetic capability, and stress defense gene expression in tobacco. Frontiers in Plant Science, Jan 2016. URL: https://doi.org/10.3389/fpls.2015.01223, doi:10.3389/fpls.2015.01223. This article has 126 citations.
+
+4. (mehra2024assemblyandrepair pages 1-2): Himanshu S. Mehra, Xiaozhuo Wang, Brandon P. Russell, Nidhi Kulkarni, Nicholas Ferrari, Brent Larson, and David J. Vinyard. Assembly and repair of photosystem ii in chlamydomonas reinhardtii. Plants, 13:811, Mar 2024. URL: https://doi.org/10.3390/plants13060811, doi:10.3390/plants13060811. This article has 7 citations.
+
+5. (mehra2024assemblyandrepair pages 13-14): Himanshu S. Mehra, Xiaozhuo Wang, Brandon P. Russell, Nidhi Kulkarni, Nicholas Ferrari, Brent Larson, and David J. Vinyard. Assembly and repair of photosystem ii in chlamydomonas reinhardtii. Plants, 13:811, Mar 2024. URL: https://doi.org/10.3390/plants13060811, doi:10.3390/plants13060811. This article has 7 citations.
+
+6. (khan2025adaptiveresponsesof pages 9-10): Imran Khan, Sohail, Shah Zaman, Guihua Li, Mei Fu, Wajid Zaman, Sima Panahirad, and Muhammad Irfan. Adaptive responses of plants to light stress: mechanisms of photoprotection and acclimation. a review. Frontiers in Plant Science, Mar 2025. URL: https://doi.org/10.3389/fpls.2025.1550125, doi:10.3389/fpls.2025.1550125. This article has 49 citations.
+
+7. (lempiainenUnknownyearphotoinhibitionandregulation pages 31-35): T Lempiäinen. Photoinhibition and regulation of photosynthesis. Unknown journal, Unknown year.
+
+8. (mehra2024assemblyandrepair pages 6-8): Himanshu S. Mehra, Xiaozhuo Wang, Brandon P. Russell, Nidhi Kulkarni, Nicholas Ferrari, Brent Larson, and David J. Vinyard. Assembly and repair of photosystem ii in chlamydomonas reinhardtii. Plants, 13:811, Mar 2024. URL: https://doi.org/10.3390/plants13060811, doi:10.3390/plants13060811. This article has 7 citations.
+
+9. (mehra2024assemblyandrepair media f077a610): Himanshu S. Mehra, Xiaozhuo Wang, Brandon P. Russell, Nidhi Kulkarni, Nicholas Ferrari, Brent Larson, and David J. Vinyard. Assembly and repair of photosystem ii in chlamydomonas reinhardtii. Plants, 13:811, Mar 2024. URL: https://doi.org/10.3390/plants13060811, doi:10.3390/plants13060811. This article has 7 citations.
+
+10. (wang2024potentialcandidatemolecule pages 9-10): Yu Wang, Dong Wang, Baozhu Dong, Jianxiu Hao, Xinyu Jia, and Hongyou Zhou. Potential candidate molecule of photosystem ii inhibitor herbicide—brassicanate a sulfoxide. International Journal of Molecular Sciences, 25:2400, Feb 2024. URL: https://doi.org/10.3390/ijms25042400, doi:10.3390/ijms25042400. This article has 2 citations.
+
+11. (mehra2024assemblyandrepair pages 2-4): Himanshu S. Mehra, Xiaozhuo Wang, Brandon P. Russell, Nidhi Kulkarni, Nicholas Ferrari, Brent Larson, and David J. Vinyard. Assembly and repair of photosystem ii in chlamydomonas reinhardtii. Plants, 13:811, Mar 2024. URL: https://doi.org/10.3390/plants13060811, doi:10.3390/plants13060811. This article has 7 citations.
+
+## Citations
+
+1. khan2025adaptiveresponsesof pages 9-10
+2. mehra2024assemblyandrepair pages 1-2
+3. chotewutmontri2018multileveleffectsof pages 1-2
+4. wang2024potentialcandidatemolecule pages 9-10
+5. huo2016overexpressionofthe pages 2-3
+6. mehra2024assemblyandrepair pages 6-8
+7. huo2016overexpressionofthe pages 1-2
+8. mehra2024assemblyandrepair pages 13-14
+9. mehra2024assemblyandrepair pages 2-4
+10. https://doi.org/10.3389/fpls.2015.01223;
+11. https://doi.org/10.3390/plants13060811
+12. https://doi.org/10.3389/fpls.2025.1550125;
+13. https://doi.org/10.3390/plants13060811;
+14. https://doi.org/10.3390/ijms25042400
+15. https://doi.org/10.1371/journal.pgen.1007555;
+16. https://doi.org/10.1016/j.xplc.2023.100611;
+17. https://doi.org/10.3390/ijms21176082
+18. https://doi.org/10.1016/j.xplc.2023.100611
+19. https://doi.org/10.1371/journal.pgen.1007555
+20. https://doi.org/10.3389/fpls.2015.01223
+21. https://doi.org/10.3389/fpls.2015.01223,
+22. https://doi.org/10.1371/journal.pgen.1007555,
+23. https://doi.org/10.3390/plants13060811,
+24. https://doi.org/10.3389/fpls.2025.1550125,
+25. https://doi.org/10.3390/ijms25042400,

--- a/genes/9POAL/psbA/psbA-goa.tsv
+++ b/genes/9POAL/psbA/psbA-goa.tsv
@@ -1,0 +1,12 @@
+GENE PRODUCT DB	GENE PRODUCT ID	SYMBOL	QUALIFIER	GO TERM	GO NAME	GO ASPECT	ECO ID	GO EVIDENCE CODE	REFERENCE	WITH/FROM	TAXON ID	TAXON NAME	ASSIGNED BY	GENE NAME	DATE
+UniProtKB	P48183	psbA	part_of	GO:0009523	photosystem II	cellular_component	ECO:0000318	IBA	GO_REF:0000033	PANTHER:PTN002108145|UniProtKB:P09192	4577	Zea mays	GO_Central	Photosystem II protein D1	20170228
+UniProtKB	P48183	psbA	enables	GO:0005506	iron ion binding	molecular_function	ECO:0000256	IEA	GO_REF:0000104	UniRule:UR000352928	4577	Zea mays	UniProt	Photosystem II protein D1	20260407
+UniProtKB	P48183	psbA	enables	GO:0010242	oxygen evolving activity	molecular_function	ECO:0000501	IEA	GO_REF:0000120	RHEA:36359|EC:1.10.3.9	4577	Zea mays	UniProt	Photosystem II protein D1	20260407
+UniProtKB	P48183	psbA	involved_in	GO:0015979	photosynthesis	biological_process	ECO:0000256	IEA	GO_REF:0000104	UniRule:UR000352928	4577	Zea mays	UniProt	Photosystem II protein D1	20260407
+UniProtKB	P48183	psbA	enables	GO:0016168	chlorophyll binding	molecular_function	ECO:0000256	IEA	GO_REF:0000104	UniRule:UR000352928	4577	Zea mays	UniProt	Photosystem II protein D1	20260407
+UniProtKB	P48183	psbA	enables	GO:0016682	oxidoreductase activity, acting on diphenols and related substances as donors, oxygen as acceptor	molecular_function	ECO:0000256	IEA	GO_REF:0000104	UniRule:UR000352928	4577	Zea mays	UniProt	Photosystem II protein D1	20260407
+UniProtKB	P48183	psbA	enables	GO:0009055	electron transfer activity	molecular_function	ECO:0000501	IEA	GO_REF:0000120	InterPro:IPR005867|UniRule:UR000352928	4577	Zea mays	UniProt	Photosystem II protein D1	20260302
+UniProtKB	P48183	psbA	located_in	GO:0009535	chloroplast thylakoid membrane	cellular_component	ECO:0000501	IEA	GO_REF:0000120	UniProtKB-SubCell:SL-0058|UniRule:UR000352928	4577	Zea mays	UniProt	Photosystem II protein D1	20260302
+UniProtKB	P48183	psbA	located_in	GO:0009536	plastid	cellular_component	ECO:0000256	IEA	GO_REF:0000117	ARBA:ARBA00027316	4577	Zea mays	UniProt	Photosystem II protein D1	20260302
+UniProtKB	P48183	psbA	involved_in	GO:0009772	photosynthetic electron transport in photosystem II	biological_process	ECO:0000256	IEA	GO_REF:0000002	InterPro:IPR000484|InterPro:IPR036854	4577	Zea mays	InterPro	Photosystem II protein D1	20260302
+UniProtKB	P48183	psbA	involved_in	GO:0019684	photosynthesis, light reaction	biological_process	ECO:0000256	IEA	GO_REF:0000002	InterPro:IPR000484|InterPro:IPR036854	4577	Zea mays	InterPro	Photosystem II protein D1	20260302

--- a/genes/9POAL/psbA/psbA-notes.md
+++ b/genes/9POAL/psbA/psbA-notes.md
@@ -1,0 +1,66 @@
+# psbA (Photosystem II protein D1) - Zea mays - Review Notes
+
+## Gene Overview
+
+psbA encodes the D1 protein, one of the two core reaction center subunits of Photosystem II (PSII). It is chloroplast-encoded and one of the most highly conserved genes across all oxygenic photosynthetic organisms. The UniProt representative entry used for this review is P48183 (Zea mays, maize).
+
+## Key Functional Features
+
+### Water:plastoquinone oxidoreductase (EC 1.10.3.9)
+- D1/D2 heterodimer catalyzes: 2 plastoquinone + 4 hν + 2 H₂O = 2 plastoquinol + O₂
+- D1 provides the QB plastoquinone binding site (His-215, Ser-264, Phe-265)
+
+### Oxygen-Evolving Complex (OEC)
+- D1 provides 5 of 7 protein ligands to the Mn₄-Ca-O₅ cluster: Asp-170, His-189, Glu-332, His-333, Ala-342, Ala-344
+- Tyr-161 (TyrZ) is the redox-active radical intermediate that extracts electrons from water
+
+### Cofactor binding
+- Chlorophyll a: ChlzD1 (His-118), PD1 (His-198, part of P680 reaction center)
+- Pheophytin a: PheoD1 (Glu-126)
+- Non-heme Fe: His-215, His-272 (shared with D2)
+- Plastoquinone QB: His-215, Ser-264, Phe-265
+
+### Herbicide target
+- QB binding pocket is the target of triazine (atrazine), urea (diuron), and nitrile (ioxynil) herbicides
+- Herbicide resistance mutations in psbA are well-characterized (e.g., Ser-264 → Gly confers atrazine resistance)
+
+### Photoinhibition and turnover
+- D1 is the primary target of light-induced damage in PSII
+- Rapid turnover: damaged D1 is degraded by FtsH and Deg1 proteases and replaced by de novo synthesis
+- In maize: D1 degradation is faster in bundle sheath cells [PMID:22833285]
+
+### Post-translational modifications
+- C-terminal processing by CTPA protease (essential for OEC assembly)
+- N-terminal acetylation at Thr-2 [PMID:22833285]
+- Phosphorylation at Thr-2, light-dependent [PMID:22833285]
+
+## Review Decisions
+
+### Accepted as core
+- GO:0009523 (photosystem II) - IBA, defining CC annotation
+- GO:0010242 (oxygen evolving activity) - IEA, core MF
+- GO:0016168 (chlorophyll binding) - IEA, core MF
+- GO:0016682 (oxidoreductase activity, diphenols as donors, O₂ as acceptor) - IEA, core MF (EC 1.10.3.9)
+- GO:0009055 (electron transfer activity) - IEA, core MF
+- GO:0009535 (chloroplast thylakoid membrane) - IEA, confirmed by PMID:22833285
+- GO:0009772 (photosynthetic electron transport in PSII) - IEA, most specific BP
+
+### Kept as non-core
+- GO:0005506 (iron ion binding) - real but subsidiary to Mn₄-Ca-O₅ cluster binding
+- GO:0015979 (photosynthesis) - too broad, redundant with GO:0009772
+- GO:0009536 (plastid) - too broad, redundant with GO:0009535
+- GO:0019684 (photosynthesis, light reaction) - intermediate specificity, redundant
+
+### Proposed new annotations
+- GO:0030145 (manganese ion binding) - D1 provides most OEC cluster ligands
+- GO:0048038 (quinone binding) - QB plastoquinone binding site, herbicide target
+
+## Organism Context
+
+9POAL (Poales) is a taxonomic grouping. The representative entry P48183 is from Zea mays (maize, NCBITaxon:4577). psbA is essentially identical across Poales grasses given its extreme conservation.
+
+## References
+
+- PMID:22833285 - Fristedt et al. 2012, thylakoid protein phosphorylation in maize M/BS cells
+- PMID:7666415 - Maier et al. 1995, complete maize chloroplast genome sequence
+- HAMAP-Rule:MF_01379 - comprehensive annotation rule for PSII D1

--- a/genes/9POAL/psbA/psbA-uniprot.txt
+++ b/genes/9POAL/psbA/psbA-uniprot.txt
@@ -1,0 +1,293 @@
+ID   PSBA_MAIZE              Reviewed;         353 AA.
+AC   P48183; Q546V9;
+DT   01-FEB-1996, integrated into UniProtKB/Swiss-Prot.
+DT   01-FEB-1996, sequence version 1.
+DT   28-JAN-2026, entry version 150.
+DE   RecName: Full=Photosystem II protein D1 {ECO:0000255|HAMAP-Rule:MF_01379};
+DE            Short=PSII D1 protein {ECO:0000255|HAMAP-Rule:MF_01379};
+DE            EC=1.10.3.9 {ECO:0000255|HAMAP-Rule:MF_01379};
+DE   AltName: Full=32 kDa thylakoid membrane protein {ECO:0000303|Ref.1};
+DE   AltName: Full=Photosystem II Q(B) protein {ECO:0000255|HAMAP-Rule:MF_01379};
+DE   Flags: Precursor;
+GN   Name=psbA {ECO:0000255|HAMAP-Rule:MF_01379};
+OS   Zea mays (Maize).
+OG   Plastid; Chloroplast.
+OC   Eukaryota; Viridiplantae; Streptophyta; Embryophyta; Tracheophyta;
+OC   Spermatophyta; Magnoliopsida; Liliopsida; Poales; Poaceae; PACMAD clade;
+OC   Panicoideae; Andropogonodae; Andropogoneae; Tripsacinae; Zea.
+OX   NCBI_TaxID=4577;
+RN   [1]
+RP   NUCLEOTIDE SEQUENCE [GENOMIC DNA].
+RC   STRAIN=cv. Surecropper;
+RA   Netto A.P., McIntyre D.J., Sathasivan K.S.;
+RT   "Maize psbA gene encoding the 32 kDa photosystem II protein.";
+RL   Submitted (SEP-2002) to the EMBL/GenBank/DDBJ databases.
+RN   [2]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE GENOMIC DNA].
+RC   STRAIN=cv. B73;
+RX   PubMed=7666415; DOI=10.1006/jmbi.1995.0460;
+RA   Maier R.M., Neckermann K., Igloi G.L., Koessel H.;
+RT   "Complete sequence of the maize chloroplast genome: gene content, hotspots
+RT   of divergence and fine tuning of genetic information by transcript
+RT   editing.";
+RL   J. Mol. Biol. 251:614-628(1995).
+RN   [3]
+RP   PROTEIN SEQUENCE OF 2-8, SUBCELLULAR LOCATION, PROTEOLYTIC CLEAVAGE,
+RP   PHOSPHORYLATION AT THR-2, AND ACETYLATION AT THR-2.
+RC   STRAIN=cv. Olenka; TISSUE=Bundle sheath cell, and Mesophyll cell;
+RX   PubMed=22833285; DOI=10.1002/pmic.201200196;
+RA   Fristedt R., Wasilewska W., Romanowska E., Vener A.V.;
+RT   "Differential phosphorylation of thylakoid proteins in mesophyll and bundle
+RT   sheath chloroplasts from maize plants grown under low or high light.";
+RL   Proteomics 12:2852-2861(2012).
+CC   -!- FUNCTION: Photosystem II (PSII) is a light-driven water:plastoquinone
+CC       oxidoreductase that uses light energy to abstract electrons from H(2)O,
+CC       generating O(2) and a proton gradient subsequently used for ATP
+CC       formation. It consists of a core antenna complex that captures photons,
+CC       and an electron transfer chain that converts photonic excitation into a
+CC       charge separation. The D1/D2 (PsbA/PsbD) reaction center heterodimer
+CC       binds P680, the primary electron donor of PSII as well as several
+CC       subsequent electron acceptors. {ECO:0000255|HAMAP-Rule:MF_01379}.
+CC   -!- CATALYTIC ACTIVITY:
+CC       Reaction=2 a plastoquinone + 4 hnu + 2 H2O = 2 a plastoquinol + O2;
+CC         Xref=Rhea:RHEA:36359, Rhea:RHEA-COMP:9561, Rhea:RHEA-COMP:9562,
+CC         ChEBI:CHEBI:15377, ChEBI:CHEBI:15379, ChEBI:CHEBI:17757,
+CC         ChEBI:CHEBI:30212, ChEBI:CHEBI:62192; EC=1.10.3.9;
+CC         Evidence={ECO:0000255|HAMAP-Rule:MF_01379};
+CC   -!- COFACTOR:
+CC       Note=The D1/D2 heterodimer binds P680, chlorophylls that are the
+CC       primary electron donor of PSII, and subsequent electron acceptors. It
+CC       shares a non-heme iron and each subunit binds pheophytin, quinone,
+CC       additional chlorophylls, carotenoids and lipids. D1 provides most of
+CC       the ligands for the Mn4-Ca-O5 cluster of the oxygen-evolving complex
+CC       (OEC). There is also a Cl(-1) ion associated with D1 and D2, which is
+CC       required for oxygen evolution. The PSII complex binds additional
+CC       chlorophylls, carotenoids and specific lipids. {ECO:0000255|HAMAP-
+CC       Rule:MF_01379};
+CC   -!- SUBUNIT: PSII is composed of 1 copy each of membrane proteins PsbA,
+CC       PsbB, PsbC, PsbD, PsbE, PsbF, PsbH, PsbI, PsbJ, PsbK, PsbL, PsbM, PsbT,
+CC       PsbX, PsbY, PsbZ, Psb30/Ycf12, at least 3 peripheral proteins of the
+CC       oxygen-evolving complex and a large number of cofactors. It forms
+CC       dimeric complexes. {ECO:0000255|HAMAP-Rule:MF_01379}.
+CC   -!- SUBCELLULAR LOCATION: Plastid, chloroplast thylakoid membrane
+CC       {ECO:0000255|HAMAP-Rule:MF_01379, ECO:0000269|PubMed:22833285}; Multi-
+CC       pass membrane protein {ECO:0000255|HAMAP-Rule:MF_01379}. Note=PSII is
+CC       more abundant in mesophyll than bundle sheath cells and more abundant
+CC       in grana than stroma lamellae in mesophyll cells.
+CC       {ECO:0000269|PubMed:22833285}.
+CC   -!- PTM: Phosphorylated in both bundle sheath and mesophyll cells,
+CC       phosphorylation increases when cells are grown under high rather than
+CC       low light regimes (70 vs 900 umol photons/m-2/s).
+CC       {ECO:0000269|PubMed:22833285}.
+CC   -!- PTM: PSII is subject to light-induced damage, in particular to D1.
+CC       Damaged protein is degraded by Deg1 and FtsH proteases and replaced. In
+CC       maize mesophyll cells D1 degradation is less extensive in grana
+CC       (stacked) vs stroma (unstacked) lamellae, in part due to exclusion of
+CC       FtsH from the grana. D1 degradation is faster in bundle sheath cells.
+CC       {ECO:0000269|PubMed:22833285}.
+CC   -!- PTM: Tyr-161 forms a radical intermediate that is referred to as redox-
+CC       active TyrZ, YZ or Y-Z. {ECO:0000255|HAMAP-Rule:MF_01379}.
+CC   -!- PTM: C-terminally processed by CTPA; processing is essential to allow
+CC       assembly of the oxygen-evolving complex and thus photosynthetic growth.
+CC       {ECO:0000255|HAMAP-Rule:MF_01379}.
+CC   -!- MISCELLANEOUS: 2 of the reaction center chlorophylls (ChlD1 and ChlD2)
+CC       are entirely coordinated by water. {ECO:0000255|HAMAP-Rule:MF_01379}.
+CC   -!- MISCELLANEOUS: Herbicides such as atrazine, BNT, diuron or ioxynil bind
+CC       in the Q(B) binding site and block subsequent electron transfer.
+CC       {ECO:0000255|HAMAP-Rule:MF_01379}.
+CC   -!- SIMILARITY: Belongs to the reaction center PufL/M/PsbA/D family.
+CC       {ECO:0000255|HAMAP-Rule:MF_01379}.
+CC   ---------------------------------------------------------------------------
+CC   Copyrighted by the UniProt Consortium, see https://www.uniprot.org/terms
+CC   Distributed under the Creative Commons Attribution (CC BY 4.0) License
+CC   ---------------------------------------------------------------------------
+DR   EMBL; AF543684; AAN33184.1; -; Genomic_DNA.
+DR   EMBL; X86563; CAA60265.1; -; Genomic_DNA.
+DR   PIR; S58531; S58531.
+DR   RefSeq; NP_043004.1; NC_001666.2.
+DR   AlphaFoldDB; P48183; -.
+DR   SMR; P48183; -.
+DR   FunCoup; P48183; 466.
+DR   STRING; 4577.P48183; -.
+DR   iPTMnet; P48183; -.
+DR   PaxDb; 4577-GRMZM5G844143_P01; -.
+DR   EnsemblPlants; Zm00001eb435340_T001; Zm00001eb435340_P001; Zm00001eb435340.
+DR   EnsemblPlants; Zm00001eb435620_T001; Zm00001eb435620_P001; Zm00001eb435620.
+DR   EnsemblPlants; Zm00001eb436890_T001; Zm00001eb436890_P001; Zm00001eb436890.
+DR   EnsemblPlants; Zm00001eb437100_T001; Zm00001eb437100_P001; Zm00001eb437100.
+DR   EnsemblPlants; Zm00001eb437310_T001; Zm00001eb437310_P001; Zm00001eb437310.
+DR   EnsemblPlants; Zm00001eb437750_T001; Zm00001eb437750_P001; Zm00001eb437750.
+DR   EnsemblPlants; Zm00001eb438280_T001; Zm00001eb438280_P001; Zm00001eb438280.
+DR   EnsemblPlants; Zm00001eb438290_T001; Zm00001eb438290_P001; Zm00001eb438290.
+DR   EnsemblPlants; Zm00001eb439910_T001; Zm00001eb439910_P001; Zm00001eb439910.
+DR   EnsemblPlants; Zm00001eb441950_T001; Zm00001eb441950_P001; Zm00001eb441950.
+DR   EnsemblPlants; Zm00001eb442710_T001; Zm00001eb442710_P001; Zm00001eb442710.
+DR   EnsemblPlants; Zm00001eb442990_T001; Zm00001eb442990_P001; Zm00001eb442990.
+DR   GeneID; 845199; -.
+DR   Gramene; Zm00001eb435340_T001; Zm00001eb435340_P001; Zm00001eb435340.
+DR   Gramene; Zm00001eb435620_T001; Zm00001eb435620_P001; Zm00001eb435620.
+DR   Gramene; Zm00001eb436890_T001; Zm00001eb436890_P001; Zm00001eb436890.
+DR   Gramene; Zm00001eb437100_T001; Zm00001eb437100_P001; Zm00001eb437100.
+DR   Gramene; Zm00001eb437310_T001; Zm00001eb437310_P001; Zm00001eb437310.
+DR   Gramene; Zm00001eb437750_T001; Zm00001eb437750_P001; Zm00001eb437750.
+DR   Gramene; Zm00001eb438280_T001; Zm00001eb438280_P001; Zm00001eb438280.
+DR   Gramene; Zm00001eb438290_T001; Zm00001eb438290_P001; Zm00001eb438290.
+DR   Gramene; Zm00001eb439910_T001; Zm00001eb439910_P001; Zm00001eb439910.
+DR   Gramene; Zm00001eb441950_T001; Zm00001eb441950_P001; Zm00001eb441950.
+DR   Gramene; Zm00001eb442710_T001; Zm00001eb442710_P001; Zm00001eb442710.
+DR   Gramene; Zm00001eb442990_T001; Zm00001eb442990_P001; Zm00001eb442990.
+DR   KEGG; zma:845199; -.
+DR   MaizeGDB; 105976; -.
+DR   eggNOG; ENOG502QR09; Eukaryota.
+DR   InParanoid; P48183; -.
+DR   OMA; CQWVTDT; -.
+DR   OrthoDB; 1911105at2759; -.
+DR   Proteomes; UP000007305; Chloroplast.
+DR   ExpressionAtlas; P48183; baseline and differential.
+DR   GO; GO:0009535; C:chloroplast thylakoid membrane; IEA:UniProtKB-SubCell.
+DR   GO; GO:0009523; C:photosystem II; IBA:GO_Central.
+DR   GO; GO:0016168; F:chlorophyll binding; IEA:UniProtKB-UniRule.
+DR   GO; GO:0009055; F:electron transfer activity; IEA:UniProtKB-UniRule.
+DR   GO; GO:0005506; F:iron ion binding; IEA:UniProtKB-UniRule.
+DR   GO; GO:0016682; F:oxidoreductase activity, acting on diphenols and related substances as donors, oxygen as acceptor; IEA:UniProtKB-UniRule.
+DR   GO; GO:0010242; F:oxygen evolving activity; IEA:UniProtKB-EC.
+DR   GO; GO:0009772; P:photosynthetic electron transport in photosystem II; IEA:InterPro.
+DR   GO; GO:0009635; P:response to herbicide; IEA:UniProtKB-KW.
+DR   CDD; cd09289; Photosystem-II_D1; 1.
+DR   FunFam; 1.20.85.10:FF:000002; Photosystem II protein D1; 1.
+DR   Gene3D; 1.20.85.10; Photosystem II protein D1-like; 1.
+DR   HAMAP; MF_01379; PSII_PsbA_D1; 1.
+DR   InterPro; IPR055266; D1/D2.
+DR   InterPro; IPR036854; Photo_II_D1/D2_sf.
+DR   InterPro; IPR000484; Photo_RC_L/M.
+DR   InterPro; IPR055265; Photo_RC_L/M_CS.
+DR   InterPro; IPR005867; PSII_D1.
+DR   NCBIfam; TIGR01151; psbA; 1.
+DR   PANTHER; PTHR33149; PHOTOSYSTEM II PROTEIN D1; 1.
+DR   PANTHER; PTHR33149:SF58; PHOTOSYSTEM II PROTEIN D1; 1.
+DR   Pfam; PF00124; Photo_RC; 1.
+DR   PRINTS; PR00256; REACTNCENTRE.
+DR   SUPFAM; SSF81483; Bacterial photosystem II reaction centre, L and M subunits; 1.
+DR   PROSITE; PS00244; REACTION_CENTER; 1.
+PE   1: Evidence at protein level;
+KW   Acetylation; Calcium; Chlorophyll; Chloroplast; Chromophore;
+KW   Direct protein sequencing; Electron transport; Herbicide resistance; Iron;
+KW   Magnesium; Manganese; Membrane; Metal-binding; Oxidoreductase;
+KW   Phosphoprotein; Photosynthesis; Photosystem II; Plastid;
+KW   Reference proteome; Thylakoid; Transmembrane; Transmembrane helix;
+KW   Transport.
+FT   INIT_MET        1
+FT                   /note="Removed"
+FT                   /evidence="ECO:0000269|PubMed:22833285"
+FT   CHAIN           2..344
+FT                   /note="Photosystem II protein D1"
+FT                   /evidence="ECO:0000255|HAMAP-Rule:MF_01379"
+FT                   /id="PRO_0000090449"
+FT   PROPEP          345..353
+FT                   /evidence="ECO:0000255|HAMAP-Rule:MF_01379"
+FT                   /id="PRO_0000316490"
+FT   TRANSMEM        29..46
+FT                   /note="Helical"
+FT                   /evidence="ECO:0000255|HAMAP-Rule:MF_01379"
+FT   TRANSMEM        118..133
+FT                   /note="Helical"
+FT                   /evidence="ECO:0000255|HAMAP-Rule:MF_01379"
+FT   TRANSMEM        142..156
+FT                   /note="Helical"
+FT                   /evidence="ECO:0000255|HAMAP-Rule:MF_01379"
+FT   TRANSMEM        197..218
+FT                   /note="Helical"
+FT                   /evidence="ECO:0000255|HAMAP-Rule:MF_01379"
+FT   TRANSMEM        274..288
+FT                   /note="Helical"
+FT                   /evidence="ECO:0000255|HAMAP-Rule:MF_01379"
+FT   BINDING         118
+FT                   /ligand="chlorophyll a"
+FT                   /ligand_id="ChEBI:CHEBI:58416"
+FT                   /ligand_label="ChlzD1"
+FT                   /ligand_part="Mg"
+FT                   /ligand_part_id="ChEBI:CHEBI:25107"
+FT                   /note="axial binding residue"
+FT                   /evidence="ECO:0000255|HAMAP-Rule:MF_01379"
+FT   BINDING         126
+FT                   /ligand="pheophytin a"
+FT                   /ligand_id="ChEBI:CHEBI:136840"
+FT                   /ligand_label="D1"
+FT                   /evidence="ECO:0000255|HAMAP-Rule:MF_01379"
+FT   BINDING         170
+FT                   /ligand="[CaMn4O5] cluster"
+FT                   /ligand_id="ChEBI:CHEBI:189552"
+FT                   /evidence="ECO:0000255|HAMAP-Rule:MF_01379"
+FT   BINDING         189
+FT                   /ligand="[CaMn4O5] cluster"
+FT                   /ligand_id="ChEBI:CHEBI:189552"
+FT                   /evidence="ECO:0000255|HAMAP-Rule:MF_01379"
+FT   BINDING         198
+FT                   /ligand="chlorophyll a"
+FT                   /ligand_id="ChEBI:CHEBI:58416"
+FT                   /ligand_label="PD1"
+FT                   /ligand_part="Mg"
+FT                   /ligand_part_id="ChEBI:CHEBI:25107"
+FT                   /note="axial binding residue"
+FT                   /evidence="ECO:0000255|HAMAP-Rule:MF_01379"
+FT   BINDING         215
+FT                   /ligand="a quinone"
+FT                   /ligand_id="ChEBI:CHEBI:132124"
+FT                   /ligand_label="B"
+FT                   /evidence="ECO:0000255|HAMAP-Rule:MF_01379"
+FT   BINDING         215
+FT                   /ligand="Fe cation"
+FT                   /ligand_id="ChEBI:CHEBI:24875"
+FT                   /ligand_note="ligand shared with heterodimeric partner"
+FT                   /evidence="ECO:0000255|HAMAP-Rule:MF_01379"
+FT   BINDING         264..265
+FT                   /ligand="a quinone"
+FT                   /ligand_id="ChEBI:CHEBI:132124"
+FT                   /ligand_label="B"
+FT                   /evidence="ECO:0000255|HAMAP-Rule:MF_01379"
+FT   BINDING         272
+FT                   /ligand="Fe cation"
+FT                   /ligand_id="ChEBI:CHEBI:24875"
+FT                   /ligand_note="ligand shared with heterodimeric partner"
+FT                   /evidence="ECO:0000255|HAMAP-Rule:MF_01379"
+FT   BINDING         332
+FT                   /ligand="[CaMn4O5] cluster"
+FT                   /ligand_id="ChEBI:CHEBI:189552"
+FT                   /evidence="ECO:0000255|HAMAP-Rule:MF_01379"
+FT   BINDING         333
+FT                   /ligand="[CaMn4O5] cluster"
+FT                   /ligand_id="ChEBI:CHEBI:189552"
+FT                   /evidence="ECO:0000255|HAMAP-Rule:MF_01379"
+FT   BINDING         342
+FT                   /ligand="[CaMn4O5] cluster"
+FT                   /ligand_id="ChEBI:CHEBI:189552"
+FT                   /evidence="ECO:0000255|HAMAP-Rule:MF_01379"
+FT   BINDING         344
+FT                   /ligand="[CaMn4O5] cluster"
+FT                   /ligand_id="ChEBI:CHEBI:189552"
+FT                   /evidence="ECO:0000255|HAMAP-Rule:MF_01379"
+FT   SITE            161
+FT                   /note="Tyrosine radical intermediate"
+FT                   /evidence="ECO:0000255|HAMAP-Rule:MF_01379"
+FT   SITE            190
+FT                   /note="Stabilizes free radical intermediate"
+FT                   /evidence="ECO:0000255|HAMAP-Rule:MF_01379"
+FT   SITE            344..345
+FT                   /note="Cleavage; by CTPA"
+FT                   /evidence="ECO:0000255|HAMAP-Rule:MF_01379"
+FT   MOD_RES         2
+FT                   /note="N-acetylthreonine"
+FT                   /evidence="ECO:0000255|HAMAP-Rule:MF_01379,
+FT                   ECO:0000269|PubMed:22833285"
+FT   MOD_RES         2
+FT                   /note="Phosphothreonine"
+FT                   /evidence="ECO:0000255|HAMAP-Rule:MF_01379,
+FT                   ECO:0000269|PubMed:22833285"
+SQ   SEQUENCE   353 AA;  39011 MW;  AA6BFB415FCE1C79 CRC64;
+     MTAILERRES TSLWGRFCNW ITSTENRLYI GWFGVLMIPT LLTATSVFII AFIAAPPVDI
+     DGIREPVSGS LLYGNNIISG AIIPTSAAIG LHFYPIWEAA SVDEWLYNGG PYELIVLHFL
+     LGVACYMGRE WELSFRLGMR PWIAVAYSAP VAAATAVFLI YPIGQGSFSD GMPLGISGTF
+     NFMIVFQAEH NILMHPFHML GVAGVFGGSL FSAMHGSLVT SSLIRETTEN ESANEGYKFG
+     QEEETYNIVA AHGYFGRLIF QYASFNNSRS LHFFLAAWPV VGIWFTALGI STMAFNLNGF
+     NFNQSVVDSQ GRVINTWADI INRANLGMEV MHERNAHNFP LDLAALEVPY LNG
+//

--- a/interpro/panther/PTHR33149/PTHR33149-entries.csv
+++ b/interpro/panther/PTHR33149/PTHR33149-entries.csv
@@ -1,0 +1,392 @@
+id,name,entry_type,source_tax_id,source_tax_name,full_tax_name,gene,length,subfamily,subfamily_name,in_alphafold
+A0A315,Photosystem II protein D1,protein,13443,Coffea arabica,Coffea arabica (Arabian coffee),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A0A330,Photosystem II D2 protein,protein,13443,Coffea arabica,Coffea arabica (Arabian coffee),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A0T097,Photosystem II D2 protein,protein,556484,Phaeodactylum tricornutum (strain CCAP 1055/1),Phaeodactylum tricornutum (strain CCAP 1055/1),psbD,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A0T0G9,Photosystem II protein D1,protein,556484,Phaeodactylum tricornutum (strain CCAP 1055/1),Phaeodactylum tricornutum (strain CCAP 1055/1),psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A0T0T0,Photosystem II D2 protein,protein,35128,Thalassiosira pseudonana,Thalassiosira pseudonana (Marine diatom),psbD,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A0T0W2,Photosystem II protein D1,protein,35128,Thalassiosira pseudonana,Thalassiosira pseudonana (Marine diatom),psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A0ZZ15,Photosystem II protein D1,protein,3634,Gossypium barbadense,Gossypium barbadense (Sea Island cotton),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A0ZZ30,Photosystem II D2 protein,protein,3634,Gossypium barbadense,Gossypium barbadense (Sea Island cotton),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A1E9Q4,Photosystem II protein D1,protein,4558,Sorghum bicolor,Sorghum bicolor (Sorghum),psbA,353,PTHR33149:SF58,PHOTOSYSTEM II PROTEIN D1,True
+A1E9Q9,Photosystem II D2 protein,protein,4558,Sorghum bicolor,Sorghum bicolor (Sorghum),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A1E9Y8,Photosystem II protein D1,protein,63632,Agrostis stolonifera,Agrostis stolonifera (Creeping bentgrass),psbA,353,PTHR33149:SF58,PHOTOSYSTEM II PROTEIN D1,True
+A1E9Z3,Photosystem II D2 protein,protein,63632,Agrostis stolonifera,Agrostis stolonifera (Creeping bentgrass),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A2BP21,Photosystem II protein D1,protein,146891,Prochlorococcus marinus (strain AS9601),Prochlorococcus marinus (strain AS9601),psbA1,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A2BUK1,Photosystem II protein D1,protein,167542,Prochlorococcus marinus (strain MIT 9515),Prochlorococcus marinus (strain MIT 9515),psbA2,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A2C057,Photosystem II protein D1,protein,167555,Prochlorococcus marinus (strain NATL1A),Prochlorococcus marinus (strain NATL1A),psbA3,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A2C6Q1,Photosystem II protein D1,protein,59922,Prochlorococcus marinus (strain MIT 9303),Prochlorococcus marinus (strain MIT 9303),psbA1,358,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A2T309,Photosystem II protein D1,protein,13825,Angiopteris evecta,Angiopteris evecta (Mule's foot fern),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A2T330,Photosystem II D2 protein,protein,13825,Angiopteris evecta,Angiopteris evecta (Mule's foot fern),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A3PAU3,Photosystem II protein D1,protein,167546,Prochlorococcus marinus (strain MIT 9301),Prochlorococcus marinus (strain MIT 9301),psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A4GGA2,Photosystem II D2 protein,protein,3885,Phaseolus vulgaris,Phaseolus vulgaris (Kidney bean),psbD,353,PTHR33149:SF57,PHOTOSYSTEM II D2 PROTEIN,True
+A4GYN9,Photosystem II protein D1,protein,3694,Populus trichocarpa,Populus trichocarpa (Western balsam poplar),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A4GYQ4,Photosystem II D2 protein,protein,3694,Populus trichocarpa,Populus trichocarpa (Western balsam poplar),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A4QJ96,Photosystem II protein D1,protein,434059,Aethionema cordifolium,Aethionema cordifolium (Lebanon stonecress),psbA,353,PTHR33149:SF55,PHOTOSYSTEM II PROTEIN D1,True
+A4QJB0,Photosystem II D2 protein,protein,434059,Aethionema cordifolium,Aethionema cordifolium (Lebanon stonecress),psbD,353,PTHR33149:SF57,PHOTOSYSTEM II D2 PROTEIN,True
+A4QJI0,Photosystem II protein D1,protein,72657,Aethionema grandiflorum,Aethionema grandiflorum (Persian stone-cress),psbA,353,PTHR33149:SF55,PHOTOSYSTEM II PROTEIN D1,True
+A4QJJ4,Photosystem II D2 protein,protein,72657,Aethionema grandiflorum,Aethionema grandiflorum (Persian stone-cress),psbD,353,PTHR33149:SF57,PHOTOSYSTEM II D2 PROTEIN,True
+A4QJR4,Photosystem II protein D1,protein,74718,Olimarabidopsis pumila,Olimarabidopsis pumila (Dwarf rocket),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A4QJS8,Photosystem II D2 protein,protein,74718,Olimarabidopsis pumila,Olimarabidopsis pumila (Dwarf rocket),psbD,353,PTHR33149:SF57,PHOTOSYSTEM II D2 PROTEIN,True
+A4QJZ9,Photosystem II protein D1,protein,78191,Arabis hirsuta,Arabis hirsuta (Hairy rock-cress),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A4QK13,Photosystem II D2 protein,protein,78191,Arabis hirsuta,Arabis hirsuta (Hairy rock-cress),psbD,353,PTHR33149:SF57,PHOTOSYSTEM II D2 PROTEIN,True
+A4QK85,Photosystem II protein D1,protein,50458,Barbarea verna,Barbarea verna (Land cress),psbA,353,PTHR33149:SF55,PHOTOSYSTEM II PROTEIN D1,True
+A4QKA0,Photosystem II D2 protein,protein,50458,Barbarea verna,Barbarea verna (Land cress),psbD,353,PTHR33149:SF57,PHOTOSYSTEM II D2 PROTEIN,True
+A4QKH2,Photosystem II protein D1,protein,3719,Capsella bursa-pastoris,Capsella bursa-pastoris (Shepherd's purse),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A4QKI7,Photosystem II D2 protein,protein,3719,Capsella bursa-pastoris,Capsella bursa-pastoris (Shepherd's purse),psbD,353,PTHR33149:SF57,PHOTOSYSTEM II D2 PROTEIN,True
+A4QKR1,Photosystem II protein D1,protein,78192,Crucihimalaya wallichii,Crucihimalaya wallichii (Rock-cress),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A4QKS6,Photosystem II D2 protein,protein,78192,Crucihimalaya wallichii,Crucihimalaya wallichii (Rock-cress),psbD,353,PTHR33149:SF57,PHOTOSYSTEM II D2 PROTEIN,True
+A4QL00,Photosystem II protein D1,protein,171822,Draba nemorosa,Draba nemorosa (Woodland whitlowgrass),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A4QL14,Photosystem II D2 protein,protein,171822,Draba nemorosa,Draba nemorosa (Woodland whitlowgrass),psbD,353,PTHR33149:SF57,PHOTOSYSTEM II D2 PROTEIN,True
+A4QL86,Photosystem II protein D1,protein,59292,Lepidium virginicum,Lepidium virginicum (Virginia pepperweed),psbA,353,PTHR33149:SF55,PHOTOSYSTEM II PROTEIN D1,True
+A4QLA1,Photosystem II D2 protein,protein,59292,Lepidium virginicum,Lepidium virginicum (Virginia pepperweed),psbD,353,PTHR33149:SF57,PHOTOSYSTEM II D2 PROTEIN,True
+A4QLH5,Photosystem II protein D1,protein,226051,Lobularia maritima,Lobularia maritima (Sweet alyssum),psbA,353,PTHR33149:SF55,PHOTOSYSTEM II PROTEIN D1,True
+A4QLI9,Photosystem II D2 protein,protein,226051,Lobularia maritima,Lobularia maritima (Sweet alyssum),psbD,353,PTHR33149:SF57,PHOTOSYSTEM II D2 PROTEIN,True
+A4QLR3,Photosystem II protein D1,protein,65948,Nasturtium officinale,Nasturtium officinale (Watercress),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A4QLS8,Photosystem II D2 protein,protein,65948,Nasturtium officinale,Nasturtium officinale (Watercress),psbD,353,PTHR33149:SF57,PHOTOSYSTEM II D2 PROTEIN,True
+A5A8K9,Photosystem II protein D1 2,protein,329726,Acaryochloris marina (strain MBIC 11017),Acaryochloris marina (strain MBIC 11017),psbA3,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A5GIM7,Photosystem II protein D1 1,protein,32051,Synechococcus sp. (strain WH7803),Synechococcus sp. (strain WH7803),psbA4,359,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A5GJU5,Photosystem II protein D1 2,protein,32051,Synechococcus sp. (strain WH7803),Synechococcus sp. (strain WH7803),psbA2,358,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A5GMA8,Photosystem II D2 protein,protein,32051,Synechococcus sp. (strain WH7803),Synechococcus sp. (strain WH7803),psbD2,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A5GQK3,Photosystem II D2 protein,protein,316278,Synechococcus sp. (strain RCC307),Synechococcus sp. (strain RCC307),psbD1,352,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A5GTY4,Photosystem II protein D1 1,protein,316278,Synechococcus sp. (strain RCC307),Synechococcus sp. (strain RCC307),psbA3,359,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A5GTY5,Photosystem II protein D1 2,protein,316278,Synechococcus sp. (strain RCC307),Synechococcus sp. (strain RCC307),psbA2,358,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A6BM28,Photosystem II protein D1,protein,33153,Gnetum parvifolium,Gnetum parvifolium (Small-leaved jointfir),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A6H5E4,Photosystem II protein D1,protein,54799,Cycas taitungensis,Cycas taitungensis (Prince sago),psbA,353,PTHR33149:SF58,PHOTOSYSTEM II PROTEIN D1,True
+A6H5G6,Photosystem II D2 protein,protein,54799,Cycas taitungensis,Cycas taitungensis (Prince sago),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A6MM16,Photosystem II protein D1,protein,153571,Buxus microphylla,Buxus microphylla (Littleleaf boxwood),psbA,353,PTHR33149:SF55,PHOTOSYSTEM II PROTEIN D1,True
+A6MM31,Photosystem II D2 protein,protein,153571,Buxus microphylla,Buxus microphylla (Littleleaf boxwood),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A6MMA2,Photosystem II protein D1,protein,13006,Chloranthus spicatus,Chloranthus spicatus (Chulantree),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A6MMB7,Photosystem II D2 protein,protein,13006,Chloranthus spicatus,Chloranthus spicatus (Chulantree),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A6MMI8,Photosystem II protein D1,protein,145284,Dioscorea elephantipes,Dioscorea elephantipes (Elephant's foot yam),psbA,353,PTHR33149:SF58,PHOTOSYSTEM II PROTEIN D1,True
+A6MMK2,Photosystem II D2 protein,protein,145284,Dioscorea elephantipes,Dioscorea elephantipes (Elephant's foot yam),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A6MMS4,Photosystem II protein D1,protein,145286,Illicium oligandrum,Illicium oligandrum (Star anise),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A6MMT9,Photosystem II D2 protein,protein,145286,Illicium oligandrum,Illicium oligandrum (Star anise),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A6MVT2,Photosystem II protein D1,protein,3034,Rhodomonas salina,Rhodomonas salina,psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A6YG76,Photosystem II D2 protein,protein,34116,Pleurastrum terricola,Pleurastrum terricola (Filamentous green alga),psbD,352,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A6YGB8,Photosystem II protein D1,protein,34116,Pleurastrum terricola,Pleurastrum terricola (Filamentous green alga),psbA,344,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A7M8Y6,Photosystem II protein D1,protein,35886,Cuscuta gronovii,Cuscuta gronovii (Common dodder),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A7M8Z6,Photosystem II D2 protein,protein,35886,Cuscuta gronovii,Cuscuta gronovii (Common dodder),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A7M961,Photosystem II D2 protein,protein,4129,Cuscuta reflexa,Cuscuta reflexa (Southern Asian dodder),psbD,353,PTHR33149:SF57,PHOTOSYSTEM II D2 PROTEIN,True
+A7Y395,Photosystem II protein D1,protein,4121,Ipomoea purpurea,Ipomoea purpurea (Common morning glory),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A7Y3C4,Photosystem II D2 protein,protein,4121,Ipomoea purpurea,Ipomoea purpurea (Common morning glory),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A8G5N5,Photosystem II protein D1,protein,93060,Prochlorococcus marinus (strain MIT 9215),Prochlorococcus marinus (strain MIT 9215),psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A8SE40,Photosystem II protein D1,protein,4428,Ceratophyllum demersum,Ceratophyllum demersum (Rigid hornwort),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A8SE98,Photosystem II D2 protein,protein,4428,Ceratophyllum demersum,Ceratophyllum demersum (Rigid hornwort),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A8W3A5,Photosystem II protein D1,protein,476139,Cuscuta exaltata,Cuscuta exaltata (Tall dodder),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A8W3B9,Photosystem II D2 protein,protein,476139,Cuscuta exaltata,Cuscuta exaltata (Tall dodder),psbD,353,PTHR33149:SF57,PHOTOSYSTEM II D2 PROTEIN,True
+A8W3H2,Photosystem II protein D1,protein,437280,Cuscuta obtusiflora,Cuscuta obtusiflora (Peruvian dodder),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A8W3I2,Photosystem II D2 protein,protein,437280,Cuscuta obtusiflora,Cuscuta obtusiflora (Peruvian dodder),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A8Y9F0,Photosystem II protein D1,protein,4522,Lolium perenne,Lolium perenne (Perennial ryegrass),psbA,353,PTHR33149:SF58,PHOTOSYSTEM II PROTEIN D1,True
+A8Y9F5,Photosystem II D2 protein,protein,4522,Lolium perenne,Lolium perenne (Perennial ryegrass),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A9L976,Photosystem II protein D1,protein,4472,Lemna minor,Lemna minor (Common duckweed),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+A9L991,Photosystem II D2 protein,protein,4472,Lemna minor,Lemna minor (Common duckweed),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B0C1V6,Photosystem II D2 protein 1,protein,329726,Acaryochloris marina (strain MBIC 11017),Acaryochloris marina (strain MBIC 11017),psbD2,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B0C3P0,Photosystem II D2 protein 2,protein,329726,Acaryochloris marina (strain MBIC 11017),Acaryochloris marina (strain MBIC 11017),psbD2,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B0CB14,Photosystem II protein D1 1,protein,329726,Acaryochloris marina (strain MBIC 11017),Acaryochloris marina (strain MBIC 11017),psbA1,363,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B0JIS8,Photosystem II protein D1,protein,449447,Microcystis aeruginosa (strain NIES-843 / IAM M-2473),Microcystis aeruginosa (strain NIES-843 / IAM M-2473),psbA4,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B0YPN1,Photosystem II protein D1,protein,280810,Aneura mirabilis,Aneura mirabilis (Parasitic liverwort),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B0Z4K6,Photosystem II protein D1,protein,3940,Oenothera argillicola,Oenothera argillicola (Appalachian evening primrose),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B0Z4M2,Photosystem II D2 protein,protein,3940,Oenothera argillicola,Oenothera argillicola (Appalachian evening primrose),psbD,353,PTHR33149:SF57,PHOTOSYSTEM II D2 PROTEIN,True
+B0Z4U0,Photosystem II protein D1,protein,3942,Oenothera biennis,Oenothera biennis (German evening primrose),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B0Z4V6,Photosystem II D2 protein,protein,3942,Oenothera biennis,Oenothera biennis (German evening primrose),psbD,353,PTHR33149:SF57,PHOTOSYSTEM II D2 PROTEIN,True
+B0Z524,Photosystem II protein D1,protein,482428,Oenothera glazioviana,Oenothera glazioviana (Large-flowered evening primrose),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B0Z540,Photosystem II D2 protein,protein,482428,Oenothera glazioviana,Oenothera glazioviana (Large-flowered evening primrose),psbD,353,PTHR33149:SF57,PHOTOSYSTEM II D2 PROTEIN,True
+B0Z5A8,Photosystem II protein D1,protein,482429,Oenothera parviflora,Oenothera parviflora (Small-flowered evening primrose),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B0Z5C4,Photosystem II D2 protein,protein,482429,Oenothera parviflora,Oenothera parviflora (Small-flowered evening primrose),psbD,353,PTHR33149:SF57,PHOTOSYSTEM II D2 PROTEIN,True
+B1A915,Photosystem II protein D1,protein,3649,Carica papaya,Carica papaya (Papaya),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B1A930,Photosystem II D2 protein,protein,3649,Carica papaya,Carica papaya (Papaya),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B1NWD0,Photosystem II protein D1,protein,3983,Manihot esculenta,Manihot esculenta (Cassava),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B1NWE5,Photosystem II D2 protein,protein,3983,Manihot esculenta,Manihot esculenta (Cassava),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B1VKF9,Photosystem II protein D1,protein,3369,Cryptomeria japonica,Cryptomeria japonica (Japanese cedar),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B1VKH0,Photosystem II D2 protein,protein,3369,Cryptomeria japonica,Cryptomeria japonica (Japanese cedar),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B1WQ89,Photosystem II D2 protein,protein,43989,Crocosphaera subtropica (strain ATCC 51142 / BH68),Crocosphaera subtropica (strain ATCC 51142 / BH68),psbD1,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B1X3H4,Photosystem II D2 protein,protein,39717,Paulinella chromatophora,Paulinella chromatophora,psbD2,352,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B1XIP3,Photosystem II protein D1 3,protein,32049,Picosynechococcus sp. (strain ATCC 27264 / PCC 7002 / PR-6),Picosynechococcus sp. (strain ATCC 27264 / PCC 7002 / PR-6),psbA3,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B1XM24,Photosystem II protein D1 1,protein,32049,Picosynechococcus sp. (strain ATCC 27264 / PCC 7002 / PR-6),Picosynechococcus sp. (strain ATCC 27264 / PCC 7002 / PR-6),psbA1,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B1XMC3,Photosystem II protein D1 2,protein,32049,Picosynechococcus sp. (strain ATCC 27264 / PCC 7002 / PR-6),Picosynechococcus sp. (strain ATCC 27264 / PCC 7002 / PR-6),psbA2,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B2IVV1,Photosystem II D2 protein,protein,63737,Nostoc punctiforme (strain ATCC 29133 / PCC 73102),Nostoc punctiforme (strain ATCC 29133 / PCC 73102),psbD1,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B2LMI8,Photosystem II D2 protein,protein,4230,Guizotia abyssinica,Guizotia abyssinica (Niger),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B2XT21,Photosystem II D2 protein,protein,536047,Heterosigma akashiwo (strain NIES-293 / 8280G21-1),Heterosigma akashiwo (strain NIES-293 / 8280G21-1),psbD1,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B2XTH7,Photosystem II D2 protein,protein,536046,Heterosigma akashiwo (strain CCMP452 / OLISTH),Heterosigma akashiwo (strain CCMP452 / OLISTH),psbD2,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B2XWK0,Photosystem II D2 protein,protein,180217,Fagopyrum esculentum subsp. ancestrale,Fagopyrum esculentum subsp. ancestrale (Wild buckwheat),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B2Y1U5,Photosystem II D2 protein,protein,3377,Welwitschia mirabilis,Welwitschia mirabilis (Tree tumbo),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B3TNB8,Photosystem II D2 protein,protein,15368,Brachypodium distachyon,Brachypodium distachyon (Purple false brome),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B4WP19,Light-dependent chlorophyll f synthase,protein,91464,Synechococcus sp. (strain ATCC 29403 / PCC 7335),Synechococcus sp. (strain ATCC 29403 / PCC 7335),chlF,419,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+B5LMM1,Photosystem II D2 protein,protein,3827,Cicer arietinum,Cicer arietinum (Chickpea),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+D0VWR8,Photosystem II D2 protein,protein,32053,Thermostichus vulcanus,Thermostichus vulcanus,psbD,342,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+O19895,Photosystem II protein D1,protein,2771,Cyanidium caldarium,Cyanidium caldarium (Red alga),psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+O78427,Photosystem II D2 protein,protein,55529,Guillardia theta,Guillardia theta (Cryptophyte),psbD,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+O78446,Photosystem II protein D1,protein,55529,Guillardia theta,Guillardia theta (Cryptophyte),psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+O98733,Photosystem II protein D1,protein,2822,Palmaria palmata,Palmaria palmata (Dulse),psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+O98736,Photosystem II protein D1,protein,44759,Magnolia fraseri var. pyramidata,Magnolia fraseri var. pyramidata (Pyramid magnolia),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P02956,Photosystem II protein D1,protein,3565,Amaranthus hybridus,Amaranthus hybridus (Slim amaranth),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P02957,Photosystem II protein D1,protein,3847,Glycine max,Glycine max (Soybean),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P04996,Photosystem II protein D1 1,protein,1140,Synechococcus elongatus (strain ATCC 33912 / PCC 7942 / FACHB-805),Synechococcus elongatus (strain ATCC 33912 / PCC 7942 / FACHB-805),psbA1,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P04997,Photosystem II protein D1 2,protein,1140,Synechococcus elongatus (strain ATCC 33912 / PCC 7942 / FACHB-805),Synechococcus elongatus (strain ATCC 33912 / PCC 7942 / FACHB-805),psbA3,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P04998,Photosystem II protein D1,protein,3879,Medicago sativa,Medicago sativa (Alfalfa),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P04999,Photosystem II protein D1,protein,4102,Petunia hybrida,Petunia hybrida (Petunia),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P05337,Photosystem II protein D1,protein,4513,Hordeum vulgare,Hordeum vulgare (Barley),psbA,353,PTHR33149:SF58,PHOTOSYSTEM II PROTEIN D1,True
+P06005,Photosystem II D2 protein,protein,3562,Spinacia oleracea,Spinacia oleracea (Spinach),psbD,353,PTHR33149:SF57,PHOTOSYSTEM II D2 PROTEIN,True
+P06006,Photosystem II D2 protein,protein,3888,Pisum sativum,Pisum sativum (Garden pea),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P06007,Photosystem II D2 protein,protein,3055,Chlamydomonas reinhardtii,Chlamydomonas reinhardtii,psbD,352,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P06402,Photosystem II protein D1,protein,3197,Marchantia polymorpha,Marchantia polymorpha (Common liverwort),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P06404,Photosystem II D2 protein,protein,3197,Marchantia polymorpha,Marchantia polymorpha (Common liverwort),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P06585,Photosystem II protein D1,protein,3888,Pisum sativum,Pisum sativum (Garden pea),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P06631,Photosystem II protein D1,protein,3039,Euglena gracilis,Euglena gracilis,psbA,345,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P07063,Photosystem II protein D1,protein,1197,Microchaete diplosiphon,Microchaete diplosiphon,psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P07753,Photosystem II protein D1,protein,3055,Chlamydomonas reinhardtii,Chlamydomonas reinhardtii,psbA,352,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P07826,Photosystem II protein D1 1,protein,1111708,Synechocystis sp. (strain ATCC 27184 / PCC 6803 / Kazusa),Synechocystis sp. (strain ATCC 27184 / PCC 6803 / Kazusa),psbA1,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P09192,Photosystem II D2 protein,protein,1111708,Synechocystis sp. (strain ATCC 27184 / PCC 6803 / Kazusa),Synechocystis sp. (strain ATCC 27184 / PCC 6803 / Kazusa),psbD,352,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P09752,Photosystem II protein D1,protein,3054,Chlamydomonas moewusii,Chlamydomonas moewusii,psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P0A444,Photosystem II protein D1 1,protein,197221,Thermosynechococcus vestitus (strain NIES-2133 / IAM M-273 / BP-1),Thermosynechococcus vestitus (strain NIES-2133 / IAM M-273 / BP-1),psbA1,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P0A445,Photosystem II protein D1 1,protein,32046,Synechococcus elongatus,Synechococcus elongatus,psbA1,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P0A446,Photosystem II protein D1 2,protein,197221,Thermosynechococcus vestitus (strain NIES-2133 / IAM M-273 / BP-1),Thermosynechococcus vestitus (strain NIES-2133 / IAM M-273 / BP-1),psbA2,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P0A447,Photosystem II protein D1 2,protein,32046,Synechococcus elongatus,Synechococcus elongatus,psbA2,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P0C157,Photosystem II protein D1,protein,4547,Saccharum officinarum,Saccharum officinarum (Sugarcane),psbA,353,PTHR33149:SF58,PHOTOSYSTEM II PROTEIN D1,True
+P0C432,Photosystem II protein D1,protein,4530,Oryza sativa,Oryza sativa (Rice),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P0C433,Photosystem II protein D1,protein,39946,Oryza sativa subsp. indica,Oryza sativa subsp. indica (Rice),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P0C434,Photosystem II protein D1,protein,39947,Oryza sativa subsp. japonica,Oryza sativa subsp. japonica (Rice),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P0C435,Photosystem II D2 protein,protein,4530,Oryza sativa,Oryza sativa (Rice),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P0C436,Photosystem II D2 protein,protein,39946,Oryza sativa subsp. indica,Oryza sativa subsp. indica (Rice),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P0C437,Photosystem II D2 protein,protein,39947,Oryza sativa subsp. japonica,Oryza sativa subsp. japonica (Rice),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P0DOC9,Light-dependent chlorophyll f synthase,protein,184925,Chlorogloeopsis fritschii (strain PCC 9212),Chlorogloeopsis fritschii (strain PCC 9212),chlF,376,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P10510,Photosystem II protein D1,protein,4550,Secale cereale,Secale cereale (Rye),psbA,353,PTHR33149:SF58,PHOTOSYSTEM II PROTEIN D1,True
+P10803,Photosystem II D2 protein,protein,4550,Secale cereale,Secale cereale (Rye),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P11005,Photosystem II D2 protein,protein,1140,Synechococcus elongatus (strain ATCC 33912 / PCC 7942 / FACHB-805),Synechococcus elongatus (strain ATCC 33912 / PCC 7942 / FACHB-805),psbD1,352,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P11848,Photosystem II protein D1,protein,3728,Sinapis alba,Sinapis alba (White mustard),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P11849,Photosystem II D2 protein,protein,4513,Hordeum vulgare,Hordeum vulgare (Barley),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P12463,Photosystem II protein D1,protein,4565,Triticum aestivum,Triticum aestivum (Wheat),psbA,353,PTHR33149:SF58,PHOTOSYSTEM II PROTEIN D1,True
+P12719,Photosystem II protein D1,protein,2762,Cyanophora paradoxa,Cyanophora paradoxa,psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P13910,Photosystem II protein D1,protein,3906,Vicia faba,Vicia faba (Broad bean),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P14660,Photosystem II protein D1,protein,1147,Synechocystis sp. (strain PCC 6714),Synechocystis sp. (strain PCC 6714),psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P15191,Photosystem II protein D1,protein,1223,Prochlorothrix hollandica,Prochlorothrix hollandica,psbA1,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P16033,Photosystem II protein D1 2,protein,1111708,Synechocystis sp. (strain ATCC 27184 / PCC 6803 / Kazusa),Synechocystis sp. (strain ATCC 27184 / PCC 6803 / Kazusa),psbA3,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P18290,Photosystem II protein D1,protein,3708,Brassica napus,Brassica napus (Rape),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P20898,Photosystem II D2 protein,protein,32049,Picosynechococcus sp. (strain ATCC 27264 / PCC 7002 / PR-6),Picosynechococcus sp. (strain ATCC 27264 / PCC 7002 / PR-6),psbD1,352,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P24625,Photosystem II protein D1,protein,2767,Antithamnion sp.,Antithamnion sp. (Red alga),psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P24725,Photosystem II protein D1,protein,130081,Galdieria sulphuraria,Galdieria sulphuraria (Red alga),psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P24726,Photosystem II protein D1,protein,2880,Ectocarpus siliculosus,Ectocarpus siliculosus (Brown alga),psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P27201,Photosystem II protein D1,protein,50518,Landoltia punctata,Landoltia punctata (Dotted duckmeat),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P28253,Photosystem II D2 protein,protein,130081,Galdieria sulphuraria,Galdieria sulphuraria (Red alga),psbD,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P29270,Photosystem II protein D1,protein,1164,Trichormus azollae,Trichormus azollae,psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P31557,Photosystem II D2 protein,protein,3039,Euglena gracilis,Euglena gracilis,psbD,352,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P31694,Photosystem II protein D1 2,protein,103690,Nostoc sp. (strain PCC 7120 / SAG 25.82 / UTEX 2576),Nostoc sp. (strain PCC 7120 / SAG 25.82 / UTEX 2576),psbA3,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P32036,Photosystem II protein D1,protein,4129,Cuscuta reflexa,Cuscuta reflexa (Southern Asian dodder),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P35860,Photosystem II protein D1,protein,3072,Chlorella ellipsoidea,Chlorella ellipsoidea,psbA,352,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P36491,Photosystem II protein D1,protein,3696,Populus deltoides,Populus deltoides (Eastern poplar),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P41644,Photosystem II D2 protein,protein,3350,Pinus thunbergii,Pinus thunbergii (Japanese black pine),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P46242,Photosystem II protein D1 1,protein,103690,Nostoc sp. (strain PCC 7120 / SAG 25.82 / UTEX 2576),Nostoc sp. (strain PCC 7120 / SAG 25.82 / UTEX 2576),psbA1,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P46895,Photosystem II protein D1,protein,167539,Prochlorococcus marinus (strain SARG / CCMP1375 / SS120),Prochlorococcus marinus (strain SARG / CCMP1375 / SS120),psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P48079,Photosystem II D2 protein,protein,2762,Cyanophora paradoxa,Cyanophora paradoxa,psbD,352,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P48183,Photosystem II protein D1,protein,4577,Zea mays,Zea mays (Maize),psbA,353,PTHR33149:SF58,PHOTOSYSTEM II PROTEIN D1,True
+P48184,Photosystem II D2 protein,protein,4577,Zea mays,Zea mays (Maize),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P48265,Photosystem II protein D1,protein,2835,Bumilleriopsis filiformis,Bumilleriopsis filiformis (Yellow-green alga),psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P49460,Photosystem II protein D1,protein,1514140,Trieres chinensis,Trieres chinensis (Marine centric diatom),psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P49478,Photosystem II D2 protein,protein,1514140,Trieres chinensis,Trieres chinensis (Marine centric diatom),psbD,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P50155,Photosystem II protein D1,protein,3329,Picea abies,Picea abies (Norway spruce),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P51212,Photosystem II protein D1,protein,2787,Porphyra purpurea,Porphyra purpurea (Red seaweed),psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P51357,Photosystem II D2 protein,protein,2787,Porphyra purpurea,Porphyra purpurea (Red seaweed),psbD,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P51759,Photosystem II protein D1,protein,43989,Crocosphaera subtropica (strain ATCC 51142 / BH68),Crocosphaera subtropica (strain ATCC 51142 / BH68),psbA1,356,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P51764,Photosystem II protein D1,protein,1126,Microcystis aeruginosa,Microcystis aeruginosa,psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P51765,Photosystem II protein D1,protein,32053,Thermostichus vulcanus,Thermostichus vulcanus,psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P51766,Photosystem II D2 protein,protein,1223,Prochlorothrix hollandica,Prochlorothrix hollandica,psbD,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P56318,Photosystem II protein D1,protein,3077,Chlorella vulgaris,Chlorella vulgaris (Green alga),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P56319,Photosystem II D2 protein,protein,3077,Chlorella vulgaris,Chlorella vulgaris (Green alga),psbD,352,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P56761,Photosystem II D2 protein,protein,3702,Arabidopsis thaliana,Arabidopsis thaliana (Mouse-ear cress),psbD,353,PTHR33149:SF57,PHOTOSYSTEM II D2 PROTEIN,True
+P69550,Photosystem II protein D1,protein,3339,Pinus contorta,Pinus contorta (Shore pine),psbA-B,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P69551,Photosystem II protein D1,protein,3350,Pinus thunbergii,Pinus thunbergii (Japanese black pine),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P69556,Photosystem II protein D1,protein,4097,Nicotiana tabacum,Nicotiana tabacum (Common tobacco),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P69557,Photosystem II protein D1,protein,4236,Lactuca sativa,Lactuca sativa (Garden lettuce),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P69560,Photosystem II protein D1,protein,3562,Spinacia oleracea,Spinacia oleracea (Spinach),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P69561,Photosystem II protein D1,protein,4089,Nicotiana debneyi,Nicotiana debneyi (Debney's tobacco),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P69562,Photosystem II protein D1,protein,4092,Nicotiana plumbaginifolia,Nicotiana plumbaginifolia (Leadwort-leaved tobacco),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P69563,Photosystem II protein D1,protein,4112,Solanum nigrum,Solanum nigrum (Black nightshade),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P69564,Photosystem II protein D1,protein,3635,Gossypium hirsutum,Gossypium hirsutum (Upland cotton),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P69565,Photosystem II protein D1,protein,3560,Oxybasis rubra,Oxybasis rubra (Red goosefoot),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P69685,Photosystem II D2 protein,protein,4151,Antirrhinum majus,Antirrhinum majus (Garden snapdragon),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P69686,Photosystem II D2 protein,protein,4097,Nicotiana tabacum,Nicotiana tabacum (Common tobacco),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P83755,Photosystem II protein D1,protein,3702,Arabidopsis thaliana,Arabidopsis thaliana (Mouse-ear cress),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+P83756,Photosystem II protein D1,protein,85636,Oenothera elata subsp. hookeri,Oenothera elata subsp. hookeri (Hooker's evening primrose),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q01366,Photosystem II protein D1,protein,3885,Phaseolus vulgaris,Phaseolus vulgaris (Kidney bean),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q06FW1,Photosystem II D2 protein,protein,4031,Pelargonium hortorum,Pelargonium hortorum (Common geranium),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q06FY1,Photosystem II protein D1,protein,4031,Pelargonium hortorum,Pelargonium hortorum (Common geranium),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q06GR5,Photosystem II D2 protein,protein,398741,Piper cenocladum,Piper cenocladum (Ant piper),psbD,354,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q06GT0,Photosystem II protein D1,protein,398741,Piper cenocladum,Piper cenocladum (Ant piper),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q06H02,Photosystem II D2 protein,protein,224735,Drimys granadensis,Drimys granadensis,psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q06H17,Photosystem II protein D1,protein,224735,Drimys granadensis,Drimys granadensis,psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q06J41,Photosystem II protein D1,protein,227086,Bigelowiella natans,Bigelowiella natans (Pedinomonas minutissima),psbA,344,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q06J67,Photosystem II D2 protein,protein,227086,Bigelowiella natans,Bigelowiella natans (Pedinomonas minutissima),psbD,352,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q06RD6,Photosystem II D2 protein,protein,126431,Jasminum nudiflorum,Jasminum nudiflorum (Winter jasmine),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q06RF1,Photosystem II protein D1,protein,126431,Jasminum nudiflorum,Jasminum nudiflorum (Winter jasmine),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q06SD2,Photosystem II protein D1,protein,55999,Stigeoclonium helveticum,Stigeoclonium helveticum (Green alga),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q06SH5,Photosystem II D2 protein,protein,55999,Stigeoclonium helveticum,Stigeoclonium helveticum (Green alga),psbD,352,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q09FW6,Photosystem II D2 protein,protein,41776,Nandina domestica,Nandina domestica (Heavenly bamboo),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q09FY1,Photosystem II protein D1,protein,41776,Nandina domestica,Nandina domestica (Heavenly bamboo),psbA,353,PTHR33149:SF55,PHOTOSYSTEM II PROTEIN D1,True
+Q09G51,Photosystem II D2 protein,protein,4403,Platanus occidentalis,Platanus occidentalis (Sycamore),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q09G66,Photosystem II protein D1,protein,4403,Platanus occidentalis,Platanus occidentalis (Sycamore),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q09MI3,Photosystem II D2 protein,protein,2711,Citrus sinensis,Citrus sinensis (Sweet orange),psbD,353,PTHR33149:SF57,PHOTOSYSTEM II D2 PROTEIN,True
+Q09MJ8,Photosystem II protein D1,protein,2711,Citrus sinensis,Citrus sinensis (Sweet orange),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q09X22,Photosystem II D2 protein,protein,248361,Morus indica,Morus indica (Mulberry),psbD,353,PTHR33149:SF57,PHOTOSYSTEM II D2 PROTEIN,True
+Q09X37,Photosystem II protein D1,protein,248361,Morus indica,Morus indica (Mulberry),psbA,353,PTHR33149:SF55,PHOTOSYSTEM II PROTEIN D1,True
+Q0G9M4,Photosystem II D2 protein,protein,3415,Liriodendron tulipifera,Liriodendron tulipifera (Tuliptree),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q0G9N9,Photosystem II protein D1,protein,3415,Liriodendron tulipifera,Liriodendron tulipifera (Tuliptree),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q0G9W7,Photosystem II D2 protein,protein,4039,Daucus carota,Daucus carota (Wild carrot),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q0G9Y2,Photosystem II protein D1,protein,4039,Daucus carota,Daucus carota (Wild carrot),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q0I6Z7,Photosystem II D2 protein,protein,64471,Synechococcus sp. (strain CC9311),Synechococcus sp. (strain CC9311),psbD2,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q0I7J2,Photosystem II protein D1 1,protein,64471,Synechococcus sp. (strain CC9311),Synechococcus sp. (strain CC9311),psbA4,359,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q0I910,Photosystem II protein D1 3,protein,64471,Synechococcus sp. (strain CC9311),Synechococcus sp. (strain CC9311),psbA3,358,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q0I912,Photosystem II protein D1 2,protein,64471,Synechococcus sp. (strain CC9311),Synechococcus sp. (strain CC9311),psbA2,359,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q0P3J1,Photosystem II protein D1,protein,70448,Ostreococcus tauri,Ostreococcus tauri (Marine green alga),psbA2,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q0P3Q0,Photosystem II D2 protein,protein,70448,Ostreococcus tauri,Ostreococcus tauri (Marine green alga),psbD,352,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q0QZ08,Photosystem II D2 protein,protein,382359,Synechococcus phage syn9,Synechococcus phage syn9,psbD,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,False
+Q0ZJ25,Photosystem II D2 protein,protein,29760,Vitis vinifera,Vitis vinifera (Grape),psbD,353,PTHR33149:SF57,PHOTOSYSTEM II D2 PROTEIN,True
+Q0ZJ40,Photosystem II protein D1,protein,29760,Vitis vinifera,Vitis vinifera (Grape),psbA,353,PTHR33149:SF55,PHOTOSYSTEM II PROTEIN D1,True
+Q10VK7,Photosystem II protein D1 2,protein,203124,Trichodesmium erythraeum (strain IMS101),Trichodesmium erythraeum (strain IMS101),psbA3,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q116J3,Photosystem II D2 protein,protein,203124,Trichodesmium erythraeum (strain IMS101),Trichodesmium erythraeum (strain IMS101),psbD,352,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q11A00,Photosystem II protein D1 1,protein,203124,Trichodesmium erythraeum (strain IMS101),Trichodesmium erythraeum (strain IMS101),psbA2,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q14FG2,Photosystem II D2 protein,protein,43335,Populus alba,Populus alba (White poplar),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q14FH6,Photosystem II protein D1,protein,43335,Populus alba,Populus alba (White poplar),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q19VC4,Photosystem II protein D1,protein,3144,Chlorokybus atmophyticus,Chlorokybus atmophyticus (Soil alga),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q19VC7,Photosystem II D2 protein,protein,3144,Chlorokybus atmophyticus,Chlorokybus atmophyticus (Soil alga),psbD,354,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q1ACJ7,Photosystem II D2 protein,protein,55564,Chara vulgaris,Chara vulgaris (Common stonewort),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q1ACM1,Photosystem II protein D1,protein,55564,Chara vulgaris,Chara vulgaris (Common stonewort),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q1KVU8,Photosystem II protein D1,protein,3088,Tetradesmus obliquus,Tetradesmus obliquus (Green alga),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q1KVW6,Photosystem II D2 protein,protein,3088,Tetradesmus obliquus,Tetradesmus obliquus (Green alga),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q1KXW4,Photosystem II D2 protein,protein,4232,Helianthus annuus,Helianthus annuus (Common sunflower),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q1KXX9,Photosystem II protein D1,protein,4232,Helianthus annuus,Helianthus annuus (Common sunflower),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q1XDD0,Photosystem II D2 protein,protein,2788,Pyropia yezoensis,Pyropia yezoensis (Susabi-nori),psbD,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,False
+Q1XDS5,Photosystem II protein D1,protein,2788,Pyropia yezoensis,Pyropia yezoensis (Susabi-nori),psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q20ET2,Photosystem II protein D1,protein,51324,Oltmannsiellopsis viridis,Oltmannsiellopsis viridis (Marine flagellate),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q20EU7,Photosystem II D2 protein,protein,51324,Oltmannsiellopsis viridis,Oltmannsiellopsis viridis (Marine flagellate),psbD,352,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q2JKT8,Photosystem II D2 protein,protein,321332,Synechococcus sp. (strain JA-2-3B'a(2-13)),Synechococcus sp. (strain JA-2-3B'a(2-13)),psbD1,352,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q2JP67,Photosystem II protein D1 2,protein,321332,Synechococcus sp. (strain JA-2-3B'a(2-13)),Synechococcus sp. (strain JA-2-3B'a(2-13)),psbA3,354,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q2JPR2,Photosystem II protein D1 1,protein,321332,Synechococcus sp. (strain JA-2-3B'a(2-13)),Synechococcus sp. (strain JA-2-3B'a(2-13)),psbA1,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q2JRJ5,Photosystem II D2 protein,protein,321327,Synechococcus sp. (strain JA-3-3Ab),Synechococcus sp. (strain JA-3-3Ab),psbD1,352,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q2JTJ2,Photosystem II protein D1 1,protein,321327,Synechococcus sp. (strain JA-3-3Ab),Synechococcus sp. (strain JA-3-3Ab),psbA1,354,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q2JTM8,Photosystem II protein D1 3,protein,321327,Synechococcus sp. (strain JA-3-3Ab),Synechococcus sp. (strain JA-3-3Ab),psbA3,354,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q2JTT0,Photosystem II protein D1 2,protein,321327,Synechococcus sp. (strain JA-3-3Ab),Synechococcus sp. (strain JA-3-3Ab),psbA2,352,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q2L902,Photosystem II D2 protein,protein,3635,Gossypium hirsutum,Gossypium hirsutum (Upland cotton),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q2MIA5,Photosystem II D2 protein,protein,4081,Solanum lycopersicum,Solanum lycopersicum (Tomato),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q2MIC0,Photosystem II protein D1,protein,4081,Solanum lycopersicum,Solanum lycopersicum (Tomato),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q2MIJ2,Photosystem II D2 protein,protein,147425,Solanum bulbocastanum,Solanum bulbocastanum (Wild potato),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q2MIK7,Photosystem II protein D1,protein,147425,Solanum bulbocastanum,Solanum bulbocastanum (Wild potato),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q2PMT8,Photosystem II D2 protein,protein,3847,Glycine max,Glycine max (Soybean),psbD,353,PTHR33149:SF57,PHOTOSYSTEM II D2 PROTEIN,True
+Q2QDA8,Photosystem II protein D1,protein,3659,Cucumis sativus,Cucumis sativus (Cucumber),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q2VEI1,Photosystem II D2 protein,protein,4113,Solanum tuberosum,Solanum tuberosum (Potato),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q2VEJ6,Photosystem II protein D1,protein,4113,Solanum tuberosum,Solanum tuberosum (Potato),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q2WGI0,Photosystem II protein D1,protein,307165,Selaginella uncinata,Selaginella uncinata (Blue spike-moss),psbA,354,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q31A92,Photosystem II protein D1,protein,74546,Prochlorococcus marinus (strain MIT 9312),Prochlorococcus marinus (strain MIT 9312),psbA2,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q32389,Photosystem II protein D1,protein,2829,Heterosigma akashiwo,Heterosigma akashiwo (Chromophytic alga),psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q32RM3,Photosystem II protein D1,protein,35869,Zygnema circumcarinatum,Zygnema circumcarinatum (Green alga),psbA,352,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q32RM5,Photosystem II D2 protein,protein,35869,Zygnema circumcarinatum,Zygnema circumcarinatum (Green alga),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q32RT0,Photosystem II D2 protein,protein,102822,Staurastrum punctulatum,Staurastrum punctulatum (Green alga),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q32RX1,Photosystem II protein D1,protein,102822,Staurastrum punctulatum,Staurastrum punctulatum (Green alga),psbA,344,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q33282,Photosystem II protein D1,protein,3917,Vigna unguiculata,Vigna unguiculata (Cowpea),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q33C42,Photosystem II D2 protein,protein,4098,Nicotiana tomentosiformis,Nicotiana tomentosiformis (Tobacco),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q33C59,Photosystem II protein D1,protein,4098,Nicotiana tomentosiformis,Nicotiana tomentosiformis (Tobacco),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q36814,Photosystem II D2 protein,protein,4565,Triticum aestivum,Triticum aestivum (Wheat),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q3AH25,Photosystem II D2 protein,protein,110662,Synechococcus sp. (strain CC9605),Synechococcus sp. (strain CC9605),psbD2,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q3AKT2,Photosystem II protein D1 2,protein,110662,Synechococcus sp. (strain CC9605),Synechococcus sp. (strain CC9605),psbA3,358,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q3AM89,Photosystem II protein D1 1,protein,110662,Synechococcus sp. (strain CC9605),Synechococcus sp. (strain CC9605),psbA2,359,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q3AV15,Photosystem II protein D1 2,protein,316279,Synechococcus sp. (strain CC9902),Synechococcus sp. (strain CC9902),psbA2,359,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q3AYB8,Photosystem II protein D1 1,protein,316279,Synechococcus sp. (strain CC9902),Synechococcus sp. (strain CC9902),psbA1,358,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q3B038,Photosystem II D2 protein,protein,316279,Synechococcus sp. (strain CC9902),Synechococcus sp. (strain CC9902),psbD2,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q3BAP5,Photosystem II D2 protein,protein,308872,Phalaenopsis aphrodite subsp. formosana,Phalaenopsis aphrodite subsp. formosana (Moth orchid),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q3BAR4,Photosystem II protein D1,protein,308872,Phalaenopsis aphrodite subsp. formosana,Phalaenopsis aphrodite subsp. formosana (Moth orchid),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q3C1G3,Photosystem II protein D1,protein,4096,Nicotiana sylvestris,Nicotiana sylvestris (Wood tobacco),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q3C1I4,Photosystem II D2 protein,protein,4096,Nicotiana sylvestris,Nicotiana sylvestris (Wood tobacco),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q3M5L6,Photosystem II protein D1 4,protein,240292,Trichormus variabilis (strain ATCC 29413 / PCC 7937),Trichormus variabilis (strain ATCC 29413 / PCC 7937),psbA6,356,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q3MA59,Photosystem II D2 protein,protein,240292,Trichormus variabilis (strain ATCC 29413 / PCC 7937),Trichormus variabilis (strain ATCC 29413 / PCC 7937),psbD2,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q3MAB1,Photosystem II protein D1 2,protein,240292,Trichormus variabilis (strain ATCC 29413 / PCC 7937),Trichormus variabilis (strain ATCC 29413 / PCC 7937),psbA4,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q3MB78,Photosystem II protein D1 3,protein,240292,Trichormus variabilis (strain ATCC 29413 / PCC 7937),Trichormus variabilis (strain ATCC 29413 / PCC 7937),psbA3,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q3MCT0,Photosystem II protein D1 1,protein,240292,Trichormus variabilis (strain ATCC 29413 / PCC 7937),Trichormus variabilis (strain ATCC 29413 / PCC 7937),psbA1,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q3V539,Photosystem II D2 protein,protein,4465,Acorus calamus,Acorus calamus (Sweet flag),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q3V554,Photosystem II protein D1,protein,4465,Acorus calamus,Acorus calamus (Sweet flag),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q3ZJ46,Photosystem II D2 protein,protein,160070,Tupiella akineta,Tupiella akineta (Green alga),psbD,352,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q3ZJ60,Photosystem II protein D1,protein,160070,Tupiella akineta,Tupiella akineta (Green alga),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q46JV2,Photosystem II protein D1,protein,59920,Prochlorococcus marinus (strain NATL2A),Prochlorococcus marinus (strain NATL2A),psbA3,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q49CA8,Photosystem II D2 protein,protein,197374,Cuscuta sandwichiana,Cuscuta sandwichiana (Hawaiian dodder),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q49L03,Photosystem II D2 protein,protein,71271,Eucalyptus globulus subsp. globulus,Eucalyptus globulus subsp. globulus (Tasmanian blue gum),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q49L18,Photosystem II protein D1,protein,71271,Eucalyptus globulus subsp. globulus,Eucalyptus globulus subsp. globulus (Tasmanian blue gum),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q4FFP1,Photosystem II D2 protein,protein,334596,Ranunculus macranthus,Ranunculus macranthus (Large buttercup),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q4FFP2,Photosystem II D2 protein,protein,77108,Nuphar advena,Nuphar advena (Common spatterdock),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q4FFP4,Photosystem II D2 protein,protein,263995,Acorus calamus var. americanus,Acorus calamus var. americanus (American sweet flag),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q4G395,Photosystem II D2 protein,protein,2903,Emiliania huxleyi,Emiliania huxleyi (Coccolithophore),psbD,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q4G3F2,Photosystem II protein D1,protein,2903,Emiliania huxleyi,Emiliania huxleyi (Coccolithophore),psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q4VZN8,Photosystem II D2 protein,protein,3659,Cucumis sativus,Cucumis sativus (Cucumber),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q56P05,Photosystem II D2 protein,protein,4236,Lactuca sativa,Lactuca sativa (Garden lettuce),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q5MZ82,Photosystem II D2 protein 2,protein,269084,Synechococcus sp. (strain ATCC 27144 / PCC 6301 / SAUG 1402/1),Synechococcus sp. (strain ATCC 27144 / PCC 6301 / SAUG 1402/1),psbD2,352,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q5N337,Photosystem II protein D1 3,protein,269084,Synechococcus sp. (strain ATCC 27144 / PCC 6301 / SAUG 1402/1),Synechococcus sp. (strain ATCC 27144 / PCC 6301 / SAUG 1402/1),psbA3,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q5N3Q7,Photosystem II D2 protein 1,protein,269084,Synechococcus sp. (strain ATCC 27144 / PCC 6301 / SAUG 1402/1),Synechococcus sp. (strain ATCC 27144 / PCC 6301 / SAUG 1402/1),psbD1,352,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q5N4D2,Photosystem II protein D1 2,protein,269084,Synechococcus sp. (strain ATCC 27144 / PCC 6301 / SAUG 1402/1),Synechococcus sp. (strain ATCC 27144 / PCC 6301 / SAUG 1402/1),psbA2,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q5N5R2,Photosystem II protein D1 1,protein,269084,Synechococcus sp. (strain ATCC 27144 / PCC 6301 / SAUG 1402/1),Synechococcus sp. (strain ATCC 27144 / PCC 6301 / SAUG 1402/1),psbA1,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q5SCW8,Photosystem II protein D1,protein,37429,Huperzia lucidula,Huperzia lucidula (Shining clubmoss),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q68S11,Photosystem II D2 protein,protein,4054,Panax ginseng,Panax ginseng (Korean ginseng),psbD,353,PTHR33149:SF57,PHOTOSYSTEM II D2 PROTEIN,True
+Q68S26,Photosystem II protein D1,protein,4054,Panax ginseng,Panax ginseng (Korean ginseng),psbA,353,PTHR33149:SF55,PHOTOSYSTEM II PROTEIN D1,True
+Q6B918,Photosystem II D2 protein,protein,285951,Gracilaria tenuistipitata var. liui,Gracilaria tenuistipitata var. liui (Red alga),psbD,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q6B929,Photosystem II protein D1,protein,285951,Gracilaria tenuistipitata var. liui,Gracilaria tenuistipitata var. liui (Red alga),psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q6ENJ1,Photosystem II D2 protein,protein,4536,Oryza nivara,Oryza nivara (Indian wild rice),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q6ENJ7,Photosystem II protein D1,protein,4536,Oryza nivara,Oryza nivara (Indian wild rice),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q6ENY1,Photosystem II D2 protein,protein,4547,Saccharum officinarum,Saccharum officinarum (Sugarcane),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q6EW53,Photosystem II D2 protein,protein,34301,Nymphaea alba,Nymphaea alba (White water-lily),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q6EW68,Photosystem II protein D1,protein,34301,Nymphaea alba,Nymphaea alba (White water-lily),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q6H952,Photosystem II D2 protein,protein,65015,Synechococcus phage S-WHM1,Synechococcus phage S-WHM1,psbD,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,False
+Q6H956,Photosystem II D2 protein,protein,264653,Synechococcus phage S-RSM2,Synechococcus phage S-RSM2,psbD,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,False
+Q6L3B1,Photosystem II D2 protein,protein,15819,Saccharum hybrid,Saccharum hybrid (Sugarcane),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q6L3B5,Photosystem II protein D1,protein,15819,Saccharum hybrid,Saccharum hybrid (Sugarcane),psbA,353,PTHR33149:SF58,PHOTOSYSTEM II PROTEIN D1,True
+Q6YXN8,Photosystem II D2 protein,protein,3218,Physcomitrium patens,Physcomitrium patens (Spreading-leaved earth moss),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q70Y08,Photosystem II D2 protein,protein,13333,Amborella trichopoda,Amborella trichopoda,psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q70Y17,Photosystem II protein D1,protein,13333,Amborella trichopoda,Amborella trichopoda,psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q7FNT3,Photosystem II protein D1,protein,33113,Atropa belladonna,Atropa belladonna (Belladonna),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q7HP56,Photosystem II protein D1,protein,107036,Amphidinium operculatum,Amphidinium operculatum (Dinoflagellate),psbA,340,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q7M7A9,Photosystem II protein D1 1,protein,251221,Gloeobacter violaceus (strain ATCC 29082 / PCC 7421),Gloeobacter violaceus (strain ATCC 29082 / PCC 7421),psbA1,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q7NH81,Photosystem II protein D1 3,protein,251221,Gloeobacter violaceus (strain ATCC 29082 / PCC 7421),Gloeobacter violaceus (strain ATCC 29082 / PCC 7421),psbA4,362,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q7NJX5,Photosystem II protein D1 2,protein,251221,Gloeobacter violaceus (strain ATCC 29082 / PCC 7421),Gloeobacter violaceus (strain ATCC 29082 / PCC 7421),psbA2,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q7TTH6,Photosystem II protein D1,protein,74547,Prochlorococcus marinus (strain MIT 9313),Prochlorococcus marinus (strain MIT 9313),psbA1,358,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q7TTI2,Photosystem II D2 protein,protein,84588,Parasynechococcus marenigrum (strain WH8102),Parasynechococcus marenigrum (strain WH8102),psbD1,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q7TTJ7,Photosystem II protein D1 1,protein,84588,Parasynechococcus marenigrum (strain WH8102),Parasynechococcus marenigrum (strain WH8102),psbA2,359,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q7U4Z3,Photosystem II protein D1 3,protein,84588,Parasynechococcus marenigrum (strain WH8102),Parasynechococcus marenigrum (strain WH8102),psbA3,359,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q7U669,Photosystem II protein D1 2,protein,84588,Parasynechococcus marenigrum (strain WH8102),Parasynechococcus marenigrum (strain WH8102),psbA2,358,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q7V365,Photosystem II protein D1,protein,59919,Prochlorococcus marinus subsp. pastoris (strain CCMP1986 / NIES-2087 / MED4),Prochlorococcus marinus subsp. pastoris (strain CCMP1986 / NIES-2087 / MED4),psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q7V6I0,Photosystem II D2 protein,protein,74547,Prochlorococcus marinus (strain MIT 9313),Prochlorococcus marinus (strain MIT 9313),psbD,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q7Y4H2,Photosystem II D2 protein,protein,238854,Synechococcus phage S-PM2,Synechococcus phage S-PM2,psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,False
+Q7YJX7,Photosystem II D2 protein,protein,212734,Calycanthus floridus var. glaucus,Calycanthus floridus var. glaucus (Eastern sweetshrub),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q7YJY8,Photosystem II protein D1,protein,212734,Calycanthus floridus var. glaucus,Calycanthus floridus var. glaucus (Eastern sweetshrub),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q85AC9,Photosystem II D2 protein,protein,48387,Anthoceros angustus,Anthoceros angustus (Hornwort),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q85BH5,Photosystem II protein D1,protein,48387,Anthoceros angustus,Anthoceros angustus (Hornwort),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q85C23,Photosystem II protein D1,protein,13818,Adiantum capillus-veneris,Adiantum capillus-veneris (Maidenhair fern),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q85FM2,Photosystem II D2 protein,protein,13818,Adiantum capillus-veneris,Adiantum capillus-veneris (Maidenhair fern),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q85G27,Photosystem II D2 protein,protein,280699,Cyanidioschyzon merolae (strain NIES-3377 / 10D),Cyanidioschyzon merolae (strain NIES-3377 / 10D) (Unicellular red alga),psbD,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q85G59,Photosystem II protein D1,protein,280699,Cyanidioschyzon merolae (strain NIES-3377 / 10D),Cyanidioschyzon merolae (strain NIES-3377 / 10D) (Unicellular red alga),psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q85WS3,Photosystem II protein D1,protein,88728,Pinus koraiensis,Pinus koraiensis (Korean pine),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q85WW5,Photosystem II D2 protein,protein,88728,Pinus koraiensis,Pinus koraiensis (Korean pine),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q8CM25,Photosystem II D2 protein,protein,197221,Thermosynechococcus vestitus (strain NIES-2133 / IAM M-273 / BP-1),Thermosynechococcus vestitus (strain NIES-2133 / IAM M-273 / BP-1),psbD2,352,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q8DIV4,Photosystem II protein D1 3,protein,197221,Thermosynechococcus vestitus (strain NIES-2133 / IAM M-273 / BP-1),Thermosynechococcus vestitus (strain NIES-2133 / IAM M-273 / BP-1),psbA3,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q8M9W3,Photosystem II protein D1,protein,96477,Chaetosphaeridium globosum,Chaetosphaeridium globosum (Charophycean green alga),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q8M9W4,Photosystem II D2 protein,protein,96477,Chaetosphaeridium globosum,Chaetosphaeridium globosum (Charophycean green alga),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q8S8X8,Photosystem II D2 protein,protein,33113,Atropa belladonna,Atropa belladonna (Belladonna),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q8WI19,Photosystem II D2 protein,protein,3240,Psilotum nudum,Psilotum nudum (Whisk fern),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q8WI36,Photosystem II protein D1,protein,3240,Psilotum nudum,Psilotum nudum (Whisk fern),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q8XFA5,Photosystem II D2 protein,protein,103690,Nostoc sp. (strain PCC 7120 / SAG 25.82 / UTEX 2576),Nostoc sp. (strain PCC 7120 / SAG 25.82 / UTEX 2576),psbD2,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q8YQS7,Photosystem II protein D1 3,protein,103690,Nostoc sp. (strain PCC 7120 / SAG 25.82 / UTEX 2576),Nostoc sp. (strain PCC 7120 / SAG 25.82 / UTEX 2576),psbA5,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q9BBC1,Photosystem II protein D1,protein,2961,Amphidinium carterae,Amphidinium carterae (Dinoflagellate),psbA,340,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q9BBT0,Photosystem II D2 protein,protein,34305,Lotus japonicus,Lotus japonicus,psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q9BBU3,Photosystem II protein D1,protein,34305,Lotus japonicus,Lotus japonicus,psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q9MSC0,Photosystem II protein D1,protein,2920,Heterocapsa niei,Heterocapsa niei (Dinoflagellate),psbA,347,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q9MSC1,Photosystem II protein D1,protein,35672,Heterocapsa pygmaea,Heterocapsa pygmaea (Dinoflagellate),psbA,348,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q9MSC2,Photosystem II protein D1,protein,89963,Heterocapsa rotundata,Heterocapsa rotundata (Dinoflagellate),psbA,348,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q9MTN1,Photosystem II D2 protein,protein,85636,Oenothera elata subsp. hookeri,Oenothera elata subsp. hookeri (Hooker's evening primrose),psbD,353,PTHR33149:SF57,PHOTOSYSTEM II D2 PROTEIN,True
+Q9MUW0,Photosystem II protein D1,protein,41882,Mesostigma viride,Mesostigma viride (Green alga),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q9MUW2,Photosystem II D2 protein,protein,41882,Mesostigma viride,Mesostigma viride (Green alga),psbD,354,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q9S3W5,Photosystem II protein D1,protein,83541,Mastigocladus laminosus,Mastigocladus laminosus,psbA,358,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q9T351,Photosystem II protein D1,protein,41839,Conocephalum conicum,Conocephalum conicum (Snakeskin liverwort),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q9TJ82,Photosystem II protein D1,protein,225107,Karenia mikimotoi,Karenia mikimotoi (Red tide dinoflagellate),psbA,360,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q9TL00,Photosystem II D2 protein,protein,31312,Nephroselmis olivacea,Nephroselmis olivacea (Green alga),psbD,352,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q9TL35,Photosystem II protein D1,protein,31312,Nephroselmis olivacea,Nephroselmis olivacea (Green alga),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q9TM47,Photosystem II D2 protein,protein,2771,Cyanidium caldarium,Cyanidium caldarium (Red alga),psbD,351,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q9TM69,Photosystem II protein D1,protein,2926,Alexandrium tamarense,Alexandrium tamarense (Red tide dinoflagellate),psbA,347,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q9TM72,Photosystem II protein D1,protein,2945,Prorocentrum micans,Prorocentrum micans (Red tide dinoflagellate),psbA,343,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q9TNF7,Photosystem II protein D1,protein,56917,Dumortiera hirsuta,Dumortiera hirsuta (Liverwort),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q9TNF8,Photosystem II protein D1,protein,134427,Conocephalum japonicum,Conocephalum japonicum (Liverwort),psbA,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q9XQA8,Photosystem II D2 protein,protein,3696,Populus deltoides,Populus deltoides (Eastern poplar),psbD,353,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True
+Q9XQV1,Photosystem II protein D1,protein,66468,Kryptoperidinium triquetrum,Kryptoperidinium triquetrum (Dinoflagellate),psbA,348,PTHR33149:SF12,PHOTOSYSTEM II D2 PROTEIN,True

--- a/interpro/panther/PTHR33149/PTHR33149-metadata.yaml
+++ b/interpro/panther/PTHR33149/PTHR33149-metadata.yaml
@@ -1,0 +1,47 @@
+metadata:
+  accession: PTHR33149
+  entry_id: null
+  type: family
+  go_terms: null
+  source_database: panther
+  member_databases: null
+  integrated: IPR055266
+  hierarchy: null
+  name:
+    name: PHOTOSYSTEM II PROTEIN D1
+    short: null
+  description: null
+  wikipedia: null
+  literature: null
+  set_info: null
+  overlaps_with: null
+  counters:
+    subfamilies: 8
+    domain_architectures: 0
+    interactions: 0
+    matches: 44669
+    pathways: 0
+    proteins: 44669
+    proteomes: 673
+    sets: 0
+    structural_models:
+      alphafold: 40654
+      bfvd: 1
+    structures: 169
+    taxa: 27985
+  entry_annotations:
+    hmm: 0
+    logo: 0
+  cross_references: {}
+  is_llm: false
+  is_reviewed_llm: false
+  is_updated_llm: false
+  representative_structure:
+    accession: 9evx
+    name: cryoEM structure of Photosystem II averaged across S2-S3 states at 1.71
+      Angstrom resolution
+_fetch_info:
+  fetched_date: '2026-04-22T22:44:07.900508'
+  api_endpoint: https://www.ebi.ac.uk/interpro/api/entry/panther/PTHR33149/
+  database: panther
+  family_id: PTHR33149

--- a/publications/PMID_22833285.md
+++ b/publications/PMID_22833285.md
@@ -1,0 +1,57 @@
+---
+reference_id: PMID:22833285
+title: Differential phosphorylation of thylakoid proteins in mesophyll and bundle sheath chloroplasts from maize plants grown under low or high light.
+authors:
+- Fristedt R
+- Wasilewska W
+- Romanowska E
+- Vener AV
+journal: Proteomics
+year: '2012'
+doi: 10.1002/pmic.201200196
+content_type: abstract_only
+---
+
+# Differential phosphorylation of thylakoid proteins in mesophyll and bundle sheath chloroplasts from maize plants grown under low or high light.
+**Authors:** Fristedt R, Wasilewska W, Romanowska E, Vener AV
+**Journal:** Proteomics (2012)
+**DOI:** [10.1002/pmic.201200196](https://doi.org/10.1002/pmic.201200196)
+
+## Content
+
+1. Proteomics. 2012 Sep;12(18):2852-61. doi: 10.1002/pmic.201200196. Epub 2012
+Aug  28.
+
+Differential phosphorylation of thylakoid proteins in mesophyll and bundle 
+sheath chloroplasts from maize plants grown under low or high light.
+
+Fristedt R(1), Wasilewska W, Romanowska E, Vener AV.
+
+Author information:
+(1)Department of Clinical and Experimental Medicine, Linköping University, 
+Linköping, Sweden.
+
+In C4 plants, such as maize, the photosynthetic apparatus is partitioned over 
+two cell types called mesophyll (M) and bundle sheath (BS), which have different 
+structure and specialization of the photosynthetic thylakoid membranes. We 
+characterized protein phosphorylation in thylakoids of the two cell types from 
+maize grown under either low or high light. Western blotting with 
+phosphothreonine antibodies and ProQ phosphostaining detected light-dependent 
+changes in the protein phosphorylation patterns. LC-MS/MS with alternating CID 
+and electron transfer dissociation sequencing of peptide ions mapped 15 protein 
+phosphorylation sites. Phosphorylated D2, CP29, CP26, Lhcb2 proteins, and 
+ATPsynthase were found only in M membranes. A previously unknown phosphorylation 
+site was mapped in phosphoenolpyruvate carboxykinase from the BS cells. 
+Phosphorylation stoichiometry was calculated from the ratios of normalized ion 
+currents for phosphorylated to nonphosphorylated peptide pairs from the D1, D2, 
+CP43, and PbsH proteins of photosystem II (PSII). Every PSII in M thylakoids 
+contained on average 1.5 ± 0.1 or 2.3 ± 0.2 phosphoryl groups in plants grown 
+under either low or high light, while in BS membranes the corresponding numbers 
+were 0.25 ± 0.1 or 0.7 ± 0.2, respectively. It is suggested that the 
+phosphorylation level, as well as turnover of PSII depend on the structure of 
+thylakoids.
+
+© 2012 WILEY-VCH Verlag GmbH & Co. KGaA, Weinheim.
+
+DOI: 10.1002/pmic.201200196
+PMID: 22833285 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary
- Complete GO annotation review for psbA (P48183, Zea mays) — Photosystem II protein D1
- Reviewed 11 existing GOA annotations: 7 ACCEPT, 4 KEEP_AS_NON_CORE
- Proposed 2 new annotations: manganese ion binding (GO:0030145) and quinone binding (GO:0048038)
- Includes core_functions synthesis, notes, UniProt/GOA data, and PANTHER family data (PTHR33149)

## Annotation Summary

| GO Term | Action | Rationale |
|---------|--------|-----------|
| GO:0009523 photosystem II | ACCEPT | Core CC — D1 is a defining subunit |
| GO:0010242 oxygen evolving activity | ACCEPT | Core MF — D1 provides OEC Mn₄-Ca-O₅ ligands |
| GO:0016168 chlorophyll binding | ACCEPT | Core MF — binds P680 reaction center chlorophylls |
| GO:0016682 oxidoreductase (EC 1.10.3.9) | ACCEPT | Core MF — water:plastoquinone oxidoreductase |
| GO:0009055 electron transfer activity | ACCEPT | Core MF — TyrZ→P680→Pheo→QB chain |
| GO:0009535 chloroplast thylakoid membrane | ACCEPT | Core CC — confirmed by PMID:22833285 |
| GO:0009772 PSII electron transport | ACCEPT | Core BP — most specific process term |
| GO:0005506 iron ion binding | KEEP_AS_NON_CORE | Real but subsidiary cofactor |
| GO:0015979 photosynthesis | KEEP_AS_NON_CORE | Too broad, redundant with GO:0009772 |
| GO:0009536 plastid | KEEP_AS_NON_CORE | Too broad, redundant with GO:0009535 |
| GO:0019684 photosynthesis, light reaction | KEEP_AS_NON_CORE | Intermediate specificity, redundant |
| GO:0030145 manganese ion binding | **NEW** | D1 provides 5/7 OEC cluster ligands |
| GO:0048038 quinone binding | **NEW** | QB site — essential for ET, herbicide target |

## Test plan
- [x] `just validate 9POAL psbA` passes
- [ ] Manual review of annotation actions and supporting evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)