### PR TITLE
Improve review workflow: parallel pub caching, fallback providers, status recipes

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -10,10 +10,25 @@ Review the gene specified in $ARGUMENTS.
 
 IMPORTANT: you MUST consult the annotation-reviewer.md subagent for this task.
 
-If the user specifies a deep research provider(s), make sure to perform deep research using at
-least this provider(s), otherwise default to falcon.
+## Step 1: Ensure gene data is fetched
 
-E.g. `just deep-research-falcon ORGANISM GENE_SYMBOL`
+Run `just fetch-gene ORGANISM GENE_SYMBOL` if the gene directory doesn't exist yet.
+
+## Step 2: Run deep research AND publication caching in parallel
+
+Publication caching only needs the GOA file (created by fetch-gene), so it can run
+concurrently with deep research. Launch both at the same time:
+
+- **Deep research**: If the user specifies a deep research provider(s), use that provider(s),
+  otherwise default to falcon. Use `--fallback perplexity-lite` so that if the primary
+  provider times out, it automatically retries with perplexity-lite.
+  E.g. `just deep-research-falcon ORGANISM GENE_SYMBOL --fallback perplexity-lite`
+- **Publication caching**: `just fetch-gene-pmids ORGANISM GENE_SYMBOL`
+
+Run these two steps **in parallel** (e.g. as concurrent background agents or shell jobs).
+Do NOT wait for deep research to finish before starting publication caching.
+
+## Step 3: Fetch additional data (bacterial organisms)
 
 For bacterial organisms (e.g. PSEPK, ECOLI, SALTY, or any prokaryote), after deep research,
 also fetch FEBA/RB-TnSeq fitness data if available:
@@ -24,3 +39,7 @@ just fetch-fitness ORGANISM GENE_SYMBOL
 
 This creates a GENE-fitness.md file with mutant fitness phenotypes and cofitness partners.
 The annotation-reviewer agent will use this data as additional evidence when reviewing annotations.
+
+## Step 4: Run annotation review
+
+Invoke the annotation-reviewer subagent to systematically review all annotations.

--- a/project.justfile
+++ b/project.justfile
@@ -136,10 +136,12 @@ descriptions-status organism *args="":
 
 # Deep research using OpenAI (GPT models)
 # Gene symbol automatically looked up from UniProt file if --alias not provided
+# Supports --fallback PROVIDER [PROVIDER ...] and --timeout SECONDS
 # Examples:
 #   just deep-research-openai human TP53              # gene_symbol=TP53, gene_id=TP53
 #   just deep-research-openai ARATH BRI1              # Looks up gene symbol from UniProt
 #   just deep-research-openai METEA C5B1I4 --alias mllA  # gene_symbol=mllA, gene_id=C5B1I4
+#   just deep-research-openai human TP53 --fallback perplexity-lite  # fallback on failure/timeout
 #   just deep-research-openai human CFAP300 --extra-args --param "model=gpt-4o"
 deep-research-openai organism gene_id *args="":
     uv run python scripts/deep_research_wrapper.py {{organism}} {{gene_id}} openai {{args}}
@@ -1295,6 +1297,94 @@ find-genes-missing-research:
     done
     echo ""
     echo "Summary: $missing_count of $total_count genes lack deep research files"
