### PR TITLE
VCP: add GO:0007084 NEW annotation (mitotic nuclear membrane reassembly)

### DIFF
--- a/genes/human/VCP/VCP-ai-review.yaml
+++ b/genes/human/VCP/VCP-ai-review.yaml
@@ -3715,7 +3715,7 @@ existing_annotations:
 - term:
     id: GO:0007084
     label: mitotic nuclear membrane reassembly
-  evidence_type: IMP
+  evidence_type: TAS
   original_reference_id: PMID:26040713
   review:
     summary: >-
@@ -3727,11 +3727,16 @@ existing_annotations:
       to the telophase NE, and reduces post-mitotic nucleo-cytoplasmic compartmentalization.
     action: NEW
     reason: >-
-      Direct experimental support in human cells (HeLa, diploid fibroblasts) for
-      VCP/p97 in mitotic NE reformation, mechanistically distinct from the ERAD,
-      autophagy, DDR, mitochondrial-QC and RQC core functions already captured.
-      Flagged as a gap in the prior scanner pass on issue #268; resolved here using
-      the cached primary reference (Olmos et al. 2015, Nature).
+      Mechanistically distinct from the ERAD, autophagy, DDR, mitochondrial-QC and
+      RQC core functions already captured. Flagged as a gap in the prior scanner
+      pass on issue #268. Evidence code TAS (rather than IMP) reflects that the
+      direct siRNA experiments in PMID:26040713 deplete the UFD1 adaptor, not VCP
+      itself; VCP/p97's role is established by a traceable author statement in the
+      same paper ("The p97 AAA-ATPase controls both phases of NE reformation...
+      through its adaptors NPL4 and UFD1 it regulates annular fusion", citing prior
+      work as reference 6). Direct VCP-manipulation primary references are not
+      currently in the publications cache; if added later, this annotation can be
+      promoted to IMP.
     supported_by:
     - reference_id: PMID:26040713
       supporting_text: >-
@@ -3741,7 +3746,8 @@ existing_annotations:
         regulates annular fusion.
     - reference_id: PMID:26040713
       supporting_text: >-
-        recruitment of CHMP2A to the forming NE was impaired
+        whilst cells depleted for UFD1 recruited CHMP2A to the midbody (Figure 3D),
+        recruitment of CHMP2A to the forming NE was impaired (Figure 3C and 3D).
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO

--- a/genes/human/VCP/VCP-ai-review.yaml
+++ b/genes/human/VCP/VCP-ai-review.yaml
@@ -3715,29 +3715,52 @@ existing_annotations:
 - term:
     id: GO:0007084
     label: mitotic nuclear membrane reassembly
-  evidence_type: TAS
-  original_reference_id: PMID:26040713
+  evidence_type: IMP
+  original_reference_id: PMID:18097415
   review:
     summary: >-
       VCP/p97, with its UFD1-NPL4 adaptors, drives annular fusion of the post-mitotic
       nuclear envelope by extracting ubiquitinated chromatin substrates (notably
       Aurora-B) and recruiting ESCRT-III (CHMP2A) to nucleo-cytoplasmic channels in
       the forming NE; the p47 adaptor separately controls membrane delivery and NE
-      expansion. UFD1 depletion delays NE-rim formation, impairs CHMP2A recruitment
-      to the telophase NE, and reduces post-mitotic nucleo-cytoplasmic compartmentalization.
+      expansion. Direct p97 manipulation in vitro and in cells (Hetzer 2001, Ramadan
+      2007) establishes the requirement; UFD1-adaptor depletion (Olmos 2015) delays
+      NE-rim formation, impairs CHMP2A recruitment to the telophase NE, and reduces
+      post-mitotic nucleo-cytoplasmic compartmentalization, defining the downstream
+      ESCRT-III recruitment step.
     action: NEW
     reason: >-
       Mechanistically distinct from the ERAD, autophagy, DDR, mitochondrial-QC and
       RQC core functions already captured. Flagged as a gap in the prior scanner
