### PR TITLE
Improve publication caching: DOI conversion, active refresh, failure logging

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -1344,6 +1344,16 @@ convert-doi-publications-preview:
     @echo "DOI-keyed files that would be converted:"
     uv run ai-gene-review convert-doi-publications --dry-run
 
+# Refresh publication stubs for genes under active review (IN_PROGRESS or DRAFT)
+refresh-publications-active *args="":
+    @echo "Refreshing publications for active gene reviews..."
+    uv run ai-gene-review refresh-publications-active {{args}}
+
+# Preview what refresh-publications-active would do
+refresh-publications-active-preview:
+    @echo "Active review publications (dry run):"
+    uv run ai-gene-review refresh-publications-active --dry-run
+
 # ============== InterPro Family Data Management ==============
 
 # Fetch PANTHER family metadata via InterPro API and store in interpro/panther/PTHRnnnn/ directory

--- a/project.justfile
+++ b/project.justfile
@@ -1334,6 +1334,16 @@ refresh-publications-force-test count="10":
     @echo "Force refreshing {{count}} publications for testing..."
     uv run ai-gene-review refresh-publications --force-all --count {{count}} --delay 1.0
 
+# Convert DOI-keyed publication files to PMID-keyed format
+convert-doi-publications *args="":
+    @echo "Converting DOI-keyed publication files to PMID format..."
+    uv run ai-gene-review convert-doi-publications {{args}}
+
+# Preview DOI-keyed files that would be converted (dry run)
+convert-doi-publications-preview:
+    @echo "DOI-keyed files that would be converted:"
+    uv run ai-gene-review convert-doi-publications --dry-run
+
 # ============== InterPro Family Data Management ==============
 
 # Fetch PANTHER family metadata via InterPro API and store in interpro/panther/PTHRnnnn/ directory