+
+# Generate per-organism quality dashboard for gene reviews
+# Shows annotation counts, action distribution, coverage gaps
+# Examples:
+#   just quality-report                          # all organisms, terminal output
+#   just quality-report human                    # single organism
+#   just quality-report "" --tsv reports/quality.tsv  # all organisms with TSV output
+quality-report organism="" *args="":
+    #!/usr/bin/env bash
+    cmd="uv run python scripts/quality_report.py {{args}}"
+    if [ -n "{{organism}}" ]; then
+        cmd="$cmd --organism {{organism}}"
+    fi
+    eval "$cmd"
+
+# Show deep research coverage status per organism
+# Displays: total genes, genes with research, missing, and per-provider counts
+# Examples:
+#   just deep-research-status            # all organisms
+#   just deep-research-status human      # single organism
+deep-research-status organism="":
+    #!/usr/bin/env python3
+    import os
+    import sys
+    from collections import defaultdict
+    from pathlib import Path
+    import re
+
+    organism_filter = "{{organism}}"
+    genes_root = Path("genes")
+
+    if organism_filter:
+        org_dirs = [genes_root / organism_filter]
+    else:
+        org_dirs = sorted(p for p in genes_root.iterdir() if p.is_dir())
+
+    grand_total = 0
+    grand_with = 0
+    grand_missing = 0
+    header_printed = False
+    all_missing = []
+
+    for org_dir in org_dirs:
+        if not org_dir.is_dir():
+            continue
+        org = org_dir.name
+        total = 0
+        with_research = 0
+        missing = 0
+        providers = defaultdict(int)
+
+        for gene_dir in sorted(org_dir.iterdir()):
+            if not gene_dir.is_dir():
+                continue
+            total += 1
+            research_files = list(gene_dir.glob("*-deep-research-*.md"))
+            if research_files:
+                with_research += 1
+                for f in research_files:
+                    m = re.search(r'-deep-research-(.+)\.md$', f.name)
+                    if m:
+                        providers[m.group(1)] += 1
+            else:
+                missing += 1
+                all_missing.append(f"{org}/{gene_dir.name}")
+
+        if total == 0:
+            continue
+
+        if not header_printed:
+            print(f"{'ORGANISM':<12s} {'TOTAL':>6s} {'WITH':>6s} {'MISSING':>7s}  PROVIDERS")
+            print(f"{'--------':<12s} {'-----':>6s} {'----':>6s} {'-------':>7s}  ---------")
+            header_printed = True
+
+        prov_str = ", ".join(f"{p}:{providers[p]}" for p in sorted(providers))
+        print(f"{org:<12s} {total:>6d} {with_research:>6d} {missing:>7d}  {prov_str}")
+        grand_total += total
+        grand_with += with_research
+        grand_missing += missing
+
+    if grand_total > 0:
+        print(f"{'--------':<12s} {'-----':>6s} {'----':>6s} {'-------':>7s}")
+        print(f"{'TOTAL':<12s} {grand_total:>6d} {grand_with:>6d} {grand_missing:>7d}")
+
+    if all_missing:
+        print(f"\nGenes missing deep research ({len(all_missing)}):")
+        for g in all_missing:
+            print(f"  {g}")
 
 # ============== Publications Cache Management ==============
 

--- a/scripts/deep_research_wrapper.py
+++ b/scripts/deep_research_wrapper.py
@@ -14,6 +14,9 @@ import sys
 from pathlib import Path
 import re
 