-      pass on issue #268. Evidence code TAS (rather than IMP) reflects that the
-      direct siRNA experiments in PMID:26040713 deplete the UFD1 adaptor, not VCP
-      itself; VCP/p97's role is established by a traceable author statement in the
-      same paper ("The p97 AAA-ATPase controls both phases of NE reformation...
-      through its adaptors NPL4 and UFD1 it regulates annular fusion", citing prior
-      work as reference 6). Direct VCP-manipulation primary references are not
-      currently in the publications cache; if added later, this annotation can be
-      promoted to IMP.
+      pass on issue #268. Evidence code IMP is supported by direct p97 manipulation
+      in PMID:18097415 (Ramadan et al. 2007, Nature) — "p97 stimulates nucleus
+      reformation by inactivating the chromatin-associated kinase Aurora B" via
+      ubiquitin-dependent extraction — and PMID:11781570 (Hetzer et al. 2001, Nat
+      Cell Biol) which dissected two discrete p97 functions in NE assembly using
+      in vitro reconstitution (p97-Ufd1-Npl4 for closed NE formation, p97-p47 for
+      NE growth). PMID:26040713 (Olmos et al. 2015) is retained as supporting
+      evidence for the downstream UFD1-dependent CHMP2A recruitment step. References
+      11781570 and 18097415 were identified via the structured bibliography of
+      PMID:26040713 (PMC4471131 XML, refs 6 and 20) — verified primary sources, not
+      guessed PMIDs.
     supported_by:
+    - reference_id: PMID:18097415
+      supporting_text: >-
+        Here we show that p97 stimulates nucleus reformation by inactivating the
+        chromatin-associated kinase Aurora B.
+    - reference_id: PMID:18097415
+      supporting_text: >-
+        During exit from mitosis, p97 binds to Aurora B after its ubiquitylation
+        and extracts it from chromatin. This leads to inactivation of Aurora B on
+        chromatin, thus allowing chromatin decondensation and nuclear envelope
+        formation.
+    - reference_id: PMID:11781570
+      supporting_text: >-
+        Here we show that p97, an AAA-ATPase previously implicated in fusion of
+        Golgi and transitional endoplasmic reticulum (ER) membranes together with
+        the adaptor p47, has two discrete functions in NE assembly. Formation of a
+        closed NE requires the p97-Ufd1-Npl4 complex, not previously implicated in
+        membrane fusion. Subsequent NE growth involves a p97-p47 complex.
     - reference_id: PMID:26040713
       supporting_text: >-
         The p97 AAA-ATPase controls both phases of NE reformation; in concert with
@@ -4052,6 +4075,47 @@ references:
 - id: PMID:25959826
   title: Quantitative interaction proteomics of neurodegenerative disease proteins.
   findings: []
+- id: PMID:11781570
+  title: Distinct AAA-ATPase p97 complexes function in discrete steps of nuclear assembly.
+  findings:
+    - statement: >-
+        p97 has two discrete functions in nuclear envelope assembly: the p97-Ufd1-Npl4
+        complex is required for formation of a closed NE, while a separate p97-p47
+        complex mediates subsequent NE growth. Established by in vitro reconstitution.
+      supporting_text: >-
+        Here we show that p97, an AAA-ATPase previously implicated in fusion of
+        Golgi and transitional endoplasmic reticulum (ER) membranes together with
+        the adaptor p47, has two discrete functions in NE assembly. Formation of a
+        closed NE requires the p97-Ufd1-Npl4 complex, not previously implicated in
+        membrane fusion. Subsequent NE growth involves a p97-p47 complex.
+      reference_section_type: ABSTRACT
+- id: PMID:18097415
+  title: Cdc48/p97 promotes reformation of the nucleus by extracting the kinase Aurora
+    B from chromatin.
+  findings:
+    - statement: >-
+        Direct experimental evidence that p97 (VCP) is required for nuclear
+        reformation after mitosis. p97 binds ubiquitylated Aurora B and extracts
+        it from chromatin, releasing Aurora-B inhibition of chromatin decondensation
+        and NE formation.
+      supporting_text: >-
+        Here we show that p97 stimulates nucleus reformation by inactivating the
+        chromatin-associated kinase Aurora B. During mitosis, Aurora B inhibits
+        nucleus reformation by preventing chromosome decondensation and formation
+        of the nuclear envelope membrane. During exit from mitosis, p97 binds to
+        Aurora B after its ubiquitylation and extracts it from chromatin. This
+        leads to inactivation of Aurora B on chromatin, thus allowing chromatin
+        decondensation and nuclear envelope formation.
+      reference_section_type: ABSTRACT
+    - statement: >-
+        Defines ubiquitin-dependent protein extraction by Cdc48/p97 as the
+        mechanistic basis for p97's role in nucleus formation, paralleling its
+        well-known activity in ERAD and other quality-control pathways.
+      supporting_text: >-
+        These data reveal an essential pathway that regulates reformation of the
+        nucleus after mitosis and defines ubiquitin-dependent protein extraction
+        as a common mechanism of Cdc48/p97 activity also during nucleus formation.
+      reference_section_type: ABSTRACT
 - id: PMID:26040713
   title: ESCRT-III controls nuclear envelope reformation.
   findings:

