### PR TITLE
Port GitHub Actions workflows from dismech

### DIFF
--- a/.claude/hooks/validate_ai_review_pretool_hook.py
+++ b/.claude/hooks/validate_ai_review_pretool_hook.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+PreToolUse hook to validate *-ai-review.yaml files BEFORE edits are applied.
+
+This hook:
+1. Intercepts Edit/Write/MultiEdit calls targeting *-ai-review.yaml
+2. Simulates what the file would look like after the edit
+3. Runs `uv run ai-gene-review validate <temp_file>` on the simulated result
+4. Returns exit code 2 to BLOCK the edit if validation fails
+
+Exit code 2 blocks the operation in PreToolUse hooks.
+https://docs.claude.com/en/docs/claude-code/hooks#exit-code-2-behavior
+"""
+
+import sys
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def simulate_edit(file_path: Path, old_string: str, new_string: str) -> str:
+    """Simulate an Edit operation and return the resulting content."""
+    if not file_path.exists():
+        print(f"Error: File not found: {file_path}", file=sys.stderr)
+        sys.exit(0)  # Let Claude Code handle missing file error
+
+    content = file_path.read_text()
+
+    if old_string not in content:
+        print("Error: old_string not found in file", file=sys.stderr)
+        sys.exit(0)  # Let Claude Code handle this error
+
+    return content.replace(old_string, new_string, 1)
+
+
+def simulate_write(content: str) -> str:
+    """Simulate a Write operation - just return the new content."""
+    return content
+
+
+def simulate_multi_edit(file_path: Path, edits: list) -> str:
+    """Simulate a MultiEdit operation and return the resulting content."""
+    if not file_path.exists():
+        print(f"Error: File not found: {file_path}", file=sys.stderr)
+        sys.exit(0)
+
+    content = file_path.read_text()
+
+    for edit in edits:
+        old_string = edit.get("old_string", "")
+        new_string = edit.get("new_string", "")
+        if old_string and old_string in content:
+            content = content.replace(old_string, new_string, 1)
+
+    return content
+
+
+def validate_content(
+    content: str, original_path: Path, project_root: Path
+) -> tuple[bool, str]:
+    """
+    Validate content by writing to temp file and running validation.
+    Returns (success, output_message).
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        temp_path = Path(tmpdir) / original_path.name
+        temp_path.write_text(content)
+
+        cmd = ["uv", "run", "ai-gene-review", "validate", str(temp_path)]
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=project_root,
+        )
+
+        # Filter out common noise from stderr
+        stderr_lines = []
+        for line in (result.stderr or "").split("\n"):
+            if "/eutils/__init__.py" in line and "UserWarning" in line:
+                continue
+            if "pkg_resources is deprecated" in line:
+                continue
+            if "warning: Failed to uninstall package" in line:
+                continue
+            stderr_lines.append(line)
+
+        output = result.stdout + "\n".join(stderr_lines)
+        return result.returncode == 0, output
+
+
+def main():
+    data = json.load(sys.stdin)
+
+    tool_name = data.get("tool_name", "")
+    tool_input = data.get("tool_input", {})
+
+    if tool_name not in ["Write", "Edit", "MultiEdit"]:
+        sys.exit(0)
+
+    file_path_str = tool_input.get("file_path", "")
+    if not file_path_str:
+        sys.exit(0)
+
+    file_path = Path(file_path_str)
+
+    # Only validate *-ai-review.yaml files
+    if not file_path.name.endswith("-ai-review.yaml"):
+        sys.exit(0)
+
+    # Determine project root (go up from .claude/hooks/)
+    project_root = Path(__file__).parent.parent.parent
+
+    # Simulate the edit to get resulting content
+    if tool_name == "Edit":
+        old_string = tool_input.get("old_string", "")
+        new_string = tool_input.get("new_string", "")
+        simulated_content = simulate_edit(file_path, old_string, new_string)
+    elif tool_name == "Write":
+        simulated_content = simulate_write(tool_input.get("content", ""))
+    elif tool_name == "MultiEdit":
+        edits = tool_input.get("edits", [])
+        simulated_content = simulate_multi_edit(file_path, edits)
+    else:
+        sys.exit(0)
+
+    success, output = validate_content(simulated_content, file_path, project_root)
+
+    print("\n" + "=" * 60, file=sys.stderr)
+    print(f"Pre-Edit Validation for {file_path.name}", file=sys.stderr)
+    print("=" * 60, file=sys.stderr)
+
+    if output.strip():
+        print(output.strip(), file=sys.stderr)
+
+    if not success:
+        print("=" * 60, file=sys.stderr)
+        print("BLOCKING EDIT: Validation failed", file=sys.stderr)
+        print("The proposed edit would create an invalid file.", file=sys.stderr)
+        print("Fix the issues above before proceeding.", file=sys.stderr)
+        print("=" * 60 + "\n", file=sys.stderr)
+        sys.exit(2)
+
+    print("Validation passed - allowing edit", file=sys.stderr)
+    print("=" * 60 + "\n", file=sys.stderr)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,6 +32,10 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/protect_files_hook.py"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/validate_ai_review_pretool_hook.py"
           }
         ]
       }