+# Default timeout for deep research subprocess (seconds)
+DEFAULT_TIMEOUT = 600
+
 
 def parse_uniprot_gene_name(uniprot_file: Path) -> str:
     """Extract gene name from UniProt file.
@@ -129,33 +132,17 @@ def parse_uniprot_context(uniprot_file: Path) -> dict:
     return context
 
 
-def run_deep_research(
+def _build_cmd(
     organism: str,
     gene_id: str,
     provider: str,
     gene_symbol: str,
     output_path: Path,
-    uniprot_context: dict = None,
-    extra_args: list = None,
-    use_template: bool = True
-) -> int:
-    """Run deep-research-client with proper arguments.
-
-    Args:
-        organism: Organism name
-        gene_id: Gene identifier (UniProt ID, locus tag, or gene symbol)
-        provider: Provider name (openai, perplexity, perplexity-lite, falcon, cyberian)
-        gene_symbol: Gene symbol/name to use in template
-        output_path: Where to write output
-        uniprot_context: Dictionary with UniProt context fields
-        extra_args: Additional arguments to pass
-        use_template: Whether to use template (False for perplexity-lite)
-
-    Returns:
-        Exit code from deep-research-client
-    """
-    # Map internal provider names to deep-research-client provider names
-    # perplexity-lite is our internal name, but we use perplexity provider with params
+    uniprot_context: dict | None = None,
+    extra_args: list | None = None,
+    use_template: bool = True,
+) -> list[str]:
+    """Build the deep-research-client command list."""
     actual_provider = "perplexity" if provider == "perplexity-lite" else provider
 
     if use_template:
@@ -169,7 +156,6 @@ def run_deep_research(
             "--output", str(output_path)
         ]
 
-        # Add UniProt context variables if available
         if uniprot_context:
             if uniprot_context.get('accession'):
                 cmd.extend(["--var", f"uniprot_accession={uniprot_context['accession']}"])
@@ -179,17 +165,14 @@ def run_deep_research(
             cmd.extend(["--var", f"gene_info={gene_info}"])
             if uniprot_context.get('organism_full'):
                 cmd.extend(["--var", f"organism_full={uniprot_context['organism_full']}"])
-            # Provide default for protein_family if not available
             protein_family = uniprot_context.get('protein_family') or "Not specified in UniProt"
             cmd.extend(["--var", f"protein_family={protein_family}"])
-            # Provide default for protein_domains if not available
             if uniprot_context.get('protein_domains'):
                 domains_str = '; '.join(uniprot_context['protein_domains'])
             else:
                 domains_str = "Not specified in UniProt"
             cmd.extend(["--var", f"protein_domains={domains_str}"])
     else:
-        # For perplexity-lite, use direct query with perplexity provider
         query = (
             f"Research the {gene_symbol} ({gene_id}) gene in {organism}, "
             f"focusing on its molecular function, biological processes, and cellular localization. "
@@ -207,9 +190,80 @@ def run_deep_research(
     if extra_args:
         cmd.extend(extra_args)
 
-    print(f"Running: {' '.join(cmd)}")
-    result = subprocess.run(cmd)
-    return result.returncode
+    return cmd
+
+
+def run_deep_research(
+    organism: str,
+    gene_id: str,
+    provider: str,
+    gene_symbol: str,
+    output_path: Path,
+    uniprot_context: dict | None = None,
+    extra_args: list[str] | None = None,
+    use_template: bool = True,
+    timeout: int = DEFAULT_TIMEOUT,
+    fallback_providers: list[str] | None = None,
+) -> int:
+    """Run deep-research-client with proper arguments.
+
+    Args:
+        organism: Organism name
+        gene_id: Gene identifier (UniProt ID, locus tag, or gene symbol)
+        provider: Provider name (openai, perplexity, perplexity-lite, falcon, cyberian)
+        gene_symbol: Gene symbol/name to use in template
+        output_path: Where to write output
+        uniprot_context: Dictionary with UniProt context fields
+        extra_args: Additional arguments to pass
+        use_template: Whether to use template (False for perplexity-lite)
+        timeout: Timeout in seconds for the subprocess (default 600)
+        fallback_providers: Ordered list of providers to try if the primary provider fails or times out
+
+    Returns:
+        Exit code from deep-research-client
+    """
+    providers_to_try: list[str] = [provider] + list(fallback_providers or [])
+
+    for i, prov in enumerate(providers_to_try):
+        is_fallback = i > 0
+        prov_use_template = use_template if not is_fallback else (prov != "perplexity-lite")
+
+        # Adjust output path for fallback providers
+        if is_fallback:
+            prov_output = output_path.parent / f"{output_path.stem.rsplit('-', 1)[0]}-{prov}{output_path.suffix}"
+        else:
+            prov_output = output_path
+
+        cmd = _build_cmd(
+            organism=organism,
+            gene_id=gene_id,
+            provider=prov,
+            gene_symbol=gene_symbol,
+            output_path=prov_output,
+            uniprot_context=uniprot_context,
+            extra_args=extra_args,
+            use_template=prov_use_template,
+        )
+
+        label = f"[fallback {i}/{len(providers_to_try)-1}] " if is_fallback else ""
+        print(f"{label}Running: {' '.join(cmd)}")
+        print(f"{label}Timeout: {timeout}s")
+
+        try:
+            result = subprocess.run(cmd, timeout=timeout)
+            if result.returncode == 0:
+                return 0
+            print(f"Provider {prov} exited with code {result.returncode}", file=sys.stderr)
+        except subprocess.TimeoutExpired:
+            print(f"Provider {prov} timed out after {timeout}s", file=sys.stderr)
+
+        if i < len(providers_to_try) - 1:
+            next_prov = providers_to_try[i + 1]
+            print(f"Trying fallback provider: {next_prov}", file=sys.stderr)
+
+    # All providers failed
+    print("All providers failed", file=sys.stderr)
+    return 1
 
 
 def main():
@@ -221,6 +275,19 @@ def main():
     parser.add_argument("gene_id", help="Gene identifier (UniProt ID, locus tag, or gene symbol)")
     parser.add_argument("provider", help="Provider (openai, perplexity, perplexity-lite, falcon)")
     parser.add_argument("--alias", help="Gene symbol alias (if not provided, will lookup from UniProt)")
+    parser.add_argument(
+        "--fallback",
+        nargs="+",
+        metavar="PROVIDER",
+        help="Ordered list of fallback providers to try if the primary provider fails or times out "
+             "(e.g. --fallback perplexity-lite falcon)"
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT,
+        help=f"Timeout in seconds for each provider attempt (default: {DEFAULT_TIMEOUT})"
+    )
     parser.add_argument("--extra-args", nargs=argparse.REMAINDER, help="Extra args to pass to deep-research-client")
 
     args = parser.parse_args()
@@ -287,7 +354,9 @@ def main():
         output_path=output_file,
         uniprot_context=uniprot_context,
         extra_args=args.extra_args,
-        use_template=use_template
+        use_template=use_template,
+        timeout=args.timeout,
+        fallback_providers=args.fallback,
     )
 
 

--- a/scripts/quality_report.py
+++ b/scripts/quality_report.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Generate per-organism quality dashboards for gene reviews.
+
+Scans all gene review YAML files and produces a summary report with:
+- Annotation counts and action distribution
+- Deep research and core function coverage
+- Review completeness metrics
+
+Usage:
+    python scripts/quality_report.py                    # all organisms
+    python scripts/quality_report.py --organism human   # single organism
+    python scripts/quality_report.py --tsv reports/quality.tsv  # TSV output
+"""
+
+import argparse
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import yaml
+
+
+def load_review(path: Path) -> dict | None:
+    """Load a gene review YAML file, returning None on failure."""
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def analyze_gene(gene_dir: Path, review: dict) -> dict:
+    """Analyze a single gene's review quality."""
+    gene = gene_dir.name
+    annotations = review.get("existing_annotations") or []
+    actions: Counter[str] = Counter()
+    for ann in annotations:
+        r = ann.get("review") or {}
+        action = r.get("action", "PENDING")
+        actions[action] += 1
+
+    core_functions = review.get("core_functions") or []
+    has_deep_research = any(gene_dir.glob("*-deep-research-*.md"))
+    has_description = bool(review.get("description"))
+    references = review.get("references") or []
+    status = review.get("status", "unknown")
+
+    reviewed_count = sum(
+        1 for ann in annotations
+        if (ann.get("review") or {}).get("action", "PENDING") != "PENDING"
+    )
+
+    return {
+        "gene": gene,
+        "status": status,
+        "total_annotations": len(annotations),
+        "reviewed_annotations": reviewed_count,
+        "actions": dict(actions),
+        "has_core_functions": len(core_functions) > 0,
+        "core_function_count": len(core_functions),
+        "has_deep_research": has_deep_research,
+        "has_description": has_description,
+        "reference_count": len(references),
+    }
+
+
+def print_organism_report(organism: str, gene_stats: list[dict]) -> None:
+    """Print a formatted report for one organism."""
+    n = len(gene_stats)
+    if n == 0:
+        return
+
+    total_ann = sum(g["total_annotations"] for g in gene_stats)
+    reviewed_ann = sum(g["reviewed_annotations"] for g in gene_stats)
+    all_actions: Counter[str] = Counter()
+    for g in gene_stats:
+        all_actions.update(g["actions"])
+
+    with_core = sum(1 for g in gene_stats if g["has_core_functions"])
+    with_research = sum(1 for g in gene_stats if g["has_deep_research"])
+    with_desc = sum(1 for g in gene_stats if g["has_description"])
+    fully_reviewed = sum(
+        1 for g in gene_stats
+        if g["reviewed_annotations"] == g["total_annotations"] and g["total_annotations"] > 0
+    )
+
+    print(f"\n{'='*60}")
+    print(f" {organism}  ({n} genes)")
+    print(f"{'='*60}")
+    print(f"  Annotations:      {total_ann} total, {reviewed_ann} reviewed ({_pct(reviewed_ann, total_ann)})")
+    print(f"  Fully reviewed:   {fully_reviewed}/{n} genes ({_pct(fully_reviewed, n)})")
+    print(f"  Core functions:   {with_core}/{n} genes ({_pct(with_core, n)})")
+    print(f"  Deep research:    {with_research}/{n} genes ({_pct(with_research, n)})")
+    print(f"  Has description:  {with_desc}/{n} genes ({_pct(with_desc, n)})")
+
+    if all_actions:
+        print("\n  Action distribution:")
+        for action in sorted(all_actions, key=lambda a: -all_actions[a]):
+            count = all_actions[action]
+            print(f"    {action:<25s} {count:>5d}  ({_pct(count, total_ann)})")
+
+    # Flag genes needing attention
+    incomplete = [
+        g for g in gene_stats
+        if g["reviewed_annotations"] < g["total_annotations"]
+    ]
+    if incomplete:
+        print(f"\n  Genes with unreviewed annotations ({len(incomplete)}):")
+        for g in sorted(incomplete, key=lambda x: x["reviewed_annotations"] / max(x["total_annotations"], 1)):
+            pending = g["total_annotations"] - g["reviewed_annotations"]
+            print(f"    {g['gene']:<20s} {pending} pending of {g['total_annotations']}")
+
+
+def _pct(num: int, denom: int) -> str:
+    if denom == 0:
+        return "N/A"
+    return f"{100 * num / denom:.0f}%"
+
+
+def write_tsv(all_stats: dict[str, list[dict]], output_path: Path) -> None:
+    """Write detailed per-gene TSV report."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    header = [
+        "organism", "gene", "status", "total_annotations", "reviewed_annotations",
+        "pct_reviewed", "has_core_functions", "core_function_count",
+        "has_deep_research", "has_description", "reference_count",
+        "ACCEPT", "MODIFY", "REMOVE", "KEEP_AS_NON_CORE",
+        "MARK_AS_OVER_ANNOTATED", "UNDECIDED", "NEW", "PENDING",
+    ]
+    with open(output_path, "w") as f:
+        f.write("\t".join(header) + "\n")
+        for organism in sorted(all_stats):
+            for g in sorted(all_stats[organism], key=lambda x: x["gene"]):
+                pct = (
+                    f"{100 * g['reviewed_annotations'] / g['total_annotations']:.0f}"
+                    if g["total_annotations"] > 0 else "N/A"
+                )
+                row = [
+                    organism, g["gene"], g["status"],
+                    str(g["total_annotations"]), str(g["reviewed_annotations"]),
+                    pct,
+                    str(g["has_core_functions"]), str(g["core_function_count"]),
+                    str(g["has_deep_research"]), str(g["has_description"]),
+                    str(g["reference_count"]),
+                ]
+                for action in ["ACCEPT", "MODIFY", "REMOVE", "KEEP_AS_NON_CORE",
+                               "MARK_AS_OVER_ANNOTATED", "UNDECIDED", "NEW", "PENDING"]:
+                    row.append(str(g["actions"].get(action, 0)))
+                f.write("\t".join(row) + "\n")
+    print(f"\nTSV report written to {output_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate per-organism quality dashboards")
+    parser.add_argument("--organism", help="Restrict to a single organism")
+    parser.add_argument("--tsv", metavar="PATH", help="Write detailed TSV report to PATH")
+    args = parser.parse_args()
+
+    genes_root = Path("genes")
+    if not genes_root.is_dir():
+        print("Error: genes/ directory not found", file=sys.stderr)
+        return 1
+
+    all_stats: dict[str, list[dict]] = defaultdict(list)
+
+    if args.organism:
+        org_dirs = [genes_root / args.organism]
+    else:
+        org_dirs = sorted(p for p in genes_root.iterdir() if p.is_dir())
+
+    for org_dir in org_dirs:
+        if not org_dir.is_dir():
+            continue
+        organism = org_dir.name
+
+        for gene_dir in sorted(org_dir.iterdir()):
+            if not gene_dir.is_dir():
+                continue
+            review_path = gene_dir / f"{gene_dir.name}-ai-review.yaml"
+            if not review_path.exists():
+                continue
+
+            review = load_review(review_path)
+            if review is None:
+                continue
+
+            stats = analyze_gene(gene_dir, review)
+            all_stats[organism].append(stats)
+
+    if not all_stats:
+        print("No gene reviews found", file=sys.stderr)
+        return 1
+
+    for organism in sorted(all_stats):
+        print_organism_report(organism, all_stats[organism])
+
+    # Grand total
+    total_genes = sum(len(v) for v in all_stats.values())
+    total_ann = sum(g["total_annotations"] for gs in all_stats.values() for g in gs)
+    reviewed_ann = sum(g["reviewed_annotations"] for gs in all_stats.values() for g in gs)
+    print(f"\n{'='*60}")
+    print(f" GRAND TOTAL: {total_genes} genes across {len(all_stats)} organisms")
+    print(f" Annotations: {total_ann} total, {reviewed_ann} reviewed ({_pct(reviewed_ann, total_ann)})")
+    print(f"{'='*60}")
+
+    if args.tsv:
+        write_tsv(all_stats, Path(args.tsv))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- **Parallelize pub caching with deep research** in `/review` skill — `fetch-gene-pmids` only needs the GOA file, so it runs concurrently with deep research instead of waiting
- **Add `--fallback` and `--timeout` flags** to `deep_research_wrapper.py` — explicit provider fallback chains (e.g. `--fallback perplexity-lite`) with configurable timeout (default 600s)
- **Add `just deep-research-status`** recipe — per-organism table showing total/with/missing gene counts and provider breakdown
- **Add `just quality-report`** recipe — per-organism dashboards with annotation counts, action distribution, review completeness, core function coverage

## Test plan
- [x] `just deep-research-status human` — produces correct table with provider counts
- [x] `uv run python scripts/quality_report.py --organism human` — produces dashboard with 533 genes, 85% reviewed
- [x] `ruff check` passes on changed files
- [x] Pre-existing mypy errors unchanged (3 in `parse_uniprot_context`, not introduced by this PR)
- [ ] Manual test: `just deep-research-falcon human TP53 --fallback perplexity-lite` with a short `--timeout 5` to verify fallback triggers

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)