--- a/genes/human/VCP/VCP-ai-review.yaml
+++ b/genes/human/VCP/VCP-ai-review.yaml
@@ -3712,6 +3712,36 @@ existing_annotations:
     reason: >-
       Core mitochondrial quality control function. VCP extracts ubiquitinated OMM proteins
       for proteasomal degradation. Supported by direct experimental evidence.
+- term:
+    id: GO:0007084
+    label: mitotic nuclear membrane reassembly
+  evidence_type: IMP
+  original_reference_id: PMID:26040713
+  review:
+    summary: >-
+      VCP/p97, with its UFD1-NPL4 adaptors, drives annular fusion of the post-mitotic
+      nuclear envelope by extracting ubiquitinated chromatin substrates (notably
+      Aurora-B) and recruiting ESCRT-III (CHMP2A) to nucleo-cytoplasmic channels in
+      the forming NE; the p47 adaptor separately controls membrane delivery and NE
+      expansion. UFD1 depletion delays NE-rim formation, impairs CHMP2A recruitment
+      to the telophase NE, and reduces post-mitotic nucleo-cytoplasmic compartmentalization.
+    action: NEW
+    reason: >-
+      Direct experimental support in human cells (HeLa, diploid fibroblasts) for
+      VCP/p97 in mitotic NE reformation, mechanistically distinct from the ERAD,
+      autophagy, DDR, mitochondrial-QC and RQC core functions already captured.
+      Flagged as a gap in the prior scanner pass on issue #268; resolved here using
+      the cached primary reference (Olmos et al. 2015, Nature).
+    supported_by:
+    - reference_id: PMID:26040713
+      supporting_text: >-
+        The p97 AAA-ATPase controls both phases of NE reformation; in concert with
+        its adaptor protein p47, it regulates membrane delivery and NE expansion
+        whilst through its adaptors Nuclear Protein Like 4 (NPL4) and UFD1 it
+        regulates annular fusion.
+    - reference_id: PMID:26040713
+      supporting_text: >-
+        recruitment of CHMP2A to the forming NE was impaired
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
@@ -4016,6 +4046,37 @@ references:
 - id: PMID:25959826
   title: Quantitative interaction proteomics of neurodegenerative disease proteins.
   findings: []
+- id: PMID:26040713
+  title: ESCRT-III controls nuclear envelope reformation.
+  findings:
+    - statement: >-
+        The p97 AAA-ATPase, via its UFD1 and NPL4 adaptors, controls annular fusion
+        during post-mitotic nuclear envelope reformation, while its p47 adaptor
+        separately controls membrane delivery and NE expansion.
+      supporting_text: >-
+        The p97 AAA-ATPase controls both phases of NE reformation; in concert with
+        its adaptor protein p47, it regulates membrane delivery and NE expansion
+        whilst through its adaptors Nuclear Protein Like 4 (NPL4) and UFD1 it
+        regulates annular fusion.
+      reference_section_type: RESULTS
+    - statement: >-
+        Through NPL4 and UFD1, the p97 complex extracts ubiquitinated Aurora-B from
+        chromatin to enable chromatin decondensation and membranation during NE
+        reformation.
+      supporting_text: >-
+        through its adaptors Nuclear Protein Like 4 (NPL4) and UFD1 it regulates
+        annular fusion. Through NPL4 and UFD1, the p97 complex extracts ubiquitinated
+        Aurora-B, a Chromosomal Passenger Complex (CPC) component, from chromatin to
+        allow chromatin decondensation and membranation
+      reference_section_type: RESULTS
+    - statement: >-
+        UFD1 (a p97 cofactor) is required for ESCRT-III (CHMP2A) recruitment to the
+        forming nuclear envelope; UFD1 depletion impairs CHMP2A recruitment to the
+        telophase NE and reduces post-mitotic nucleo-cytoplasmic compartmentalization
+        in human cells (HeLa).
+      supporting_text: >-
+        recruitment of CHMP2A to the forming NE was impaired
+      reference_section_type: RESULTS
 - id: PMID:26265139
   title: UBXN2A regulates nicotinic receptor degradation by modulating the E3 ligase
     activity of CHIP.

