### PR TITLE
ATF3: resolve UNDECIDED protein binding annotation (#307)

### DIFF
--- a/genes/human/ATF3/ATF3-ai-review.yaml
+++ b/genes/human/ATF3/ATF3-ai-review.yaml
@@ -504,17 +504,18 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:10327051
   review:
-    summary: The cached abstract for this protein-binding row concerns ATF2/p300/c-jun and does not mention
-      ATF3, but the full text is unavailable locally to verify the IntAct ATF3-JUN interaction assertion.
-    action: UNDECIDED
-    reason: The accessible abstract does not provide direct ATF3 interaction evidence, while the GOA row
-      asserts an IntAct IPI interaction with JUN. Because the relevant full text was not available, this
-      should remain undecided rather than removed outright; even if verified, the generic protein binding
-      term would still be less informative than a dimerization-specific annotation.
+    summary: This is a generic protein binding row from interaction data; ATF3 dimerization is real, but
+      this term does not capture the informative function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: ATF3 function depends on bZIP homo- and heterodimerization, and several interaction screens
+      identify ATF3 partners. However, protein binding is too generic for curator use here. Specific dimerization
+      annotations and transcription-factor complex annotations better represent the biologically meaningful
+      interaction function. Same treatment applied to all other GO:0005515 IPI rows in this review.
     supported_by:
-    - reference_id: PMID:10327051
-      supporting_text: The N-terminal transactivation domain of ATF2 is a target for the co-operative
-        activation of the c-jun promoter by p300 and 12S E1A.
+    - reference_id: file:human/ATF3/ATF3-deep-research-falcon.md
+      supporting_text: Human ATF3 is best annotated as a stress-inducible nuclear bZIP transcription factor that binds CRE-like motifs and acts via partner-dependent dimerization to remodel transcriptional programs across stress, immunity, metabolism, and cell fate.
+    - reference_id: PMID:28186491
+      supporting_text: Genome-wide binding of ATF3 is best explained by considering many dimers in which it participates.
 - term:
     id: GO:0005515
     label: protein binding


### PR DESCRIPTION
## Summary

Resolves the lone `UNDECIDED` annotation in `genes/human/ATF3/ATF3-ai-review.yaml` (issue #307) as `MARK_AS_OVER_ANNOTATED`, completing the cleanup of the ATF3 review.

| Annotation | Evidence | Resolution |
|---|---|---|
| `GO:0005515` protein binding | IPI, PMID:10327051 (IntAct ATF3-JUN row) | `MARK_AS_OVER_ANNOTATED` — `protein binding` is uninformative per CLAUDE.md guidance regardless of whether the underlying interaction is verifiable; matches treatment of 7 other `GO:0005515` IPI rows in the same file |

## Why this is straightforward

ATF3 has 8 `GO:0005515` IPI annotations from different IntAct rows. The other 7 (PMID:18255255, 19164757, 20102225, 20211142, 23661758, 25609649, 27107012) are all `MARK_AS_OVER_ANNOTATED` with identical `summary`/`reason` text, supported by the deep-research file plus PMID:28186491 (genome-wide ATF3 dimer survey).

The lone `UNDECIDED` row (PMID:10327051) was held back because the cached abstract of that 1999 paper is about ATF2/p300/c-jun and doesn't directly mention ATF3 — the reviewer was being conservative. But the original `reason` text already concedes the point:

> "even if verified, the generic protein binding term would still be less informative than a dimerization-specific annotation"

That's the textbook `MARK_AS_OVER_ANNOTATED` case. CLAUDE.md is explicit: *"Avoid the term `protein binding`, this doesn't tell us anything about the actual function."* This fix aligns the row with the consistent treatment elsewhere in the same file.

The IntAct ATF3-JUN interaction itself is well-established field biology (referenced in PMID:28186491); only the term granularity is the issue.

## Test plan

- [x] `just validate human ATF3` → ✅ Valid (3 pre-existing warnings unrelated to this change — they concern ACCEPT/REMOVE inconsistencies on three transcription-related terms, untouched by this PR)
- [x] No remaining `UNDECIDED` actions: `grep -c "action: UNDECIDED" genes/human/ATF3/ATF3-ai-review.yaml` → 0
- [ ] Maintainer sanity-check on the over-annotation reasoning

Same pattern as PR #317 for BCAP31 (#309) and PR #304 for AATF (#270): a single low-risk loose-end cleanup on an otherwise complete review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)