--- a/.github/ai-controllers.json
+++ b/.github/ai-controllers.json
@@ -1,1 +1,1 @@
-["cmungall"]
+["cmungall", "balhoff", "caufieldjh", "kevinschaper"]

--- a/.github/workflows/arba-issue-monitor.yml
+++ b/.github/workflows/arba-issue-monitor.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -37,7 +37,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
 
       - name: Install just
         run: |
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -74,7 +74,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
 
       - name: Install just
         run: |
@@ -82,7 +82,7 @@ jobs:
           uv sync
 
       - name: Run Claude ARBA Review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           mode: agent

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,13 +27,13 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude-issue-summarize.yml
+++ b/.github/workflows/claude-issue-summarize.yml
@@ -14,7 +14,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run Claude Issue summarize
         uses: ./.github/actions/claude-issue-summarize-action

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -14,7 +14,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run Claude Issue Triage
         uses: ./.github/actions/claude-issue-triage-action

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -9,6 +9,16 @@ on:
     types: [opened, assigned]
   pull_request_review:
     types: [submitted]
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "Claude model to use"
+        default: claude-sonnet-4-6
+        type: choice
+        options:
+          - claude-sonnet-4-6
+          - claude-haiku-4-5-20251001
+          - claude-opus-4-7
 
 jobs:
   claude:
@@ -26,12 +36,12 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
             
       - name: Install python tools
         run: |
@@ -39,7 +49,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -66,8 +76,7 @@ jobs:
           additional_permissions: |
             actions: read
           
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          model: ${{ inputs.model || 'claude-sonnet-4-6' }}
           
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"

--- a/.github/workflows/curation-scanner.yml
+++ b/.github/workflows/curation-scanner.yml
@@ -1,0 +1,108 @@
+name: Curation Scanner
+
+on:
+  schedule:
+    - cron: "0 */4 * * *"
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "Claude model to use"
+        default: claude-opus-4-7
+        type: choice
+        options:
+          - claude-sonnet-4-6
+          - claude-haiku-4-5-20251001
+          - claude-opus-4-7
+
+concurrency:
+  group: curation-scanner
+  cancel-in-progress: true
+
+jobs:
+  curation-scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          # Use PAT so follow-up review automation can act on resulting work
+          token: ${{ secrets.PAT_FOR_PR }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install python tools
+        run: uv sync
+
+      - name: Install just
+        run: uv tool install rust-just
+
+      - name: Run Curation Scanner
+        id: curation-scanner
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.PAT_FOR_PR }}
+          show_full_output: true
+          claude_args: |
+            --dangerously-skip-permissions
+            --mcp-config '{"mcpServers": {"ols": {"command": "uvx", "args": ["ols-mcp"]}}}'
+            --model ${{ inputs.model || 'claude-opus-4-7' }}
+            --max-turns 40
+          prompt: |
+            REPO: ${{ github.repository }}
+            TRIGGER: ${{ github.event_name }}
+
+            You are running an automated curation scanner for the AI Gene Review repository.
+
+            Scan for open issues and pull requests labeled `curation` that are unassigned.
+            Start by gathering candidate items with `gh issue list` and `gh pr list`, including
+            metadata such as labels, assignees, updated time, review state, and reaction counts.
+
+            You may scan multiple candidates, but you must choose exactly one issue or pull request
+            to actively work on in this run. Leave all other items untouched.
+
+            Rank candidates before acting. Use judgment, with these signals in mind:
+            - prioritize `high-priority` items when that label is present
+            - prioritize items with stronger positive reaction signals, especially `THUMBS_UP`
+            - prioritize stale items that have not been updated recently
+            - deprioritize `low-priority` items
+            - deprioritize items that were updated very recently, unless they are clearly the best use of this run
+            - prefer the single item where a safe, meaningful next step can be completed in one run
+
+            Avoid repeatedly touching the freshest bottom-of-queue items while older unassigned
+            candidates remain. If signals conflict, explain your choice briefly in the comment or PR
+            you post for the selected item.
+
+            For the single selected unassigned curation issue:
+            - Analyze the request (gene review, annotation fix, new organism, tooling improvement, etc.)
+            - Post a concise assessment comment covering the gene/organism, what work is needed, and estimated scope/risk
+            - If the first step is straightforward and low-risk, create an initial PR
+              - For gene review issues: run `just fetch-gene <organism> <gene>` first, then follow CLAUDE.md review workflow
+            - Otherwise, leave the assessment comment and flag the issue for human review
+
+            For the single selected unassigned curation PR:
+            - Inspect its current state, review history, and discussion
+            - Address review comments when the right fix is clear and safe
+            - If the branch is stale or conflicted, refresh it carefully
+            - Prefer GitHub's update-branch flow via `gh api` rather than local rebases for branch refreshes
+            - Never use a local rebase to resolve PR conflicts
+            - If the next step is unclear or risky, post a comment asking for guidance instead of guessing
+
+            General guidance:
+            - Use judgment rather than rigid rules
+            - Be conservative. When in doubt, comment with your assessment instead of making a risky change
+            - Prefer draft PRs for new work unless the result is clearly ready for review
+            - Follow `CLAUDE.md` and the repository conventions
+            - Do not edit derived files (`*-uniprot.txt`, `*-goa.tsv`, `*-deep-research*.md`, `publications/*`)
+              — regenerate them with `just fetch-gene` or `just fetch-reference` if needed
+            - Validate any file edits with `just validate <organism> <gene>` before committing
+            - After choosing a target, spend the run on that one item only