--- a/genes/human/VCP/VCP-notes.md
+++ b/genes/human/VCP/VCP-notes.md
@@ -45,3 +45,36 @@ is a real, correctly-identified primary reference (ref 21 of Olmos 2015) and
 may be useful for future annotations in the chromosome-segregation context,
 and (b) caching reflects evaluation work that future reviewers should not
 have to repeat.
+
+### Experimental systems supporting the IMP evidence code
+
+The IMP evidence code on GO:0007084 annotates *human* VCP (P55072), but the
+two direct-p97 manipulation primary references use heterologous /
+reconstitution systems rather than direct loss-of-function in human cells:
+
+- **PMID:11781570 (Hetzer 2001)** — in vitro NE assembly reconstitution.
+  The abstract describes two discrete p97 functions dissected by direct
+  manipulation of the AAA-ATPase in a reconstituted assembly system, not
+  by p97 depletion in cultured cells.
+- **PMID:18097415 (Ramadan 2007)** — explicitly states "In vitro, nucleus
+  formation requires p97" in the abstract. The Aurora-B chromatin-extraction
+  mechanism is established by direct p97 manipulation in this in vitro
+  nucleus-formation system, with corroborating in-cell data on p97-Aurora-B
+  binding after ubiquitylation.
+- **PMID:26040713 (Olmos 2015)** — the only primary reference in the
+  `supported_by` set with direct loss-of-function data in human cells (HeLa,
+  diploid fibroblasts). Olmos depletes UFD1 (a VCP adaptor), not VCP itself,
+  which is the indirect-evidence concern that motivated the IMP→TAS interim
+  on commit `3d7c271c`.
+
+Annotating human VCP with IMP via direct p97 manipulation in in vitro / in
+egg-extract systems is standard GO practice (cross-species annotation by
+orthology, with the in vitro reconstitution providing the strongest
+mechanistic dissection). This note documents the experimental-system
+limitation transparently so a future curator does not need to re-derive it.
+
+A direct human-cell VCP loss-of-function experiment in an NE-reformation
+assay (e.g., VCP siRNA, NMS-873, or CB-5083 in HeLa/RPE-1 with NE-rim
+imaging) would further strengthen the IMP annotation. This was raised as a
+non-blocking suggestion by claude-review on commit `2407bdcf` and is left as
+a future-pass concern.

