### PR TITLE
AATF: resolve UNDECIDED GO:0030968 (UPR) using cached PMID:19911006

### DIFF
--- a/genes/human/AATF/AATF-ai-review.yaml
+++ b/genes/human/AATF/AATF-ai-review.yaml
@@ -139,17 +139,25 @@ existing_annotations:
   original_reference_id: GO_REF:0000107
   review:
     summary: >-
-      IEA annotation transferred from mouse ortholog via Ensembl Compara. There is no
-      direct experimental evidence in the literature linking AATF to the ER unfolded protein
-      response in the publications reviewed. AATF is primarily characterized as a nuclear/nucleolar
-      protein involved in transcription regulation, ribosome biogenesis, and DNA damage response.
-    action: UNDECIDED
+      IEA annotation transferred from mouse ortholog via Ensembl Compara. The role of AATF
+      in the UPR is directly supported by Ishigaki et al. 2010 (PMID:19911006), which showed
+      that AATF is induced by ER stress through the PERK-eIF2alpha pathway and acts as an
+      antiapoptotic transcriptional cofactor that drives AKT1 expression via STAT3 in
+      pancreatic beta-cells. Knockdown of AATF sensitizes cells to ER stress-mediated death.
+    action: KEEP_AS_NON_CORE
     reason: >-
-      None of the reviewed literature (PMID:10580117, PMID:10783144, PMID:12847090,
-      PMID:17157788, PMID:22909821, PMID:34516797, or the falcon deep research) mentions
-      a role for AATF in the ER unfolded protein response. This may reflect a mouse-specific
-      finding or an over-annotation from the ortholog transfer. Without access to the
-      underlying mouse data, marking as UNDECIDED rather than removing.
+      The UPR/antiapoptotic role is well-supported experimentally (PMID:19911006) but is a
+      context-specific secondary function of AATF rather than a core activity. AATF's core
+      functions are SSU processome / 40S ribosome biogenesis (PMID:34516797) and
+      transcription coactivator activity at TP53/CDKN1A and other promoters
+      (PMID:12847090, PMID:17157788). The UPR contribution is downstream of the more
+      general transcription coactivator activity acting on the AKT1 promoter via STAT3, so
+      it is appropriately retained as non-core rather than promoted to a core function.
+    supported_by:
+      - reference_id: PMID:19911006
+        supporting_text: "AATF is induced by ER stress through the PERK-eIF2alpha pathway and transcriptionally activates the v-akt murine thymoma viral oncogene homolog 1 (AKT1) gene through signal transducer and activator of transcription 3 (Stat3), which sustains Akt1 activation and promotes cell survival"
+      - reference_id: PMID:19911006
+        supporting_text: "RNAi-mediated knockdown of AATF or AKT1 renders cells sensitive to ER stress"
 - term:
     id: GO:0005515
     label: protein binding
@@ -908,6 +916,35 @@ references:
         responses to DNA damage.
       reference_section_type: ABSTRACT
       full_text_unavailable: true
+- id: PMID:19911006
+  title: AATF mediates an antiapoptotic effect of the unfolded protein response through
+    transcriptional regulation of AKT1.
+  findings:
+    - statement: >-
+        AATF is induced by ER stress through the PERK-eIF2alpha pathway and is an
+        antiapoptotic component of the unfolded protein response.
+      supporting_text: >-
+        We show that AATF is induced by ER stress through the PERK-eIF2alpha pathway and
+        transcriptionally activates the v-akt murine thymoma viral oncogene homolog 1 (AKT1)
+        gene through signal transducer and activator of transcription 3 (Stat3), which
+        sustains Akt1 activation and promotes cell survival.
+      reference_section_type: ABSTRACT
+    - statement: >-
+        AATF acts as a transcriptional cofactor that drives AKT1 expression via STAT3,
+        sustaining AKT1 activation to promote cell survival under ER stress.
+      supporting_text: >-
+        Ectopic expression of AATF or a constitutively active form of AKT1 confers on cells
+        resistance to ER stress-mediated cell death, whereas RNAi-mediated knockdown of AATF
+        or AKT1 renders cells sensitive to ER stress.
+      reference_section_type: ABSTRACT
+    - statement: >-
+        AATF and WFS1 form a positive feedback loop in pancreatic beta-cells, and loss of
+        either drives a self-perpetuating cycle of ER-stress-mediated cell death.
+      supporting_text: >-
+        We also discovered a positive crosstalk between the AATF and WFS1 signaling pathways.
+        Thus, WFS1 deficiency or AATF deficiency mediates a self-perpetuating cycle of cell
+        death.
+      reference_section_type: ABSTRACT
 - id: PMID:22658674
   title: Insights into RNA biology from an atlas of mammalian mRNA-binding proteins.
   findings:


### PR DESCRIPTION
## Summary

Resolves the single `UNDECIDED` annotation in the AATF review (`GO:0030968` endoplasmic reticulum unfolded protein response) using PMID:19911006 (Ishigaki et al. 2010, *Cell Death Differ*), which is already cached in `publications/`.

The original triage on #270 explicitly flagged this paper as the key reference establishing AATF as a PERK–eIF2α-induced antiapoptotic UPR component that drives AKT1 transcription via STAT3, but it was not consulted by the merged review (#272), which left the annotation as `UNDECIDED` citing lack of literature.

### Changes
- `existing_annotations` entry for GO:0030968: `UNDECIDED` → `KEEP_AS_NON_CORE` with two `supported_by` entries citing PMID:19911006
- `references`: add PMID:19911006 with three structured findings drawn from the abstract
- UPR role retained as non-core (not promoted to a core function) because AATF's core activities are SSU processome / 40S biogenesis (PMID:34516797) and transcription coactivator activity at TP53/CDKN1A and other promoters (PMID:12847090, PMID:17157788). The UPR contribution is a downstream context-specific application of the coactivator activity.

### Validation
`just validate human AATF` → ✓ Valid

## Test plan
- [x] Schema validation passes
- [ ] Reviewer confirms KEEP_AS_NON_CORE is the right call vs ACCEPT (UPR role is real and substrate-specific, but secondary to the core ribosome biogenesis / transcription coactivator functions already captured)

Refs #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)