--- a/.github/workflows/post-review-agent.yml
+++ b/.github/workflows/post-review-agent.yml
@@ -5,6 +5,7 @@ name: Post Review Agent
 # 2. Replies in review threads when clarification is needed
 # 3. Creates issues for larger cross-gene or tooling follow-up work
 
+
 on:
   schedule:
     - cron: "0 8 * * *"
@@ -26,21 +27,17 @@ on:
         type: string
       model:
         description: "Claude model to use"
-        default: claude-opus-4-5-20251101
+        default: claude-opus-4-7
         type: choice
         options:
-          - claude-sonnet-4-5-20250929
+          - claude-sonnet-4-6
           - claude-haiku-4-5-20251001
-          - claude-opus-4-5-20251101
-          - claude-opus-4-1-20250805
-          - claude-sonnet-4-20250514
-          - claude-opus-4-20250514
-          - claude-3-7-sonnet-20250219
-          - claude-3-haiku-20240307
+          - claude-opus-4-7
 
 jobs:
   post-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write
@@ -50,43 +47,34 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Install python tools
         run: uv sync
 
       - name: Install just
-        run: uv tool install rust-just
+        run: |
+          uv tool install rust-just
+          uv sync
 
       - name: Run Post Review Agent
         id: post-review-agent
-        uses: anthropics/claude-code-action@beta
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GITHUB_TOKEN: ${{ github.token }}
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: ${{ inputs.model }}
-          allowed_tools: "Bash(*),mcp__ols_mcp__search_all_ontologies,mcp__ols_mcp__get_terms_from_ontology"
-          mcp_config: |
-            {
-              "mcpServers": {
-                "ols": {
-                  "command": "uvx",
-                  "args": [
-                    "ols-mcp"
-                  ]
-                }
-              }
-            }
-          additional_permissions: |
-            actions: read
-          direct_prompt: |
+          show_full_output: true
+
+          claude_args: |
+            --dangerously-skip-permissions
+            --mcp-config '{"mcpServers": {"ols": {"command": "uvx", "args": ["ols-mcp"]}}}'
+            --model ${{ inputs.model || 'claude-opus-4-7' }}
+
+          prompt: |
             # AIGR Post Review Agent Task
 
             You are a post-review agent for the AI Gene Review (AIGR) repository.
@@ -278,7 +266,7 @@ jobs:
             List affected genes/files/workflows if known.
 
             ## Proposed action