--- a/genes/human/VCP/VCP-notes.md
+++ b/genes/human/VCP/VCP-notes.md
@@ -1,0 +1,47 @@
+# VCP review notes
+
+## NE reformation annotation (GO:0007084) — primary reference selection
+
+The `GO:0007084` (mitotic nuclear membrane reassembly) NEW annotation in
+`VCP-ai-review.yaml` cites three references in `supported_by`:
+
+- **PMID:18097415** — Ramadan et al. 2007, *Nature* — primary IMP reference;
+  direct p97 manipulation showing p97 binds ubiquitylated Aurora-B and
+  extracts it from chromatin during exit from mitosis.
+- **PMID:11781570** — Hetzer et al. 2001, *Nat Cell Biol* — direct in vitro
+  dissection of two discrete p97 functions in NE assembly: p97-Ufd1-Npl4 for
+  closed NE formation, p97-p47 for NE growth.
+- **PMID:26040713** — Olmos et al. 2015, *Nature* — retained as supporting
+  evidence for the downstream UFD1-dependent CHMP2A recruitment step.
+
+PMIDs 11781570 and 18097415 were identified via the structured bibliography
+of PMID:26040713 (PMC4471131 NCBI eutils XML, refs 6 and 20) — verified
+primary sources, not guessed.
+
+### PMID:21486945 — cached but intentionally excluded
+
+`publications/PMID_21486945.md` (Dobrynin et al. 2011, *J Cell Sci*,
+"Cdc48/p97-Ufd1-Npl4 antagonizes Aurora B during chromosome segregation in
+HeLa cells") was cached during the same pass that added the direct-VCP
+primary references, but is **not** cited in `supported_by` for GO:0007084.
+
+Reasons for exclusion:
+
+1. **Wrong process focus.** The paper's experimental data and conclusions
+   concern Aurora-B antagonism on prometaphase/metaphase chromosomes during
+   chromosome alignment and segregation, not post-mitotic NE reformation.
+   The relevant GO terms would be in the chromosome-segregation /
+   spindle-checkpoint area, not `GO:0007084`.
+2. **Indirect for VCP.** The siRNA experiments deplete Ufd1-Npl4 (the
+   adaptor complex), not VCP itself — the same indirect-evidence concern
+   that motivated switching the original Olmos-only annotation to TAS in
+   commit `3d7c271c`.
+3. **Already covered.** The Aurora-B / chromatin extraction mechanism that
+   *is* relevant to NE reformation is more directly established by
+   PMID:18097415 (Ramadan 2007), which manipulates p97 directly.
+
+The file was retained in `publications/` rather than removed because (a) it
+is a real, correctly-identified primary reference (ref 21 of Olmos 2015) and
+may be useful for future annotations in the chromosome-segregation context,
+and (b) caching reflects evaluation work that future reviewers should not
+have to repeat.

--- a/publications/PMID_11781570.md
+++ b/publications/PMID_11781570.md
@@ -1,0 +1,50 @@
+---
+pmid: '11781570'
+title: Distinct AAA-ATPase p97 complexes function in discrete steps of nuclear assembly.
+authors:
+- Hetzer M
+- Meyer HH
+- Walther TC
+- Bilbao-Cortes D
+- Warren G
+- Mattaj IW
+journal: Nat Cell Biol
+year: '2001'
+full_text_available: false
+doi: 10.1038/ncb1201-1086
+---
+
+# Distinct AAA-ATPase p97 complexes function in discrete steps of nuclear assembly.
+**Authors:** Hetzer M, Meyer HH, Walther TC, Bilbao-Cortes D, Warren G, Mattaj IW
+**Journal:** Nat Cell Biol (2001)
+**DOI:** [10.1038/ncb1201-1086](https://doi.org/10.1038/ncb1201-1086)
+
+## Abstract
+
+1. Nat Cell Biol. 2001 Dec;3(12):1086-91. doi: 10.1038/ncb1201-1086.
+
+Distinct AAA-ATPase p97 complexes function in discrete steps of nuclear 
+assembly.
+
+Hetzer M(1), Meyer HH, Walther TC, Bilbao-Cortes D, Warren G, Mattaj IW.
+
+Author information:
+(1)European Molecular Biology Laboratory, Meyerhofstrasse 1, D-69117 Heidelberg, 
+Germany.
+
+Comment in
+    Nat Cell Biol. 2001 Dec;3(12):E273-4. doi: 10.1038/ncb1201-e273.
+
+Although nuclear envelope (NE) assembly is known to require the GTPase Ran, the 
+membrane fusion machinery involved is uncharacterized. NE assembly involves 
+formation of a reticular network on chromatin, fusion of this network into a 
+closed NE and subsequent expansion. Here we show that p97, an AAA-ATPase 
+previously implicated in fusion of Golgi and transitional endoplasmic reticulum 
+(ER) membranes together with the adaptor p47, has two discrete functions in NE 
+assembly. Formation of a closed NE requires the p97-Ufd1-Npl4 complex, not 
+previously implicated in membrane fusion. Subsequent NE growth involves a 
+p97-p47 complex. This study provides the first insights into the molecular 
+mechanisms and specificity of fusion events involved in NE formation.
+
+DOI: 10.1038/ncb1201-1086
+PMID: 11781570 [Indexed for MEDLINE]

--- a/publications/PMID_18097415.md
+++ b/publications/PMID_18097415.md
@@ -1,0 +1,55 @@
+---
+pmid: '18097415'
+title: Cdc48/p97 promotes reformation of the nucleus by extracting the kinase Aurora
+  B from chromatin.
+authors:
+- Ramadan K
+- Bruderer R
+- Spiga FM
+- Popp O
+- Baur T
+- Gotta M
+- Meyer HH
+journal: Nature
+year: '2007'
+full_text_available: false
+doi: 10.1038/nature06388
+---
+
+# Cdc48/p97 promotes reformation of the nucleus by extracting the kinase Aurora B from chromatin.
+**Authors:** Ramadan K, Bruderer R, Spiga FM, Popp O, Baur T, Gotta M, Meyer HH
+**Journal:** Nature (2007)
+**DOI:** [10.1038/nature06388](https://doi.org/10.1038/nature06388)
+
+## Abstract
+
+1. Nature. 2007 Dec 20;450(7173):1258-62. doi: 10.1038/nature06388.
+
+Cdc48/p97 promotes reformation of the nucleus by extracting the kinase Aurora B 
+from chromatin.
+
+Ramadan K(1), Bruderer R, Spiga FM, Popp O, Baur T, Gotta M, Meyer HH.
+
+Author information:
+(1)Institute of Biochemistry, ETH Zurich, 8093 Zurich, Switzerland.
+
+During division of metazoan cells, the nucleus disassembles to allow chromosome 
+segregation, and then reforms in each daughter cell. Reformation of the nucleus 
+involves chromatin decondensation and assembly of the double-membrane nuclear 
+envelope around the chromatin; however, regulation of the process is still 
+poorly understood. In vitro, nucleus formation requires p97 (ref. 3), a 
+hexameric ATPase implicated in membrane fusion and ubiquitin-dependent 
+processes. However, the role and relevance of p97 in nucleus formation have 
+remained controversial. Here we show that p97 stimulates nucleus reformation by 
+inactivating the chromatin-associated kinase Aurora B. During mitosis, Aurora B 
+inhibits nucleus reformation by preventing chromosome decondensation and 
+formation of the nuclear envelope membrane. During exit from mitosis, p97 binds 
+to Aurora B after its ubiquitylation and extracts it from chromatin. This leads 
+to inactivation of Aurora B on chromatin, thus allowing chromatin decondensation 
+and nuclear envelope formation. These data reveal an essential pathway that 
+regulates reformation of the nucleus after mitosis and defines 
+ubiquitin-dependent protein extraction as a common mechanism of Cdc48/p97 
+activity also during nucleus formation.
+
+DOI: 10.1038/nature06388
+PMID: 18097415 [Indexed for MEDLINE]

--- a/publications/PMID_21486945.md
+++ b/publications/PMID_21486945.md
@@ -1,0 +1,57 @@
+---
+pmid: '21486945'
+title: Cdc48/p97-Ufd1-Npl4 antagonizes Aurora B during chromosome segregation in HeLa
+  cells.
+authors:
+- Dobrynin G
+- Popp O
+- Romer T
+- Bremer S
+- Schmitz MH
+- Gerlich DW
+- Meyer H
+journal: J Cell Sci
+year: '2011'
+full_text_available: false
+doi: 10.1242/jcs.069500
+---
+
+# Cdc48/p97-Ufd1-Npl4 antagonizes Aurora B during chromosome segregation in HeLa cells.
+**Authors:** Dobrynin G, Popp O, Romer T, Bremer S, Schmitz MH, Gerlich DW, Meyer H
+**Journal:** J Cell Sci (2011)
+**DOI:** [10.1242/jcs.069500](https://doi.org/10.1242/jcs.069500)
+
+## Abstract
+
+1. J Cell Sci. 2011 May 1;124(Pt 9):1571-80. doi: 10.1242/jcs.069500. Epub 2011
+Apr  12.
+
+Cdc48/p97-Ufd1-Npl4 antagonizes Aurora B during chromosome segregation in HeLa 
+cells.
+
+Dobrynin G(1), Popp O, Romer T, Bremer S, Schmitz MH, Gerlich DW, Meyer H.
+
+Author information:
+(1)Centre for Medical Biotechnology, University of Duisburg-Essen, 45117 Essen, 
+Germany.
+
+During exit from mitosis in Xenopus laevis egg extracts, the AAA+ ATPase 
+Cdc48/p97 (also known as VCP in vertebrates) and its adapter Ufd1-Npl4 remove 
+the kinase Aurora B from chromatin to allow nucleus formation. Here, we show 
+that in HeLa cells Ufd1-Npl4 already antagonizes Aurora B on chromosomes during 
+earlier mitotic stages and that this is crucial for proper chromosome 
+segregation. Depletion of Ufd1-Npl4 by small interfering RNA (siRNA) caused 
+chromosome alignment and anaphase defects resulting in missegregated chromosomes 
+and multi-lobed nuclei. Ufd1-Npl4 depletion also led to increased levels of 
+Aurora B on prometaphase and metaphase chromosomes. This increase was associated 
+with higher Aurora B activity, as evidenced by the partial resistance of CENP-A 
+phosphorylation to the Aurora B inhibitor hesperadin. Furthermore, low 
+concentrations of hesperadin partially rescued chromosome alignment in 
+Ufd1-depleted cells, whereas, conversely, Ufd1-depletion partially restored 
+congression in the presence of hesperadin. These data establish 
+Cdc48/p97-Ufd1-Npl4 as a crucial negative regulator of Aurora B early in mitosis 
+of human somatic cells and suggest that the activity of Aurora B on chromosomes 
+needs to be restrained to ensure faithful chromosome segregation.
+
+DOI: 10.1242/jcs.069500
+PMID: 21486945 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary

Adds a `NEW` annotation `GO:0007084` (mitotic nuclear membrane reassembly) to the VCP review, closing the NE-reformation gap flagged on #268.

The merged review (#269) captured 5 core functions — ERAD, autophagy/lysophagy, DDR, mitochondrial QC, RQC — but the role of VCP/p97 in post-mitotic nuclear envelope reformation (a mechanistically distinct membrane-remodeling activity) was not covered.

### Evolution of this PR (3 commits)

1. **`1fc83584`** — initial draft, `evidence_type: IMP`, primary ref `PMID:26040713` (Olmos 2015). claude-review flagged this as IMP-via-adaptor-depletion (the siRNA in Olmos targets UFD1, not VCP itself).
2. **`3d7c271c`** — conservative interim: switched `IMP → TAS` on the same Olmos reference; expanded one supporting quote with UFD1 context. claude-review approved with non-blocking suggestions.
3. **`2407bdcf`** — current state: promoted back to `IMP` after fetching the actual direct-p97 primary references (identified via the structured bibliography of PMC4471131, refs 6 and 20 — verified, not guessed).

### Current state (commit 2407bdcf)

- **Annotation:** `GO:0007084` (mitotic nuclear membrane reassembly), `action: NEW`, `evidence_type: IMP`, `original_reference_id: PMID:18097415`
- **Five `supported_by` quotes** across three primary references:
  - `PMID:18097415` (Ramadan et al. 2007, *Nature*) — direct p97 manipulation: "p97 stimulates nucleus reformation by inactivating the chromatin-associated kinase Aurora B"; mechanistic detail of p97 binding ubiquitylated Aurora-B and extracting it from chromatin
  - `PMID:11781570` (Hetzer et al. 2001, *Nat Cell Biol*) — in vitro reconstitution dissecting two discrete p97 functions: p97-Ufd1-Npl4 for closed NE formation, p97-p47 for NE growth
  - `PMID:26040713` (Olmos et al. 2015, *Nature*) — retained as supporting evidence for the downstream UFD1-dependent CHMP2A recruitment step
- **Three new publication files cached:** `publications/PMID_11781570.md`, `publications/PMID_18097415.md`, `publications/PMID_21486945.md` (Dobrynin 2011 cached for completeness; not cited because its focus is chromosome segregation, not NE reformation)
- **`references` block:** structured findings added for PMID:11781570, PMID:18097415, PMID:26040713

### Validation
`just validate human VCP` → ✓ Valid (only the same pre-existing deep-research density warning; no regression).

### Why a NEW existing-annotation rather than a 6th core_function
The molecular activity is the same one already captured in core_functions[1] (ERAD), [3] (DDR), and [4] (mito-QC) — ATP-dependent extraction of ubiquitinated substrates via the UFD1-NPL4 adaptor — just deployed at the post-mitotic NE. Capturing as a NEW annotation flags the cellular context without inflating the core-function list. Confirmed approvable by claude-review on commits `3d7c271c` and `2407bdcf`.

## Test plan
- [x] Schema validation passes
- [x] Reviewer confirms `GO:0007084` is the correct term vs. `GO:0006998` (nuclear envelope organization)
- [x] Reviewer confirms keeping this as a NEW existing-annotation rather than promoting to a 6th `core_function`
- [x] IMP evidence backed by direct-p97 primary references (Ramadan 2007, Hetzer 2001), not adaptor-depletion alone

> **Review state note:** Formal `reviewDecision` still reads `CHANGES_REQUESTED` from the original review on commit `1fc83584` (the initial IMP draft). The two later claude-review comments — on `3d7c271c` (TAS) and `2407bdcf` (IMP-promoted) — both find the PR APPROVABLE. Maintainers should treat the latest review comment as the current state.

Refs #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)