--- a/src/ai_gene_review/cli.py
+++ b/src/ai_gene_review/cli.py
@@ -11,6 +11,8 @@ from linkml_data_qc.analyzer import ComplianceAnalyzer
 from ai_gene_review.etl.gene import fetch_gene_data, fetch_gene_data_ncRNA, expand_organism_name
 from ai_gene_review.etl.publication import (
     cache_publications,
+    convert_doi_publication,
+    doi_to_pmid,
     extract_pmids_from_yaml,
 )
 from ai_gene_review.etl.publication_refresh import (
@@ -1287,6 +1289,79 @@ def refresh_publications(
         typer.echo(f"Success rate: {success_rate:.1f}%")
 
     typer.echo("\nRefresh complete!")
+
+
+@app.command()
+def convert_doi_publications(
+    publications_dir: Annotated[
+        Path, typer.Option("--dir", help="Publications directory")
+    ] = Path("publications"),
+    dry_run: Annotated[
+        bool, typer.Option("--dry-run", help="Show what would be converted without making changes")
+    ] = False,
+    delay: Annotated[
+        float, typer.Option("--delay", "-d", help="Delay between DOI lookups in seconds")
+    ] = 0.5,
+):
+    """Convert DOI-keyed publication files to PMID-keyed format.
+
+    Finds all DOI_*.md files in the publications directory, resolves each DOI
+    to a PMID via NCBI Entrez, and creates standard PMID-keyed files. The
+    original DOI files are removed after successful conversion.
+
+    Examples:
+        ai-gene-review convert-doi-publications
+        ai-gene-review convert-doi-publications --dry-run
+        ai-gene-review convert-doi-publications --dir ./publications --delay 1.0
+    """
+    import time
+    import yaml
+
+    doi_files = sorted(publications_dir.glob("DOI_*.md"))
+
+    if not doi_files:
+        typer.echo("No DOI-keyed publication files found.")
+        return
+
+    typer.echo(f"Found {len(doi_files)} DOI-keyed publication files.")
+
+    if dry_run:
+        for f in doi_files:
+            typer.echo(f"  Would convert: {f.name}")
+        return
+
+    converted = 0
+    failed = 0
+    skipped = 0
+
+    for i, doi_file in enumerate(doi_files):
+        if i > 0:
+            time.sleep(delay)
+
+        typer.echo(f"[{i + 1}/{len(doi_files)}] {doi_file.name}...")
+        result = convert_doi_publication(doi_file, publications_dir)
+
+        if result:
+            converted += 1
+        elif not doi_file.exists():
+            # File was removed by conversion
+            converted += 1
+        else:
+            # Check if it was skipped (PMID file exists) vs failed (no PMID found)
+            content = doi_file.read_text()
+            parts = content.split("---", 2)
+            if len(parts) >= 3:
+                fm = yaml.safe_load(parts[1])
+                doi = fm.get("doi", "")
+                resolved = doi_to_pmid(doi)
+                if resolved and (publications_dir / f"PMID_{resolved}.md").exists():
+                    skipped += 1
+                else:
+                    failed += 1
+            else:
+                failed += 1
+
+    typer.echo(f"\nConversion complete: {converted} converted, {skipped} skipped (PMID exists), {failed} failed")
 
 
 @app.command()

--- a/src/ai_gene_review/cli.py
+++ b/src/ai_gene_review/cli.py
@@ -19,6 +19,7 @@ from ai_gene_review.etl.publication_refresh import (
     find_pmc_candidates,
     refetch_publications,
     get_refresh_summary,
+    find_active_review_pmids,
 )
 from ai_gene_review.validation import (
     validate_gene_review,
@@ -1362,6 +1363,73 @@ def convert_doi_publications(
                 failed += 1
 
     typer.echo(f"\nConversion complete: {converted} converted, {skipped} skipped (PMID exists), {failed} failed")
+
+
+@app.command()
+def refresh_publications_active(
+    genes_dir: Annotated[
+        Path, typer.Option("--genes-dir", help="Genes directory")
+    ] = Path("genes"),
+    publications_dir: Annotated[
+        Path, typer.Option("--dir", help="Publications directory")
+    ] = Path("publications"),
+    force: Annotated[
+        bool, typer.Option("--force", "-f", help="Force re-download even if cached")
+    ] = False,
+    delay: Annotated[
+        float, typer.Option("--delay", "-d", help="Delay between requests")
+    ] = 0.5,
+    dry_run: Annotated[
+        bool, typer.Option("--dry-run", help="Show what would be refreshed without fetching")
+    ] = False,
+):
+    """Refresh publication stubs for genes under active review.
+
+    Finds gene reviews with status IN_PROGRESS or DRAFT, collects all
+    referenced PMIDs, and refreshes any that are missing or lack full text.
+
+    Examples:
+        ai-gene-review refresh-publications-active
+        ai-gene-review refresh-publications-active --dry-run
+        ai-gene-review refresh-publications-active --force --delay 1.0
+    """
+    typer.echo("Scanning for active gene reviews (IN_PROGRESS, DRAFT)...")
+
+    result = find_active_review_pmids(genes_dir)
+
+    if not result["reviews"]:
+        typer.echo("No active reviews found.")
+        return
+
+    typer.echo(f"Found {len(result['reviews'])} active reviews with {len(result['pmids'])} unique PMIDs")
+
+    for r in result["reviews"]:
+        typer.echo(f"  {r['organism']}/{r['gene']} ({r['status']}) - {r['pmid_count']} PMIDs")
+
+    if dry_run:
+        missing = []
+        stubs = []
+        cached = []
+        for pmid in result["pmids"]:
+            pub_file = publications_dir / f"PMID_{pmid}.md"
+            if not pub_file.exists():
+                missing.append(pmid)
+            elif force:
+                stubs.append(pmid)
+            else:
+                content = pub_file.read_text()
+                if "full_text_available: false" in content or "full_text_available: true" not in content:
+                    stubs.append(pmid)
+                else:
+                    cached.append(pmid)
+
+        typer.echo(f"\n  Missing (need fetch): {len(missing)}")
+        typer.echo(f"  Stubs (need refresh): {len(stubs)}")
+        typer.echo(f"  Cached (have full text): {len(cached)}")
+        return
+
+    success_count = cache_publications(result["pmids"], publications_dir, force, delay)
+    typer.echo(f"\nRefreshed {success_count}/{len(result['pmids'])} publications for active reviews")
 
 
 @app.command()

--- a/src/ai_gene_review/etl/pmc_override_candidates.tsv
+++ b/src/ai_gene_review/etl/pmc_override_candidates.tsv
@@ -1,0 +1,8 @@
+# PMC Override Candidates
+# Publications where PMC full-text retrieval failed during refresh.
+# Review these manually and add confirmed overrides to pmc_overrides.tsv.
+#
+# Columns: PMID	PMCID	failure_reason	date_logged
+# To resolve: verify in browser at https://pmc.ncbi.nlm.nih.gov/articles/PMCNNNNN/
+# If article is not in PMC, add to pmc_overrides.tsv with blank PMCID.
+# If article IS in PMC, investigate why fetch failed and file a bug.

--- a/src/ai_gene_review/etl/publication.py
+++ b/src/ai_gene_review/etl/publication.py
@@ -241,6 +241,110 @@ def extract_pmid(pmid_str: str) -> str:
     return pmid.strip()
 
 
+def doi_to_pmid(doi: str) -> Optional[str]:
+    """Resolve a DOI to a PMID using NCBI Entrez API.
+
+    Uses the ESearch API to look up a DOI in PubMed.
+
+    Args:
+        doi: DOI string (e.g., "10.1038/s41431-018-0141-z")
+
+    Returns:
+        PMID string if found, None otherwise
+
+    Example:
+        >>> # Network-dependent example:
+        >>> # doi_to_pmid("10.1038/s41431-018-0141-z")
+        >>> # '29727692'
+    """
+    try:
+        handle = Entrez.esearch(db="pubmed", term=f"{doi}[DOI]", retmax=1)
+        record = Entrez.read(handle)
+        handle.close()
+
+        id_list = record.get("IdList", [])
+        if id_list:
+            return str(id_list[0])
+        return None
+    except Exception as e:
+        print(f"Error resolving DOI {doi} to PMID: {e}")
+        return None
+
+
+def convert_doi_publication(
+    doi_file: Path,
+    publications_dir: Path,
+    pmid: Optional[str] = None,
+) -> bool:
+    """Convert a DOI-keyed publication file to PMID-keyed format.
+
+    Reads the legacy DOI file (reference_id/content_type schema), resolves
+    the DOI to a PMID if not provided, creates a new PMID-keyed file in
+    the standard schema (pmid/full_text_available), and removes the DOI file.
+
+    Args:
+        doi_file: Path to the DOI-keyed markdown file
+        publications_dir: Directory containing publications
+        pmid: Pre-resolved PMID (skips DOI lookup if provided)
+
+    Returns:
+        True if conversion succeeded, False otherwise
+    """
+    content = doi_file.read_text()
+
+    # Parse frontmatter
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        print(f"Warning: Could not parse frontmatter in {doi_file.name}")
+        return False
+
+    frontmatter = yaml.safe_load(parts[1])
+    doi = frontmatter.get("doi", "")
+
+    # Resolve PMID if not provided
+    if pmid is None:
+        pmid = doi_to_pmid(doi)
+        if pmid is None:
+            print(f"Could not resolve DOI {doi} to PMID")
+            return False
+
+    # Check if PMID file already exists
+    pmid_file = publications_dir / f"PMID_{pmid}.md"
+    if pmid_file.exists():
+        print(f"PMID file already exists: {pmid_file.name}, skipping conversion")
+        return False
+
+    # Build a Publication in the standard schema
+    content_type = frontmatter.get("content_type", "unavailable")
+    full_text_available = content_type not in ("unavailable", "abstract_only")
+
+    # Extract abstract from body if present
+    body = parts[2]
+    abstract = ""
+    if "## Content" in body:
+        abstract_section = body.split("## Content", 1)[1].strip()
+        if abstract_section:
+            abstract = abstract_section
+    if not abstract:
+        abstract = "No abstract available."
+
+    pub = Publication(
+        pmid=pmid,
+        title=frontmatter.get("title", "Unknown title"),
+        authors=frontmatter.get("authors", []),
+        journal=frontmatter.get("journal", "Unknown journal"),
+        year=str(frontmatter.get("year", "Unknown")),
+        abstract=abstract,
+        doi=doi,
+        full_text_available=full_text_available,
+    )
+
+    pmid_file.write_text(pub.to_markdown())
+    doi_file.unlink()
+    print(f"Converted {doi_file.name} -> {pmid_file.name}")
+    return True
+
+
 def get_cached_title(
     pmid: str, cache_dir: Path = Path("publications")
 ) -> Optional[str]:

--- a/src/ai_gene_review/etl/publication.py
+++ b/src/ai_gene_review/etl/publication.py
@@ -257,18 +257,14 @@ def doi_to_pmid(doi: str) -> Optional[str]:
         >>> # doi_to_pmid("10.1038/s41431-018-0141-z")
         >>> # '29727692'
     """
-    try:
-        handle = Entrez.esearch(db="pubmed", term=f"{doi}[DOI]", retmax=1)
-        record = Entrez.read(handle)
-        handle.close()
+    handle = Entrez.esearch(db="pubmed", term=f"{doi}[DOI]", retmax=1)
+    record = Entrez.read(handle)
+    handle.close()
 
-        id_list = record.get("IdList", [])
-        if id_list:
-            return str(id_list[0])
-        return None
-    except Exception as e:
-        print(f"Error resolving DOI {doi} to PMID: {e}")
-        return None
+    id_list = record.get("IdList", [])
+    if id_list:
+        return str(id_list[0])
+    return None
 
 
 def convert_doi_publication(

--- a/src/ai_gene_review/etl/publication_refresh.py
+++ b/src/ai_gene_review/etl/publication_refresh.py
@@ -35,6 +35,7 @@ All refresh operations include rate limiting (0.5-2.0 second delays) to:
 
 import time
 import yaml
+from datetime import date
 from pathlib import Path
 from typing import Dict, List, Optional, Any
 
@@ -197,19 +198,27 @@ def refetch_publications(
                         else:
                             print("  ⚠ Full text too short (may be restricted)")
                             stats["failed"] += 1
+                            if pmcid:
+                                log_pmc_failure(pmid, pmcid, "full_text_too_short")
                     else:
                         print("  ⚠ Still no full text (may be restricted)")
                         stats["failed"] += 1
+                        if pmcid:
+                            log_pmc_failure(pmid, pmcid, "no_full_text_after_refresh")
                 else:
                     print("  ✗ Cache file disappeared")
                     stats["failed"] += 1
             else:
                 print("  ✗ Failed to fetch publication")
                 stats["failed"] += 1
+                if pmcid:
+                    log_pmc_failure(pmid, pmcid, "fetch_failed")
 
         except Exception as e:
             print(f"  ✗ Error: {e}")
             stats["failed"] += 1
+            if pmcid:
+                log_pmc_failure(pmid, pmcid, f"error: {e}")
 
         stats["processed"] += 1
 
@@ -342,3 +351,87 @@ def find_active_review_pmids(
         "pmids": sorted(all_pmids),
         "reviews": reviews,
     }
+
+
+def _get_default_candidates_path() -> Path:
+    """Get the default path for pmc_override_candidates.tsv.
+
+    Searches in the same locations as pmc_overrides.tsv.
+    """
+    candidate_paths = [
+        Path(__file__).parent / "pmc_override_candidates.tsv",
+        Path("src/ai_gene_review/etl/pmc_override_candidates.tsv"),
+        Path("pmc_override_candidates.tsv"),
+    ]
+    for p in candidate_paths:
+        if p.exists():
+            return p
+    # Default to module directory
+    return Path(__file__).parent / "pmc_override_candidates.tsv"
+
+
+def log_pmc_failure(
+    pmid: str,
+    pmcid: str,
+    reason: str,
+    candidates_file: Optional[Path] = None,
+) -> None:
+    """Log a PMC full-text retrieval failure to the candidates file.
+
+    Appends a line to pmc_override_candidates.tsv for manual review.
+    Skips if the PMID is already logged.
+
+    Args:
+        pmid: PubMed ID that failed
+        pmcid: PMC ID that was attempted
+        reason: Short description of the failure
+        candidates_file: Path to candidates TSV (auto-detected if None)
+    """
+    if candidates_file is None:
+        candidates_file = _get_default_candidates_path()
+
+    # Check for existing entry
+    if candidates_file.exists():
+        existing = candidates_file.read_text()
+        for line in existing.splitlines():
+            if line.startswith(f"{pmid}\t"):
+                return  # Already logged
+
+    # Append new entry
+    today = date.today().isoformat()
+    with open(candidates_file, "a") as f:
+        f.write(f"{pmid}\t{pmcid}\t{reason}\t{today}\n")
+
+
+def load_pmc_candidates(
+    candidates_file: Optional[Path] = None,
+) -> Dict[str, Dict[str, str]]:
+    """Load PMC override candidates from the TSV file.
+
+    Args:
+        candidates_file: Path to candidates TSV (auto-detected if None)
+
+    Returns:
+        Dictionary mapping PMID to dict with pmcid, reason, date keys.
+    """
+    if candidates_file is None:
+        candidates_file = _get_default_candidates_path()
+
+    candidates: Dict[str, Dict[str, str]] = {}
+
+    if not candidates_file.exists():
+        return candidates
+
+    for line in candidates_file.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split("\t")
+        if len(parts) >= 3:
+            candidates[parts[0]] = {
+                "pmcid": parts[1],
+                "reason": parts[2],
+                "date": parts[3] if len(parts) >= 4 else "",
+            }
+
+    return candidates

--- a/src/ai_gene_review/etl/publication_refresh.py
+++ b/src/ai_gene_review/etl/publication_refresh.py
@@ -38,7 +38,7 @@ import yaml
 from pathlib import Path
 from typing import Dict, List, Optional, Any
 
-from .publication import cache_publication
+from .publication import cache_publication, extract_pmids_from_yaml
 
 
 def find_pmc_candidates(
@@ -267,4 +267,78 @@ def get_refresh_summary(
         "need_refresh": len(candidates),
         "estimated_success": int(len(candidates) * 0.9),
         "success_rate_estimate": 0.9,
+    }
+
+
+def find_active_review_pmids(
+    genes_dir: Path = Path("genes"),
+    active_statuses: Optional[tuple] = None,
+) -> Dict[str, Any]:
+    """Find all PMIDs referenced by gene reviews under active review.
+
+    Scans gene review YAML files for those with status IN_PROGRESS or DRAFT,
+    and collects all PMIDs referenced in their annotations and references.
+
+    Args:
+        genes_dir: Root directory containing organism/gene subdirectories
+        active_statuses: Tuple of status values to consider active.
+            Defaults to ("IN_PROGRESS", "DRAFT").
+
+    Returns:
+        Dictionary with:
+        - pmids: Deduplicated sorted list of PMID strings
+        - reviews: List of dicts with gene, organism, status, pmid_count
+
+    Examples:
+        >>> import tempfile, yaml
+        >>> from pathlib import Path
+        >>> with tempfile.TemporaryDirectory() as tmpdir:
+        ...     genes_dir = Path(tmpdir)
+        ...     gene_dir = genes_dir / "human" / "TP53"
+        ...     gene_dir.mkdir(parents=True)
+        ...     review = {"id": "P04637", "gene_symbol": "TP53", "status": "IN_PROGRESS", "references": [{"id": "PMID:12345"}]}
+        ...     _ = open(gene_dir / "TP53-ai-review.yaml", "w").write(yaml.dump(review))
+        ...     result = find_active_review_pmids(genes_dir)
+        ...     result["pmids"]
+        ['12345']
+    """
+    if active_statuses is None:
+        active_statuses = ("IN_PROGRESS", "DRAFT")
+
+    all_pmids: set[str] = set()
+    reviews: List[Dict[str, Any]] = []
+
+    for review_file in sorted(genes_dir.glob("*/*/*.yaml")):
+        if not review_file.name.endswith("-ai-review.yaml"):
+            continue
+
+        with open(review_file) as f:
+            data = yaml.safe_load(f)
+
+        if not data:
+            continue
+
+        status = data.get("status", "")
+        if status not in active_statuses:
+            continue
+
+        pmids = extract_pmids_from_yaml(review_file)
+        all_pmids.update(pmids)
+
+        # Derive organism and gene from path: genes/<organism>/<gene>/<gene>-ai-review.yaml
+        parts = review_file.parts
+        gene_idx = len(genes_dir.parts)
+        organism = parts[gene_idx] if len(parts) > gene_idx else "unknown"
+        gene = parts[gene_idx + 1] if len(parts) > gene_idx + 1 else "unknown"
+
+        reviews.append({
+            "gene": gene,
+            "organism": organism,
+            "status": status,
+            "pmid_count": len(pmids),
+        })
+
+    return {
+        "pmids": sorted(all_pmids),
+        "reviews": reviews,
     }

--- a/tests/test_active_refresh.py
+++ b/tests/test_active_refresh.py
@@ -1,0 +1,125 @@
+"""Tests for active review publication refresh."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ai_gene_review.etl.publication_refresh import find_active_review_pmids
+
+
+def test_find_active_review_pmids_in_progress():
+    """Should collect PMIDs from IN_PROGRESS reviews."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        genes_dir = Path(tmpdir)
+
+        gene_dir = genes_dir / "human" / "TP53"
+        gene_dir.mkdir(parents=True)
+        review = {
+            "id": "P04637",
+            "gene_symbol": "TP53",
+            "status": "IN_PROGRESS",
+            "references": [
+                {"id": "PMID:11111"},
+                {"id": "PMID:22222"},
+            ],
+            "existing_annotations": [
+                {"term": {"id": "GO:0005515"}, "original_reference_id": "PMID:33333"},
+            ],
+        }
+        review_file = gene_dir / "TP53-ai-review.yaml"
+        with open(review_file, "w") as f:
+            yaml.dump(review, f)
+
+        result = find_active_review_pmids(genes_dir)
+
+        assert set(result["pmids"]) == {"11111", "22222", "33333"}
+        assert len(result["reviews"]) == 1
+        assert result["reviews"][0]["gene"] == "TP53"
+
+
+def test_find_active_review_pmids_draft():
+    """Should collect PMIDs from DRAFT reviews."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        genes_dir = Path(tmpdir)
+
+        gene_dir = genes_dir / "human" / "BRCA1"
+        gene_dir.mkdir(parents=True)
+        review = {
+            "id": "P38398",
+            "gene_symbol": "BRCA1",
+            "status": "DRAFT",
+            "references": [{"id": "PMID:44444"}],
+        }
+        with open(gene_dir / "BRCA1-ai-review.yaml", "w") as f:
+            yaml.dump(review, f)
+
+        result = find_active_review_pmids(genes_dir)
+
+        assert "44444" in result["pmids"]
+
+
+def test_find_active_review_pmids_skips_complete():
+    """Should NOT collect PMIDs from COMPLETE reviews."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        genes_dir = Path(tmpdir)
+
+        gene_dir = genes_dir / "human" / "CDK1"
+        gene_dir.mkdir(parents=True)
+        review = {
+            "id": "P06493",
+            "gene_symbol": "CDK1",
+            "status": "COMPLETE",
+            "references": [{"id": "PMID:55555"}],
+        }
+        with open(gene_dir / "CDK1-ai-review.yaml", "w") as f:
+            yaml.dump(review, f)
+
+        result = find_active_review_pmids(genes_dir)
+
+        assert "55555" not in result["pmids"]
+        assert len(result["reviews"]) == 0
+
+
+def test_find_active_review_pmids_deduplicates():
+    """PMIDs shared across reviews should appear only once."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        genes_dir = Path(tmpdir)
+
+        for gene in ("A", "B"):
+            gene_dir = genes_dir / "human" / gene
+            gene_dir.mkdir(parents=True)
+            review = {
+                "id": f"Q{gene}",
+                "gene_symbol": gene,
+                "status": "IN_PROGRESS",
+                "references": [{"id": "PMID:77777"}],
+            }
+            with open(gene_dir / f"{gene}-ai-review.yaml", "w") as f:
+                yaml.dump(review, f)
+
+        result = find_active_review_pmids(genes_dir)
+
+        assert result["pmids"].count("77777") == 1
+
+
+@pytest.mark.parametrize("status", ["INITIALIZED", "COMPLETE"])
+def test_find_active_review_pmids_excludes_non_active(status):
+    """Should exclude INITIALIZED and COMPLETE reviews."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        genes_dir = Path(tmpdir)
+        gene_dir = genes_dir / "human" / "TEST"
+        gene_dir.mkdir(parents=True)
+        review = {
+            "id": "Q99999",
+            "gene_symbol": "TEST",
+            "status": status,
+            "references": [{"id": "PMID:88888"}],
+        }
+        with open(gene_dir / "TEST-ai-review.yaml", "w") as f:
+            yaml.dump(review, f)
+
+        result = find_active_review_pmids(genes_dir)
+
+        assert len(result["pmids"]) == 0

--- a/tests/test_doi_conversion.py
+++ b/tests/test_doi_conversion.py
@@ -11,6 +11,7 @@ from ai_gene_review.etl.publication import (
 )
 
 
+@pytest.mark.integration
 def test_doi_to_pmid_returns_none_for_unfound():
     """doi_to_pmid should return None for a DOI that can't be resolved."""
     result = doi_to_pmid("10.9999/nonexistent-fake-doi-xyz")

--- a/tests/test_doi_conversion.py
+++ b/tests/test_doi_conversion.py
@@ -1,0 +1,96 @@
+"""Tests for DOI-to-PMID conversion functionality."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ai_gene_review.etl.publication import (
+    doi_to_pmid,
+    convert_doi_publication,
+)
+
+
+def test_doi_to_pmid_returns_none_for_unfound():
+    """doi_to_pmid should return None for a DOI that can't be resolved."""
+    result = doi_to_pmid("10.9999/nonexistent-fake-doi-xyz")
+    assert result is None
+
+
+@pytest.mark.integration
+def test_doi_to_pmid_real():
+    """Test DOI-to-PMID resolution with a known mapping."""
+    result = doi_to_pmid("10.1038/s41431-018-0141-z")
+    assert result == "29727692"
+
+
+def test_convert_doi_publication_creates_pmid_file():
+    """convert_doi_publication should create a PMID-keyed file and remove the DOI file."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        pub_dir = Path(tmpdir)
+
+        doi_content = """---
+reference_id: DOI:10.1234/test.2024.001
+title: Test Article Title
+authors:
+- Smith J
+- Doe J
+journal: Test Journal
+year: '2024'
+doi: 10.1234/test.2024.001
+content_type: abstract_only
+---
+
+# Test Article Title
+**Authors:** Smith J, Doe J
+**Journal:** Test Journal (2024)
+
+## Content
+
+This is the abstract text.
+"""
+        doi_file = pub_dir / "DOI_10.1234_test.2024.001.md"
+        doi_file.write_text(doi_content)
+
+        result = convert_doi_publication(doi_file, pub_dir, pmid="99887766")
+
+        assert result is True
+        pmid_file = pub_dir / "PMID_99887766.md"
+        assert pmid_file.exists()
+
+        content = pmid_file.read_text()
+        assert "pmid:" in content
+        assert "full_text_available:" in content
+        assert "reference_id:" not in content
+        assert "content_type:" not in content
+
+        assert not doi_file.exists()
+
+
+def test_convert_doi_publication_skips_if_pmid_file_exists():
+    """Should not overwrite an existing PMID file."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        pub_dir = Path(tmpdir)
+
+        doi_file = pub_dir / "DOI_10.1234_test.md"
+        doi_file.write_text("""---
+reference_id: DOI:10.1234/test
+title: Test
+authors: []
+journal: J
+year: '2024'
+doi: 10.1234/test
+content_type: unavailable
+---
+# Test
+""")
+
+        pmid_file = pub_dir / "PMID_11111111.md"
+        pmid_file.write_text("existing content")
+
+        result = convert_doi_publication(doi_file, pub_dir, pmid="11111111")
+
+        assert result is False
+        assert pmid_file.read_text() == "existing content"
+        assert doi_file.exists()

--- a/tests/test_doi_conversion.py
+++ b/tests/test_doi_conversion.py
@@ -4,7 +4,6 @@ import tempfile
 from pathlib import Path
 
 import pytest
-import yaml
 
 from ai_gene_review.etl.publication import (
     doi_to_pmid,

--- a/tests/test_pmc_failure_logging.py
+++ b/tests/test_pmc_failure_logging.py
@@ -3,8 +3,6 @@
 import tempfile
 from pathlib import Path
 
-import pytest
-
 from ai_gene_review.etl.publication_refresh import log_pmc_failure, load_pmc_candidates
 
 

--- a/tests/test_pmc_failure_logging.py
+++ b/tests/test_pmc_failure_logging.py
@@ -1,0 +1,50 @@
+"""Tests for PMC failure candidate logging."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from ai_gene_review.etl.publication_refresh import log_pmc_failure, load_pmc_candidates
+
+
+def test_log_pmc_failure_creates_entry():
+    """Should append a TSV line to the candidates file."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        candidates_file = Path(tmpdir) / "pmc_override_candidates.tsv"
+        candidates_file.write_text("# PMC Override Candidates\n# PMID\tPMCID\tfailure_reason\tdate_logged\n")
+
+        log_pmc_failure("12345", "PMC999999", "html_too_short", candidates_file)
+
+        content = candidates_file.read_text()
+        assert "12345\tPMC999999\thtml_too_short\t" in content
+
+
+def test_log_pmc_failure_does_not_duplicate():
+    """Should not log the same PMID twice."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        candidates_file = Path(tmpdir) / "pmc_override_candidates.tsv"
+        candidates_file.write_text("# header\n")
+
+        log_pmc_failure("12345", "PMC999999", "failed", candidates_file)
+        log_pmc_failure("12345", "PMC999999", "failed_again", candidates_file)
+
+        content = candidates_file.read_text()
+        assert content.count("12345\t") == 1
+
+
+def test_load_pmc_candidates():
+    """Should load candidates from the TSV file."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        candidates_file = Path(tmpdir) / "pmc_override_candidates.tsv"
+        candidates_file.write_text(
+            "# header\n"
+            "12345\tPMC999999\thtml_too_short\t2026-04-24\n"
+            "67890\tPMC888888\tfetch_error\t2026-04-24\n"
+        )
+
+        candidates = load_pmc_candidates(candidates_file)
+
+        assert len(candidates) == 2
+        assert candidates["12345"]["pmcid"] == "PMC999999"
+        assert candidates["67890"]["reason"] == "fetch_error"


### PR DESCRIPTION
## Summary
- Add DOI-to-PMID conversion: `doi_to_pmid()` resolves DOIs via NCBI Entrez, `convert_doi_publication()` converts the 50 DOI-keyed files to standard PMID format
- Add `refresh-publications-active` recipe to refresh publication stubs for IN_PROGRESS/DRAFT gene reviews (538 active reviews)
- Log PMC full-text retrieval failures to `pmc_override_candidates.tsv` for manual review (extends the existing 2-entry `pmc_overrides.tsv` system)

Closes #294

## New CLI Commands
- `ai-gene-review convert-doi-publications [--dry-run] [--delay N]`
- `ai-gene-review refresh-publications-active [--dry-run] [--force] [--delay N]`

## New Just Recipes
- `just convert-doi-publications` / `just convert-doi-publications-preview`
- `just refresh-publications-active` / `just refresh-publications-active-preview`

## Test plan
- [x] `uv run pytest tests/test_doi_conversion.py -v` (3 unit tests)
- [x] `uv run pytest tests/test_active_refresh.py -v` (6 unit tests)
- [x] `uv run pytest tests/test_pmc_failure_logging.py -v` (3 unit tests)
- [ ] `just convert-doi-publications-preview` shows 50 DOI files
- [ ] `just refresh-publications-active-preview` shows active reviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)