-            Describe the larger fix." 
+            Describe the larger fix."
             ```
 
             ## Step 4: Summary

--- a/.github/workflows/weekly-compliance.yaml
+++ b/.github/workflows/weekly-compliance.yaml
@@ -1,0 +1,106 @@
+---
+name: Weekly Compliance
+
+on:
+  schedule:
+    # Runs every Friday at 8:00 AM UTC
+    - cron: '0 8 * * 5'
+  workflow_dispatch:
+    inputs:
+      num_files:
+        description: 'Number of lowest-scoring gene review files to improve'
+        required: false
+        default: '5'
+        type: string
+
+      areas_for_improvement:
+        description: 'Focus areas: data model (core_functions, references); annotation type (evidence, action); organism (human, worm); or ALL'
+        required: false
+        default: 'ALL'
+        type: string
+
+      model:
+        description: "Claude model to use"
+        default: claude-opus-4-7
+        type: choice
+        options:
+          - claude-sonnet-4-6
+          - claude-haiku-4-5-20251001
+          - claude-opus-4-7
+
+jobs:
+  compliance-fixes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install python tools
+        run: uv sync
+
+      - name: Install just
+        run: |
+          uv tool install rust-just
+          uv sync
+
+      - name: Run Claude Compliance Fixes
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          claude_args: |
+            --dangerously-skip-permissions
+            --mcp-config '{"mcpServers": {"ols": {"command": "uvx", "args": ["ols-mcp"]}}}'
+            --model ${{ inputs.model || 'claude-opus-4-7' }}
+
+          prompt: |
+            You are running as part of an automated CI workflow to improve the AI Gene Review knowledge base.
+
+            ## Your Task
+
+            1. **Get overall compliance report**: Run `just compliance-all` and examine per-file compliance scores
+               in `reports/compliance-all.tsv`.
+
+            2. **Select ${{ inputs.num_files || '5' }} poorly performing files**: From the report, identify the
+               gene review YAML files with the LOWEST weighted compliance scores.
+               Some randomness is fine; try for a common theme (organism, pathway, annotation gap) if possible.
+               Gradual, incremental improvement is the goal.
+
+               Focus areas requested: ${{ inputs.areas_for_improvement }}
+
+            3. **For each selected file**:
+               - Determine the organism and gene from the file path (e.g. `genes/human/CFAP300/CFAP300-ai-review.yaml`)
+               - Run `just validate <organism> <gene>` to get a detailed validation report
+               - Identify gaps: missing or weak `core_functions`, under-justified annotation `action` choices,
+                 missing `references`, over-generic GO terms, absent `review.summary` or `review.reason` text
+               - Read the gene's companion files (`*-uniprot.txt`, `*-deep-research*.md`, `*-notes.md`,
+                 cited `publications/PMID_*.md`) for evidence to fill gaps
+               - Use OLS MCP to find more specific GO terms when existing terms are over-generic
+               - Edit the `-ai-review.yaml` file to improve compliance
+               - Run `just validate <organism> <gene>` again to confirm validity
+               - Create a **per-file PR**:
+                 - Branch name: `weekly-compliance-YYYY-MM-DD-GENE`
+                 - Title: "Weekly Compliance: improve GENE review (YYYY-MM-DD)"
+                 - Include a report in the PR body: what was changed, original compliance gaps,
+                   what was fixed, and any remaining issues
+
+            ## Important Guidelines
+
+            - Only add GO terms you can verify via OLS — never hallucinate IDs or labels
+            - Use the exact label returned by OLS for the `label` field
+            - Do not edit derived files (`*-uniprot.txt`, `*-goa.tsv`, `*-deep-research*.md`, `publications/*`)
+            - Incremental fixes are fine — we will get to everything eventually
+            - Follow `CLAUDE.md` conventions and the gene review schema
+            - Be conservative with annotation `action` changes; only upgrade confidence when evidence is clear


### PR DESCRIPTION
## Summary

Closes #293. Ports three priority GitHub Actions workflows from the dismech repository, adapted for the gene review domain:

- **weekly-compliance.yaml** — Runs Fridays at 8 AM UTC. Picks the N lowest-scoring gene review files via `just compliance-all`, improves them using OLS for GO term lookup, and creates per-file PRs
- **curation-scanner.yml** — Runs every 4 hours. Scans unassigned `curation`-labeled issues/PRs, ranks by priority/staleness/reactions, picks ONE item to work on per run
- **post-review-agent.yml** — Rewritten to align with dismech patterns: uses `claude_args` with `--dangerously-skip-permissions` and inline MCP config instead of separate `model`/`allowed_tools`/`mcp_config` fields

Additional changes:
- **PreToolUse validation hook** (`validate_ai_review_pretool_hook.py`): Simulates proposed edits to `*-ai-review.yaml` files and runs `uv run ai-gene-review validate` on the result *before* applying — blocks invalid edits with exit code 2
- **Model selection inputs**: All agent workflows now offer `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`, `claude-opus-4-7` via `workflow_dispatch` choice input
- **ai-controllers.json**: Expanded allowlist to include `balhoff`, `caufieldjh`, `kevinschaper`
- **Action version upgrades**: All Claude-related workflows updated to `checkout@v6`, `setup-uv@v7`, `claude-code-action@v1`

## Test plan

- [ ] Verify `weekly-compliance.yaml` can be triggered via workflow_dispatch
- [ ] Verify `curation-scanner.yml` can be triggered via workflow_dispatch
- [ ] Verify `post-review-agent.yml` can be triggered via workflow_dispatch with model selection
- [ ] Confirm PreToolUse hook blocks invalid YAML edits locally
- [ ] Confirm existing workflows (`claude.yml`, `claude-code-review.yml`) still work with upgraded actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)