### PR TITLE
[codex] Complete human review batch 05

### DIFF
--- a/genes/human/PFDN1/PFDN1-ai-review.html
+++ b/genes/human/PFDN1/PFDN1-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>PFDN1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/O60925" target="_blank" class="term-link">
                         O60925
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>PFDN1 (Prefoldin subunit 1) encodes a beta-type subunit of the heterohexameric prefoldin complex (also known as GimC). The prefoldin complex is a jellyfish-shaped molecular chaperone composed of two alpha subunits (PFDN3, PFDN5) and four beta subunits (PFDN1, PFDN2, PFDN4, PFDN6). Prefoldin functions as a co-chaperone/holdase that captures unfolded nascent polypeptides -- primarily actin and tubulin -- and delivers them to the group II chaperonin TRiC/CCT for ATP-dependent folding. The prefoldin-TRiC interaction is mediated through a conserved electrostatic interface, and PFD alternates between open &#34;latched&#34; and closed &#34;engaged&#34; conformations during substrate transfer (PMID:30955883). The client repertoire extends beyond cytoskeletal proteins: prefoldin stabilizes the von Hippel-Lindau tumor suppressor protein (pVHL) against aggregation and degradation, with prefoldin knockdown reducing pVHL expression (DOI:10.1371/journal.pgen.1009183). A 2024 DIP-MS (deep interactome profiling) study resolved canonical and alternative prefoldin assemblies in human cells, demonstrating that prefoldin may exist in modular complex isoforms potentially underlying context-specific functions (DOI:10.1038/s41592-024-02211-y). Beyond its cytosolic chaperone role, PFDN1 has non-canonical nuclear functions in cancer contexts: it can repress cyclin A transcription via direct promoter interaction, promoting EMT and metastasis through a TGF-beta1/PFDN1/cyclin A axis in lung cancer (DOI:10.1038/onc.2016.257). Prefoldin has also been shown to inhibit amyloid-beta fibrillation and alpha-synuclein aggregation, suggesting roles in neuroprotection. PFDN1 is ubiquitously expressed and located on chromosome 5.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,77 +795,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0006457 &#34;protein folding&#34; is a well-supported core function of PFDN1. This IBA annotation was inferred from phylogenetic analysis (PANTHER) with evidence from yeast GimC/prefoldin (SGD:S000003715), Arabidopsis, and human PFDN1 itself. The prefoldin complex is a bona fide co-chaperone that captures unfolded nascent polypeptides (primarily actin and tubulin) and delivers them to TRiC/CCT for ATP-dependent folding (PMID:9630229). Gestaut et al. 2019 (PMID:30955883) showed that PFD enhances the rate and yield of TRiC-mediated folding, directly demonstrating involvement in protein folding. The Reactome pathway R-HSA-389957 &#34;Prefoldin mediated transfer of substrate to CCT/TriC&#34; also supports this annotation. This is the central biological process for PFDN1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein folding is the core biological process for all prefoldin subunits. The IBA annotation is phylogenetically well-supported and consistent with the extensive experimental literature demonstrating prefoldin&#39;s role in delivering substrates to TRiC/CCT for folding (PMID:9630229, PMID:30955883).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We describe the discovery of a heterohexameric chaperone protein, prefoldin, based on its ability to capture unfolded actin. Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PFDN1/PFDN1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Prefoldin is a conserved hetero-hexameric cochaperone complex that binds non-native polypeptides, protects exposed hydrophobic regions to prevent aggregation, and transfers/shuttles folding clients to the cytosolic chaperonin TRiC/CCT for productive folding.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -877,88 +888,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). This IBA annotation was inferred from phylogenetic analysis (PANTHER) with evidence from yeast (SGD:S000003715) and human PFDN1 itself. While prefoldin does indeed bind unfolded proteins, the term &#34;unfolded protein binding&#34; is a pure binding term that fails to capture the functional significance of this interaction. Prefoldin acts as a holdase/transfer chaperone: it captures unfolded substrates (primarily actin and tubulin) and delivers them to the TRiC/CCT chaperonin for folding. As described in Vainberg et al. 1998 (PMID:9630229), &#34;Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.&#34; The more appropriate term is GO:0044183 &#34;protein folding chaperone&#34; which captures the functional chaperone activity rather than just substrate binding. Notably, PFDN1 already has an IBA annotation to GO:0044183 in this same annotation set.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. The term describes only a binding activity and does not capture the chaperone function of prefoldin. Prefoldin is a molecular chaperone that binds unfolded substrates and delivers them to TRiC/CCT for folding (PMID:9630229, PMID:30955883). GO:0044183 &#34;protein folding chaperone&#34; (defined as &#34;Binding to a protein or a protein-containing complex to assist the protein folding process&#34;) is the recommended replacement and already exists as a separate IBA annotation for this gene.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFD alternates between an open &#34;latched&#34; conformation and a closed &#34;engaged&#34; conformation that aligns the PFD-TRiC substrate binding chambers.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -970,77 +981,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005737 &#34;cytoplasm&#34; is an appropriate cellular component annotation for PFDN1. This IBA annotation was inferred from phylogenetic analysis (PANTHER) with evidence from C. elegans (WB:WBGene00007443). The prefoldin complex is a cytoplasmic chaperone that operates in the cytosol to capture unfolded nascent polypeptides and deliver them to the cytosolic chaperonin TRiC/CCT (PMID:9630229). The UniProt GO cross-references list this annotation, and the GOA qualifier &#34;is_active_in&#34; confirms that PFDN1 is active in the cytoplasm. Liang et al. 2020 (PMID:32699605) describe prefoldin as &#34;a cytoplasmic chaperone protein.&#34; The term &#34;cytoplasm&#34; is appropriately broad, as a more specific CC annotation to &#34;prefoldin complex&#34; (GO:0016272) is already present in this annotation set. Having both is correct: one describes the subcellular location and the other describes the complex membership.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PFDN1 operates as part of the cytoplasmic prefoldin complex. The cytoplasm annotation is well-supported and appropriately broad, complementing the more specific prefoldin complex (GO:0016272) annotation. The IBA phylogenetic inference is sound (PMID:9630229, PMID:32699605).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link">
                                         PMID:32699605
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">As a cytoplasmic chaperone protein, the prefoldin complex is a hybrid oligomer assembled from six different proteins (six subunits).</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     GO:0044183
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1052,77 +1063,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0044183 &#34;protein folding chaperone&#34; (defined as &#34;Binding to a protein or a protein-containing complex to assist the protein folding process&#34;) is the most appropriate molecular function term for PFDN1. This IBA annotation was inferred from phylogenetic analysis (PANTHER) with evidence from human PFDN1 itself. Prefoldin functions as a holdase/transfer chaperone that captures unfolded nascent polypeptides and delivers them to TRiC/CCT for folding (PMID:9630229). Gestaut et al. 2019 (PMID:30955883) demonstrated that the PFD-TRiC supra-chaperone assembly enhances folding rates and suppresses non-productive reaction cycles. This term precisely captures the functional role of PFDN1 as a co-chaperone that assists in protein folding, and is also the recommended replacement for the obsoleting GO:0051082 &#34;unfolded protein binding.&#34;
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is the core molecular function of PFDN1. The prefoldin complex is a bona fide protein folding chaperone that captures unfolded substrates and delivers them to TRiC/CCT (PMID:9630229, PMID:30955883). The IBA annotation is phylogenetically well-supported and represents the best available MF term for prefoldin subunits.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We describe the discovery of a heterohexameric chaperone protein, prefoldin, based on its ability to capture unfolded actin. Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1134,46 +1145,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0006457 &#34;protein folding&#34; inferred electronically from InterPro domain mapping (IPR002777, the prefoldin beta-like domain). This IEA annotation is consistent with the IBA and IDA annotations to the same term, and with the well-established role of the prefoldin complex in protein folding (PMID:9630229). The InterPro-to-GO mapping is appropriate for this domain.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The IEA annotation to protein folding via InterPro is correct and consistent with the higher-confidence IBA and IDA annotations. The prefoldin beta-like domain (IPR002777) is specifically associated with the protein folding function of the prefoldin complex (PMID:9630229, PMID:30955883).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016272" target="_blank" class="term-link">
                                     GO:0016272
                                 </a>
                             </span>
                             <span class="term-label">prefoldin complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1185,46 +1196,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0016272 &#34;prefoldin complex&#34; inferred electronically from InterPro domain mapping (IPR002777, the prefoldin beta-like domain). PFDN1 is one of the four beta subunits (PFDN1, PFDN2, PFDN4, PFDN6) of the heterohexameric prefoldin complex (PMID:9630229, PMID:32699605). The complex is also registered in ComplexPortal as CPX-6149 and CPX-25767. This IEA annotation is consistent with the IDA annotations to the same term from PMID:30955883 and PMID:23614719.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PFDN1 is a core structural subunit of the prefoldin complex. The IEA mapping from the prefoldin beta-like domain (IPR002777) to prefoldin complex membership is appropriate and consistent with experimental evidence (PMID:9630229, PMID:30955883).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
                                     GO:0032991
                                 </a>
                             </span>
                             <span class="term-label">protein-containing complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1236,46 +1247,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0032991 &#34;protein-containing complex&#34; was inferred electronically by the ARBA machine learning model (ARBA:ARBA00028902). While technically correct -- PFDN1 is part of the prefoldin complex, which is indeed a protein-containing complex -- this annotation is redundant and overly general given the more specific GO:0016272 &#34;prefoldin complex&#34; annotation that is already present in this annotation set from both IEA (InterPro) and IDA (PMID:30955883, PMID:23614719) evidence. The term &#34;protein-containing complex&#34; adds no informational value beyond what is already captured.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is an overly general annotation. PFDN1 is part of the prefoldin complex (GO:0016272), which is a child term of protein-containing complex. The more specific term is already annotated with both IEA and IDA evidence. The generic &#34;protein-containing complex&#34; adds no useful information.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1287,99 +1298,99 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). This IEA annotation was inferred electronically from InterPro domain mapping (IPR002777, the prefoldin beta-like domain). The InterPro-to-GO mapping associates the prefoldin domain with unfolded protein binding, which is functionally accurate in that prefoldin subunits do contact unfolded substrates. However, since the term is being obsoleted, the annotation should be replaced with GO:0044183 &#34;protein folding chaperone&#34; which better describes the functional role of the prefoldin complex as a holdase/transfer chaperone that delivers substrates to TRiC/CCT. As noted by Liang et al. 2020 (PMID:32699605), &#34;The prefoldin complex helps protein fold correctly and prevents aggregation by providing class II chaperones ... with a linear, unnatural substrate in the cytoplasm.&#34;
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. While the InterPro mapping correctly identifies that the prefoldin domain binds unfolded proteins, the replacement term GO:0044183 &#34;protein folding chaperone&#34; better captures the functional role of prefoldin as a chaperone that assists in protein folding by delivering unfolded substrates to the TRiC/CCT chaperonin (PMID:32699605, PMID:9630229).
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link">
                                         PMID:32699605
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The prefoldin complex helps protein fold correctly and prevents aggregation by providing class II chaperones (Hsp60 molecular chaperones found in archaebacteria and eukaryotic cytoplasm) with a linear, unnatural substrate in the cytoplasm [2]</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16169070" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16169070
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A human protein-protein interaction network: a resource for ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1391,57 +1402,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:Q9Y2X7/GIT1) from Stelzl et al. 2005 (PMID:16169070), a large-scale yeast two-hybrid screen of the human proteome. The interaction between PFDN1 and GIT1 (G protein-coupled receptor kinase interacting ArfGAP 1) was identified in this high-throughput screen. GIT1 is involved in cell signaling and cytoskeletal organization. While this could represent a biologically relevant interaction (GIT1 is involved in cytoskeletal remodeling, and prefoldin assists in actin/tubulin folding), the &#34;protein binding&#34; term is uninformative. However, the interaction itself is from a large-scale screen and may not reflect a direct functional relationship.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is an uninformative term that does not describe any specific molecular function. The interaction with GIT1 (Q9Y2X7) was detected in a high-throughput Y2H screen (PMID:16169070), and while the interaction may be real, the GO term provides no functional insight. More informative annotations such as GO:0044183 &#34;protein folding chaperone&#34; already capture the core binding function of PFDN1.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16876117" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16876117
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interaction of hepatitis C virus F protein with prefoldin 2 ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1453,75 +1464,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:Q9UHV9/PFDN2) from Tsao et al. 2006 (PMID:16876117). This study used yeast two-hybrid and co-immunoprecipitation to demonstrate that HCV F protein interacts with PFDN2, and that HCV F protein &#34;impeded the interaction between prefoldin 1 and 2.&#34; This confirms the PFDN1-PFDN2 interaction, which is expected since they are both subunits of the same heterohexameric prefoldin complex. The UniProt record confirms this interaction (NbExp=6). However, &#34;protein binding&#34; is uninformative -- this interaction reflects prefoldin complex assembly rather than a generic binding function. The annotation is not wrong but the term is too vague to be useful.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. The PFDN1-PFDN2 interaction reflects subunit assembly within the prefoldin complex and is already captured by the GO:0016272 &#34;prefoldin complex&#34; CC annotation. The PMID:16876117 study was primarily about HCV F protein interaction with PFDN2, not PFDN1 function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16876117" target="_blank" class="term-link">
                                         PMID:16876117
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">In the yeast three-hybrid system, it was found that expression of HCV F protein impeded the interaction between prefoldin 1 and 2.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21900206" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21900206
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A directed protein interaction network for investigating int...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1533,57 +1544,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:Q9Y2X7/GIT1) from Vinayagam et al. 2011 (PMID:21900206), a directed protein interaction network study. This is a second independent detection of the PFDN1-GIT1 interaction (also seen in PMID:16169070). While the replication adds some confidence that the interaction is real, &#34;protein binding&#34; remains uninformative as a GO annotation for PFDN1. The biological significance of a PFDN1-GIT1 interaction is unclear.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. This high-throughput interaction screen detection of PFDN1-GIT1 binding does not provide functional insight. The core molecular function of PFDN1 is already captured by GO:0044183 &#34;protein folding chaperone.&#34;
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28514442
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Architecture of the human interactome defines protein commun...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1595,57 +1606,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:Q9UHV9/PFDN2) from Huttlin et al. 2017 (PMID:28514442), the BioPlex human interactome study. This is another independent detection of the PFDN1-PFDN2 intra-complex interaction, which is expected for subunits of the same hexameric complex. The &#34;protein binding&#34; term is uninformative and the interaction is already captured by the prefoldin complex membership annotation (GO:0016272).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. The PFDN1-PFDN2 interaction reflects co-membership in the prefoldin complex, already captured by GO:0016272. This high-throughput interactome study provides no additional functional insight beyond complex membership.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32296183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A reference map of the human binary protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1657,57 +1668,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:Q9NPF5/DMAP1) from Luck et al. 2020 (PMID:32296183), a reference map of the human binary protein interactome (HuRI). DMAP1 (DNA methyltransferase 1-associated protein 1) is a component of NuA4/TIP60 histone acetyltransferase complex. The UniProt record for PFDN1 lists this interaction (NbExp=3). While the interaction may be real, its biological significance for PFDN1 function is unclear. DMAP1 is a nuclear protein whereas PFDN1 functions primarily in the cytoplasm. The &#34;protein binding&#34; term is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. The PFDN1-DMAP1 interaction was detected in a high-throughput binary interactome screen. The biological relevance is unclear given that PFDN1 is cytoplasmic and DMAP1 is nuclear. The core molecular function of PFDN1 is already captured by GO:0044183.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1719,57 +1730,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:Q9UHV9/PFDN2 and UniProtKB:Q9Y2X7/GIT1) from Huttlin et al. 2021 (PMID:33961781), a dual proteome-scale network study of the human interactome. This confirms previously observed interactions: the PFDN1-PFDN2 interaction (intra-complex) and the PFDN1-GIT1 interaction. Both interactions have been detected in multiple independent studies. However, &#34;protein binding&#34; remains uninformative as a functional annotation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. These are replications of previously observed interactions (PFDN1-PFDN2 intra-complex; PFDN1-GIT1) that do not add functional insight beyond what is captured by GO:0016272 (prefoldin complex) and GO:0044183 (protein folding chaperone).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:40205054
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Multimodal cell maps as a foundation for structural and func...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1781,57 +1792,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:Q9UHV9/PFDN2 and UniProtKB:Q9Y2X7/GIT1) from multimodal cell maps study (PMID:40205054). This is yet another replication of the PFDN1-PFDN2 and PFDN1-GIT1 interactions. The PFDN1-PFDN2 interaction is expected as both are subunits of the prefoldin complex. The &#34;protein binding&#34; term remains uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. This is a further replication of known interactions (PFDN1-PFDN2, PFDN1-GIT1) from a large-scale study. The relevant functions are already captured by more specific annotations (GO:0044183, GO:0016272).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32699605
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The functions and mechanisms of prefoldin complex and prefol...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1843,75 +1854,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0006457 &#34;protein folding&#34; (NAS) from ComplexPortal, citing Liang et al. 2020 (PMID:32699605), a comprehensive review of prefoldin complex functions. The review describes how &#34;the prefoldin complex helps protein fold correctly and prevents aggregation by providing class II chaperones ... with a linear, unnatural substrate in the cytoplasm.&#34; This NAS annotation is consistent with the IBA and IDA annotations to the same term and is well-supported by the review literature.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein folding is the core biological process for PFDN1. This NAS annotation from ComplexPortal cites a well-sourced review (PMID:32699605) that accurately describes the protein folding function of the prefoldin complex. Consistent with IBA and IDA evidence to the same term.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link">
                                         PMID:32699605
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The prefoldin complex helps protein fold correctly and prevents aggregation by providing class II chaperones (Hsp60 molecular chaperones found in archaebacteria and eukaryotic cytoplasm) with a linear, unnatural substrate in the cytoplasm [2]</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/34761191" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:34761191
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A comprehensive analysis of prefoldins and their implication...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1923,75 +1934,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0006457 &#34;protein folding&#34; (NAS) from ComplexPortal, citing Herranz-Montoya et al. 2021 (PMID:34761191), a comprehensive analysis of prefoldins and their implication in cancer. The review describes prefoldins as &#34;evolutionary conserved co-chaperones&#34; that &#34;act as co-chaperones escorting misfolded or non-native proteins to group II chaperonins.&#34; This NAS annotation is consistent with the IBA and IDA annotations to the same term and is well-supported.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein folding is the core biological process for PFDN1. This NAS annotation from ComplexPortal cites a comprehensive review (PMID:34761191) that accurately describes the co-chaperone function of prefoldin subunits. Consistent with IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/34761191" target="_blank" class="term-link">
                                         PMID:34761191
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFDNs are prevalently organized into hetero-hexameric complexes. Although they have been overlooked since their discovery and their functions remain elusive, several reports indicate they act as co-chaperones escorting misfolded or non-native proteins to group II chaperonins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                     GO:0050821
                                 </a>
                             </span>
                             <span class="term-label">protein stabilization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/34761191" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:34761191
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A comprehensive analysis of prefoldins and their implication...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2003,75 +2014,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0050821 &#34;protein stabilization&#34; (NAS) from ComplexPortal, citing Herranz-Montoya et al. 2021 (PMID:34761191). The GO definition of protein stabilization is &#34;Any process involved in maintaining the structure and integrity of a protein and preventing it from degradation or aggregation.&#34; Prefoldin does prevent aggregation of unfolded substrates by capturing them and delivering them to TRiC/CCT (PMID:9630229). However, &#34;protein stabilization&#34; typically implies maintaining a folded protein in its native state, whereas prefoldin acts on unfolded nascent polypeptides as a holdase and transfer chaperone. The term is not entirely wrong -- prefoldin does prevent aggregation -- but it mischaracterizes the nature of the chaperone activity. The more accurate process annotation is GO:0006457 &#34;protein folding,&#34; which is already well-annotated.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While prefoldin does prevent protein aggregation (which is part of the GO definition of protein stabilization), the primary function is not to stabilize already-folded proteins but rather to capture unfolded substrates and transfer them to TRiC/CCT for folding. The annotation is not wrong but represents a secondary aspect of prefoldin function rather than its core activity. The core process (protein folding, GO:0006457) is already well-annotated with IBA, IDA, and NAS evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/34761191" target="_blank" class="term-link">
                                         PMID:34761191
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFDNs are prevalently organized into hetero-hexameric complexes. Although they have been overlooked since their discovery and their functions remain elusive, several reports indicate they act as co-chaperones escorting misfolded or non-native proteins to group II chaperonins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30955883
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Chaperonin TRiC/CCT Associates with Prefoldin through a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2083,88 +2094,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0006457 &#34;protein folding&#34; (IDA) from Gestaut et al. 2019 (PMID:30955883), which used cryo-EM, crosslinking mass spectrometry, and biochemical reconstitution to characterize the structural and functional interplay between the prefoldin (PFD) complex and TRiC/CCT chaperonin. The study demonstrates that &#34;PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles,&#34; directly showing involvement in protein folding. This is the highest-quality direct experimental evidence for the protein folding function of the prefoldin complex.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This IDA annotation is supported by strong direct experimental evidence from Gestaut et al. 2019 (PMID:30955883), which demonstrated through cryo-EM and biochemical approaches that the PFD-TRiC supra-chaperone assembly enhances protein folding rates. Protein folding is the core biological process for PFDN1.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The supra-chaperone assembly formed by PFD and TRiC is essential to prevent toxic conformations and ensure effective cellular proteostasis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016272" target="_blank" class="term-link">
                                     GO:0016272
                                 </a>
                             </span>
                             <span class="term-label">prefoldin complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30955883
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Chaperonin TRiC/CCT Associates with Prefoldin through a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2176,75 +2187,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0016272 &#34;prefoldin complex&#34; (IDA) from Gestaut et al. 2019 (PMID:30955883). This study used reconstituted human prefoldin complex (containing all six subunits including PFDN1) and characterized its structure and function through cryo-EM, crosslinking mass spectrometry, and biochemical assays. The study resolved the architecture of the PFD-TRiC supra-chaperone complex, directly demonstrating that PFDN1 is a component of the prefoldin complex. The cryo-EM structures (PDB: 6NR8, 6NR9, 6NRB, 6NRC, 6NRD) include PFDN1 as a structural component.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PFDN1 is a core structural subunit of the prefoldin complex. This IDA annotation is supported by high-resolution cryo-EM structural data from Gestaut et al. 2019 (PMID:30955883) that directly demonstrates PFDN1 as a component of the human prefoldin complex.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Maintaining proteostasis in eukaryotic protein folding involves cooperation of distinct chaperone systems. To understand how the essential ring-shaped chaperonin TRiC/CCT cooperates with the chaperone prefoldin/GIMc (PFD), we integrate cryoelectron microscopy (cryo-EM), crosslinking-mass-spectrometry and biochemical and cellular approaches to elucidate the structural and functional interplay between TRiC/CCT and PFD.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30955883
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Chaperonin TRiC/CCT Associates with Prefoldin through a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -2256,125 +2267,125 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). This IDA annotation cites Gestaut et al. 2019 (PMID:30955883), which used cryo-EM, crosslinking mass spectrometry, and biochemical reconstitution to characterize the structural and functional interplay between the prefoldin (PFD) complex and TRiC/CCT chaperonin. The study demonstrates that prefoldin associates with TRiC through a conserved electrostatic interface and undergoes conformational cycling between &#34;latched&#34; (open) and &#34;engaged&#34; (closed) states during substrate transfer. Critically, the paper shows that PFD functions not merely as a passive binder of unfolded substrates but as an active co-chaperone that &#34;can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles.&#34; This demonstrates prefoldin is a bona fide protein folding chaperone. GO:0044183 &#34;protein folding chaperone&#34; is the appropriate replacement, capturing the functional role of prefoldin in the chaperone-assisted folding pathway.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. Gestaut et al. 2019 (PMID:30955883) demonstrates that prefoldin functions as a co-chaperone/holdase that cooperates with TRiC/CCT in substrate folding, not merely as an unfolded protein binder. The study shows prefoldin enhances the rate and yield of TRiC-mediated folding and that disrupting the PFD-TRiC interaction leads to accumulation of amyloid aggregates in vivo. GO:0044183 &#34;protein folding chaperone&#34; accurately describes this co-chaperone activity. Note that while prefoldin itself functions primarily as a holdase (it does not fold proteins on its own but transfers them to TRiC), the GO:0044183 definition (&#34;Binding to a protein or a protein-containing complex to assist the protein folding process&#34;) appropriately encompasses this transfer/holdase function.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Disrupting the TRiC-PFD interaction in vivo is strongly deleterious, leading to accumulation of amyloid aggregates.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The supra-chaperone assembly formed by PFD and TRiC is essential to prevent toxic conformations and ensure effective cellular proteostasis.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it. ... prefoldin promotes folding in an environment in which there are many competing pathways for nonnative proteins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001540" target="_blank" class="term-link">
                                     GO:0001540
                                 </a>
                             </span>
                             <span class="term-label">amyloid-beta binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23614719
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human prefoldin inhibits amyloid-β (Aβ) fibrillation and con...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2386,75 +2397,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0001540 &#34;amyloid-beta binding&#34; (IDA) from Sorgjerd et al. 2013 (PMID:23614719). This study demonstrated that recombinant human prefoldin (hPFD) inhibits amyloid-beta (Abeta 1-42) fibrillation in vitro and induces formation of soluble Abeta oligomers with reduced toxicity. The study used thioflavin T measurements and immunoblotting to show that hPFD directly interacts with Abeta peptides and modifies their aggregation pathway. While this demonstrates that the prefoldin complex can bind Abeta, this is not the core function of PFDN1 -- it reflects the general chaperone/holdase property of prefoldin applied to an amyloidogenic substrate. The annotation was made on the intact prefoldin complex, not PFDN1 individually.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Amyloid-beta binding is a secondary, non-core function that reflects the general holdase/chaperone activity of the prefoldin complex applied to an amyloidogenic substrate. The study (PMID:23614719) used the intact hexameric complex rather than individual PFDN1. While the data are solid, this represents a peripheral function compared to the core role in actin/tubulin folding via TRiC/CCT delivery.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                                         PMID:23614719
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we investigated the effect of recombinant human PFD (hPFD) on Abeta(1-42) aggregation in vitro and found that hPFD inhibited Abeta fibrillation and induced formation of soluble Abeta oligomers.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016272" target="_blank" class="term-link">
                                     GO:0016272
                                 </a>
                             </span>
                             <span class="term-label">prefoldin complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23614719
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human prefoldin inhibits amyloid-β (Aβ) fibrillation and con...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2466,75 +2477,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0016272 &#34;prefoldin complex&#34; (IDA) from Sorgjerd et al. 2013 (PMID:23614719). This study expressed and purified recombinant human prefoldin complex (hPFD) to investigate its effect on amyloid-beta aggregation. The successful reconstitution and purification of the hexameric complex containing PFDN1 provides direct evidence for PFDN1 membership in the prefoldin complex. This is consistent with the IDA annotation from PMID:30955883 and the IEA annotation from InterPro.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PFDN1 is a core structural subunit of the prefoldin complex. This IDA annotation from PMID:23614719 provides independent experimental evidence through reconstitution of the human prefoldin hexamer, consistent with the structural data from PMID:30955883.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                                         PMID:23614719
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin (PFD) is a molecular chaperone that prevents aggregation of misfolded proteins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905907" target="_blank" class="term-link">
                                     GO:1905907
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of amyloid fibril formation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23614719
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human prefoldin inhibits amyloid-β (Aβ) fibrillation and con...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2546,88 +2557,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:1905907 &#34;negative regulation of amyloid fibril formation&#34; (IDA) from Sorgjerd et al. 2013 (PMID:23614719). The study demonstrated that recombinant human prefoldin &#34;inhibited Abeta fibrillation and induced formation of soluble Abeta oligomers&#34; that were 30-40% less toxic than Abeta fibrils. Thioflavin T measurements confirmed reduced fibril formation. While the experimental evidence is sound, this represents a non-core function of the prefoldin complex -- an extension of its general holdase/chaperone properties to amyloidogenic substrates rather than its primary role in actin/tubulin folding. The study was performed on the intact hexameric complex, not PFDN1 individually.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The experimental evidence from PMID:23614719 is solid, but this is a secondary function reflecting the general anti-aggregation properties of the prefoldin complex rather than its core role in delivering unfolded actin/tubulin to TRiC/CCT. The study was performed in vitro on the intact hexameric complex, and the relevance to PFDN1 specifically (as opposed to the complex as a whole) is indirect.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                                         PMID:23614719
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we investigated the effect of recombinant human PFD (hPFD) on Abeta(1-42) aggregation in vitro and found that hPFD inhibited Abeta fibrillation and induced formation of soluble Abeta oligomers.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                                         PMID:23614719
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Our findings show a relation between cytotoxicity of Abeta oligomers and structure and suggest a possible protective role of PFD in AD.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     GO:0044183
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16876117" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16876117
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interaction of hepatitis C virus F protein with prefoldin 2 ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2639,63 +2650,63 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0044183 &#34;protein folding chaperone&#34; (IPI with UniProtKB:Q9UHV9/PFDN2) from Tsao et al. 2006 (PMID:16876117), annotated by AgBase. This study demonstrated that HCV F protein interacts with PFDN2 and that this interaction &#34;impeded the interaction between prefoldin 1 and 2,&#34; resulting in &#34;aberrant organization of tubulin cytoskeleton.&#34; The study describes prefoldin as &#34;a hexameric molecular chaperone complex ... which delivers nascent actin and tubulin proteins to the eukaryotic cytosolic chaperonin for facilitated folding.&#34; The IPI evidence code is appropriate because the chaperone function of PFDN1 was demonstrated through its interaction with PFDN2 in the context of prefoldin complex assembly and function. The study shows that disrupting the PFDN1-PFDN2 interaction (via HCV F protein) impairs the chaperone function of the complex, providing indirect evidence that PFDN1 enables protein folding chaperone activity through the complex.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0044183 &#34;protein folding chaperone&#34; is the core molecular function of PFDN1. This IPI annotation is supported by PMID:16876117, which demonstrates that PFDN1-PFDN2 interaction is essential for prefoldin complex assembly and chaperone function. Disruption of this interaction by HCV F protein leads to aberrant tubulin cytoskeleton, confirming the functional significance.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16876117" target="_blank" class="term-link">
                                         PMID:16876117
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin 2 is a subunit of a hexameric molecular chaperone complex, named prefoldin, which delivers nascent actin and tubulin proteins to the eukaryotic cytosolic chaperonin for facilitated folding.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16876117" target="_blank" class="term-link">
                                         PMID:16876117
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">In the yeast three-hybrid system, it was found that expression of HCV F protein impeded the interaction between prefoldin 1 and 2.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>PFDN1 is a beta-type subunit of the heterohexameric prefoldin co-chaperone complex that captures unfolded nascent polypeptides (primarily actin and tubulin) and delivers them to the TRiC/CCT chaperonin for ATP-dependent folding. The prefoldin-TRiC supra-chaperone assembly enhances the rate and yield of the folding reaction and suppresses non-productive reaction cycles (PMID:30955883). The client repertoire extends beyond cytoskeletal proteins to include the VHL tumor suppressor, where prefoldin prevents pVHL aggregation and degradation (DOI:10.1371/journal.pgen.1009183). A 2024 DIP-MS study resolved canonical and alternative prefoldin assemblies, suggesting context-specific modular complex organization (DOI:10.1038/s41592-024-02211-y).</h3>
                 <span class="vote-buttons" data-g="O60925" data-a="FUNCTION: PFDN1 is a beta-type subunit of the heterohexameri..." data-r="" data-act="CORE_FUNCTION">
@@ -2703,10 +2714,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -2715,39 +2726,39 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                 protein folding
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                 cytoplasm
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">In Complex:</div>
                     <span class="badge">
@@ -2756,449 +2767,483 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                 PMID:9630229
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">We describe the discovery of a heterohexameric chaperone protein, prefoldin, based on its ability to capture unfolded actin. Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                 PMID:30955883
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles.</div>
-                        
+
                     </li>
-                    
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PFDN1/PFDN1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Prefoldin is a conserved hetero-hexameric cochaperone complex that binds non-native polypeptides, protects exposed hydrophobic regions to prevent aggregation, and transfers/shuttles folding clients to the cytosolic chaperonin TRiC/CCT for productive folding.</div>
+
+                    </li>
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/PFDN1/PFDN1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for PFDN1</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">PFDN1 is a canonical beta subunit of the prefoldin complex, which binds non-native polypeptides and transfers folding clients to TRiC/CCT.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16169070" target="_blank" class="term-link">
                             PMID:16169070
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A human protein-protein interaction network: a resource for annotating the proteome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16876117" target="_blank" class="term-link">
                             PMID:16876117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interaction of hepatitis C virus F protein with prefoldin 2 perturbs tubulin cytoskeleton organization.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21900206" target="_blank" class="term-link">
                             PMID:21900206
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A directed protein interaction network for investigating intracellular signal transduction.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                             PMID:23614719
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Human prefoldin inhibits amyloid-β (Aβ) fibrillation and contributes to formation of nontoxic Aβ aggregates.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
                             PMID:28514442
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                             PMID:30955883
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The Chaperonin TRiC/CCT Associates with Prefoldin through a Conserved Electrostatic Interface Essential for Cellular Proteostasis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                             PMID:32296183
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A reference map of the human binary protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link">
                             PMID:32699605
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The functions and mechanisms of prefoldin complex and prefoldin-subunits.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/34761191" target="_blank" class="term-link">
                             PMID:34761191
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A comprehensive analysis of prefoldins and their implication in cancer.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
                             PMID:40205054
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                             PMID:9630229
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Prefoldin, a chaperone that delivers unfolded proteins to cytosolic chaperonin.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1371/journal.pgen.1009183
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The prefoldin complex stabilizes the von Hippel-Lindau protein against aggregation and degradation</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Prefoldin complex physically associates with pVHL in human cells and prefoldin knockdown reduces pVHL expression</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">In yeast, prefoldin mutants promote pVHL aggregation, supporting a role in client stabilization beyond actin and tubulin</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1038/s41592-024-02211-y
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">DIP-MS ultra-deep interaction proteomics for the deconvolution of protein complexes</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">DIP-MS resolved canonical and alternative prefoldin assemblies in human cells, with PFDN1 as a component, supporting modular complex isoforms</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Prefoldin subunits show coelution and association patterns linked to CCT/TRiC with n equals 3 biologically independent replicates</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1038/onc.2016.257
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Prefoldin 1 promotes EMT and lung cancer progression by suppressing cyclin A expression</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">PFDN1 increases during TGF-beta1-induced EMT and localizes to the nucleus in cancer contexts</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">PFDN1 represses cyclin A expression by directly interacting with the cyclin A promoter near the transcription start site</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1007/s12032-015-0710-z
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">PFDN1 an indicator for colorectal cancer prognosis enhances tumor cell proliferation and motility through cytoskeletal reorganization</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">PFDN1 knockdown reduces F-actin levels and alpha-tubulin staining in colorectal cancer cells, consistent with impaired cytoskeletal homeostasis</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">PFDN1 knockdown in xenografts reduced tumor weight to 346.8 mg versus 783.4 mg in controls (P less than 0.01)</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.3389/fcell.2021.816214
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Prefoldin function in cellular protein homeostasis and human diseases</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Review emphasizes canonical prefoldin function as transfer of cytoskeletal polypeptides to TRiC/CCT while highlighting non-canonical functions in transcription regulation and proteasome-dependent degradation</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -3474,9 +3519,9 @@ this with annotations you find in gene/protein databases, but these can be outda
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -3488,7 +3533,7 @@ this with annotations you find in gene/protein databases, but these can be outda
                 <pre><code>id: O60925
 gene_symbol: PFDN1
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -3549,6 +3594,12 @@ existing_annotations:
       supporting_text: &gt;-
         PFD can act after TRiC bound its substrates to enhance the rate and yield
         of the folding reaction, suppressing non-productive reaction cycles.
+    - reference_id: file:human/PFDN1/PFDN1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Prefoldin is a conserved hetero-hexameric cochaperone complex that binds
+        non-native polypeptides, protects exposed hydrophobic regions to prevent
+        aggregation, and transfers/shuttles folding clients to the cytosolic
+        chaperonin TRiC/CCT for productive folding.
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -4250,6 +4301,12 @@ existing_annotations:
         In the yeast three-hybrid system, it was found that expression of HCV F
         protein impeded the interaction between prefoldin 1 and 2.
 references:
+- id: file:human/PFDN1/PFDN1-deep-research-falcon.md
+  title: Falcon deep research report for PFDN1
+  findings:
+    - statement: &gt;-
+        PFDN1 is a canonical beta subunit of the prefoldin complex, which binds
+        non-native polypeptides and transfers folding clients to TRiC/CCT.
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
     terms
@@ -4375,13 +4432,19 @@ core_functions:
         supporting_text: &gt;-
           PFD can act after TRiC bound its substrates to enhance the rate and yield
           of the folding reaction, suppressing non-productive reaction cycles.
+      - reference_id: file:human/PFDN1/PFDN1-deep-research-falcon.md
+        supporting_text: &gt;-
+          Prefoldin is a conserved hetero-hexameric cochaperone complex that binds
+          non-native polypeptides, protects exposed hydrophobic regions to prevent
+          aggregation, and transfers/shuttles folding clients to the cytosolic
+          chaperonin TRiC/CCT for productive folding.
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/PFDN1/PFDN1-ai-review.yaml
+++ b/genes/human/PFDN1/PFDN1-ai-review.yaml
@@ -1,7 +1,7 @@
 id: O60925
 gene_symbol: PFDN1
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -62,6 +62,12 @@ existing_annotations:
       supporting_text: >-
         PFD can act after TRiC bound its substrates to enhance the rate and yield
         of the folding reaction, suppressing non-productive reaction cycles.
+    - reference_id: file:human/PFDN1/PFDN1-deep-research-falcon.md
+      supporting_text: >-
+        Prefoldin is a conserved hetero-hexameric cochaperone complex that binds
+        non-native polypeptides, protects exposed hydrophobic regions to prevent
+        aggregation, and transfers/shuttles folding clients to the cytosolic
+        chaperonin TRiC/CCT for productive folding.
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -763,6 +769,12 @@ existing_annotations:
         In the yeast three-hybrid system, it was found that expression of HCV F
         protein impeded the interaction between prefoldin 1 and 2.
 references:
+- id: file:human/PFDN1/PFDN1-deep-research-falcon.md
+  title: Falcon deep research report for PFDN1
+  findings:
+    - statement: >-
+        PFDN1 is a canonical beta subunit of the prefoldin complex, which binds
+        non-native polypeptides and transfers folding clients to TRiC/CCT.
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
     terms
@@ -888,3 +900,9 @@ core_functions:
         supporting_text: >-
           PFD can act after TRiC bound its substrates to enhance the rate and yield
           of the folding reaction, suppressing non-productive reaction cycles.
+      - reference_id: file:human/PFDN1/PFDN1-deep-research-falcon.md
+        supporting_text: >-
+          Prefoldin is a conserved hetero-hexameric cochaperone complex that binds
+          non-native polypeptides, protects exposed hydrophobic regions to prevent
+          aggregation, and transfers/shuttles folding clients to the cytosolic
+          chaperonin TRiC/CCT for productive folding.

--- a/genes/human/PFDN2/PFDN2-ai-review.html
+++ b/genes/human/PFDN2/PFDN2-ai-review.html
@@ -3286,10 +3286,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9UHV9" data-a="GO:0005515" data-r="PMID:17936702" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="Q9UHV9" data-a="GO:0005515" data-r="PMID:17936702" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -3302,20 +3302,100 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Generic protein binding should be replaced by a specific cellular component annotation reflecting PFDN2 membership in the RPAP3/R2TP/prefoldin-like complex. This captures the URI1/PFDL context without treating it as the canonical prefoldin complex.
+                            <strong>Reason:</strong> Generic protein binding is a true but low-information interaction annotation. The specific URI1/PFDL context is better represented as a separate cellular component annotation to the RPAP3/R2TP/prefoldin-like complex.
                         </div>
 
 
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
 
-                            <span class="badge">
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PFDN2/PFDN2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Component of the PAQosome complex which is responsible for the biogenesis of several protein complexes and which consists of R2TP complex members RUVBL1, RUVBL2, RPAP3 and PIH1D1, URI complex members PFDN2, PFDN6, PDRG1, UXT and URI1 as well as ASDURF, POLR2E and DNAAF10/WDR92.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29662061" target="_blank" class="term-link">
+                                        PMID:29662061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This PFDL module includes prefoldin and prefoldin-like proteins PFDN2, PFDN6, URI1, UXT, PDRG1, and it associates with two additional components, the RNA polymerase subunit POLR2E/RPB5 and WDR92/Monad5.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990062" target="_blank" class="term-link">
-                                    RPAP3/R2TP/prefoldin-like complex
+                                    GO:1990062
                                 </a>
                             </span>
+                            <span class="term-label">RPAP3/R2TP/prefoldin-like complex</span>
 
                         </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29662061" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:29662061
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    RPAP3 provides a flexible scaffold for coupling HSP90 to the...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UHV9" data-a="GO:1990062" data-r="PMID:29662061" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PFDN2 is a component of the PAQosome/R2TP prefoldin-like module together with PFDN6, URI1, UXT, and PDRG1. This cellular component annotation captures the specific complex membership underlying the generic URI1 protein-binding evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GO:1990062 specifically represents the RPAP3/R2TP/prefoldin-like complex curated for PAQosome/PFDL membership. It is more informative than generic protein binding and does not conflate this PAQosome context with the canonical prefoldin complex.
+                        </div>
+
 
 
                         <div class="supported-by">
@@ -5341,15 +5421,42 @@ existing_annotations:
       interaction with URI1 and subsequent work places PFDN2 in the PAQosome/R2TP
       prefoldin-like complex. Generic protein binding is uninformative for this
       context.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      Generic protein binding should be replaced by a specific cellular component
-      annotation reflecting PFDN2 membership in the RPAP3/R2TP/prefoldin-like
-      complex. This captures the URI1/PFDL context without treating it as the
+      Generic protein binding is a true but low-information interaction annotation.
+      The specific URI1/PFDL context is better represented as a separate cellular
+      component annotation to the RPAP3/R2TP/prefoldin-like complex.
+    supported_by:
+      - reference_id: file:human/PFDN2/PFDN2-uniprot.txt
+        supporting_text: &gt;-
+          Component of the PAQosome complex which is responsible for the
+          biogenesis of several protein complexes and which consists of R2TP
+          complex members RUVBL1, RUVBL2, RPAP3 and PIH1D1, URI complex members
+          PFDN2, PFDN6, PDRG1, UXT and URI1 as well as ASDURF, POLR2E and
+          DNAAF10/WDR92.
+      - reference_id: PMID:29662061
+        supporting_text: &gt;-
+          This PFDL module includes prefoldin and prefoldin-like proteins PFDN2,
+          PFDN6, URI1, UXT, PDRG1, and it associates with two additional
+          components, the RNA polymerase subunit POLR2E/RPB5 and WDR92/Monad5.
+
+- term:
+    id: GO:1990062
+    label: RPAP3/R2TP/prefoldin-like complex
+  evidence_type: IPI
+  original_reference_id: PMID:29662061
+  review:
+    summary: &gt;-
+      PFDN2 is a component of the PAQosome/R2TP prefoldin-like module together
+      with PFDN6, URI1, UXT, and PDRG1. This cellular component annotation captures
+      the specific complex membership underlying the generic URI1 protein-binding
+      evidence.
+    action: NEW
+    reason: &gt;-
+      GO:1990062 specifically represents the RPAP3/R2TP/prefoldin-like complex
+      curated for PAQosome/PFDL membership. It is more informative than generic
+      protein binding and does not conflate this PAQosome context with the
       canonical prefoldin complex.
-    proposed_replacement_terms:
-      - id: GO:1990062
-        label: RPAP3/R2TP/prefoldin-like complex
     supported_by:
       - reference_id: file:human/PFDN2/PFDN2-uniprot.txt
         supporting_text: &gt;-

--- a/genes/human/PFDN2/PFDN2-ai-review.html
+++ b/genes/human/PFDN2/PFDN2-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>PFDN2</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/Q9UHV9" target="_blank" class="term-link">
                         Q9UHV9
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>Prefoldin subunit 2 (PFDN2) is a beta-class subunit of the canonical heterohexameric prefoldin co-chaperone complex (2 alpha + 4 beta subunits). Prefoldin functions as an ATP-independent holdase that captures nascent or unfolded polypeptides, principally actin and tubulin, and delivers them to the group II chaperonin TRiC/CCT for ATP-dependent folding. PFDN2 also participates in the PAQosome (prefoldin-like/R2TP complex) involved in biogenesis of multisubunit complexes. Beyond cytosolic proteostasis, PFDN2 localizes to the nucleus where the prefoldin complex supports transcription elongation and co-transcriptional splicing.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,77 +795,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for cytoplasm localization. Prefoldin is a cytosolic chaperone complex; PFDN2 functions primarily in the cytoplasm where it captures nascent actin and tubulin and delivers them to TRiC/CCT (PMID:9630229). Experimental evidence from PMID:16876117 and PMID:17936702 confirms cytoplasmic localization by immunofluorescence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization. The IBA annotation is phylogenetically supported and confirmed by multiple experimental studies showing cytoplasmic localization of PFDN2.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We describe the discovery of a heterohexameric chaperone protein, prefoldin, based on its ability to capture unfolded actin.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16876117" target="_blank" class="term-link">
                                         PMID:16876117
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin 2 is a subunit of a hexameric molecular chaperone complex, named prefoldin, which delivers nascent actin and tubulin proteins to the eukaryotic cytosolic chaperonin for facilitated folding.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -877,77 +877,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for protein folding. Prefoldin is a co-chaperone that participates in protein folding by capturing unfolded substrates and delivering them to TRiC/CCT (PMID:9630229, PMID:30955883). Well-established core function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core biological process for prefoldin. The IBA is phylogenetically well-supported and consistent with extensive biochemical evidence for prefoldin&#39;s role in protein folding.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">prefoldin promotes folding in an environment in which there are many competing pathways for nonnative proteins.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The supra-chaperone assembly formed by PFD and TRiC is essential to prevent toxic conformations and ensure effective cellular proteostasis.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PFDN2/PFDN2-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PFDN2 is a structural subunit of the canonical eukaryotic prefoldin holdase. It contributes to the capture of nascent or non-native polypeptides, principally cytoskeletal actins and tubulins, and their targeted delivery to TRiC/CCT.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     GO:0044183
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -959,77 +970,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for protein folding chaperone molecular function. GO:0044183 is defined as &#34;Binding to a protein or a protein-containing complex to assist the protein folding process.&#34; This precisely describes prefoldin&#39;s holdase function - binding unfolded substrates and transferring them to TRiC/CCT (PMID:9630229, PMID:30955883).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is the correct and most appropriate MF term for prefoldin subunits. Prefoldin acts as a holdase/transfer chaperone, binding unfolded actin and tubulin and delivering them to TRiC/CCT. The IBA is well-supported phylogenetically.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1041,64 +1052,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IEA annotation for nuclear localization based on UniProt subcellular location mapping. Nuclear localization of PFDN2 is supported by experimental evidence from PMID:17936702 (immunofluorescence) and by functional studies showing prefoldin subunits on transcribed chromatin supporting RNAPII CTD phosphorylation and co-transcriptional splicing.
+                            <strong>Summary:</strong> IEA annotation for nuclear localization based on UniProt subcellular location mapping. Nuclear localization of PFDN2 is supported by UniProt&#39;s curated subcellular location statement and by functional studies showing prefoldin subunits on transcribed chromatin supporting RNAPII CTD phosphorylation and co-transcriptional splicing.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Although IEA, this is consistent with experimental data from PMID:17936702 and PMID:16876117 showing nuclear localization, plus functional evidence for nuclear roles in transcription/splicing.
+                            <strong>Reason:</strong> Although IEA, this is consistent with UniProt&#39;s curated localization and functional evidence for nuclear roles in transcription/splicing.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17936702" target="_blank" class="term-link">
-                                        PMID:17936702
-                                    </a>
-                                    
+
+                                    file:human/PFDN2/PFDN2-uniprot.txt
+
                                 </span>
-                                
-                                <div class="support-text">URI forms stable complexes with protein phosphatase (PP)1gamma at mitochondria</div>
-                                
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Nucleus {ECO:0000269|PubMed:17936702}. Cytoplasm {ECO:0000269|PubMed:17936702}. Mitochondrion {ECO:0000269|PubMed:17936702}.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1110,46 +1119,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for cytoplasm based on UniProt subcellular location mapping. Redundant with the IBA annotation for the same term but from a different source. Cytoplasmic localization is well-established experimentally.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Duplicates the IBA annotation but from IEA source. Both are valid. Cytoplasmic localization is well-supported.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1161,64 +1170,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IEA annotation for mitochondrial localization. PMID:17936702 identified PFDN2 interaction with URI1 in a mitochondrial context. This was confirmed by IDA evidence in the same dataset. Mitochondrial localization relates to the URI/PAQosome complex rather than canonical prefoldin function.
+                            <strong>Summary:</strong> IEA annotation for mitochondrial localization based on UniProt subcellular location mapping. UniProt curates PFDN2 to mitochondrion from PMID:17936702. This localization is non-core relative to canonical cytosolic prefoldin function.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Mitochondrial localization is experimentally supported (PMID:17936702) but relates to the URI1/PAQosome interaction rather than canonical prefoldin chaperone function. Not a core localization for prefoldin function.
+                            <strong>Reason:</strong> Mitochondrial localization is curated by UniProt from PMID:17936702 but is not the core location for canonical prefoldin chaperone function. Not a core localization for prefoldin function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17936702" target="_blank" class="term-link">
-                                        PMID:17936702
-                                    </a>
-                                    
+
+                                    file:human/PFDN2/PFDN2-uniprot.txt
+
                                 </span>
-                                
-                                <div class="support-text">URI represents a mitochondrial substrate of S6K1</div>
-                                
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Nucleus {ECO:0000269|PubMed:17936702}. Cytoplasm {ECO:0000269|PubMed:17936702}. Mitochondrion {ECO:0000269|PubMed:17936702}.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1230,46 +1237,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for protein folding based on InterPro domain mapping. Consistent with the IBA and IDA annotations for the same term. Prefoldin&#39;s role in protein folding is well-established.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Redundant with IBA and IDA annotations for the same term. The InterPro-based mapping is correct and consistent with the known function of prefoldin.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016272" target="_blank" class="term-link">
                                     GO:0016272
                                 </a>
                             </span>
                             <span class="term-label">prefoldin complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1281,64 +1288,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for prefoldin complex based on InterPro domain mapping. PFDN2 is a well-established component of the canonical prefoldin heterohexameric complex, confirmed by cryo-EM structures (PDB:6NR8, 7WU7) and biochemical studies (PMID:9630229, PMID:30955883).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core cellular component. PFDN2 is a structural subunit of the prefoldin complex, confirmed by multiple structures and biochemical characterization.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We describe the discovery of a heterohexameric chaperone protein, prefoldin</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
                                     GO:0032991
                                 </a>
                             </span>
                             <span class="term-label">protein-containing complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1350,46 +1357,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from ARBA machine learning for generic protein-containing complex. This is technically correct but too general - PFDN2 is specifically part of the prefoldin complex (GO:0016272) which is already annotated.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Too generic. The more specific term GO:0016272 (prefoldin complex) is already annotated and better describes the actual complex membership. This parent term adds no information.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1401,68 +1408,68 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for unfolded protein binding based on InterPro mapping. While prefoldin does bind unfolded proteins, the more informative and accurate MF term is GO:0044183 (protein folding chaperone), which captures the functional role of binding unfolded substrates to assist folding, not merely binding them.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 &#34;unfolded protein binding&#34; describes only the binding aspect. The correct MF term for prefoldin is GO:0044183 &#34;protein folding chaperone&#34; which captures the complete holdase/transfer chaperone function. The IBA already uses GO:0044183.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15923622" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15923622
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The HRPT2 tumor suppressor gene product parafibromin associa...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1474,57 +1481,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI protein binding from PMID:15923622 (Yart et al., 2005). This paper is about parafibromin (HRPT2) associating with PAF1 and RNAPII. The interaction with PFDN2 may have been detected as part of a larger interactome study. The generic protein binding term is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Generic protein binding from a study focused on parafibromin/PAF1/RNAPII. Does not provide specific functional information about PFDN2. The term &#34;protein binding&#34; is uninformative per curation guidelines.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16876117" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16876117
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interaction of hepatitis C virus F protein with prefoldin 2 ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1536,75 +1543,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI protein binding from PMID:16876117 (Tsao et al., 2006). This study demonstrated that HCV F protein interacts with PFDN2 via yeast two-hybrid and co-immunoprecipitation. The interaction impedes PFDN1-PFDN2 interaction and perturbs tubulin cytoskeleton. While a genuine interaction, the generic term is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Generic protein binding. The actual functional annotation from this paper (protein folding chaperone activity, positive regulation of cytoskeleton organization) is captured by other annotations from the same reference.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16876117" target="_blank" class="term-link">
                                         PMID:16876117
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">hepatitis C virus (HCV) F protein was found to interact with a cellular protein named prefoldin 2</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17353931" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17353931
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Large-scale mapping of human protein-protein interactions by...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1616,57 +1623,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI protein binding from large-scale mass spectrometry interactome study (Ewing et al., 2007). High-throughput interactome data. Generic protein binding is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Generic protein binding from high-throughput interactome study. Uninformative per curation guidelines.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25036637
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A quantitative chaperone interaction network reveals the arc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1678,57 +1685,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI protein binding from quantitative chaperone interaction network study (Taipale et al., 2014). While this study provides valuable context about PFDN2&#39;s position in the chaperone network, the generic protein binding term is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Generic protein binding from chaperone interactome study. The actual functional annotations from prefoldin studies are better captured by GO:0044183.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28514442
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Architecture of the human interactome defines protein commun...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1740,57 +1747,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI protein binding from large-scale interactome architecture study (Huttlin et al., 2017). High-throughput study. Generic term is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Generic protein binding from high-throughput interactome study. Uninformative.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32296183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A reference map of the human binary protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1802,57 +1809,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI protein binding from binary protein interactome reference map (Luck et al., 2020). High-throughput study. Generic term is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Generic protein binding from high-throughput interactome study. Uninformative.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32814053
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interactome Mapping Provides a Network of Neurodegenerative ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1864,57 +1871,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI protein binding from neurodegenerative disease protein interactome mapping study (Haenig et al., 2020). High-throughput study. Generic term is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Generic protein binding from high-throughput interactome study. Uninformative.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1926,57 +1933,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI protein binding from dual proteome-scale network study. High-throughput study. Generic term is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Generic protein binding from high-throughput interactome study. Uninformative.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:40205054
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Multimodal cell maps as a foundation for structural and func...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1988,46 +1995,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI protein binding from multimodal cell maps study. High-throughput study. Generic term is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Generic protein binding from high-throughput interactome study. Uninformative.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2039,46 +2046,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for nucleoplasm based on immunofluorescence data curation (HPA). Consistent with known nuclear roles of prefoldin subunits in transcription elongation and co-transcriptional splicing.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Supported by immunofluorescence data from HPA and consistent with nuclear functions of prefoldin in transcription/splicing regulation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2090,46 +2097,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for mitochondrion based on immunofluorescence data curation (HPA). Consistent with PMID:17936702 showing PFDN2 association with URI1 at mitochondria.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Mitochondrial localization is experimentally supported but is a non-core localization relating to URI/PAQosome function rather than canonical prefoldin chaperone activity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2141,57 +2148,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for cytosol based on immunofluorescence data curation (HPA). Cytosol is the primary site of prefoldin&#39;s canonical co-chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization. Cytosol is where prefoldin performs its primary function of capturing nascent actin/tubulin and delivering to TRiC/CCT.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                     GO:0050821
                                 </a>
                             </span>
                             <span class="term-label">protein stabilization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31738558" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31738558
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Upstream ORF-Encoded ASDURF Is a Novel Prefoldin-like Subuni...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2203,57 +2210,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NAS annotation for protein stabilization from PMID:31738558 (Cloutier et al., 2020). This paper describes ASDURF as a novel prefoldin-like subunit of the PAQosome, which includes PFDN2. The PAQosome is involved in biogenesis of protein complexes, which involves stabilization. Prefoldin&#39;s holdase activity does stabilize unfolded proteins against aggregation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein stabilization is a secondary consequence of prefoldin&#39;s holdase function. The primary function is better captured as protein folding chaperone. Stabilization is not incorrect but is a secondary effect rather than core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32699605
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The functions and mechanisms of prefoldin complex and prefol...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2265,57 +2272,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NAS annotation for protein folding from the review by Liang et al. (2020) covering prefoldin functions and mechanisms. Consistent with core function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Redundant with IBA and IDA annotations but from a review source. Protein folding is a core function of prefoldin.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/34761191" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:34761191
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A comprehensive analysis of prefoldins and their implication...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2327,57 +2334,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NAS annotation for protein folding from Herranz-Montoya et al. (2021) comprehensive analysis of prefoldins. Consistent with core function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Redundant with other protein folding annotations. Consistent with the well-established core function of the prefoldin complex.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                     GO:0050821
                                 </a>
                             </span>
                             <span class="term-label">protein stabilization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/34761191" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:34761191
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A comprehensive analysis of prefoldins and their implication...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2389,57 +2396,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NAS annotation for protein stabilization from Herranz-Montoya et al. (2021). Prefoldin stabilizes client proteins (e.g., VHL) against aggregation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein stabilization is a secondary consequence of prefoldin&#39;s holdase function, not the primary molecular activity. Core function is better captured as protein folding chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                     GO:0050821
                                 </a>
                             </span>
                             <span class="term-label">protein stabilization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/29662061" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:29662061
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     RPAP3 provides a flexible scaffold for coupling HSP90 to the...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2451,57 +2458,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NAS annotation for protein stabilization from PMID:29662061 (Martino et al., 2018). This paper is about RPAP3 providing a scaffold for coupling HSP90 to the R2TP co-chaperone complex. Relevant to the PAQosome context of PFDN2.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Relates to the R2TP/PAQosome complex stabilization function. Not a core function of PFDN2 in the canonical prefoldin complex.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30955883
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Chaperonin TRiC/CCT Associates with Prefoldin through a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2513,75 +2520,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for protein folding from Gestaut et al. (2019) Cell paper. This landmark study used cryo-EM, crosslinking-MS, and biochemical approaches to show that prefoldin associates with TRiC/CCT through a conserved electrostatic interface, with PFD enhancing folding rate and yield while suppressing non-productive cycles.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Strong experimental evidence from a landmark Cell paper demonstrating the structural and functional basis for prefoldin-TRiC cooperation in protein folding.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016272" target="_blank" class="term-link">
                                     GO:0016272
                                 </a>
                             </span>
                             <span class="term-label">prefoldin complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30955883
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Chaperonin TRiC/CCT Associates with Prefoldin through a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2593,75 +2600,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for prefoldin complex from Gestaut et al. (2019). Cryo-EM structures of the prefoldin-TRiC complex were resolved, directly demonstrating prefoldin complex architecture.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Strong structural evidence from cryo-EM demonstrating prefoldin complex structure in association with TRiC/CCT.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we integrate cryoelectron microscopy (cryo-EM), crosslinking-mass-spectrometry and biochemical and cellular approaches to elucidate the structural and functional interplay between TRiC/CCT and PFD.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30955883
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Chaperonin TRiC/CCT Associates with Prefoldin through a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -2673,86 +2680,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for unfolded protein binding from Gestaut et al. (2019). While prefoldin does bind unfolded proteins, the more accurate MF term is GO:0044183 (protein folding chaperone) which captures the complete functional role.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 describes only the binding aspect. GO:0044183 &#34;protein folding chaperone&#34; better captures prefoldin&#39;s complete holdase/transfer function. The binding is in service of assisted folding, not binding per se.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFD alternates between an open &#34;latched&#34; conformation and a closed &#34;engaged&#34; conformation that aligns the PFD-TRiC substrate binding chambers.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001540" target="_blank" class="term-link">
                                     GO:0001540
                                 </a>
                             </span>
                             <span class="term-label">amyloid-beta binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23614719
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human prefoldin inhibits amyloid-β (Aβ) fibrillation and con...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2764,75 +2771,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for amyloid-beta binding from Sorgjerd et al. (2013). The study demonstrated that recombinant human prefoldin (hPFD) inhibits Abeta fibrillation and induces formation of less toxic Abeta oligomers. This is a property of the intact hexameric complex, not specific to PFDN2.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The study demonstrated Abeta binding as a property of the intact prefoldin complex. This is consistent with prefoldin&#39;s general holdase function against misfolded proteins. However, this is not a core physiological function but rather reflects the general anti-aggregation capacity of the complex.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                                         PMID:23614719
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we investigated the effect of recombinant human PFD (hPFD) on Abeta(1-42) aggregation in vitro and found that hPFD inhibited Abeta fibrillation and induced formation of soluble Abeta oligomers.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016272" target="_blank" class="term-link">
                                     GO:0016272
                                 </a>
                             </span>
                             <span class="term-label">prefoldin complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23614719
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human prefoldin inhibits amyloid-β (Aβ) fibrillation and con...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2844,57 +2851,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for prefoldin complex from Sorgjerd et al. (2013). The study used recombinant human prefoldin complex to study Abeta interactions, confirming the hexameric complex assembly.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Confirms prefoldin complex formation with recombinant human subunits.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905907" target="_blank" class="term-link">
                                     GO:1905907
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of amyloid fibril formation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23614719
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human prefoldin inhibits amyloid-β (Aβ) fibrillation and con...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2906,75 +2913,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for negative regulation of amyloid fibril formation from Sorgjerd et al. (2013). The study showed hPFD inhibits Abeta fibrillation in vitro. This is a property of the intact complex and reflects the general anti-aggregation holdase function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This reflects in vitro anti-aggregation activity of the prefoldin complex rather than a primary physiological function. It is a secondary consequence of the holdase activity. The annotation is not wrong but represents a non-core function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                                         PMID:23614719
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">hPFD inhibited Abeta fibrillation and induced formation of soluble Abeta oligomers. Interestingly, cell viability measurements...showed that Abeta oligomers formed by hPFD were 30-40% less toxic</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16876117" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16876117
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interaction of hepatitis C virus F protein with prefoldin 2 ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2986,75 +2993,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for nuclear localization from Tsao et al. (2006). The study used confocal immunofluorescence microscopy and showed PFDN2 in both nucleus and cytoplasm.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimental evidence (immunofluorescence) supports nuclear localization. Consistent with known nuclear roles of prefoldin in transcription and splicing regulation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16876117" target="_blank" class="term-link">
                                         PMID:16876117
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The interaction was confirmed by confocal immunofluorescence microscopy as well as coimmunoprecipitation experiments.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16876117" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16876117
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interaction of hepatitis C virus F protein with prefoldin 2 ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3066,57 +3073,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for cytoplasm from Tsao et al. (2006). Immunofluorescence confirms cytoplasmic localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization confirmed by experimental immunofluorescence data. Consistent with canonical cytosolic chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     GO:0044183
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16876117" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16876117
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interaction of hepatitis C virus F protein with prefoldin 2 ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3128,75 +3135,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein folding chaperone from Tsao et al. (2006). The study showed PFDN2 interacts with HCV F protein, and that this interaction impedes PFDN1-PFDN2 interaction and perturbs tubulin cytoskeleton. This demonstrates PFDN2&#39;s role as a chaperone for tubulin folding.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Demonstrates PFDN2&#39;s chaperone function via perturbation - HCV F protein interaction with PFDN2 disrupts prefoldin complex assembly and impairs tubulin folding, confirming PFDN2&#39;s role as a protein folding chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16876117" target="_blank" class="term-link">
                                         PMID:16876117
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">expression of HCV F protein impeded the interaction between prefoldin 1 and 2...expression of HCV F protein resulted in aberrant organization of tubulin cytoskeleton.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051495" target="_blank" class="term-link">
                                     GO:0051495
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of cytoskeleton organization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16876117" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16876117
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interaction of hepatitis C virus F protein with prefoldin 2 ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3208,137 +3215,177 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for positive regulation of cytoskeleton organization from Tsao et al. (2006). The study showed that disruption of PFDN2 function (by HCV F protein) leads to aberrant tubulin cytoskeleton organization, implying PFDN2 normally promotes proper cytoskeleton organization through its chaperone activity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While the study demonstrates that PFDN2 is required for proper cytoskeleton organization, this is a downstream consequence of its chaperone function (folding actin and tubulin) rather than a direct regulatory role. The annotation captures a true biological effect but the mechanism is indirect through protein folding.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16876117" target="_blank" class="term-link">
                                         PMID:16876117
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">expression of HCV F protein resulted in aberrant organization of tubulin cytoskeleton</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17936702" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17936702
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     S6K1-mediated disassembly of mitochondrial URI/PP1gamma comp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q9UHV9" data-a="GO:0005515" data-r="PMID:17936702" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="Q9UHV9" data-a="GO:0005515" data-r="PMID:17936702" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IPI protein binding from Djouder et al. (2007). This study showed PFDN2 interaction with URI1 in a phosphorylation-dependent manner. Generic protein binding is uninformative.
+                            <strong>Summary:</strong> IPI protein binding from Djouder et al. (2007). UniProt curates PFDN2 interaction with URI1 and subsequent work places PFDN2 in the PAQosome/R2TP prefoldin-like complex. Generic protein binding is uninformative for this context.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Generic protein binding. The interaction with URI1 is more specifically captured by the PAQosome/prefoldin complex annotations.
+                            <strong>Reason:</strong> Generic protein binding should be replaced by a specific cellular component annotation reflecting PFDN2 membership in the RPAP3/R2TP/prefoldin-like complex. This captures the URI1/PFDL context without treating it as the canonical prefoldin complex.
                         </div>
-                        
-                        
-                        
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990062" target="_blank" class="term-link">
+                                    RPAP3/R2TP/prefoldin-like complex
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PFDN2/PFDN2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Component of the PAQosome complex which is responsible for the biogenesis of several protein complexes and which consists of R2TP complex members RUVBL1, RUVBL2, RPAP3 and PIH1D1, URI complex members PFDN2, PFDN6, PDRG1, UXT and URI1 as well as ASDURF, POLR2E and DNAAF10/WDR92.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29662061" target="_blank" class="term-link">
+                                        PMID:29662061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This PFDL module includes prefoldin and prefoldin-like proteins PFDN2, PFDN6, URI1, UXT, PDRG1, and it associates with two additional components, the RNA polymerase subunit POLR2E/RPB5 and WDR92/Monad5.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17936702" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17936702
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     S6K1-mediated disassembly of mitochondrial URI/PP1gamma comp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3350,57 +3397,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for nuclear localization from Djouder et al. (2007). The study showed PFDN2 localizes to nucleus, cytoplasm, and mitochondria through immunofluorescence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimental evidence for nuclear localization by immunofluorescence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17936702" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17936702
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     S6K1-mediated disassembly of mitochondrial URI/PP1gamma comp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3412,57 +3459,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for cytoplasm from Djouder et al. (2007). Confirmed by immunofluorescence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization confirmed experimentally.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17936702" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17936702
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     S6K1-mediated disassembly of mitochondrial URI/PP1gamma comp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3474,75 +3521,73 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IDA annotation for mitochondrial localization from Djouder et al. (2007). PFDN2 interacts with URI1 at mitochondria in a phosphorylation-dependent manner.
+                            <strong>Summary:</strong> IDA annotation for mitochondrial localization from Djouder et al. (2007), represented in UniProt&#39;s curated subcellular-location statement.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Experimentally supported mitochondrial localization, but this relates to the URI1/PAQosome interaction rather than canonical prefoldin chaperone function.
+                            <strong>Reason:</strong> Experimentally supported mitochondrial localization, but not the core location for canonical prefoldin chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17936702" target="_blank" class="term-link">
-                                        PMID:17936702
-                                    </a>
-                                    
+
+                                    file:human/PFDN2/PFDN2-uniprot.txt
+
                                 </span>
-                                
-                                <div class="support-text">URI represents a mitochondrial substrate of S6K1</div>
-                                
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Nucleus {ECO:0000269|PubMed:17936702}. Cytoplasm {ECO:0000269|PubMed:17936702}. Mitochondrion {ECO:0000269|PubMed:17936702}.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9630229
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Prefoldin, a chaperone that delivers unfolded proteins to cy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -3554,86 +3599,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NAS annotation for unfolded protein binding from Vainberg et al. (1998), the original prefoldin discovery paper. While accurate that prefoldin binds unfolded proteins, GO:0044183 is the more appropriate MF term.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 describes only the binding aspect. GO:0044183 &#34;protein folding chaperone&#34; better captures the complete holdase/transfer function described in this paper.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016272" target="_blank" class="term-link">
                                     GO:0016272
                                 </a>
                             </span>
                             <span class="term-label">prefoldin complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9630229
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Prefoldin, a chaperone that delivers unfolded proteins to cy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3645,75 +3690,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NAS annotation for prefoldin complex from the original prefoldin discovery paper (Vainberg et al., 1998). Describes the heterohexameric complex architecture.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The foundational paper establishing the prefoldin complex. Core annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We describe the discovery of a heterohexameric chaperone protein, prefoldin, based on its ability to capture unfolded actin.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9630229
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Prefoldin, a chaperone that delivers unfolded proteins to cy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3725,50 +3770,50 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NAS annotation for protein folding from Vainberg et al. (1998). This paper established that prefoldin promotes protein folding by delivering substrates to c-CPN (TRiC/CCT).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core function established in the original prefoldin paper.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">prefoldin promotes folding in an environment in which there are many competing pathways for nonnative proteins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>PFDN2 is a beta-type subunit of the heterohexameric prefoldin co-chaperone complex that captures unfolded nascent polypeptides (primarily actin and tubulin) and delivers them to the TRiC/CCT chaperonin for ATP-dependent folding. Disruption of PFDN1-PFDN2 interaction (e.g., by HCV F protein) leads to aberrant tubulin cytoskeleton organization, confirming the functional importance of PFDN2 in cytoskeletal protein folding.</h3>
                 <span class="vote-buttons" data-g="Q9UHV9" data-a="FUNCTION: PFDN2 is a beta-type subunit of the heterohexameri..." data-r="" data-act="CORE_FUNCTION">
@@ -3776,10 +3821,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -3788,39 +3833,39 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                 protein folding
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">In Complex:</div>
                     <span class="badge">
@@ -3829,538 +3874,595 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                 PMID:9630229
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">We describe the discovery of a heterohexameric chaperone protein, prefoldin, based on its ability to capture unfolded actin. Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                 PMID:30955883
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16876117" target="_blank" class="term-link">
                                 PMID:16876117
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">expression of HCV F protein impeded the interaction between prefoldin 1 and 2...expression of HCV F protein resulted in aberrant organization of tubulin cytoskeleton.</div>
-                        
+
                     </li>
-                    
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PFDN2/PFDN2-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">PFDN2 is a structural subunit of the canonical eukaryotic prefoldin holdase. It contributes to the capture of nascent or non-native polypeptides, principally cytoskeletal actins and tubulins, and their targeted delivery to TRiC/CCT.</div>
+
+                    </li>
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/PFDN2/PFDN2-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for PFDN2</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">PFDN2 is a beta prefoldin subunit that helps capture nascent actin and tubulin clients and deliver them to TRiC/CCT for folding.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PFDN2/PFDN2-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProt record for human PFDN2</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">UniProt curates PFDN2 as a component of both the canonical prefoldin complex and the PAQosome/R2TP prefoldin-like complex, with nucleus, cytoplasm, and mitochondrion localization from PMID:17936702.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
                             GO_REF:0000052
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15923622" target="_blank" class="term-link">
                             PMID:15923622
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The HRPT2 tumor suppressor gene product parafibromin associates with human PAF1 and RNA polymerase II.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16876117" target="_blank" class="term-link">
                             PMID:16876117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interaction of hepatitis C virus F protein with prefoldin 2 perturbs tubulin cytoskeleton organization.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">PFDN2 interacts with HCV F protein via yeast two-hybrid and co-IP</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HCV F protein impedes PFDN1-PFDN2 interaction</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Disruption leads to aberrant tubulin cytoskeleton organization</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17353931" target="_blank" class="term-link">
                             PMID:17353931
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Large-scale mapping of human protein-protein interactions by mass spectrometry.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17936702" target="_blank" class="term-link">
                             PMID:17936702
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">S6K1-mediated disassembly of mitochondrial URI/PP1gamma complexes activates a negative feedback program that counters S6K1 survival signaling.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">PFDN2 interacts with URI1 in phosphorylation-dependent manner</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">PFDN2 localizes to nucleus, cytoplasm, and mitochondria</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                             PMID:23614719
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Human prefoldin inhibits amyloid-β (Aβ) fibrillation and contributes to formation of nontoxic Aβ aggregates.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Recombinant human prefoldin inhibits Abeta fibrillation</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">hPFD induces formation of less toxic Abeta oligomers</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link">
                             PMID:25036637
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A quantitative chaperone interaction network reveals the architecture of cellular protein homeostasis pathways.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
                             PMID:28514442
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/29662061" target="_blank" class="term-link">
                             PMID:29662061
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RPAP3 provides a flexible scaffold for coupling HSP90 to the human R2TP co-chaperone complex.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                             PMID:30955883
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The Chaperonin TRiC/CCT Associates with Prefoldin through a Conserved Electrostatic Interface Essential for Cellular Proteostasis.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Cryo-EM structure of prefoldin-TRiC complex</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Conserved electrostatic interface between PFD and TRiC</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">PFD enhances folding rate and yield</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/31738558" target="_blank" class="term-link">
                             PMID:31738558
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Upstream ORF-Encoded ASDURF Is a Novel Prefoldin-like Subunit of the PAQosome.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">PFDN2 is a component of the PAQosome complex</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">PAQosome contains prefoldin-like module with PFDN2 and PFDN6</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                             PMID:32296183
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A reference map of the human binary protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link">
                             PMID:32699605
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The functions and mechanisms of prefoldin complex and prefoldin-subunits.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
                             PMID:32814053
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/34761191" target="_blank" class="term-link">
                             PMID:34761191
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A comprehensive analysis of prefoldins and their implication in cancer.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
                             PMID:40205054
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                             PMID:9630229
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Prefoldin, a chaperone that delivers unfolded proteins to cytosolic chaperonin.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Discovery of prefoldin as heterohexameric chaperone</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Prefoldin captures unfolded actin and delivers to cytosolic chaperonin</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Promotes folding in competitive environment</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -4566,9 +4668,9 @@ We first verified the target identity to avoid gene symbol ambiguity. Human PFDN
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -4580,7 +4682,7 @@ We first verified the target identity to avoid gene symbol ambiguity. Human PFDN
                 <pre><code>id: Q9UHV9
 gene_symbol: PFDN2
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -4633,6 +4735,12 @@ existing_annotations:
         supporting_text: &#34;prefoldin promotes folding in an environment in which there are many competing pathways for nonnative proteins.&#34;
       - reference_id: PMID:30955883
         supporting_text: &#34;The supra-chaperone assembly formed by PFD and TRiC is essential to prevent toxic conformations and ensure effective cellular proteostasis.&#34;
+      - reference_id: file:human/PFDN2/PFDN2-deep-research-falcon.md
+        supporting_text: &gt;-
+          PFDN2 is a structural subunit of the canonical eukaryotic prefoldin
+          holdase. It contributes to the capture of nascent or non-native
+          polypeptides, principally cytoskeletal actins and tubulins, and their
+          targeted delivery to TRiC/CCT.
 
 - term:
     id: GO:0044183
@@ -4664,17 +4772,20 @@ existing_annotations:
   review:
     summary: &gt;-
       IEA annotation for nuclear localization based on UniProt subcellular location mapping.
-      Nuclear localization of PFDN2 is supported by experimental evidence from PMID:17936702
-      (immunofluorescence) and by functional studies showing prefoldin subunits on transcribed
-      chromatin supporting RNAPII CTD phosphorylation and co-transcriptional splicing.
+      Nuclear localization of PFDN2 is supported by UniProt&#39;s curated subcellular
+      location statement and by functional studies showing prefoldin subunits on
+      transcribed chromatin supporting RNAPII CTD phosphorylation and co-transcriptional
+      splicing.
     action: ACCEPT
     reason: &gt;-
-      Although IEA, this is consistent with experimental data from PMID:17936702 and
-      PMID:16876117 showing nuclear localization, plus functional evidence for nuclear
-      roles in transcription/splicing.
+      Although IEA, this is consistent with UniProt&#39;s curated localization and
+      functional evidence for nuclear roles in transcription/splicing.
     supported_by:
-      - reference_id: PMID:17936702
-        supporting_text: &#34;URI forms stable complexes with protein phosphatase (PP)1gamma at mitochondria&#34;
+      - reference_id: file:human/PFDN2/PFDN2-uniprot.txt
+        supporting_text: &gt;-
+          SUBCELLULAR LOCATION: Nucleus {ECO:0000269|PubMed:17936702}. Cytoplasm
+          {ECO:0000269|PubMed:17936702}. Mitochondrion
+          {ECO:0000269|PubMed:17936702}.
 
 - term:
     id: GO:0005737
@@ -4698,18 +4809,21 @@ existing_annotations:
   original_reference_id: GO_REF:0000044
   review:
     summary: &gt;-
-      IEA annotation for mitochondrial localization. PMID:17936702 identified PFDN2 interaction
-      with URI1 in a mitochondrial context. This was confirmed by IDA evidence in the same
-      dataset. Mitochondrial localization relates to the URI/PAQosome complex rather than
-      canonical prefoldin function.
+      IEA annotation for mitochondrial localization based on UniProt subcellular
+      location mapping. UniProt curates PFDN2 to mitochondrion from PMID:17936702.
+      This localization is non-core relative to canonical cytosolic prefoldin
+      function.
     action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Mitochondrial localization is experimentally supported (PMID:17936702) but relates
-      to the URI1/PAQosome interaction rather than canonical prefoldin chaperone function.
+      Mitochondrial localization is curated by UniProt from PMID:17936702 but is
+      not the core location for canonical prefoldin chaperone function.
       Not a core localization for prefoldin function.
     supported_by:
-      - reference_id: PMID:17936702
-        supporting_text: &#34;URI represents a mitochondrial substrate of S6K1&#34;
+      - reference_id: file:human/PFDN2/PFDN2-uniprot.txt
+        supporting_text: &gt;-
+          SUBCELLULAR LOCATION: Nucleus {ECO:0000269|PubMed:17936702}. Cytoplasm
+          {ECO:0000269|PubMed:17936702}. Mitochondrion
+          {ECO:0000269|PubMed:17936702}.
 
 - term:
     id: GO:0006457
@@ -5223,12 +5337,32 @@ existing_annotations:
   original_reference_id: PMID:17936702
   review:
     summary: &gt;-
-      IPI protein binding from Djouder et al. (2007). This study showed PFDN2 interaction
-      with URI1 in a phosphorylation-dependent manner. Generic protein binding is uninformative.
-    action: MARK_AS_OVER_ANNOTATED
+      IPI protein binding from Djouder et al. (2007). UniProt curates PFDN2
+      interaction with URI1 and subsequent work places PFDN2 in the PAQosome/R2TP
+      prefoldin-like complex. Generic protein binding is uninformative for this
+      context.
+    action: MODIFY
     reason: &gt;-
-      Generic protein binding. The interaction with URI1 is more specifically captured
-      by the PAQosome/prefoldin complex annotations.
+      Generic protein binding should be replaced by a specific cellular component
+      annotation reflecting PFDN2 membership in the RPAP3/R2TP/prefoldin-like
+      complex. This captures the URI1/PFDL context without treating it as the
+      canonical prefoldin complex.
+    proposed_replacement_terms:
+      - id: GO:1990062
+        label: RPAP3/R2TP/prefoldin-like complex
+    supported_by:
+      - reference_id: file:human/PFDN2/PFDN2-uniprot.txt
+        supporting_text: &gt;-
+          Component of the PAQosome complex which is responsible for the
+          biogenesis of several protein complexes and which consists of R2TP
+          complex members RUVBL1, RUVBL2, RPAP3 and PIH1D1, URI complex members
+          PFDN2, PFDN6, PDRG1, UXT and URI1 as well as ASDURF, POLR2E and
+          DNAAF10/WDR92.
+      - reference_id: PMID:29662061
+        supporting_text: &gt;-
+          This PFDL module includes prefoldin and prefoldin-like proteins PFDN2,
+          PFDN6, URI1, UXT, PDRG1, and it associates with two additional
+          components, the RNA polymerase subunit POLR2E/RPB5 and WDR92/Monad5.
 
 - term:
     id: GO:0005634
@@ -5262,15 +5396,18 @@ existing_annotations:
   original_reference_id: PMID:17936702
   review:
     summary: &gt;-
-      IDA annotation for mitochondrial localization from Djouder et al. (2007). PFDN2
-      interacts with URI1 at mitochondria in a phosphorylation-dependent manner.
+      IDA annotation for mitochondrial localization from Djouder et al. (2007),
+      represented in UniProt&#39;s curated subcellular-location statement.
     action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Experimentally supported mitochondrial localization, but this relates to the
-      URI1/PAQosome interaction rather than canonical prefoldin chaperone function.
+      Experimentally supported mitochondrial localization, but not the core
+      location for canonical prefoldin chaperone function.
     supported_by:
-      - reference_id: PMID:17936702
-        supporting_text: &#34;URI represents a mitochondrial substrate of S6K1&#34;
+      - reference_id: file:human/PFDN2/PFDN2-uniprot.txt
+        supporting_text: &gt;-
+          SUBCELLULAR LOCATION: Nucleus {ECO:0000269|PubMed:17936702}. Cytoplasm
+          {ECO:0000269|PubMed:17936702}. Mitochondrion
+          {ECO:0000269|PubMed:17936702}.
 
 - term:
     id: GO:0051082
@@ -5326,6 +5463,19 @@ existing_annotations:
         supporting_text: &#34;prefoldin promotes folding in an environment in which there are many competing pathways for nonnative proteins.&#34;
 
 references:
+- id: file:human/PFDN2/PFDN2-deep-research-falcon.md
+  title: Falcon deep research report for PFDN2
+  findings:
+    - statement: &gt;-
+        PFDN2 is a beta prefoldin subunit that helps capture nascent actin and
+        tubulin clients and deliver them to TRiC/CCT for folding.
+- id: file:human/PFDN2/PFDN2-uniprot.txt
+  title: UniProt record for human PFDN2
+  findings:
+    - statement: &gt;-
+        UniProt curates PFDN2 as a component of both the canonical prefoldin
+        complex and the PAQosome/R2TP prefoldin-like complex, with nucleus,
+        cytoplasm, and mitochondrion localization from PMID:17936702.
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
   findings: []
@@ -5453,13 +5603,19 @@ core_functions:
           expression of HCV F protein impeded the interaction between prefoldin 1 and
           2...expression of HCV F protein resulted in aberrant organization of tubulin
           cytoskeleton.
+      - reference_id: file:human/PFDN2/PFDN2-deep-research-falcon.md
+        supporting_text: &gt;-
+          PFDN2 is a structural subunit of the canonical eukaryotic prefoldin
+          holdase. It contributes to the capture of nascent or non-native
+          polypeptides, principally cytoskeletal actins and tubulins, and their
+          targeted delivery to TRiC/CCT.
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/PFDN2/PFDN2-ai-review.yaml
+++ b/genes/human/PFDN2/PFDN2-ai-review.yaml
@@ -1,7 +1,7 @@
 id: Q9UHV9
 gene_symbol: PFDN2
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -54,6 +54,12 @@ existing_annotations:
         supporting_text: "prefoldin promotes folding in an environment in which there are many competing pathways for nonnative proteins."
       - reference_id: PMID:30955883
         supporting_text: "The supra-chaperone assembly formed by PFD and TRiC is essential to prevent toxic conformations and ensure effective cellular proteostasis."
+      - reference_id: file:human/PFDN2/PFDN2-deep-research-falcon.md
+        supporting_text: >-
+          PFDN2 is a structural subunit of the canonical eukaryotic prefoldin
+          holdase. It contributes to the capture of nascent or non-native
+          polypeptides, principally cytoskeletal actins and tubulins, and their
+          targeted delivery to TRiC/CCT.
 
 - term:
     id: GO:0044183
@@ -85,17 +91,20 @@ existing_annotations:
   review:
     summary: >-
       IEA annotation for nuclear localization based on UniProt subcellular location mapping.
-      Nuclear localization of PFDN2 is supported by experimental evidence from PMID:17936702
-      (immunofluorescence) and by functional studies showing prefoldin subunits on transcribed
-      chromatin supporting RNAPII CTD phosphorylation and co-transcriptional splicing.
+      Nuclear localization of PFDN2 is supported by UniProt's curated subcellular
+      location statement and by functional studies showing prefoldin subunits on
+      transcribed chromatin supporting RNAPII CTD phosphorylation and co-transcriptional
+      splicing.
     action: ACCEPT
     reason: >-
-      Although IEA, this is consistent with experimental data from PMID:17936702 and
-      PMID:16876117 showing nuclear localization, plus functional evidence for nuclear
-      roles in transcription/splicing.
+      Although IEA, this is consistent with UniProt's curated localization and
+      functional evidence for nuclear roles in transcription/splicing.
     supported_by:
-      - reference_id: PMID:17936702
-        supporting_text: "URI forms stable complexes with protein phosphatase (PP)1gamma at mitochondria"
+      - reference_id: file:human/PFDN2/PFDN2-uniprot.txt
+        supporting_text: >-
+          SUBCELLULAR LOCATION: Nucleus {ECO:0000269|PubMed:17936702}. Cytoplasm
+          {ECO:0000269|PubMed:17936702}. Mitochondrion
+          {ECO:0000269|PubMed:17936702}.
 
 - term:
     id: GO:0005737
@@ -119,18 +128,21 @@ existing_annotations:
   original_reference_id: GO_REF:0000044
   review:
     summary: >-
-      IEA annotation for mitochondrial localization. PMID:17936702 identified PFDN2 interaction
-      with URI1 in a mitochondrial context. This was confirmed by IDA evidence in the same
-      dataset. Mitochondrial localization relates to the URI/PAQosome complex rather than
-      canonical prefoldin function.
+      IEA annotation for mitochondrial localization based on UniProt subcellular
+      location mapping. UniProt curates PFDN2 to mitochondrion from PMID:17936702.
+      This localization is non-core relative to canonical cytosolic prefoldin
+      function.
     action: KEEP_AS_NON_CORE
     reason: >-
-      Mitochondrial localization is experimentally supported (PMID:17936702) but relates
-      to the URI1/PAQosome interaction rather than canonical prefoldin chaperone function.
+      Mitochondrial localization is curated by UniProt from PMID:17936702 but is
+      not the core location for canonical prefoldin chaperone function.
       Not a core localization for prefoldin function.
     supported_by:
-      - reference_id: PMID:17936702
-        supporting_text: "URI represents a mitochondrial substrate of S6K1"
+      - reference_id: file:human/PFDN2/PFDN2-uniprot.txt
+        supporting_text: >-
+          SUBCELLULAR LOCATION: Nucleus {ECO:0000269|PubMed:17936702}. Cytoplasm
+          {ECO:0000269|PubMed:17936702}. Mitochondrion
+          {ECO:0000269|PubMed:17936702}.
 
 - term:
     id: GO:0006457
@@ -644,12 +656,32 @@ existing_annotations:
   original_reference_id: PMID:17936702
   review:
     summary: >-
-      IPI protein binding from Djouder et al. (2007). This study showed PFDN2 interaction
-      with URI1 in a phosphorylation-dependent manner. Generic protein binding is uninformative.
-    action: MARK_AS_OVER_ANNOTATED
+      IPI protein binding from Djouder et al. (2007). UniProt curates PFDN2
+      interaction with URI1 and subsequent work places PFDN2 in the PAQosome/R2TP
+      prefoldin-like complex. Generic protein binding is uninformative for this
+      context.
+    action: MODIFY
     reason: >-
-      Generic protein binding. The interaction with URI1 is more specifically captured
-      by the PAQosome/prefoldin complex annotations.
+      Generic protein binding should be replaced by a specific cellular component
+      annotation reflecting PFDN2 membership in the RPAP3/R2TP/prefoldin-like
+      complex. This captures the URI1/PFDL context without treating it as the
+      canonical prefoldin complex.
+    proposed_replacement_terms:
+      - id: GO:1990062
+        label: RPAP3/R2TP/prefoldin-like complex
+    supported_by:
+      - reference_id: file:human/PFDN2/PFDN2-uniprot.txt
+        supporting_text: >-
+          Component of the PAQosome complex which is responsible for the
+          biogenesis of several protein complexes and which consists of R2TP
+          complex members RUVBL1, RUVBL2, RPAP3 and PIH1D1, URI complex members
+          PFDN2, PFDN6, PDRG1, UXT and URI1 as well as ASDURF, POLR2E and
+          DNAAF10/WDR92.
+      - reference_id: PMID:29662061
+        supporting_text: >-
+          This PFDL module includes prefoldin and prefoldin-like proteins PFDN2,
+          PFDN6, URI1, UXT, PDRG1, and it associates with two additional
+          components, the RNA polymerase subunit POLR2E/RPB5 and WDR92/Monad5.
 
 - term:
     id: GO:0005634
@@ -683,15 +715,18 @@ existing_annotations:
   original_reference_id: PMID:17936702
   review:
     summary: >-
-      IDA annotation for mitochondrial localization from Djouder et al. (2007). PFDN2
-      interacts with URI1 at mitochondria in a phosphorylation-dependent manner.
+      IDA annotation for mitochondrial localization from Djouder et al. (2007),
+      represented in UniProt's curated subcellular-location statement.
     action: KEEP_AS_NON_CORE
     reason: >-
-      Experimentally supported mitochondrial localization, but this relates to the
-      URI1/PAQosome interaction rather than canonical prefoldin chaperone function.
+      Experimentally supported mitochondrial localization, but not the core
+      location for canonical prefoldin chaperone function.
     supported_by:
-      - reference_id: PMID:17936702
-        supporting_text: "URI represents a mitochondrial substrate of S6K1"
+      - reference_id: file:human/PFDN2/PFDN2-uniprot.txt
+        supporting_text: >-
+          SUBCELLULAR LOCATION: Nucleus {ECO:0000269|PubMed:17936702}. Cytoplasm
+          {ECO:0000269|PubMed:17936702}. Mitochondrion
+          {ECO:0000269|PubMed:17936702}.
 
 - term:
     id: GO:0051082
@@ -747,6 +782,19 @@ existing_annotations:
         supporting_text: "prefoldin promotes folding in an environment in which there are many competing pathways for nonnative proteins."
 
 references:
+- id: file:human/PFDN2/PFDN2-deep-research-falcon.md
+  title: Falcon deep research report for PFDN2
+  findings:
+    - statement: >-
+        PFDN2 is a beta prefoldin subunit that helps capture nascent actin and
+        tubulin clients and deliver them to TRiC/CCT for folding.
+- id: file:human/PFDN2/PFDN2-uniprot.txt
+  title: UniProt record for human PFDN2
+  findings:
+    - statement: >-
+        UniProt curates PFDN2 as a component of both the canonical prefoldin
+        complex and the PAQosome/R2TP prefoldin-like complex, with nucleus,
+        cytoplasm, and mitochondrion localization from PMID:17936702.
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
   findings: []
@@ -874,3 +922,9 @@ core_functions:
           expression of HCV F protein impeded the interaction between prefoldin 1 and
           2...expression of HCV F protein resulted in aberrant organization of tubulin
           cytoskeleton.
+      - reference_id: file:human/PFDN2/PFDN2-deep-research-falcon.md
+        supporting_text: >-
+          PFDN2 is a structural subunit of the canonical eukaryotic prefoldin
+          holdase. It contributes to the capture of nascent or non-native
+          polypeptides, principally cytoskeletal actins and tubulins, and their
+          targeted delivery to TRiC/CCT.

--- a/genes/human/PFDN2/PFDN2-ai-review.yaml
+++ b/genes/human/PFDN2/PFDN2-ai-review.yaml
@@ -660,15 +660,42 @@ existing_annotations:
       interaction with URI1 and subsequent work places PFDN2 in the PAQosome/R2TP
       prefoldin-like complex. Generic protein binding is uninformative for this
       context.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      Generic protein binding should be replaced by a specific cellular component
-      annotation reflecting PFDN2 membership in the RPAP3/R2TP/prefoldin-like
-      complex. This captures the URI1/PFDL context without treating it as the
+      Generic protein binding is a true but low-information interaction annotation.
+      The specific URI1/PFDL context is better represented as a separate cellular
+      component annotation to the RPAP3/R2TP/prefoldin-like complex.
+    supported_by:
+      - reference_id: file:human/PFDN2/PFDN2-uniprot.txt
+        supporting_text: >-
+          Component of the PAQosome complex which is responsible for the
+          biogenesis of several protein complexes and which consists of R2TP
+          complex members RUVBL1, RUVBL2, RPAP3 and PIH1D1, URI complex members
+          PFDN2, PFDN6, PDRG1, UXT and URI1 as well as ASDURF, POLR2E and
+          DNAAF10/WDR92.
+      - reference_id: PMID:29662061
+        supporting_text: >-
+          This PFDL module includes prefoldin and prefoldin-like proteins PFDN2,
+          PFDN6, URI1, UXT, PDRG1, and it associates with two additional
+          components, the RNA polymerase subunit POLR2E/RPB5 and WDR92/Monad5.
+
+- term:
+    id: GO:1990062
+    label: RPAP3/R2TP/prefoldin-like complex
+  evidence_type: IPI
+  original_reference_id: PMID:29662061
+  review:
+    summary: >-
+      PFDN2 is a component of the PAQosome/R2TP prefoldin-like module together
+      with PFDN6, URI1, UXT, and PDRG1. This cellular component annotation captures
+      the specific complex membership underlying the generic URI1 protein-binding
+      evidence.
+    action: NEW
+    reason: >-
+      GO:1990062 specifically represents the RPAP3/R2TP/prefoldin-like complex
+      curated for PAQosome/PFDL membership. It is more informative than generic
+      protein binding and does not conflate this PAQosome context with the
       canonical prefoldin complex.
-    proposed_replacement_terms:
-      - id: GO:1990062
-        label: RPAP3/R2TP/prefoldin-like complex
     supported_by:
       - reference_id: file:human/PFDN2/PFDN2-uniprot.txt
         supporting_text: >-

--- a/genes/human/PFDN4/PFDN4-ai-review.html
+++ b/genes/human/PFDN4/PFDN4-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>PFDN4</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/Q9NQP4" target="_blank" class="term-link">
                         Q9NQP4
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>PFDN4 (Prefoldin subunit 4) encodes a beta-type subunit of the heterohexameric prefoldin complex (also known as GimC). The prefoldin complex is a jellyfish-shaped molecular chaperone composed of two alpha subunits (PFDN3/VBP1, PFDN5) and four beta subunits (PFDN1, PFDN2, PFDN4, PFDN6). Prefoldin functions as a co-chaperone/holdase that captures unfolded nascent polypeptides -- primarily actin and tubulin -- and delivers them to the group II chaperonin TRiC/CCT for ATP-dependent folding. The prefoldin-TRiC interaction is mediated through a conserved electrostatic interface (PMID:30955883). Beyond cytoskeletal protein folding, the prefoldin complex has been shown to inhibit amyloid-beta fibrillation (PMID:23614719), suggesting roles in neuroprotection. PFDN4 (also known as Protein C-1) interacts with URI1 at mitochondria in a phosphorylation- and growth-dependent manner (PMID:17936702). PFDN4 is ubiquitously expressed and located on chromosome 20q13.2. Structural data from cryo-EM places PFDN4 within the PFD-TRiC supra-chaperone complex (PDB: 6NR8, 6NR9, 6NRB, 6NRC, 6NRD, 7WU7).</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,64 +795,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005737 &#34;cytoplasm&#34; is an appropriate cellular component annotation for PFDN4. This IBA annotation was inferred from phylogenetic analysis (PANTHER) with evidence from yeast (SGD:S000005097), Arabidopsis (TAIR:locus:2025655), and human PFDN4 itself. The prefoldin complex is a cytoplasmic chaperone that operates in the cytosol to capture unfolded nascent polypeptides and deliver them to the cytosolic chaperonin TRiC/CCT (PMID:9630229). The deep research review describes prefoldin as a predominantly cytosolic complex for the canonical chaperone role. This is also supported by the IDA annotation from PMID:17936702 for the same term. The term &#34;cytoplasm&#34; is appropriately broad, as a more specific CC annotation to &#34;prefoldin complex&#34; (GO:0016272) is already present in this annotation set.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PFDN4 operates as part of the cytoplasmic prefoldin complex. The cytoplasm annotation is well-supported phylogenetically and consistent with direct experimental data (PMID:17936702, PMID:9630229). The IBA is sound and complements the more specific prefoldin complex (GO:0016272) annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -864,88 +864,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0006457 &#34;protein folding&#34; is a well-supported core function of PFDN4. This IBA annotation was inferred from phylogenetic analysis (PANTHER) with evidence from Arabidopsis (TAIR:locus:2025655) and human PFDN4 itself. The prefoldin complex is a bona fide co-chaperone that captures unfolded nascent polypeptides (primarily actin and tubulin) and delivers them to TRiC/CCT for ATP-dependent folding (PMID:9630229). Gestaut et al. 2019 (PMID:30955883) showed that PFD enhances the rate and yield of TRiC-mediated folding, directly demonstrating involvement in protein folding. The deep research review (PFDN4-deep-research-falcon.md) confirms this as the primary function: &#34;Non-enzymatic co-chaperone; assists folding of cytoskeletal proteins by handing off clients to TRiC/CCT.&#34; This is the central biological process for PFDN4.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein folding is the core biological process for all prefoldin subunits. The IBA annotation is phylogenetically well-supported and consistent with extensive experimental literature demonstrating prefoldin&#39;s role in delivering substrates to TRiC/CCT for folding (PMID:9630229, PMID:30955883).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We describe the discovery of a heterohexameric chaperone protein, prefoldin, based on its ability to capture unfolded actin. Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:human/PFDN4/PFDN4-deep-research-falcon.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Primary function: Non-enzymatic co-chaperone; assists folding of cytoskeletal proteins by handing off clients to TRiC/CCT. Substrate specificity centers on actin and tubulin.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -957,88 +957,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). This IBA annotation was inferred from phylogenetic analysis (PANTHER) with evidence from human PFDN4 itself. While prefoldin does indeed bind unfolded proteins, the term &#34;unfolded protein binding&#34; is a pure binding term that fails to capture the functional significance of this interaction. Prefoldin acts as a holdase/transfer chaperone: it captures unfolded substrates (primarily actin and tubulin) and delivers them to the TRiC/CCT chaperonin for folding. As described in Vainberg et al. 1998 (PMID:9630229), &#34;Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.&#34; The more appropriate term is GO:0044183 &#34;protein folding chaperone&#34; which captures the functional chaperone activity rather than just substrate binding. Note that unlike PFDN1, PFDN4 does not have an existing IBA annotation to GO:0044183, so a NEW annotation for that term is proposed separately.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. The term describes only a binding activity and does not capture the chaperone function of prefoldin. Prefoldin is a molecular chaperone that binds unfolded substrates and delivers them to TRiC/CCT for folding (PMID:9630229, PMID:30955883). GO:0044183 &#34;protein folding chaperone&#34; (defined as &#34;Binding to a protein or a protein-containing complex to assist the protein folding process&#34;) is the recommended replacement.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFD alternates between an open &#34;latched&#34; conformation and a closed &#34;engaged&#34; conformation that aligns the PFD-TRiC substrate binding chambers.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016272" target="_blank" class="term-link">
                                     GO:0016272
                                 </a>
                             </span>
                             <span class="term-label">prefoldin complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1050,77 +1050,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0016272 &#34;prefoldin complex&#34; is a well-supported core annotation for PFDN4. This IBA annotation was inferred from phylogenetic analysis (PANTHER) with evidence from yeast (SGD:S000005097) and human PFDN4 itself. PFDN4 is one of the four beta subunits (PFDN1, PFDN2, PFDN4, PFDN6) of the heterohexameric prefoldin complex (PMID:9630229). The complex is registered in ComplexPortal as CPX-6149 (&#34;Prefoldin co-chaperone complex&#34;). Structural data from cryo-EM (PMID:30955883) includes PFDN4 as chain 4 in PDB structures 6NR8/6NR9/6NRB/6NRC/6NRD and 7WU7.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PFDN4 is a core structural subunit of the prefoldin complex. The IBA phylogenetic inference is strongly supported and consistent with multiple experimental studies (PMID:9630229, PMID:30955883, PMID:23614719).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We describe the discovery of a heterohexameric chaperone protein, prefoldin, based on its ability to capture unfolded actin.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Maintaining proteostasis in eukaryotic protein folding involves cooperation of distinct chaperone systems. To understand how the essential ring-shaped chaperonin TRiC/CCT cooperates with the chaperone prefoldin/GIMc (PFD), we integrate cryoelectron microscopy (cryo-EM), crosslinking-mass-spectrometry and biochemical and cellular approaches to elucidate the structural and functional interplay between TRiC/CCT and PFD.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1132,46 +1132,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005634 &#34;nucleus&#34; inferred electronically from UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping (GO_REF:0000044). The UniProt record for PFDN4 reports nuclear localization based on PMID:17936702. Djouder et al. 2007 studied URI1 (a prefoldin-like protein) interactions and found PFDN4 co-purified with URI1 in various subcellular compartments. The deep research review (PFDN4-deep-research-falcon.md) notes &#34;nuclear functions are suggested for certain prefoldin subunits and for PFDN4/Protein C-1 as a transcriptional cofactor.&#34; However, the nuclear localization likely reflects a secondary, non-canonical role distinct from the primary cytoplasmic chaperone function. This IEA is consistent with the IDA annotation from the same publication.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The IEA mapping from UniProt subcellular location is correct and reflects the experimental observation from PMID:17936702. However, nuclear localization represents a non-canonical localization for PFDN4. The primary site of prefoldin chaperone function is the cytoplasm. Keeping as non-core consistent with the IDA annotation for the same term.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1183,46 +1183,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005737 &#34;cytoplasm&#34; inferred electronically by combined automated annotation methods (ARBA:ARBA00026971 and UniProtKB-SubCell:SL-0086). This IEA annotation is consistent with the IBA annotation to the same term and with the IDA annotation from PMID:17936702. The prefoldin complex primarily operates in the cytoplasm (PMID:9630229).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The IEA annotation to cytoplasm is correct and consistent with higher-confidence IBA and IDA annotations. The prefoldin complex is a cytoplasmic chaperone (PMID:9630229, PMID:17936702).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1234,46 +1234,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005739 &#34;mitochondrion&#34; inferred electronically from UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping (GO_REF:0000044). The UniProt record for PFDN4 reports mitochondrial localization based on PMID:17936702. Djouder et al. 2007 showed that the prefoldin-like protein URI1 forms complexes with PP1gamma at mitochondria, and PFDN4 was identified as an interactor of URI1. The mitochondrial localization of PFDN4 appears to be related to the URI1/PAQosome axis rather than canonical prefoldin chaperone function. This IEA is consistent with the IDA annotation from the same publication.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The IEA mapping from UniProt subcellular location is correct and reflects the experimental observation from PMID:17936702. However, mitochondrial localization represents a non-canonical localization related to the URI1 interaction. The primary site of prefoldin chaperone function is the cytoplasm. Keeping as non-core consistent with the IDA annotation for the same term.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1285,46 +1285,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0006457 &#34;protein folding&#34; inferred electronically from InterPro domain mapping (IPR002777, the prefoldin beta-like domain, and IPR016661, the PFDN4-specific domain). This IEA annotation is consistent with the IBA and IDA annotations to the same term, and with the well-established role of the prefoldin complex in protein folding (PMID:9630229).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The IEA annotation to protein folding via InterPro is correct and consistent with the higher-confidence IBA and IDA annotations. The prefoldin beta-like domain (IPR002777) is specifically associated with the protein folding function of the prefoldin complex (PMID:9630229, PMID:30955883).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016272" target="_blank" class="term-link">
                                     GO:0016272
                                 </a>
                             </span>
                             <span class="term-label">prefoldin complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1336,46 +1336,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0016272 &#34;prefoldin complex&#34; inferred electronically from InterPro domain mapping (IPR002777, the prefoldin beta-like domain, and IPR016661, the PFDN4-specific domain). PFDN4 is one of the four beta subunits of the heterohexameric prefoldin complex (PMID:9630229). The complex is registered in ComplexPortal as CPX-6149. This IEA annotation is consistent with the IDA annotations to the same term from PMID:30955883 and PMID:23614719 and the IBA annotation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PFDN4 is a core structural subunit of the prefoldin complex. The IEA mapping from the prefoldin beta-like domain (IPR002777) to prefoldin complex membership is appropriate and consistent with experimental evidence (PMID:9630229, PMID:30955883).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
                                     GO:0032991
                                 </a>
                             </span>
                             <span class="term-label">protein-containing complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1387,46 +1387,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0032991 &#34;protein-containing complex&#34; was inferred electronically by the ARBA machine learning model (ARBA:ARBA00028902). While technically correct -- PFDN4 is part of the prefoldin complex, which is indeed a protein-containing complex -- this annotation is redundant and overly general given the more specific GO:0016272 &#34;prefoldin complex&#34; annotation that is already present from IBA, IEA (InterPro), and IDA (PMID:30955883, PMID:23614719) evidence. The term &#34;protein-containing complex&#34; adds no informational value beyond what is already captured.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is an overly general annotation. PFDN4 is part of the prefoldin complex (GO:0016272), which is a child term of protein-containing complex. The more specific term is already annotated with IBA, IEA, and IDA evidence. The generic &#34;protein-containing complex&#34; adds no useful information.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1438,86 +1438,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). This IEA annotation was inferred electronically from InterPro domain mapping (IPR002777, the prefoldin beta-like domain). The InterPro-to-GO mapping associates the prefoldin domain with unfolded protein binding, which is functionally accurate in that prefoldin subunits do contact unfolded substrates. However, since the term is being obsoleted, the annotation should be replaced with GO:0044183 &#34;protein folding chaperone&#34; which better describes the functional role of the prefoldin complex as a holdase/transfer chaperone that delivers substrates to TRiC/CCT.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. While the InterPro mapping correctly identifies that the prefoldin domain binds unfolded proteins, the replacement term GO:0044183 &#34;protein folding chaperone&#34; better captures the functional role of prefoldin as a chaperone that assists in protein folding by delivering unfolded substrates to the TRiC/CCT chaperonin (PMID:9630229, PMID:30955883).
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25416956
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A proteome-scale map of the human interactome network.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1529,75 +1529,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:P61758/VBP1) from Rolland et al. 2014 (PMID:25416956), a proteome-scale map of the human interactome network. P61758 is VBP1 (von Hippel-Lindau binding protein 1), which is also known as prefoldin subunit 3 (PFDN3), an alpha-type subunit of the prefoldin complex. The PFDN4-VBP1/PFDN3 interaction reflects intra-complex subunit assembly within the prefoldin hexamer. UniProt confirms this interaction (NbExp=10 for the VBP1 interaction). While the interaction is real and well-supported, the &#34;protein binding&#34; term is uninformative -- this interaction is already captured by the GO:0016272 &#34;prefoldin complex&#34; annotation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. The PFDN4-VBP1/PFDN3 interaction reflects co-membership in the prefoldin complex, already captured by GO:0016272 &#34;prefoldin complex.&#34; This high-throughput interactome study provides no additional functional insight.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
                                         PMID:25416956
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Here, we describe a systematic map of ...high-quality human binary protein-protein interactions.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28514442
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Architecture of the human interactome defines protein commun...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1609,57 +1609,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:P61758/VBP1) from Huttlin et al. 2017 (PMID:28514442), the BioPlex human interactome study (architecture of the human interactome). This is another detection of the PFDN4-VBP1/PFDN3 interaction, expected for subunits of the same hexameric prefoldin complex. The &#34;protein binding&#34; term is uninformative and the interaction is already captured by the prefoldin complex membership annotation (GO:0016272).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. The PFDN4-VBP1/PFDN3 interaction reflects co-membership in the prefoldin complex, already captured by GO:0016272. This high-throughput interactome study provides no additional functional insight beyond complex membership.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32296183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A reference map of the human binary protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1671,57 +1671,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:O75679/RFPL3 and UniProtKB:P61758/VBP1) from Luck et al. 2020 (PMID:32296183), a reference map of the human binary protein interactome (HuRI). The VBP1/PFDN3 interaction again reflects intra-complex assembly. The RFPL3 (Ret finger protein-like 3) interaction is also confirmed in the UniProt record (NbExp=3). RFPL3 is involved in protein ubiquitination, and its biological significance for PFDN4 function is unclear. In either case, the &#34;protein binding&#34; term is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. The PFDN4-VBP1/PFDN3 interaction is captured by GO:0016272. The RFPL3 interaction, while replicated (NbExp=3 in IntAct), does not clarify PFDN4 function. The core molecular function is better captured by GO:0044183 &#34;protein folding chaperone.&#34;
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1733,57 +1733,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:P61758/VBP1) from Huttlin et al. 2021 (PMID:33961781), a dual proteome-scale network study of the human interactome. This is yet another independent detection of the PFDN4-VBP1/PFDN3 intra-complex interaction. The &#34;protein binding&#34; term is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. This is a replication of the PFDN4-VBP1 interaction (intra-complex) that does not add functional insight beyond what is captured by GO:0016272 (prefoldin complex).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:40205054
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Multimodal cell maps as a foundation for structural and func...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1795,57 +1795,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:P61758/VBP1) from multimodal cell maps study (PMID:40205054). This is yet another replication of the PFDN4-VBP1/PFDN3 interaction, expected for co-members of the prefoldin complex. The &#34;protein binding&#34; term is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. This is a further replication of the known PFDN4-VBP1/PFDN3 intra-complex interaction from a large-scale study. The relevant functions are already captured by more specific annotations (GO:0016272 for complex membership).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32699605
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The functions and mechanisms of prefoldin complex and prefol...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1857,75 +1857,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0006457 &#34;protein folding&#34; (NAS) from ComplexPortal, citing Liang et al. 2020 (PMID:32699605), a comprehensive review of prefoldin complex functions and mechanisms. The review describes how the prefoldin complex helps protein fold correctly by providing the TRiC/CCT chaperonin with unfolded substrates. This NAS annotation is consistent with the IBA and IDA annotations to the same term.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein folding is the core biological process for PFDN4. This NAS annotation from ComplexPortal cites a well-sourced review (PMID:32699605) that accurately describes the protein folding function of the prefoldin complex. Consistent with IBA and IDA evidence to the same term.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link">
                                         PMID:32699605
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The correct folding is a key process for a protein to acquire its functional structure and conformation. Prefoldin is a well-known chaperone protein that regulates the correct folding of proteins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30955883
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Chaperonin TRiC/CCT Associates with Prefoldin through a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1937,88 +1937,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0006457 &#34;protein folding&#34; (IDA) from Gestaut et al. 2019 (PMID:30955883), which used cryo-EM, crosslinking mass spectrometry, and biochemical reconstitution to characterize the structural and functional interplay between the prefoldin (PFD) complex and TRiC/CCT chaperonin. The study demonstrates that &#34;PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles,&#34; directly showing involvement in protein folding. The reconstituted human prefoldin complex includes PFDN4 as a structural component.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This IDA annotation is supported by strong direct experimental evidence from Gestaut et al. 2019 (PMID:30955883), which demonstrated through cryo-EM and biochemical approaches that the PFD-TRiC supra-chaperone assembly enhances protein folding rates. Protein folding is the core biological process for PFDN4.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The supra-chaperone assembly formed by PFD and TRiC is essential to prevent toxic conformations and ensure effective cellular proteostasis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016272" target="_blank" class="term-link">
                                     GO:0016272
                                 </a>
                             </span>
                             <span class="term-label">prefoldin complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30955883
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Chaperonin TRiC/CCT Associates with Prefoldin through a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2030,75 +2030,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0016272 &#34;prefoldin complex&#34; (IDA) from Gestaut et al. 2019 (PMID:30955883). This study used reconstituted human prefoldin complex (containing all six subunits including PFDN4) and characterized its structure and function through cryo-EM, crosslinking mass spectrometry, and biochemical assays. The cryo-EM structures (PDB: 6NR8, 6NR9, 6NRB, 6NRC, 6NRD) include PFDN4 as chain 4, directly demonstrating that PFDN4 is a component of the prefoldin complex.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PFDN4 is a core structural subunit of the prefoldin complex. This IDA annotation is supported by high-resolution cryo-EM structural data from Gestaut et al. 2019 (PMID:30955883) that directly demonstrates PFDN4 as a component of the human prefoldin complex.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Maintaining proteostasis in eukaryotic protein folding involves cooperation of distinct chaperone systems. To understand how the essential ring-shaped chaperonin TRiC/CCT cooperates with the chaperone prefoldin/GIMc (PFD), we integrate cryoelectron microscopy (cryo-EM), crosslinking-mass-spectrometry and biochemical and cellular approaches to elucidate the structural and functional interplay between TRiC/CCT and PFD.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30955883
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Chaperonin TRiC/CCT Associates with Prefoldin through a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -2110,112 +2110,112 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). This IDA annotation cites Gestaut et al. 2019 (PMID:30955883), which demonstrated that prefoldin associates with TRiC through a conserved electrostatic interface and undergoes conformational cycling during substrate transfer. Critically, the paper shows that PFD functions not merely as a passive binder of unfolded substrates but as an active co-chaperone that enhances the rate and yield of TRiC-mediated folding. GO:0044183 &#34;protein folding chaperone&#34; is the appropriate replacement, capturing the functional role of prefoldin in the chaperone-assisted folding pathway.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. Gestaut et al. 2019 (PMID:30955883) demonstrates that prefoldin functions as a co-chaperone/holdase that cooperates with TRiC/CCT in substrate folding, not merely as an unfolded protein binder. GO:0044183 &#34;protein folding chaperone&#34; accurately describes this co-chaperone activity. The GO:0044183 definition (&#34;Binding to a protein or a protein-containing complex to assist the protein folding process&#34;) appropriately encompasses the holdase/transfer function.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Disrupting the TRiC-PFD interaction in vivo is strongly deleterious, leading to accumulation of amyloid aggregates.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001540" target="_blank" class="term-link">
                                     GO:0001540
                                 </a>
                             </span>
                             <span class="term-label">amyloid-beta binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23614719
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human prefoldin inhibits amyloid-β (Aβ) fibrillation and con...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2227,75 +2227,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0001540 &#34;amyloid-beta binding&#34; (IDA) from Sorgjerd et al. 2013 (PMID:23614719). This study demonstrated that recombinant human prefoldin (hPFD) inhibits amyloid-beta (Abeta 1-42) fibrillation in vitro and induces formation of soluble Abeta oligomers with reduced toxicity. The study used thioflavin T measurements and immunoblotting to show that hPFD directly interacts with Abeta peptides and modifies their aggregation pathway. While this demonstrates that the prefoldin complex can bind Abeta, this is not the core function of PFDN4 -- it reflects the general chaperone/holdase property of prefoldin applied to an amyloidogenic substrate. The annotation was made on the intact prefoldin complex, not PFDN4 individually.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Amyloid-beta binding is a secondary, non-core function that reflects the general holdase/chaperone activity of the prefoldin complex applied to an amyloidogenic substrate. The study (PMID:23614719) used the intact hexameric complex rather than individual PFDN4. While the data are solid, this represents a peripheral function compared to the core role in actin/tubulin folding via TRiC/CCT delivery.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                                         PMID:23614719
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we investigated the effect of recombinant human PFD (hPFD) on Abeta(1-42) aggregation in vitro and found that hPFD inhibited Abeta fibrillation and induced formation of soluble Abeta oligomers.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016272" target="_blank" class="term-link">
                                     GO:0016272
                                 </a>
                             </span>
                             <span class="term-label">prefoldin complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23614719
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human prefoldin inhibits amyloid-β (Aβ) fibrillation and con...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2307,75 +2307,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0016272 &#34;prefoldin complex&#34; (IDA) from Sorgjerd et al. 2013 (PMID:23614719). This study expressed and purified recombinant human prefoldin complex (hPFD) to investigate its effect on amyloid-beta aggregation. The successful reconstitution and purification of the hexameric complex provides direct evidence for PFDN4 membership in the prefoldin complex, consistent with the IDA annotation from PMID:30955883 and the IBA and IEA annotations.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PFDN4 is a core structural subunit of the prefoldin complex. This IDA annotation from PMID:23614719 provides independent experimental evidence through reconstitution of the human prefoldin hexamer, consistent with the structural data from PMID:30955883.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                                         PMID:23614719
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin (PFD) is a molecular chaperone that prevents aggregation of misfolded proteins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905907" target="_blank" class="term-link">
                                     GO:1905907
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of amyloid fibril formation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23614719
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human prefoldin inhibits amyloid-β (Aβ) fibrillation and con...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2387,88 +2387,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:1905907 &#34;negative regulation of amyloid fibril formation&#34; (IDA) from Sorgjerd et al. 2013 (PMID:23614719). The study demonstrated that recombinant human prefoldin &#34;inhibited Abeta fibrillation and induced formation of soluble Abeta oligomers&#34; that were 30-40% less toxic than Abeta fibrils. Thioflavin T measurements confirmed reduced fibril formation. While the experimental evidence is sound, this represents a non-core function of the prefoldin complex -- an extension of its general holdase/chaperone properties to amyloidogenic substrates rather than its primary role in actin/tubulin folding. The study was performed on the intact hexameric complex, not PFDN4 individually.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The experimental evidence from PMID:23614719 is solid, but this is a secondary function reflecting the general anti-aggregation properties of the prefoldin complex rather than its core role in delivering unfolded actin/tubulin to TRiC/CCT. The study was performed in vitro on the intact hexameric complex, and the relevance to PFDN4 specifically (as opposed to the complex as a whole) is indirect.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                                         PMID:23614719
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we investigated the effect of recombinant human PFD (hPFD) on Abeta(1-42) aggregation in vitro and found that hPFD inhibited Abeta fibrillation and induced formation of soluble Abeta oligomers.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                                         PMID:23614719
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Our findings show a relation between cytotoxicity of Abeta oligomers and structure and suggest a possible protective role of PFD in AD.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17936702" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17936702
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     S6K1-mediated disassembly of mitochondrial URI/PP1gamma comp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2480,75 +2480,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:O94763/URI1) from Djouder et al. 2007 (PMID:17936702). This study identified PFDN4 as an interactor of URI1 (unconventional prefoldin RPB5 interactor 1) in a growth-dependent and phosphorylation-dependent manner. The UniProt record for PFDN4 confirms the interaction: &#34;Interacts with URI1; the interaction is phosphorylation- dependent and occurs in a growth-dependent manner.&#34; URI1 is a component of the PAQosome/R2TP-prefoldin-like complex involved in macromolecular assembly. While the interaction is genuine and biologically interesting (linking PFDN4 to the URI1/PAQosome pathway), the &#34;protein binding&#34; term is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. The PFDN4-URI1 interaction was demonstrated by focused biochemistry (PMID:17936702) and is biologically interesting, but the GO term provides no functional insight. The specific interaction with URI1 is noted in the UniProt record. The core molecular function of PFDN4 is better captured by GO:0044183 &#34;protein folding chaperone.&#34;
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17936702" target="_blank" class="term-link">
                                         PMID:17936702
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the prefoldin chaperone URI represents a mitochondrial substrate of S6K1.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17936702" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17936702
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     S6K1-mediated disassembly of mitochondrial URI/PP1gamma comp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2560,75 +2560,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005634 &#34;nucleus&#34; (IDA) from Djouder et al. 2007 (PMID:17936702). This study investigated URI1-mediated signaling pathways and identified PFDN4 among URI1 interactors. The subcellular localization data for PFDN4 comes from this study, where PFDN4 was detected in the nucleus. The UniProt record cites this reference for nuclear localization. The deep research review (PFDN4-deep-research-falcon.md) notes &#34;nuclear functions are suggested for certain prefoldin subunits and for PFDN4/Protein C-1 as a transcriptional cofactor, indicating potential nucleocytoplasmic distribution depending on context.&#34; While the canonical prefoldin chaperone function is cytoplasmic, nuclear presence is documented and may relate to non-canonical transcriptional or chromatin-related functions reported for prefoldin family members.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear localization is documented by IDA evidence from PMID:17936702, but this represents a non-canonical localization. The primary site of prefoldin chaperone function is the cytoplasm. The nuclear presence may relate to non-canonical transcriptional cofactor roles suggested for PFDN4/Protein C-1.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17936702" target="_blank" class="term-link">
                                         PMID:17936702
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">S6 kinase 1 (S6K1) acts to integrate nutrient and growth factor signals to promote cell growth but also cell survival as a mitochondria-tethered protein kinase</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17936702" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17936702
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     S6K1-mediated disassembly of mitochondrial URI/PP1gamma comp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2640,75 +2640,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005737 &#34;cytoplasm&#34; (IDA) from Djouder et al. 2007 (PMID:17936702). This study detected PFDN4 in the cytoplasm, consistent with its role as a subunit of the cytoplasmic prefoldin complex. The UniProt record confirms cytoplasmic localization citing this reference. This is the primary location for prefoldin chaperone function (PMID:9630229).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization is the primary site of prefoldin chaperone function. This IDA annotation from PMID:17936702 is consistent with the established cytoplasmic role of the prefoldin complex and with the IBA annotation to the same term.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17936702" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17936702
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     S6K1-mediated disassembly of mitochondrial URI/PP1gamma comp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2720,75 +2720,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005739 &#34;mitochondrion&#34; (IDA) from Djouder et al. 2007 (PMID:17936702). This study demonstrated that URI1 forms complexes with PP1gamma at mitochondria, and PFDN4 was identified as an interactor of URI1. The UniProt record reports mitochondrial localization based on this study. The mitochondrial localization of PFDN4 appears to be related to its interaction with URI1 and the PAQosome axis, rather than canonical prefoldin chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Mitochondrial localization is documented by IDA evidence from PMID:17936702, but this represents a non-canonical localization related to the URI1 interaction pathway. The primary site of prefoldin chaperone function is the cytoplasm.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17936702" target="_blank" class="term-link">
                                         PMID:17936702
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the prefoldin chaperone URI represents a mitochondrial substrate of S6K1. In growth factor-deprived or rapamycin-treated cells, URI forms stable complexes with protein phosphatase (PP)1gamma at mitochondria</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9630229
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Prefoldin, a chaperone that delivers unfolded proteins to cy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2800,75 +2800,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0006457 &#34;protein folding&#34; (TAS) citing the landmark Vainberg et al. 1998 paper (PMID:9630229) that first described the discovery of the prefoldin complex and its role in capturing unfolded proteins and delivering them to cytosolic chaperonin for folding. This is the original paper establishing the protein folding function of the prefoldin complex.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein folding is the core biological process for PFDN4. This TAS annotation cites the foundational paper (PMID:9630229) establishing prefoldin as a chaperone that delivers unfolded proteins to cytosolic chaperonin for folding. Consistent with IBA, IDA, and NAS evidence to the same term.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We describe the discovery of a heterohexameric chaperone protein, prefoldin, based on its ability to capture unfolded actin. Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9630229
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Prefoldin, a chaperone that delivers unfolded proteins to cy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2880,88 +2880,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051087 &#34;protein-folding chaperone binding&#34; (TAS) citing Vainberg et al. 1998 (PMID:9630229). This term is defined as &#34;Binding to a chaperone protein, a class of proteins that bind to nascent or unfolded polypeptides and ensure correct folding or transport.&#34; Prefoldin binds specifically to the TRiC/CCT chaperonin to deliver unfolded substrates for folding. Vainberg et al. 1998 demonstrated that &#34;Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.&#34; This annotation accurately captures that PFDN4 (as part of the prefoldin complex) binds to another chaperone (TRiC/CCT). Gestaut et al. 2019 (PMID:30955883) further characterized this interface at the structural level.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This term correctly describes the binding of prefoldin to TRiC/CCT, a protein-folding chaperone. The prefoldin-TRiC interaction is a well-established core function (PMID:9630229, PMID:30955883). The term complements GO:0044183 &#34;protein folding chaperone&#34; (which describes prefoldin&#39;s own chaperone activity) and GO:0006457 (the process).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We find these hetero-oligomeric chaperones associate in a defined architecture, through a conserved interface of electrostatic contacts that serves as a pivot point for a TRiC-PFD conformational cycle.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9630229
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Prefoldin, a chaperone that delivers unfolded proteins to cy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2973,75 +2973,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005829 &#34;cytosol&#34; (NAS) citing Vainberg et al. 1998 (PMID:9630229). The prefoldin complex operates in the cytosol, where it captures unfolded nascent polypeptides and delivers them to the cytosolic chaperonin TRiC/CCT. The term &#34;cytosol&#34; is more specific than &#34;cytoplasm&#34; (GO:0005737) and accurately describes the compartment where prefoldin functions. Both Vainberg et al. 1998 and Gestaut et al. 2019 (PMID:30955883) describe prefoldin as a cytosolic complex.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The cytosol is the correct subcellular location for prefoldin chaperone function. This NAS annotation is consistent with the well-established role of prefoldin as a cytosolic co-chaperone (PMID:9630229, PMID:30955883). The term provides a more specific localization than the broader &#34;cytoplasm&#34; annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     GO:0044183
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30955883
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Chaperonin TRiC/CCT Associates with Prefoldin through a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-new">
@@ -3053,63 +3053,63 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0044183 &#34;protein folding chaperone&#34; is proposed as a NEW annotation for PFDN4 based on strong experimental evidence. Unlike PFDN1, PFDN4 does not currently have an IBA or IDA annotation to this term. Gestaut et al. 2019 (PMID:30955883) demonstrated that the prefoldin complex (containing PFDN4) functions as a co-chaperone that binds unfolded substrates and delivers them to TRiC/CCT, enhancing the rate and yield of protein folding. Vainberg et al. 1998 (PMID:9630229) established that &#34;Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.&#34; The GO:0044183 definition (&#34;Binding to a protein or a protein-containing complex to assist the protein folding process&#34;) precisely captures the prefoldin co-chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0044183 &#34;protein folding chaperone&#34; is the core molecular function of PFDN4 as a subunit of the prefoldin complex. Unlike PFDN1, PFDN4 lacks this annotation, and the existing GO:0051082 &#34;unfolded protein binding&#34; annotations are being obsoleted. This term is the recommended replacement and accurately captures the holdase/transfer chaperone activity of PFDN4 demonstrated by PMID:30955883 and PMID:9630229.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We describe the discovery of a heterohexameric chaperone protein, prefoldin, based on its ability to capture unfolded actin. Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>PFDN4 is a beta-type subunit of the heterohexameric prefoldin co-chaperone complex that captures unfolded nascent polypeptides (primarily actin and tubulin) and delivers them to the TRiC/CCT chaperonin for ATP-dependent folding. Cryo-EM structural data show PFDN4 as chain 4 in the PFD-TRiC supra-chaperone complex. The prefoldin complex alternates between an open &#34;latched&#34; conformation and a closed &#34;engaged&#34; conformation that aligns the PFD-TRiC substrate binding chambers, and this conformational cycling enhances the rate and yield of TRiC-mediated protein folding. Disrupting the TRiC-PFD interaction in vivo leads to accumulation of amyloid aggregates.</h3>
                 <span class="vote-buttons" data-g="Q9NQP4" data-a="FUNCTION: PFDN4 is a beta-type subunit of the heterohexameri..." data-r="" data-act="CORE_FUNCTION">
@@ -3117,10 +3117,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -3129,39 +3129,39 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                 protein folding
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">In Complex:</div>
                     <span class="badge">
@@ -3170,327 +3170,350 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                 PMID:9630229
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">We describe the discovery of a heterohexameric chaperone protein, prefoldin, based on its ability to capture unfolded actin. Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                 PMID:30955883
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                 PMID:30955883
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">Disrupting the TRiC-PFD interaction in vivo is strongly deleterious, leading to accumulation of amyloid aggregates.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/PFDN4/PFDN4-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for PFDN4</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">PFDN4 is a beta-class prefoldin subunit whose primary function is cytoskeletal client handoff to TRiC/CCT.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17936702" target="_blank" class="term-link">
                             PMID:17936702
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">S6K1-mediated disassembly of mitochondrial URI/PP1gamma complexes activates a negative feedback program that counters S6K1 survival signaling.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                             PMID:23614719
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Human prefoldin inhibits amyloid-β (Aβ) fibrillation and contributes to formation of nontoxic Aβ aggregates.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
                             PMID:25416956
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A proteome-scale map of the human interactome network.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
                             PMID:28514442
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                             PMID:30955883
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The Chaperonin TRiC/CCT Associates with Prefoldin through a Conserved Electrostatic Interface Essential for Cellular Proteostasis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                             PMID:32296183
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A reference map of the human binary protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link">
                             PMID:32699605
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The functions and mechanisms of prefoldin complex and prefoldin-subunits.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
                             PMID:40205054
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                             PMID:9630229
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Prefoldin, a chaperone that delivers unfolded proteins to cytosolic chaperonin.</div>
-                
-                
+
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -3709,9 +3732,9 @@ Human PFDN4 (Q9NQP4) is a canonical beta‑class subunit of the prefoldin comple
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -3723,7 +3746,7 @@ Human PFDN4 (Q9NQP4) is a canonical beta‑class subunit of the prefoldin comple
                 <pre><code>id: Q9NQP4
 gene_symbol: PFDN4
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -4634,6 +4657,12 @@ core_functions:
         Disrupting the TRiC-PFD interaction in vivo is strongly deleterious,
         leading to accumulation of amyloid aggregates.
 references:
+- id: file:human/PFDN4/PFDN4-deep-research-falcon.md
+  title: Falcon deep research report for PFDN4
+  findings:
+    - statement: &gt;-
+        PFDN4 is a beta-class prefoldin subunit whose primary function is
+        cytoskeletal client handoff to TRiC/CCT.
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
     terms
@@ -4693,7 +4722,7 @@ references:
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/PFDN4/PFDN4-ai-review.yaml
+++ b/genes/human/PFDN4/PFDN4-ai-review.yaml
@@ -1,7 +1,7 @@
 id: Q9NQP4
 gene_symbol: PFDN4
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -912,6 +912,12 @@ core_functions:
         Disrupting the TRiC-PFD interaction in vivo is strongly deleterious,
         leading to accumulation of amyloid aggregates.
 references:
+- id: file:human/PFDN4/PFDN4-deep-research-falcon.md
+  title: Falcon deep research report for PFDN4
+  findings:
+    - statement: >-
+        PFDN4 is a beta-class prefoldin subunit whose primary function is
+        cytoskeletal client handoff to TRiC/CCT.
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
     terms

--- a/genes/human/PFDN5/PFDN5-ai-review.html
+++ b/genes/human/PFDN5/PFDN5-ai-review.html
@@ -3403,14 +3403,25 @@
                         </div>
                     </td>
                     <td>
-                        <span class="evidence-code">IBA</span>
+                        <span class="evidence-code">IDA</span>
 
 
 
                         <br>
                         <span style="font-size: 0.75rem;">
 
-                            GO_REF:0000033
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30955883
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The Chaperonin TRiC/CCT Associates with Prefoldin through a ...
+                                </span>
+
+
 
                         </span>
 
@@ -3419,7 +3430,7 @@
                         <span class="action-badge action-new">
                             NEW
                         </span>
-                        <span class="vote-buttons" data-g="Q99471" data-a="GO:0044183" data-r="GO_REF:0000033" data-act="NEW">
+                        <span class="vote-buttons" data-g="Q99471" data-a="GO:0044183" data-r="PMID:30955883" data-act="NEW">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -3427,12 +3438,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> GO:0044183 &#34;protein folding chaperone&#34; is the most appropriate molecular function term for PFDN5 as a prefoldin subunit. This annotation is proposed as a NEW entry to match the IBA annotation that exists for PFDN1 (which has this term with IBA evidence). Prefoldin functions as a holdase/transfer chaperone that captures unfolded nascent polypeptides and delivers them to TRiC/CCT for folding (PMID:9630229). Gestaut et al. 2019 (PMID:30955883) demonstrated that the PFD-TRiC supra-chaperone assembly enhances folding rates. This term is also the recommended replacement for the obsoleting GO:0051082 &#34;unfolded protein binding.&#34; Note: PFDN5 does not currently have an explicit IBA annotation to GO:0044183 in the GOA data, unlike PFDN1 which does. The two MODIFY actions for GO:0051082 above recommend this term as replacement.
+                            <strong>Summary:</strong> GO:0044183 &#34;protein folding chaperone&#34; is the most appropriate molecular function term for PFDN5 as a prefoldin subunit. This annotation is proposed as a manual NEW entry supported by direct experimental evidence from Gestaut et al. 2019. Prefoldin functions as a holdase/transfer chaperone that captures unfolded nascent polypeptides and delivers them to TRiC/CCT for folding (PMID:9630229). Gestaut et al. 2019 (PMID:30955883) demonstrated that the PFD-TRiC supra-chaperone assembly enhances folding rates. This term is also the recommended replacement for the obsoleting GO:0051082 &#34;unfolded protein binding.&#34;
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> GO:0044183 &#34;protein folding chaperone&#34; is the core molecular function of PFDN5 as a prefoldin subunit. PFDN1 already has this annotation with IBA evidence. The prefoldin complex is a bona fide protein folding chaperone that captures unfolded substrates and delivers them to TRiC/CCT (PMID:9630229, PMID:30955883). This term should be added to PFDN5 to replace the obsoleting GO:0051082.
+                            <strong>Reason:</strong> GO:0044183 &#34;protein folding chaperone&#34; is the core molecular function of PFDN5 as a prefoldin subunit. The prefoldin complex is a bona fide protein folding chaperone that captures unfolded substrates and delivers them to TRiC/CCT (PMID:9630229, PMID:30955883). This term should be added to PFDN5 to replace the obsoleting GO:0051082.
                         </div>
 
 
@@ -5320,34 +5331,25 @@ existing_annotations:
 - term:
     id: GO:0044183
     label: protein folding chaperone
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
+  evidence_type: IDA
+  original_reference_id: PMID:30955883
   review:
     summary: &gt;-
       GO:0044183 &#34;protein folding chaperone&#34; is the most appropriate molecular function
-      term for PFDN5 as a prefoldin subunit. This annotation is proposed as a NEW
-      entry
-      to match the IBA annotation that exists for PFDN1 (which has this term with
-      IBA
-      evidence). Prefoldin functions as a holdase/transfer chaperone that captures
-      unfolded
+      term for PFDN5 as a prefoldin subunit. This annotation is proposed as a manual
+      NEW entry supported by direct experimental evidence from Gestaut et al. 2019.
+      Prefoldin functions as a holdase/transfer chaperone that captures unfolded
       nascent polypeptides and delivers them to TRiC/CCT for folding (PMID:9630229).
       Gestaut et al. 2019 (PMID:30955883) demonstrated that the PFD-TRiC supra-chaperone
       assembly enhances folding rates. This term is also the recommended replacement
-      for
-      the obsoleting GO:0051082 &#34;unfolded protein binding.&#34; Note: PFDN5 does not currently
-      have an explicit IBA annotation to GO:0044183 in the GOA data, unlike PFDN1
-      which
-      does. The two MODIFY actions for GO:0051082 above recommend this term as replacement.
+      for the obsoleting GO:0051082 &#34;unfolded protein binding.&#34;
     action: NEW
     reason: &gt;-
       GO:0044183 &#34;protein folding chaperone&#34; is the core molecular function of PFDN5
-      as
-      a prefoldin subunit. PFDN1 already has this annotation with IBA evidence. The
-      prefoldin complex is a bona fide protein folding chaperone that captures unfolded
+      as a prefoldin subunit. The prefoldin complex is a bona fide protein folding
+      chaperone that captures unfolded
       substrates and delivers them to TRiC/CCT (PMID:9630229, PMID:30955883). This
-      term
-      should be added to PFDN5 to replace the obsoleting GO:0051082.
+      term should be added to PFDN5 to replace the obsoleting GO:0051082.
     supported_by:
     - reference_id: PMID:9630229
       supporting_text: &gt;-

--- a/genes/human/PFDN5/PFDN5-ai-review.html
+++ b/genes/human/PFDN5/PFDN5-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>PFDN5</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/Q99471" target="_blank" class="term-link">
                         Q99471
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>PFDN5 (Prefoldin subunit 5) encodes an alpha-type subunit of the heterohexameric prefoldin complex (also known as GimC). The prefoldin complex is a jellyfish-shaped molecular chaperone composed of two alpha subunits (PFDN3, PFDN5) and four beta subunits (PFDN1, PFDN2, PFDN4, PFDN6). Prefoldin functions as a co-chaperone/holdase that captures unfolded nascent polypeptides -- primarily actin and tubulin -- and delivers them to the group II chaperonin TRiC/CCT for ATP-dependent folding. PFDN5 is also known as MM-1 (Myc Modulator-1) and has a well-characterized moonlighting function as a transcriptional corepressor of c-Myc. PFDN5/MM-1 binds the MBII region of the c-Myc N-terminal domain and represses c-Myc transcriptional activity through multiple mechanisms including recruitment of the TIF1beta/HDAC-mSin3 corepressor complex, promotion of c-Myc proteasomal degradation via Rabring7, and negative regulation of Wnt4 expression via Egr-1 binding. The MM-1 isoforms show differential localization: MM-1alpha and MM-1gamma are nuclear and bind c-Myc, while MM-1beta is cytoplasmic and does not repress c-Myc transcription. Beyond cytoskeletal protein folding, the prefoldin complex has been shown to inhibit amyloid-beta fibrillation, suggesting roles in neuroprotection. PFDN5 is also implicated in RNA polymerase assembly through phylogenetic inference from yeast.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,77 +795,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005737 &#34;cytoplasm&#34; is a well-supported cellular component annotation for PFDN5. This IBA annotation was inferred from phylogenetic analysis (PANTHER) with evidence from yeast (SGD:S000001871, SGD:S000004559), Arabidopsis, and human PFDN5 itself. The prefoldin complex is a cytoplasmic chaperone that operates in the cytosol to capture unfolded nascent polypeptides and deliver them to the cytosolic chaperonin TRiC/CCT (PMID:9630229). Liang et al. 2020 (PMID:32699605) describe prefoldin as &#34;a cytoplasmic chaperone protein.&#34; The term &#34;cytoplasm&#34; is appropriately broad, as a more specific CC annotation to &#34;prefoldin complex&#34; (GO:0016272) is already present. Having both is correct: one describes the subcellular location and the other describes complex membership.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PFDN5 operates as part of the cytoplasmic prefoldin complex. The cytoplasm annotation is well-supported and appropriately broad, complementing the more specific prefoldin complex (GO:0016272) annotation. The IBA phylogenetic inference is sound (PMID:9630229, PMID:32699605). Consistent with PFDN1 review.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link">
                                         PMID:32699605
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">As a cytoplasmic chaperone protein, the prefoldin complex is a hybrid oligomer assembled from six different proteins (six subunits).</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990113" target="_blank" class="term-link">
                                     GO:1990113
                                 </a>
                             </span>
                             <span class="term-label">RNA polymerase I assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -877,64 +877,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:1990113 &#34;RNA polymerase I assembly&#34; is an IBA annotation inferred from phylogenetic analysis (PANTHER:PTN000293176) with evidence from yeast (SGD:S000001871). In yeast, prefoldin subunits have been shown to participate in the assembly of RNA polymerases I, II, and III. Tahmaz et al. 2022 describe that &#34;canonical prefoldin contributes to transcription elongation&#34; and has roles in nuclear gene expression control. This function is conserved across eukaryotes per phylogenetic inference and is consistent with the known nuclear localization of PFDN5 isoforms MM-1alpha and MM-1gamma (PMID:32699605). This represents a nuclear, non-core function distinct from the primary cytoplasmic chaperone role.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> RNA polymerase I assembly is a secondary function for PFDN5, distinct from its core cytoplasmic co-chaperone role. The IBA phylogenetic inference from yeast (SGD:S000001871) is reasonable, and prefoldin subunits have documented nuclear roles in transcription-related processes. However, this is not the primary function of PFDN5 in humans.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link">
                                         PMID:32699605
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">MM-1β and MM-1δ are mainly localized in the cytoplasm, while MM-1α and MM-1γ are localized in the nucleus, and MM1 isoforms that bind to c-Myc and TIF1β are located in the nucleus [101].</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990114" target="_blank" class="term-link">
                                     GO:1990114
                                 </a>
                             </span>
                             <span class="term-label">RNA polymerase II core complex assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -946,46 +946,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:1990114 &#34;RNA polymerase II core complex assembly&#34; is an IBA annotation inferred from phylogenetic analysis (PANTHER:PTN000293176) with evidence from yeast (SGD:S000001871). In yeast, prefoldin subunits contribute to RNA polymerase II assembly. This function is consistent with the known nuclear localization of PFDN5 isoforms and the broader role of prefoldin in transcription-related processes. However, this is a secondary function for PFDN5 in humans, distinct from its core cytoplasmic chaperone role.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> RNA polymerase II assembly is a secondary function for PFDN5, supported by phylogenetic inference from yeast. While prefoldin subunits have documented roles in nuclear transcription processes, this is not the primary function of PFDN5 in humans, where its core role is as a cytoplasmic co-chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990115" target="_blank" class="term-link">
                                     GO:1990115
                                 </a>
                             </span>
                             <span class="term-label">RNA polymerase III assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -997,46 +997,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:1990115 &#34;RNA polymerase III assembly&#34; is an IBA annotation inferred from phylogenetic analysis (PANTHER:PTN000293176) with evidence from yeast (SGD:S000001871). In yeast, prefoldin subunits contribute to RNA polymerase III assembly. This function is consistent with the nuclear roles of prefoldin subunits but represents a secondary function for PFDN5 in humans.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> RNA polymerase III assembly is a secondary function for PFDN5, supported by phylogenetic inference from yeast. Not the core function of PFDN5 in humans.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016272" target="_blank" class="term-link">
                                     GO:0016272
                                 </a>
                             </span>
                             <span class="term-label">prefoldin complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1048,77 +1048,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0016272 &#34;prefoldin complex&#34; is a core cellular component annotation for PFDN5. This IBA annotation was inferred from phylogenetic analysis (PANTHER) with evidence from Drosophila (FB:FBgn0038976), yeast (SGD:S000004559), Arabidopsis, and human PFDN5. PFDN5 is one of the two alpha subunits (PFDN3 and PFDN5) of the heterohexameric prefoldin complex (PMID:9630229, PMID:30955883). The complex is registered in ComplexPortal as CPX-6149 and CPX-25767. Liang et al. 2020 (PMID:32699605) confirm: &#34;Eukaryotic prefoldin complex is a heterohexameric complex like a jellyfish-like structure, consisting of six different subunits (PFDN1-6): two alpha subunits (PFDN3 and PFDN5) and four beta subunits.&#34;
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PFDN5 is a core structural alpha subunit of the prefoldin complex. The IBA annotation is phylogenetically well-supported and consistent with extensive experimental evidence from cryo-EM structural studies (PMID:30955883) and reconstitution experiments (PMID:23614719).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link">
                                         PMID:32699605
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Eukaryotic prefoldin complex is a heterohexameric complex like a jellyfish-like structure, consisting of six different subunits (PFDN1–6): two α subunits (PFDN3 and PFDN5) and four β subunits (PFDN1, PFDN2, PFDN4, and PFDN6) [8]</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Maintaining proteostasis in eukaryotic protein folding involves cooperation of distinct chaperone systems.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1130,64 +1130,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005634 &#34;nucleus&#34; inferred electronically from UniProtKB subcellular location vocabulary mapping. UniProt records isoform-specific localization: isoform 1 (MM-1alpha) and isoform 3 (MM-1gamma) localize to the nucleus, while isoform 2 (MM-1beta) is cytoplasmic. Liang et al. 2020 (PMID:32699605) confirm: &#34;MM-1alpha and MM-1gamma are localized in the nucleus.&#34; The nuclear localization is consistent with the moonlighting function of PFDN5/MM-1 as a c-Myc transcriptional corepressor (PMID:9792694). This IEA annotation is correct and consistent with the TAS annotation from PMID:9792694.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear localization of PFDN5 is well-established for the MM-1alpha and MM-1gamma isoforms. The IEA mapping from UniProt subcellular location is correct and consistent with the c-Myc corepressor function (PMID:9792694, PMID:32699605).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link">
                                         PMID:32699605
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">MM-1β and MM-1δ are mainly localized in the cytoplasm, while MM-1α and MM-1γ are localized in the nucleus, and MM1 isoforms that bind to c-Myc and TIF1β are located in the nucleus [101].</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1199,46 +1199,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005737 &#34;cytoplasm&#34; inferred electronically from UniProtKB subcellular location vocabulary mapping. UniProt records that isoform 2 (MM-1beta) localizes to the cytoplasm. The prefoldin complex operates primarily in the cytoplasm for its co-chaperone function (PMID:9630229, PMID:32699605). This IEA annotation is consistent with the IBA annotation to the same term and is correct.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization is correct for PFDN5 -- both for the canonical prefoldin complex function and for the MM-1beta isoform specifically. Consistent with the IBA annotation and experimental evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1250,46 +1250,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0006457 &#34;protein folding&#34; inferred electronically from InterPro domain mapping (IPR011599, the prefoldin alpha-type domain). This IEA annotation is consistent with the IDA and NAS annotations to the same term, and with the well-established role of the prefoldin complex in protein folding (PMID:9630229, PMID:30955883).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The IEA annotation to protein folding via InterPro is correct and consistent with the higher-confidence IDA and NAS annotations. The prefoldin alpha domain (IPR011599) is specifically associated with the protein folding function of the prefoldin complex (PMID:9630229, PMID:30955883).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016272" target="_blank" class="term-link">
                                     GO:0016272
                                 </a>
                             </span>
                             <span class="term-label">prefoldin complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1301,46 +1301,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0016272 &#34;prefoldin complex&#34; inferred electronically from InterPro domain mapping (IPR011599, the prefoldin alpha domain). PFDN5 is one of the two alpha subunits of the heterohexameric prefoldin complex (PMID:9630229, PMID:32699605). This IEA annotation is consistent with the IBA and IDA annotations to the same term.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PFDN5 is a core structural subunit of the prefoldin complex. The IEA mapping from the prefoldin alpha domain (IPR011599) to prefoldin complex membership is appropriate and consistent with experimental evidence (PMID:9630229, PMID:30955883).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
                                     GO:0032991
                                 </a>
                             </span>
                             <span class="term-label">protein-containing complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1352,46 +1352,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0032991 &#34;protein-containing complex&#34; was inferred electronically by the ARBA machine learning model (ARBA:ARBA00028902). While technically correct -- PFDN5 is part of the prefoldin complex, which is indeed a protein-containing complex -- this annotation is redundant and overly general given the more specific GO:0016272 &#34;prefoldin complex&#34; annotation that is already present from IBA, IEA, and IDA evidence. The term &#34;protein-containing complex&#34; adds no informational value.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is an overly general annotation. PFDN5 is part of the prefoldin complex (GO:0016272), which is a child term of protein-containing complex. The more specific term is already annotated with IBA, IEA, and IDA evidence. The generic &#34;protein-containing complex&#34; adds no useful information. Consistent with PFDN1 review decision.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1403,99 +1403,99 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). This IEA annotation was inferred electronically from InterPro domain mapping (IPR011599, the prefoldin alpha domain). While prefoldin does indeed bind unfolded proteins, the term &#34;unfolded protein binding&#34; is a pure binding term that fails to capture the functional significance of this interaction. Prefoldin acts as a holdase/transfer chaperone: it captures unfolded substrates (primarily actin and tubulin) and delivers them to the TRiC/CCT chaperonin for folding (PMID:9630229). The more appropriate term is GO:0044183 &#34;protein folding chaperone&#34; which captures the functional chaperone activity rather than just substrate binding. Consistent with PFDN1 review.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. The term describes only a binding activity and does not capture the chaperone function of prefoldin. GO:0044183 &#34;protein folding chaperone&#34; (defined as &#34;Binding to a protein or a protein-containing complex to assist the protein folding process&#34;) is the recommended replacement (PMID:9630229, PMID:30955883).
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17728244" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17728244
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Stimulation of c-Myc transcriptional activity by vIRF-3 of K...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1507,57 +1507,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:Q9DUN1/vIRF-3) from PMID:17728244, a study on Kaposi sarcoma-associated herpesvirus vIRF-3 stimulation of c-Myc transcriptional activity. The UniProt record confirms this interaction (NbExp=8). This is a viral-host interaction where vIRF-3 interacts with PFDN5/MM-1 to modulate c-Myc activity. While the interaction may be biologically relevant in the context of viral infection, &#34;protein binding&#34; is uninformative as an annotation for the host protein PFDN5.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. While the PFDN5-vIRF-3 interaction is supported by multiple experiments and is relevant to viral manipulation of the c-Myc pathway, the GO term provides no functional insight. The transcriptional corepressor function is better captured by GO:0003714.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21516116" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21516116
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Next-generation sequencing to generate interactome datasets.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1569,57 +1569,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:Q13137/CALCOCO2) from PMID:21516116, a next-generation sequencing study to generate interactome datasets. This is a high-throughput interaction study. The biological significance of a PFDN5-CALCOCO2 interaction is unclear. &#34;Protein binding&#34; is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. This high-throughput interaction screen detection does not provide functional insight. The core functions of PFDN5 are already captured by more specific annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25036637
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A quantitative chaperone interaction network reveals the arc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1631,57 +1631,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:O14775/GNB5, UniProtKB:P62873/GNB1, UniProtKB:Q9NYS7/WSB2, UniProtKB:Q9UHV9/PFDN2) from PMID:25036637, a quantitative chaperone interaction network study. The PFDN5-PFDN2 interaction is expected since both are subunits of the prefoldin complex (UniProt records NbExp=8 for this interaction). The other interactions are from a large-scale chaperone network study. &#34;Protein binding&#34; is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. The PFDN5-PFDN2 interaction is already captured by prefoldin complex membership (GO:0016272). The other interactions detected in the chaperone network study do not provide functional insight beyond what is captured by GO:0044183 and GO:0016272.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25416956
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A proteome-scale map of the human interactome network.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1693,57 +1693,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:O76003/GLRX3, UniProtKB:P61289/PSME3, UniProtKB:Q13137/CALCOCO2, UniProtKB:Q9UKT9/IKZF3) from PMID:25416956, a proteome-scale map of the human interactome network. These are high-throughput interactions. The PFDN5-PSME3 interaction (NbExp=6 in UniProt) could reflect a connection between prefoldin and proteasome regulation, consistent with the known role of PFDN5/MM-1 in promoting c-Myc proteasomal degradation. However, &#34;protein binding&#34; remains uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. While some interactions (e.g., PSME3) may relate to the proteasome-mediated c-Myc degradation function of PFDN5, the GO term itself provides no functional insight. The core functions are captured by more specific terms.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28514442
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Architecture of the human interactome defines protein commun...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1755,57 +1755,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:P61758/VBP1, UniProtKB:Q9UHV9/PFDN2) from Huttlin et al. 2017 (PMID:28514442), the BioPlex human interactome study. The PFDN5-PFDN2 interaction (NbExp=8) and PFDN5-VBP1 interaction (NbExp=9) reflect prefoldin complex subunit and prefoldin-like complex interactions. VBP1 (von Hippel-Lindau binding protein 1) is a prefoldin-like protein. These interactions are already captured by GO:0016272. &#34;Protein binding&#34; is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. The PFDN5-PFDN2 and PFDN5-VBP1 interactions reflect co-membership in prefoldin/prefoldin-like complexes, already captured by GO:0016272. The BioPlex study does not add functional insight beyond complex membership.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31515488
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Extensive disruption of protein interactions by genetic vari...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1817,57 +1817,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:Q9UKT9/IKZF3) from PMID:31515488, a study on extensive disruption of protein interactions by genetic variants. The PFDN5-IKZF3 interaction (NbExp=7 in UniProt) has been detected in multiple studies. IKZF3/Aiolos is a transcription factor, and this interaction could relate to PFDN5&#39;s transcriptional regulatory functions. However, &#34;protein binding&#34; is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. While the PFDN5-IKZF3 interaction has been detected multiple times, the GO term provides no functional insight.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32296183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A reference map of the human binary protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1879,57 +1879,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with numerous interactors) from Luck et al. 2020 (PMID:32296183), a reference map of the human binary protein interactome (HuRI). This study detected a very large number of interactions for PFDN5, including with other prefoldin subunits (PFDN2, VBP1), transcription factors, and many other proteins. While the large number of interactions may partly reflect the coiled-coil structure of PFDN5, &#34;protein binding&#34; is uninformative as a GO annotation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. This large-scale binary interactome study detected many interactions for PFDN5, but the GO term provides no functional insight. The core molecular functions of PFDN5 are already captured by GO:0044183 (protein folding chaperone) and GO:0003714 (transcription corepressor activity).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32814053
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interactome Mapping Provides a Network of Neurodegenerative ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1941,57 +1941,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:O14901/KLF11, UniProtKB:P42858/HTT, UniProtKB:Q7Z412/PEX26) from PMID:32814053, an interactome mapping study for neurodegenerative disease proteins. The PFDN5-HTT (Huntingtin) interaction is biologically interesting given prefoldin&#39;s role in preventing Huntingtin protein aggregation (PMID:32699605). However, &#34;protein binding&#34; remains uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. While the PFDN5-HTT interaction may be relevant to prefoldin&#39;s neuroprotective role, the GO term provides no functional insight.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2003,57 +2003,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:O14775/GNB5, UniProtKB:P61758/VBP1, UniProtKB:P62873/GNB1, UniProtKB:Q9UHV9/PFDN2) from Huttlin et al. 2021 (PMID:33961781), a dual proteome-scale network study. These are replications of previously observed interactions. The PFDN5-PFDN2 and PFDN5-VBP1 interactions reflect prefoldin complex membership. &#34;Protein binding&#34; is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. These are replications of previously observed interactions that do not add functional insight beyond what is captured by GO:0016272 (prefoldin complex) and GO:0044183 (protein folding chaperone).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:40205054
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Multimodal cell maps as a foundation for structural and func...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2065,46 +2065,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:P62873/GNB1, UniProtKB:Q9NYS7/WSB2, UniProtKB:Q9UHV9/PFDN2) from multimodal cell maps study (PMID:40205054). This is a further replication of known interactions. &#34;Protein binding&#34; is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. These are further replications of known interactions. The relevant functions are already captured by more specific annotations (GO:0044183, GO:0016272).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2116,57 +2116,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005829 &#34;cytosol&#34; (IDA) from the Human Protein Atlas, based on curation of immunofluorescence data. The prefoldin complex operates in the cytosol for its co-chaperone function, binding nascent polypeptides and delivering them to TRiC/CCT (PMID:9630229). This is consistent with the IBA annotation to &#34;cytoplasm&#34; (GO:0005737) and provides a more specific localization. The cytosolic localization is expected for the canonical chaperone function of PFDN5 as part of the prefoldin complex.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization is well-supported by immunofluorescence data and is consistent with the cytoplasmic co-chaperone function of the prefoldin complex. This provides a more specific localization than the broader &#34;cytoplasm&#34; annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32699605
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The functions and mechanisms of prefoldin complex and prefol...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2178,75 +2178,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0006457 &#34;protein folding&#34; (NAS) from ComplexPortal, citing Liang et al. 2020 (PMID:32699605), a comprehensive review of prefoldin complex functions. The review describes how &#34;the prefoldin complex helps protein fold correctly and prevents aggregation by providing class II chaperones ... with a linear, unnatural substrate in the cytoplasm.&#34; This NAS annotation is consistent with the IDA annotations to the same term and is well-supported by the review literature.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein folding is the core biological process for PFDN5 as part of the prefoldin complex. This NAS annotation from ComplexPortal cites a well-sourced review (PMID:32699605) that accurately describes the protein folding function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link">
                                         PMID:32699605
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The prefoldin complex helps protein fold correctly and prevents aggregation by providing class II chaperones (Hsp60 molecular chaperones found in archaebacteria and eukaryotic cytoplasm) with a linear, unnatural substrate in the cytoplasm [2]</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/34761191" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:34761191
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A comprehensive analysis of prefoldins and their implication...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2258,75 +2258,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0006457 &#34;protein folding&#34; (NAS) from ComplexPortal, citing Herranz-Montoya et al. 2021 (PMID:34761191), a comprehensive analysis of prefoldins and their implication in cancer. The review describes prefoldins as &#34;evolutionary conserved co-chaperones&#34; that &#34;act as co-chaperones escorting misfolded or non-native proteins to group II chaperonins.&#34; This NAS annotation is consistent with the IDA annotations and is well-supported.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein folding is the core biological process for PFDN5. This NAS annotation from ComplexPortal cites a comprehensive review (PMID:34761191) that accurately describes the co-chaperone function of prefoldin subunits.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/34761191" target="_blank" class="term-link">
                                         PMID:34761191
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFDNs are prevalently organized into hetero-hexameric complexes. Although they have been overlooked since their discovery and their functions remain elusive, several reports indicate they act as co-chaperones escorting misfolded or non-native proteins to group II chaperonins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                     GO:0050821
                                 </a>
                             </span>
                             <span class="term-label">protein stabilization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/34761191" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:34761191
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A comprehensive analysis of prefoldins and their implication...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2338,75 +2338,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0050821 &#34;protein stabilization&#34; (NAS) from ComplexPortal, citing Herranz-Montoya et al. 2021 (PMID:34761191). The GO definition of protein stabilization is &#34;Any process involved in maintaining the structure and integrity of a protein and preventing it from degradation or aggregation.&#34; Prefoldin does prevent aggregation of unfolded substrates by capturing them and delivering them to TRiC/CCT (PMID:9630229). However, &#34;protein stabilization&#34; typically implies maintaining a folded protein in its native state, whereas prefoldin acts on unfolded nascent polypeptides as a holdase and transfer chaperone. The term is not entirely wrong but mischaracterizes the nature of the chaperone activity. Consistent with PFDN1 review.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While prefoldin does prevent protein aggregation (which is part of the GO definition of protein stabilization), the primary function is not to stabilize already-folded proteins but rather to capture unfolded substrates and transfer them to TRiC/CCT for folding. The annotation is not wrong but represents a secondary aspect of prefoldin function. The core process (protein folding, GO:0006457) is already well-annotated with IDA and NAS evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/34761191" target="_blank" class="term-link">
                                         PMID:34761191
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFDNs are prevalently organized into hetero-hexameric complexes. Although they have been overlooked since their discovery and their functions remain elusive, several reports indicate they act as co-chaperones escorting misfolded or non-native proteins to group II chaperonins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30955883
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Chaperonin TRiC/CCT Associates with Prefoldin through a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2418,88 +2418,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0006457 &#34;protein folding&#34; (IDA) from Gestaut et al. 2019 (PMID:30955883), which used cryo-EM, crosslinking mass spectrometry, and biochemical reconstitution to characterize the structural and functional interplay between the prefoldin (PFD) complex and TRiC/CCT chaperonin. The study demonstrates that &#34;PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles.&#34; This is the highest-quality direct experimental evidence for the protein folding function of the prefoldin complex.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This IDA annotation is supported by strong direct experimental evidence from Gestaut et al. 2019 (PMID:30955883), which demonstrated through cryo-EM and biochemical approaches that the PFD-TRiC supra-chaperone assembly enhances protein folding rates. Protein folding is the core biological process for PFDN5.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The supra-chaperone assembly formed by PFD and TRiC is essential to prevent toxic conformations and ensure effective cellular proteostasis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016272" target="_blank" class="term-link">
                                     GO:0016272
                                 </a>
                             </span>
                             <span class="term-label">prefoldin complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30955883
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Chaperonin TRiC/CCT Associates with Prefoldin through a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2511,75 +2511,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0016272 &#34;prefoldin complex&#34; (IDA) from Gestaut et al. 2019 (PMID:30955883). This study used reconstituted human prefoldin complex (containing all six subunits including PFDN5) and characterized its structure and function through cryo-EM, crosslinking mass spectrometry, and biochemical assays. The cryo-EM structures (PDB: 6NR8, 6NR9, 6NRB, 6NRC, 6NRD) include PFDN5 as chain 5. This provides direct structural evidence for PFDN5 membership in the prefoldin complex.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PFDN5 is a core structural subunit of the prefoldin complex. This IDA annotation is supported by high-resolution cryo-EM structural data from Gestaut et al. 2019 (PMID:30955883) that directly demonstrates PFDN5 as a component of the human prefoldin complex.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Maintaining proteostasis in eukaryotic protein folding involves cooperation of distinct chaperone systems. To understand how the essential ring-shaped chaperonin TRiC/CCT cooperates with the chaperone prefoldin/GIMc (PFD), we integrate cryoelectron microscopy (cryo-EM), crosslinking-mass-spectrometry and biochemical and cellular approaches to elucidate the structural and functional interplay between TRiC/CCT and PFD.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30955883
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Chaperonin TRiC/CCT Associates with Prefoldin through a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -2591,112 +2591,112 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). This IDA annotation cites Gestaut et al. 2019 (PMID:30955883), which demonstrated that prefoldin associates with TRiC through a conserved electrostatic interface and undergoes conformational cycling between &#34;latched&#34; (open) and &#34;engaged&#34; (closed) states during substrate transfer. The paper shows that PFD functions not merely as a passive binder of unfolded substrates but as an active co-chaperone. GO:0044183 &#34;protein folding chaperone&#34; is the appropriate replacement. Consistent with PFDN1 review.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. Gestaut et al. 2019 (PMID:30955883) demonstrates that prefoldin functions as a co-chaperone/holdase that cooperates with TRiC/CCT, not merely as an unfolded protein binder. GO:0044183 &#34;protein folding chaperone&#34; accurately describes this co-chaperone activity. The GO:0044183 definition (&#34;Binding to a protein or a protein-containing complex to assist the protein folding process&#34;) appropriately encompasses the holdase/transfer function.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFD alternates between an open &#34;latched&#34; conformation and a closed &#34;engaged&#34; conformation that aligns the PFD-TRiC substrate binding chambers.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001540" target="_blank" class="term-link">
                                     GO:0001540
                                 </a>
                             </span>
                             <span class="term-label">amyloid-beta binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23614719
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human prefoldin inhibits amyloid-β (Aβ) fibrillation and con...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2708,75 +2708,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0001540 &#34;amyloid-beta binding&#34; (IDA) from Sorgjerd et al. 2013 (PMID:23614719). This study demonstrated that recombinant human prefoldin (hPFD) inhibits amyloid-beta (Abeta 1-42) fibrillation in vitro and induces formation of soluble Abeta oligomers with reduced toxicity. The study used thioflavin T measurements and immunoblotting to show that hPFD directly interacts with Abeta peptides and modifies their aggregation pathway. While this demonstrates that the prefoldin complex can bind Abeta, this is not the core function of PFDN5 -- it reflects the general chaperone/holdase property of prefoldin applied to an amyloidogenic substrate. The annotation was made on the intact prefoldin complex, not PFDN5 individually.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Amyloid-beta binding is a secondary, non-core function that reflects the general holdase/chaperone activity of the prefoldin complex applied to an amyloidogenic substrate. The study (PMID:23614719) used the intact hexameric complex rather than individual PFDN5. While the data are solid, this represents a peripheral function compared to the core role in actin/tubulin folding via TRiC/CCT delivery. Consistent with PFDN1 review.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                                         PMID:23614719
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we investigated the effect of recombinant human PFD (hPFD) on Abeta(1-42) aggregation in vitro and found that hPFD inhibited Abeta fibrillation and induced formation of soluble Abeta oligomers.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016272" target="_blank" class="term-link">
                                     GO:0016272
                                 </a>
                             </span>
                             <span class="term-label">prefoldin complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23614719
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human prefoldin inhibits amyloid-β (Aβ) fibrillation and con...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2788,75 +2788,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0016272 &#34;prefoldin complex&#34; (IDA) from Sorgjerd et al. 2013 (PMID:23614719). This study expressed and purified recombinant human prefoldin complex (hPFD) to investigate its effect on amyloid-beta aggregation. The successful reconstitution and purification of the hexameric complex containing PFDN5 provides direct evidence for PFDN5 membership in the prefoldin complex. This is consistent with the IDA annotation from PMID:30955883 and the IBA/IEA annotations.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PFDN5 is a core structural subunit of the prefoldin complex. This IDA annotation from PMID:23614719 provides independent experimental evidence through reconstitution of the human prefoldin hexamer, consistent with the structural data from PMID:30955883.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                                         PMID:23614719
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin (PFD) is a molecular chaperone that prevents aggregation of misfolded proteins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905907" target="_blank" class="term-link">
                                     GO:1905907
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of amyloid fibril formation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23614719
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human prefoldin inhibits amyloid-β (Aβ) fibrillation and con...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2868,88 +2868,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:1905907 &#34;negative regulation of amyloid fibril formation&#34; (IDA) from Sorgjerd et al. 2013 (PMID:23614719). The study demonstrated that recombinant human prefoldin &#34;inhibited Abeta fibrillation and induced formation of soluble Abeta oligomers&#34; that were 30-40% less toxic than Abeta fibrils. Thioflavin T measurements confirmed reduced fibril formation. While the experimental evidence is sound, this represents a non-core function of the prefoldin complex -- an extension of its general holdase/chaperone properties to amyloidogenic substrates. The study was performed on the intact hexameric complex, not PFDN5 individually.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The experimental evidence from PMID:23614719 is solid, but this is a secondary function reflecting the general anti-aggregation properties of the prefoldin complex rather than its core role in delivering unfolded actin/tubulin to TRiC/CCT. The study was performed in vitro on the intact hexameric complex. Consistent with PFDN1 review.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                                         PMID:23614719
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we investigated the effect of recombinant human PFD (hPFD) on Abeta(1-42) aggregation in vitro and found that hPFD inhibited Abeta fibrillation and induced formation of soluble Abeta oligomers.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                                         PMID:23614719
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Our findings show a relation between cytotoxicity of Abeta oligomers and structure and suggest a possible protective role of PFD in AD.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045892" target="_blank" class="term-link">
                                     GO:0045892
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of DNA-templated transcription</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18281035" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18281035
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Negative regulation of the Wnt signal by MM-1 through inhibi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2961,75 +2961,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0045892 &#34;negative regulation of DNA-templated transcription&#34; (IMP) from PMID:18281035, annotated by BHF-UCL. PFDN5/MM-1 is well-established as a transcriptional corepressor of c-Myc. Mori et al. 1998 (PMID:9792694) originally identified MM-1 as &#34;a novel c-Myc-associating protein that represses transcriptional activity of c-Myc.&#34; Liang et al. 2020 (PMID:32699605) describe multiple regulatory mechanisms including inhibition of c-Myc E-box-dependent transcriptional activity via TIF1beta/HDAC-mSin3 recruitment. This is a well-supported moonlighting function of PFDN5 that is independent of its prefoldin complex chaperone role.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Negative regulation of transcription is a well-supported moonlighting function of PFDN5/MM-1, independent of its core cytoplasmic co-chaperone role. The c-Myc corepressor function is mediated by nuclear isoforms (MM-1alpha, MM-1gamma) and involves recruitment of TIF1beta/HDAC-mSin3 corepressor complex (PMID:9792694, PMID:32699605). Classified as non-core because the primary function of PFDN5 as a prefoldin subunit is protein folding chaperone activity.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link">
                                         PMID:32699605
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">(c)MM-1 inhibits the E-box-dependent transcriptional activity of c-Myc by recruiting a histone deacetylase (HDAC-mSin3) complex from TIF1β/KAP1/TRIM28 (a transcriptional co-inhibitor) (Fig</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090090" target="_blank" class="term-link">
                                     GO:0090090
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of canonical Wnt signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18281035" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18281035
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Negative regulation of the Wnt signal by MM-1 through inhibi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3041,75 +3041,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0090090 &#34;negative regulation of canonical Wnt signaling pathway&#34; (IMP) from PMID:18281035, annotated by BHF-UCL. Liang et al. 2020 (PMID:32699605) describe this mechanism: MM-1 negatively regulates the expression of wnt4 by binding to Egr-1, thereby indirectly inhibiting c-Myc expression. This represents one of the multiple mechanisms by which PFDN5/MM-1 inhibits c-Myc activity. This is part of the moonlighting transcriptional regulatory function of PFDN5.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Negative regulation of Wnt signaling is part of the moonlighting transcriptional regulatory function of PFDN5/MM-1. It represents one of the multiple mechanisms by which MM-1 inhibits c-Myc activity (PMID:32699605). This is a secondary function compared to the core co-chaperone role.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link">
                                         PMID:32699605
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">MM-1 negatively regulates the expression of wnt4 by binding to Egr-1, thereby indirectly inhibiting c-Myc expression (Fig</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16130169" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16130169
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomics of human umbilical vein endothelial cells applied...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3121,57 +3121,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005737 &#34;cytoplasm&#34; (TAS) from PMID:16130169, a proteomics study of human umbilical vein endothelial cells. This study identified PFDN5 in the proteome of HUVECs, consistent with its cytoplasmic localization. The cytoplasmic localization is well-established for the prefoldin complex (PMID:9630229, PMID:32699605) and is consistent with the IBA and IEA annotations to the same term.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization is well-supported and consistent with the canonical co-chaperone function of the prefoldin complex. This TAS annotation is consistent with multiple other annotations to the same term.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003714" target="_blank" class="term-link">
                                     GO:0003714
                                 </a>
                             </span>
                             <span class="term-label">transcription corepressor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9792694" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9792694
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     MM-1, a novel c-Myc-associating protein that represses trans...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3183,88 +3183,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0003714 &#34;transcription corepressor activity&#34; (TAS) from PMID:9792694, the original paper by Mori et al. 1998 that identified MM-1 as &#34;a novel c-Myc-associating protein that represses transcriptional activity of c-Myc.&#34; UniProt confirms: &#34;Represses the transcriptional activity of MYC.&#34; Liang et al. 2020 (PMID:32699605) describe multiple corepressor mechanisms including recruitment of HDAC-mSin3 complex via TIF1beta/KAP1/TRIM28, proteasomal degradation of c-Myc via Rabring7, and suppression of Wnt4 via Egr-1. This is a well-characterized moonlighting function of PFDN5/MM-1 that is distinct from and independent of its prefoldin complex chaperone role.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Transcription corepressor activity is a well-established moonlighting function of PFDN5/MM-1, distinct from the core cytoplasmic co-chaperone role. It is mediated specifically by the nuclear isoforms (MM-1alpha, MM-1gamma) and involves binding to the MBII region of c-Myc&#39;s N-terminal domain and recruitment of TIF1beta/HDAC-mSin3 corepressor complex (PMID:9792694, PMID:32699605). While this is an important biological function, the primary identity of PFDN5 is as a prefoldin subunit, so this is classified as non-core.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link">
                                         PMID:32699605
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">MM-1 is one of the c-Myc NTD-terminated proteins which is bound to the MBII region of the NTD and can compete with TRRAP for c-Myc [99].</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link">
                                         PMID:32699605
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">MM1, a nuclear c-Myc binding protein, inhibits c-Myc activity in the nucleus in various ways and is therefore considered a tumor suppressor.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9792694" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9792694
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     MM-1, a novel c-Myc-associating protein that represses trans...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3276,75 +3276,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005634 &#34;nucleus&#34; (TAS) from PMID:9792694, the original paper by Mori et al. 1998 that identified MM-1. The nuclear localization of PFDN5/MM-1 is well-established for the MM-1alpha and MM-1gamma isoforms, which bind c-Myc and function as transcriptional corepressors in the nucleus (PMID:32699605). Consistent with the IEA annotation to the same term from GO_REF:0000044.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear localization is well-supported for PFDN5 isoforms MM-1alpha and MM-1gamma. This is consistent with the moonlighting transcriptional corepressor function (PMID:9792694, PMID:32699605) and the IEA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link">
                                         PMID:32699605
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">MM-1β and MM-1δ are mainly localized in the cytoplasm, while MM-1α and MM-1γ are localized in the nucleus, and MM1 isoforms that bind to c-Myc and TIF1β are located in the nucleus [101].</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006355" target="_blank" class="term-link">
                                     GO:0006355
                                 </a>
                             </span>
                             <span class="term-label">regulation of DNA-templated transcription</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9792694" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9792694
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     MM-1, a novel c-Myc-associating protein that represses trans...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3356,64 +3356,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0006355 &#34;regulation of DNA-templated transcription&#34; (TAS) from PMID:9792694. This is a broad parent term that encompasses the more specific GO:0045892 &#34;negative regulation of DNA-templated transcription&#34; already annotated with IMP evidence from PMID:18281035. PFDN5/MM-1 is well-established as a transcriptional regulator through its c-Myc corepressor function. However, this term is redundant with the more specific GO:0045892 annotation. The annotation should be modified to the more specific child term or kept as-is since GO:0045892 already exists.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Regulation of transcription is well-supported for PFDN5/MM-1 through its c-Myc corepressor function (PMID:9792694, PMID:32699605). While this term is broader than the existing GO:0045892 annotation, it is not wrong -- PFDN5 does regulate transcription. This is a secondary/moonlighting function. The more specific GO:0045892 from PMID:18281035 provides better resolution.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link">
                                         PMID:32699605
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">MM1, a nuclear c-Myc binding protein, inhibits c-Myc activity in the nucleus in various ways and is therefore considered a tumor suppressor.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     GO:0044183
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-new">
@@ -3425,63 +3425,74 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0044183 &#34;protein folding chaperone&#34; is the most appropriate molecular function term for PFDN5 as a prefoldin subunit. This annotation is proposed as a NEW entry to match the IBA annotation that exists for PFDN1 (which has this term with IBA evidence). Prefoldin functions as a holdase/transfer chaperone that captures unfolded nascent polypeptides and delivers them to TRiC/CCT for folding (PMID:9630229). Gestaut et al. 2019 (PMID:30955883) demonstrated that the PFD-TRiC supra-chaperone assembly enhances folding rates. This term is also the recommended replacement for the obsoleting GO:0051082 &#34;unfolded protein binding.&#34; Note: PFDN5 does not currently have an explicit IBA annotation to GO:0044183 in the GOA data, unlike PFDN1 which does. The two MODIFY actions for GO:0051082 above recommend this term as replacement.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0044183 &#34;protein folding chaperone&#34; is the core molecular function of PFDN5 as a prefoldin subunit. PFDN1 already has this annotation with IBA evidence. The prefoldin complex is a bona fide protein folding chaperone that captures unfolded substrates and delivers them to TRiC/CCT (PMID:9630229, PMID:30955883). This term should be added to PFDN5 to replace the obsoleting GO:0051082.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We describe the discovery of a heterohexameric chaperone protein, prefoldin, based on its ability to capture unfolded actin. Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PFDN5/PFDN5-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Cytosolic co-chaperone: Prefoldin binds nascent actin and tubulin, prevents aggregation, and transfers clients to TRiC/CCT, accelerating folding efficiency.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>Alpha subunit of the heterohexameric prefoldin co-chaperone complex that captures unfolded nascent polypeptides -- primarily actin and tubulin -- and delivers them to the group II chaperonin TRiC/CCT for ATP-dependent folding. The prefoldin complex acts as a holdase/transfer chaperone that alternates between open (latched) and closed (engaged) conformations during substrate handoff to TRiC. The PFD-TRiC supra-chaperone assembly enhances the rate and yield of the folding reaction and suppresses non-productive reaction cycles.</h3>
                 <span class="vote-buttons" data-g="Q99471" data-a="FUNCTION: Alpha subunit of the heterohexameric prefoldin co-..." data-r="" data-act="CORE_FUNCTION">
@@ -3489,10 +3500,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -3501,39 +3512,39 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                 protein folding
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">In Complex:</div>
                     <span class="badge">
@@ -3542,601 +3553,530 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                 PMID:9630229
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">We describe the discovery of a heterohexameric chaperone protein, prefoldin, based on its ability to capture unfolded actin. Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                 PMID:30955883
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
+
         </div>
-        
-        <div class="core-function-card">
-            
-            <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>Moonlighting function as c-Myc transcriptional corepressor (MM-1). Nuclear isoforms (MM-1alpha and MM-1gamma) bind the MBII region of the c-Myc N-terminal domain and repress c-Myc transcriptional activity through multiple mechanisms including recruitment of the TIF1beta/HDAC-mSin3 corepressor complex, promotion of c-Myc proteasomal degradation via Rabring7, and negative regulation of Wnt4 expression via Egr-1 binding. This function is independent of the cytoplasmic prefoldin co-chaperone role and is mediated by isoform-specific nuclear localization.</h3>
-                <span class="vote-buttons" data-g="Q99471" data-a="FUNCTION: Moonlighting function as c-Myc transcriptional cor..." data-r="" data-act="CORE_FUNCTION">
-                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
-                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
-                </span>
-            </div>
-            
 
-            <div class="core-function-terms">
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">Molecular Function:</div>
-                    <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003714" target="_blank" class="term-link">
-                            transcription corepressor activity
-                        </a>
-                    </span>
-                </div>
-                
-
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">Directly Involved In:</div>
-                    <div class="function-annotations">
-                        
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045892" target="_blank" class="term-link">
-                                negative regulation of DNA-templated transcription
-                            </a>
-                        </span>
-                        
-                    </div>
-                </div>
-                
-
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">Cellular Locations:</div>
-                    <div class="function-annotations">
-                        
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
-                                nucleus
-                            </a>
-                        </span>
-                        
-                    </div>
-                </div>
-                
-
-                
-
-                
-            </div>
-
-            
-            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
-                <strong>Supporting Evidence:</strong>
-                <ul class="findings-list">
-                    
-                    <li class="finding-item">
-                        <span class="reference-id">
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/9792694" target="_blank" class="term-link">
-                                PMID:9792694
-                            </a>
-                            
-                        </span>
-                        
-                        <div class="finding-text">MM-1, a novel c-Myc-associating protein that represses transcriptional activity of c-Myc</div>
-                        
-                    </li>
-                    
-                    <li class="finding-item">
-                        <span class="reference-id">
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link">
-                                PMID:32699605
-                            </a>
-                            
-                        </span>
-                        
-                        <div class="finding-text">MM-1 inhibits the E-box-dependent transcriptional activity of c-Myc by recruiting a histone deacetylase (HDAC-mSin3) complex from TIF1beta/KAP1/TRIM28.</div>
-                        
-                    </li>
-                    
-                </ul>
-            </div>
-            
-        </div>
-        
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/PFDN5/PFDN5-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for PFDN5</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">PFDN5 is the alpha prefoldin subunit MM-1, with canonical cytosolic prefoldin co-chaperone activity and a reviewed non-core nuclear c-Myc corepressor role.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
                             GO_REF:0000052
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                             PMID:9630229
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Prefoldin, a chaperone that delivers unfolded proteins to cytosolic chaperonin.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Discovered the heterohexameric chaperone protein prefoldin, based on its ability to capture unfolded actin. Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it. Deletion of the gene encoding a prefoldin subunit in S. cerevisiae results in impaired actin and tubulin-based cytoskeleton functions.</div>
-                        
+
                         <div class="finding-text">"We describe the discovery of a heterohexameric chaperone protein, prefoldin, based on its ability to capture unfolded actin. Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9792694" target="_blank" class="term-link">
                             PMID:9792694
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">MM-1, a novel c-Myc-associating protein that represses transcriptional activity of c-Myc.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Original identification of MM-1 (PFDN5) as a c-Myc-binding protein that represses c-Myc transcriptional activity. MM-1 binds the N-terminal domain of c-Myc.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16130169" target="_blank" class="term-link">
                             PMID:16130169
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteomics of human umbilical vein endothelial cells applied to etoposide-induced apoptosis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17728244" target="_blank" class="term-link">
                             PMID:17728244
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Stimulation of c-Myc transcriptional activity by vIRF-3 of Kaposi sarcoma-associated herpesvirus.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18281035" target="_blank" class="term-link">
                             PMID:18281035
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Negative regulation of the Wnt signal by MM-1 through inhibiting expression of the wnt4 gene.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Demonstrates that PFDN5/MM-1 negatively regulates canonical Wnt signaling by cooperating with Egr-1 to repress Wnt4 transcription, thereby indirectly inhibiting c-Myc expression.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21516116" target="_blank" class="term-link">
                             PMID:21516116
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Next-generation sequencing to generate interactome datasets.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                             PMID:23614719
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Human prefoldin inhibits amyloid-β (Aβ) fibrillation and contributes to formation of nontoxic Aβ aggregates.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Demonstrated that recombinant human prefoldin (hPFD) inhibits Abeta(1-42) fibrillation in vitro and induces formation of soluble Abeta oligomers that are 30-40% less toxic. Shows prefoldin complex membership and amyloid-beta binding.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link">
                             PMID:25036637
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A quantitative chaperone interaction network reveals the architecture of cellular protein homeostasis pathways.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
                             PMID:25416956
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A proteome-scale map of the human interactome network.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
                             PMID:28514442
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                             PMID:30955883
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The Chaperonin TRiC/CCT Associates with Prefoldin through a Conserved Electrostatic Interface Essential for Cellular Proteostasis.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Used cryo-EM, crosslinking mass spectrometry, and biochemical approaches to characterize the PFD-TRiC supra-chaperone assembly. Demonstrated that PFD enhances the rate and yield of TRiC-mediated protein folding, and that disrupting the TRiC-PFD interaction leads to accumulation of amyloid aggregates.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link">
                             PMID:31515488
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Extensive disruption of protein interactions by genetic variants across the allele frequency spectrum in human populations.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                             PMID:32296183
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A reference map of the human binary protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link">
                             PMID:32699605
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The functions and mechanisms of prefoldin complex and prefoldin-subunits.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Comprehensive review of prefoldin complex functions and individual subunit roles. Describes PFDN5/MM-1 as the most well-known prefoldin subunit with documented c-Myc corepressor function through multiple mechanisms: HDAC-mSin3 recruitment, Rabring7-mediated c-Myc degradation, and Wnt4 repression via Egr-1.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
                             PMID:32814053
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/34761191" target="_blank" class="term-link">
                             PMID:34761191
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A comprehensive analysis of prefoldins and their implication in cancer.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Describes prefoldins as evolutionary conserved co-chaperones that act as escorts for misfolded or non-native proteins to group II chaperonins. Comprehensive analysis of prefoldin genomic alterations across cancer types.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
                             PMID:40205054
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
-                
-                
+
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -4347,9 +4287,9 @@ PFDN5/MM-1 is a canonical α-subunit of the prefoldin co-chaperone that contribu
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -4361,7 +4301,7 @@ PFDN5/MM-1 is a canonical α-subunit of the prefoldin co-chaperone that contribu
                 <pre><code>id: Q99471
 gene_symbol: PFDN5
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -5418,6 +5358,11 @@ existing_annotations:
       supporting_text: &gt;-
         PFD can act after TRiC bound its substrates to enhance the rate and yield
         of the folding reaction, suppressing non-productive reaction cycles.
+    - reference_id: file:human/PFDN5/PFDN5-deep-research-falcon.md
+      supporting_text: &gt;-
+        Cytosolic co-chaperone: Prefoldin binds nascent actin and tubulin,
+        prevents aggregation, and transfers clients to TRiC/CCT, accelerating
+        folding efficiency.
 core_functions:
 - molecular_function:
     id: GO:0044183
@@ -5450,44 +5395,23 @@ core_functions:
   in_complex:
     id: GO:0016272
     label: prefoldin complex
-- molecular_function:
-    id: GO:0003714
-    label: transcription corepressor activity
-  description: &gt;-
-    Moonlighting function as c-Myc transcriptional corepressor (MM-1). Nuclear
-    isoforms (MM-1alpha and MM-1gamma) bind the MBII region of the c-Myc
-    N-terminal domain and repress c-Myc transcriptional activity through
-    multiple mechanisms including recruitment of the TIF1beta/HDAC-mSin3
-    corepressor complex, promotion of c-Myc proteasomal degradation via Rabring7,
-    and negative regulation of Wnt4 expression via Egr-1 binding. This function
-    is independent of the cytoplasmic prefoldin co-chaperone role and is mediated
-    by isoform-specific nuclear localization.
-  supported_by:
-  - reference_id: PMID:9792694
-    supporting_text: &gt;-
-      MM-1, a novel c-Myc-associating protein that represses transcriptional activity
-      of c-Myc
-  - reference_id: PMID:32699605
-    supporting_text: &gt;-
-      MM-1 inhibits the E-box-dependent transcriptional activity of c-Myc by
-      recruiting a histone deacetylase (HDAC-mSin3) complex from
-      TIF1beta/KAP1/TRIM28.
-  directly_involved_in:
-  - id: GO:0045892
-    label: negative regulation of DNA-templated transcription
-  locations:
-  - id: GO:0005634
-    label: nucleus
 references:
+- id: file:human/PFDN5/PFDN5-deep-research-falcon.md
+  title: Falcon deep research report for PFDN5
+  findings:
+  - statement: &gt;-
+      PFDN5 is the alpha prefoldin subunit MM-1, with canonical cytosolic
+      prefoldin co-chaperone activity and a reviewed non-core nuclear c-Myc
+      corepressor role.
 - id: GO_REF:0000002
-  title: Gene Ontology annotation through association of InterPro records with 
+  title: Gene Ontology annotation through association of InterPro records with
     GO terms
   findings: []
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular 
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular
     Location vocabulary mapping, accompanied by conservative changes to GO terms
     applied by UniProt
   findings: []
@@ -5495,7 +5419,7 @@ references:
   title: Gene Ontology annotation based on curation of immunofluorescence data
   findings: []
 - id: GO_REF:0000117
-  title: Electronic Gene Ontology annotations created by ARBA machine learning 
+  title: Electronic Gene Ontology annotations created by ARBA machine learning
     models
   findings: []
 - id: PMID:9630229
@@ -5519,15 +5443,15 @@ references:
       Original identification of MM-1 (PFDN5) as a c-Myc-binding protein that represses
       c-Myc transcriptional activity. MM-1 binds the N-terminal domain of c-Myc.
 - id: PMID:16130169
-  title: Proteomics of human umbilical vein endothelial cells applied to 
+  title: Proteomics of human umbilical vein endothelial cells applied to
     etoposide-induced apoptosis.
   findings: []
 - id: PMID:17728244
-  title: Stimulation of c-Myc transcriptional activity by vIRF-3 of Kaposi 
+  title: Stimulation of c-Myc transcriptional activity by vIRF-3 of Kaposi
     sarcoma-associated herpesvirus.
   findings: []
 - id: PMID:18281035
-  title: Negative regulation of the Wnt signal by MM-1 through inhibiting 
+  title: Negative regulation of the Wnt signal by MM-1 through inhibiting
     expression of the wnt4 gene.
   findings:
   - statement: &gt;-
@@ -5547,18 +5471,18 @@ references:
       are
       30-40% less toxic. Shows prefoldin complex membership and amyloid-beta binding.
 - id: PMID:25036637
-  title: A quantitative chaperone interaction network reveals the architecture 
+  title: A quantitative chaperone interaction network reveals the architecture
     of cellular protein homeostasis pathways.
   findings: []
 - id: PMID:25416956
   title: A proteome-scale map of the human interactome network.
   findings: []
 - id: PMID:28514442
-  title: Architecture of the human interactome defines protein communities and 
+  title: Architecture of the human interactome defines protein communities and
     disease networks.
   findings: []
 - id: PMID:30955883
-  title: The Chaperonin TRiC/CCT Associates with Prefoldin through a Conserved 
+  title: The Chaperonin TRiC/CCT Associates with Prefoldin through a Conserved
     Electrostatic Interface Essential for Cellular Proteostasis.
   findings:
   - statement: &gt;-
@@ -5574,7 +5498,7 @@ references:
   title: A reference map of the human binary protein interactome.
   findings: []
 - id: PMID:32699605
-  title: The functions and mechanisms of prefoldin complex and 
+  title: The functions and mechanisms of prefoldin complex and
     prefoldin-subunits.
   findings:
   - statement: &gt;-
@@ -5583,11 +5507,11 @@ references:
       c-Myc corepressor function through multiple mechanisms: HDAC-mSin3 recruitment,
       Rabring7-mediated c-Myc degradation, and Wnt4 repression via Egr-1.
 - id: PMID:32814053
-  title: Interactome Mapping Provides a Network of Neurodegenerative Disease 
+  title: Interactome Mapping Provides a Network of Neurodegenerative Disease
     Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.
   findings: []
 - id: PMID:33961781
-  title: Dual proteome-scale networks reveal cell-specific remodeling of the 
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the
     human interactome.
   findings: []
 - id: PMID:34761191
@@ -5599,7 +5523,7 @@ references:
       analysis
       of prefoldin genomic alterations across cancer types.
 - id: PMID:40205054
-  title: Multimodal cell maps as a foundation for structural and functional 
+  title: Multimodal cell maps as a foundation for structural and functional
     genomics.
   findings: []
 </code></pre>
@@ -5608,7 +5532,7 @@ references:
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/PFDN5/PFDN5-ai-review.yaml
+++ b/genes/human/PFDN5/PFDN5-ai-review.yaml
@@ -1020,34 +1020,25 @@ existing_annotations:
 - term:
     id: GO:0044183
     label: protein folding chaperone
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
+  evidence_type: IDA
+  original_reference_id: PMID:30955883
   review:
     summary: >-
       GO:0044183 "protein folding chaperone" is the most appropriate molecular function
-      term for PFDN5 as a prefoldin subunit. This annotation is proposed as a NEW
-      entry
-      to match the IBA annotation that exists for PFDN1 (which has this term with
-      IBA
-      evidence). Prefoldin functions as a holdase/transfer chaperone that captures
-      unfolded
+      term for PFDN5 as a prefoldin subunit. This annotation is proposed as a manual
+      NEW entry supported by direct experimental evidence from Gestaut et al. 2019.
+      Prefoldin functions as a holdase/transfer chaperone that captures unfolded
       nascent polypeptides and delivers them to TRiC/CCT for folding (PMID:9630229).
       Gestaut et al. 2019 (PMID:30955883) demonstrated that the PFD-TRiC supra-chaperone
       assembly enhances folding rates. This term is also the recommended replacement
-      for
-      the obsoleting GO:0051082 "unfolded protein binding." Note: PFDN5 does not currently
-      have an explicit IBA annotation to GO:0044183 in the GOA data, unlike PFDN1
-      which
-      does. The two MODIFY actions for GO:0051082 above recommend this term as replacement.
+      for the obsoleting GO:0051082 "unfolded protein binding."
     action: NEW
     reason: >-
       GO:0044183 "protein folding chaperone" is the core molecular function of PFDN5
-      as
-      a prefoldin subunit. PFDN1 already has this annotation with IBA evidence. The
-      prefoldin complex is a bona fide protein folding chaperone that captures unfolded
+      as a prefoldin subunit. The prefoldin complex is a bona fide protein folding
+      chaperone that captures unfolded
       substrates and delivers them to TRiC/CCT (PMID:9630229, PMID:30955883). This
-      term
-      should be added to PFDN5 to replace the obsoleting GO:0051082.
+      term should be added to PFDN5 to replace the obsoleting GO:0051082.
     supported_by:
     - reference_id: PMID:9630229
       supporting_text: >-

--- a/genes/human/PFDN5/PFDN5-ai-review.yaml
+++ b/genes/human/PFDN5/PFDN5-ai-review.yaml
@@ -1,7 +1,7 @@
 id: Q99471
 gene_symbol: PFDN5
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -1058,6 +1058,11 @@ existing_annotations:
       supporting_text: >-
         PFD can act after TRiC bound its substrates to enhance the rate and yield
         of the folding reaction, suppressing non-productive reaction cycles.
+    - reference_id: file:human/PFDN5/PFDN5-deep-research-falcon.md
+      supporting_text: >-
+        Cytosolic co-chaperone: Prefoldin binds nascent actin and tubulin,
+        prevents aggregation, and transfers clients to TRiC/CCT, accelerating
+        folding efficiency.
 core_functions:
 - molecular_function:
     id: GO:0044183
@@ -1090,44 +1095,23 @@ core_functions:
   in_complex:
     id: GO:0016272
     label: prefoldin complex
-- molecular_function:
-    id: GO:0003714
-    label: transcription corepressor activity
-  description: >-
-    Moonlighting function as c-Myc transcriptional corepressor (MM-1). Nuclear
-    isoforms (MM-1alpha and MM-1gamma) bind the MBII region of the c-Myc
-    N-terminal domain and repress c-Myc transcriptional activity through
-    multiple mechanisms including recruitment of the TIF1beta/HDAC-mSin3
-    corepressor complex, promotion of c-Myc proteasomal degradation via Rabring7,
-    and negative regulation of Wnt4 expression via Egr-1 binding. This function
-    is independent of the cytoplasmic prefoldin co-chaperone role and is mediated
-    by isoform-specific nuclear localization.
-  supported_by:
-  - reference_id: PMID:9792694
-    supporting_text: >-
-      MM-1, a novel c-Myc-associating protein that represses transcriptional activity
-      of c-Myc
-  - reference_id: PMID:32699605
-    supporting_text: >-
-      MM-1 inhibits the E-box-dependent transcriptional activity of c-Myc by
-      recruiting a histone deacetylase (HDAC-mSin3) complex from
-      TIF1beta/KAP1/TRIM28.
-  directly_involved_in:
-  - id: GO:0045892
-    label: negative regulation of DNA-templated transcription
-  locations:
-  - id: GO:0005634
-    label: nucleus
 references:
+- id: file:human/PFDN5/PFDN5-deep-research-falcon.md
+  title: Falcon deep research report for PFDN5
+  findings:
+  - statement: >-
+      PFDN5 is the alpha prefoldin subunit MM-1, with canonical cytosolic
+      prefoldin co-chaperone activity and a reviewed non-core nuclear c-Myc
+      corepressor role.
 - id: GO_REF:0000002
-  title: Gene Ontology annotation through association of InterPro records with 
+  title: Gene Ontology annotation through association of InterPro records with
     GO terms
   findings: []
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular 
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular
     Location vocabulary mapping, accompanied by conservative changes to GO terms
     applied by UniProt
   findings: []
@@ -1135,7 +1119,7 @@ references:
   title: Gene Ontology annotation based on curation of immunofluorescence data
   findings: []
 - id: GO_REF:0000117
-  title: Electronic Gene Ontology annotations created by ARBA machine learning 
+  title: Electronic Gene Ontology annotations created by ARBA machine learning
     models
   findings: []
 - id: PMID:9630229
@@ -1159,15 +1143,15 @@ references:
       Original identification of MM-1 (PFDN5) as a c-Myc-binding protein that represses
       c-Myc transcriptional activity. MM-1 binds the N-terminal domain of c-Myc.
 - id: PMID:16130169
-  title: Proteomics of human umbilical vein endothelial cells applied to 
+  title: Proteomics of human umbilical vein endothelial cells applied to
     etoposide-induced apoptosis.
   findings: []
 - id: PMID:17728244
-  title: Stimulation of c-Myc transcriptional activity by vIRF-3 of Kaposi 
+  title: Stimulation of c-Myc transcriptional activity by vIRF-3 of Kaposi
     sarcoma-associated herpesvirus.
   findings: []
 - id: PMID:18281035
-  title: Negative regulation of the Wnt signal by MM-1 through inhibiting 
+  title: Negative regulation of the Wnt signal by MM-1 through inhibiting
     expression of the wnt4 gene.
   findings:
   - statement: >-
@@ -1187,18 +1171,18 @@ references:
       are
       30-40% less toxic. Shows prefoldin complex membership and amyloid-beta binding.
 - id: PMID:25036637
-  title: A quantitative chaperone interaction network reveals the architecture 
+  title: A quantitative chaperone interaction network reveals the architecture
     of cellular protein homeostasis pathways.
   findings: []
 - id: PMID:25416956
   title: A proteome-scale map of the human interactome network.
   findings: []
 - id: PMID:28514442
-  title: Architecture of the human interactome defines protein communities and 
+  title: Architecture of the human interactome defines protein communities and
     disease networks.
   findings: []
 - id: PMID:30955883
-  title: The Chaperonin TRiC/CCT Associates with Prefoldin through a Conserved 
+  title: The Chaperonin TRiC/CCT Associates with Prefoldin through a Conserved
     Electrostatic Interface Essential for Cellular Proteostasis.
   findings:
   - statement: >-
@@ -1214,7 +1198,7 @@ references:
   title: A reference map of the human binary protein interactome.
   findings: []
 - id: PMID:32699605
-  title: The functions and mechanisms of prefoldin complex and 
+  title: The functions and mechanisms of prefoldin complex and
     prefoldin-subunits.
   findings:
   - statement: >-
@@ -1223,11 +1207,11 @@ references:
       c-Myc corepressor function through multiple mechanisms: HDAC-mSin3 recruitment,
       Rabring7-mediated c-Myc degradation, and Wnt4 repression via Egr-1.
 - id: PMID:32814053
-  title: Interactome Mapping Provides a Network of Neurodegenerative Disease 
+  title: Interactome Mapping Provides a Network of Neurodegenerative Disease
     Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.
   findings: []
 - id: PMID:33961781
-  title: Dual proteome-scale networks reveal cell-specific remodeling of the 
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the
     human interactome.
   findings: []
 - id: PMID:34761191
@@ -1239,6 +1223,6 @@ references:
       analysis
       of prefoldin genomic alterations across cancer types.
 - id: PMID:40205054
-  title: Multimodal cell maps as a foundation for structural and functional 
+  title: Multimodal cell maps as a foundation for structural and functional
     genomics.
   findings: []

--- a/genes/human/PFDN6/PFDN6-ai-review.html
+++ b/genes/human/PFDN6/PFDN6-ai-review.html
@@ -1531,10 +1531,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O15212" data-a="GO:0050821" data-r="PMID:31738558" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="O15212" data-a="GO:0050821" data-r="PMID:31738558" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1547,7 +1547,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Protein stabilization is a legitimate downstream consequence of the prefoldin co-chaperone function. The prefoldin complex prevents aggregation of non-native proteins, which constitutes protein stabilization. The NAS evidence from ComplexPortal is appropriately inferred from the PAQosome characterization study.
+                            <strong>Reason:</strong> Protein stabilization is a true downstream consequence of the prefoldin/PAQosome chaperone context, but it is not the core molecular activity. The core role is better captured by protein folding chaperone activity and chaperone-mediated protein complex assembly.
                         </div>
 
 
@@ -1753,10 +1753,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O15212" data-a="GO:0050821" data-r="PMID:34761191" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="O15212" data-a="GO:0050821" data-r="PMID:34761191" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1769,7 +1769,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Protein stabilization through prevention of aggregation is a well-documented aspect of prefoldin function, consistent with the co-chaperone holdase role.
+                            <strong>Reason:</strong> Protein stabilization through prevention of aggregation is a documented consequence of prefoldin holdase activity, but it is downstream of the core chaperone mechanism rather than a primary molecular function for PFDN6.
                         </div>
 
 
@@ -1815,10 +1815,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O15212" data-a="GO:0050821" data-r="PMID:29662061" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="O15212" data-a="GO:0050821" data-r="PMID:29662061" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1831,7 +1831,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Protein stabilization is an appropriate annotation for PFDN6 as part of the PAQosome, which functions in biogenesis and stabilization of protein complexes.
+                            <strong>Reason:</strong> Protein stabilization is appropriate as a downstream, non-core annotation for PFDN6 as part of the PAQosome. The core functional interpretation remains prefoldin-like chaperone activity and client complex assembly rather than stabilization as the primary role.
                         </div>
 
 
@@ -2852,6 +2852,97 @@
                     </td>
                 </tr>
 
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990062" target="_blank" class="term-link">
+                                    GO:1990062
+                                </a>
+                            </span>
+                            <span class="term-label">RPAP3/R2TP/prefoldin-like complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29662061" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:29662061
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    RPAP3 provides a flexible scaffold for coupling HSP90 to the...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="O15212" data-a="GO:1990062" data-r="PMID:29662061" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PFDN6 is part of the PAQosome/R2TP prefoldin-like module together with PFDN2, URI1, UXT, and PDRG1. This NEW cellular component annotation captures the PAQosome/PFDL complex membership separately from canonical prefoldin complex membership.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GO:1990062 is the specific cellular component term for the RPAP3/R2TP/prefoldin-like complex. UniProt and Martino et al. 2018 both support PFDN6 membership in this PAQosome/PFDL module.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PFDN6/PFDN6-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Component of the PAQosome complex which is responsible for the biogenesis of several protein complexes and which consists of R2TP complex members RUVBL1, RUVBL2, RPAP3 and PIH1D1, URI complex members PFDN2, PFDN6, PDRG1, UXT and URI1 as well as ASDURF, POLR2E and DNAAF10/WDR92.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29662061" target="_blank" class="term-link">
+                                        PMID:29662061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This PFDL module includes prefoldin and prefoldin-like proteins PFDN2, PFDN6, URI1, UXT, PDRG1, and it associates with two additional components, the RNA polymerase subunit POLR2E/RPB5 and WDR92/Monad5.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
             </tbody>
         </table>
     </div>
@@ -2999,6 +3090,20 @@
                 </div>
 
                 <div class="reference-title">Falcon deep research report for PFDN6</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PFDN6/PFDN6-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProt record for PFDN6</div>
 
 
             </div>
@@ -3692,12 +3797,12 @@ existing_annotations:
       complexes. While protein stabilization is a downstream consequence of chaperone activity,
       this annotation is reasonable given the role of prefoldin/PAQosome in preventing
       aggregation and promoting proper folding.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Protein stabilization is a legitimate downstream consequence of the prefoldin co-chaperone
-      function. The prefoldin complex prevents aggregation of non-native proteins, which constitutes
-      protein stabilization. The NAS evidence from ComplexPortal is appropriately inferred from
-      the PAQosome characterization study.
+      Protein stabilization is a true downstream consequence of the prefoldin/PAQosome
+      chaperone context, but it is not the core molecular activity. The core role is
+      better captured by protein folding chaperone activity and chaperone-mediated
+      protein complex assembly.
     supported_by:
       - reference_id: PMID:31738558
         supporting_text: &gt;-
@@ -3746,10 +3851,11 @@ existing_annotations:
       NAS annotation from ComplexPortal citing Herranz-Montoya et al. 2021 review. Prefoldin
       prevents aggregation of non-native proteins, which constitutes protein stabilization.
       This is a legitimate aspect of the prefoldin function.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Protein stabilization through prevention of aggregation is a well-documented aspect
-      of prefoldin function, consistent with the co-chaperone holdase role.
+      Protein stabilization through prevention of aggregation is a documented consequence
+      of prefoldin holdase activity, but it is downstream of the core chaperone mechanism
+      rather than a primary molecular function for PFDN6.
 - term:
     id: GO:0050821
     label: protein stabilization
@@ -3761,10 +3867,12 @@ existing_annotations:
       coupling HSP90 to the R2TP co-chaperone complex. PFDN6 is part of the PAQosome which
       includes the R2TP complex and prefoldin-like module. The PAQosome stabilizes client
       complexes during their assembly, so protein stabilization is a reasonable annotation.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Protein stabilization is an appropriate annotation for PFDN6 as part of the PAQosome,
-      which functions in biogenesis and stabilization of protein complexes.
+      Protein stabilization is appropriate as a downstream, non-core annotation for PFDN6
+      as part of the PAQosome. The core functional interpretation remains prefoldin-like
+      chaperone activity and client complex assembly rather than stabilization as the
+      primary role.
     supported_by:
       - reference_id: PMID:29662061
         supporting_text: &gt;-
@@ -4040,9 +4148,40 @@ existing_annotations:
           Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target
           proteins to it ... prefoldin promotes folding in an environment in which there are
           many competing pathways for nonnative proteins.
+- term:
+    id: GO:1990062
+    label: RPAP3/R2TP/prefoldin-like complex
+  evidence_type: IPI
+  original_reference_id: PMID:29662061
+  review:
+    summary: &gt;-
+      PFDN6 is part of the PAQosome/R2TP prefoldin-like module together with PFDN2,
+      URI1, UXT, and PDRG1. This NEW cellular component annotation captures the
+      PAQosome/PFDL complex membership separately from canonical prefoldin complex
+      membership.
+    action: NEW
+    reason: &gt;-
+      GO:1990062 is the specific cellular component term for the RPAP3/R2TP/prefoldin-like
+      complex. UniProt and Martino et al. 2018 both support PFDN6 membership in
+      this PAQosome/PFDL module.
+    supported_by:
+      - reference_id: file:human/PFDN6/PFDN6-uniprot.txt
+        supporting_text: &gt;-
+          Component of the PAQosome complex which is responsible for the biogenesis
+          of several protein complexes and which consists of R2TP complex members
+          RUVBL1, RUVBL2, RPAP3 and PIH1D1, URI complex members PFDN2, PFDN6,
+          PDRG1, UXT and URI1 as well as ASDURF, POLR2E and DNAAF10/WDR92.
+      - reference_id: PMID:29662061
+        supporting_text: &gt;-
+          This PFDL module includes prefoldin and prefoldin-like proteins PFDN2,
+          PFDN6, URI1, UXT, PDRG1, and it associates with two additional components,
+          the RNA polymerase subunit POLR2E/RPB5 and WDR92/Monad5.
 references:
 - id: file:human/PFDN6/PFDN6-deep-research-falcon.md
   title: Falcon deep research report for PFDN6
+  findings: []
+- id: file:human/PFDN6/PFDN6-uniprot.txt
+  title: UniProt record for PFDN6
   findings: []
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO

--- a/genes/human/PFDN6/PFDN6-ai-review.html
+++ b/genes/human/PFDN6/PFDN6-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>PFDN6</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/O15212" target="_blank" class="term-link">
                         O15212
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>PFDN6 encodes prefoldin subunit 6, a beta-class subunit of the canonical heterohexameric prefoldin co-chaperone complex (2 alpha + 4 beta subunits). The prefoldin complex captures non-native/unfolded polypeptides, particularly nascent actin and tubulin, and delivers them to the TRiC/CCT chaperonin for ATP-dependent folding. PFDN6 contributes one coiled-coil tentacle bearing hydrophobic residues at its tip to engage exposed hydrophobic patches on non-native substrates. PFDN6 is also a component of the PAQosome (prefoldin-like module containing URI1, PFDN2, PFDN6, PDRG1, UXT, and ASDURF), which is involved in the biogenesis of several protein complexes. The protein localizes primarily to the cytoplasm. Beyond its canonical co-chaperone role, prefoldin subunits have been reported to exhibit nuclear functions related to transcriptional regulation, and recent work has linked PFDN6 upregulation to colorectal cancer biology.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,64 +795,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PFDN6 is a cytoplasmic protein as part of the prefoldin heterohexamer that captures unfolded substrates in the cytoplasm and delivers them to TRiC/CCT. This is well supported by the IBA annotation which is phylogenetically consistent across eukaryotes. UniProt does not specify a subcellular location annotation for PFDN6, but the canonical function of prefoldin as a cytosolic co-chaperone is well established (PMID:9630229).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The cytoplasmic localization is the canonical site of prefoldin function, capturing unfolded actin and tubulin for delivery to TRiC/CCT. The IBA annotation is phylogenetically well supported by data from yeast, plants, worm, and human.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We describe the discovery of a heterohexameric chaperone protein, prefoldin, based on its ability to capture unfolded actin. Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -864,77 +864,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein folding is the core biological process in which prefoldin participates, capturing non-native substrates and delivering them to TRiC/CCT for productive folding. The IBA annotation is phylogenetically well supported. PFDN6 as a beta subunit contributes directly to this function through its coiled-coil tentacle that engages unfolded substrates (PMID:9630229, PMID:30955883).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein folding is the core biological process of the prefoldin complex. The annotation is at the right level of specificity for the BP axis. More specific terms like chaperone-mediated protein complex assembly are also captured separately.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">prefoldin promotes folding in an environment in which there are many competing pathways for nonnative proteins.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The supra-chaperone assembly formed by PFD and TRiC is essential to prevent toxic conformations and ensure effective cellular proteostasis.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PFDN6/PFDN6-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PFDN6 functions as one beta subunit in the canonical prefoldin hexamer that captures non-native clients, for example nascent actin/tubulin, and delivers them to TRiC/CCT.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016272" target="_blank" class="term-link">
                                     GO:0016272
                                 </a>
                             </span>
                             <span class="term-label">prefoldin complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -946,77 +957,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PFDN6 is one of the four beta subunits of the canonical prefoldin heterohexamer. This is a core localization for the protein, well established from the original discovery (PMID:9630229) through to recent structural studies (PMID:30955883). The IBA annotation is phylogenetically consistent.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Membership in the prefoldin complex is a defining feature of PFDN6. This is supported by multiple lines of experimental evidence as well as phylogenetic inference.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We describe the discovery of a heterohexameric chaperone protein, prefoldin, based on its ability to capture unfolded actin.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">these hetero-oligomeric chaperones associate in a defined architecture, through a conserved interface of electrostatic contacts</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1028,77 +1039,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Prefoldin binds specifically to the TRiC/CCT chaperonin to transfer substrate proteins to it for folding. The interaction between prefoldin and TRiC/CCT is mediated through a conserved electrostatic interface (PMID:30955883). This MF term accurately captures the binding of prefoldin subunits to the downstream chaperonin.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Binding to the TRiC/CCT chaperonin is a core molecular function of prefoldin subunits. The IBA annotation is consistent with experimental data showing prefoldin-TRiC/CCT interaction through a conserved electrostatic interface.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">these hetero-oligomeric chaperones associate in a defined architecture, through a conserved interface of electrostatic contacts that serves as a pivot point for a TRiC-PFD conformational cycle.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051131" target="_blank" class="term-link">
                                     GO:0051131
                                 </a>
                             </span>
                             <span class="term-label">chaperone-mediated protein complex assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1110,64 +1121,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Prefoldin assists in the assembly of cytoskeletal protein complexes by capturing unfolded actin and tubulin monomers and delivering them to TRiC/CCT, which folds them into conformations competent for polymerization and complex assembly. The IBA annotation is consistent with experimental evidence (PMID:9630229).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This term appropriately captures the role of prefoldin in assisting the chaperonin-mediated assembly of cytoskeletal complexes (actin filaments, tubulin heterodimers/microtubules). The IBA annotation is phylogenetically well supported.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Deletion of the gene encoding a prefoldin subunit in S. cerevisiae results in a phenotype similar to those found when c-cpn is mutated, namely impaired functions of the actin and tubulin-based cytoskeleton.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1179,46 +1190,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from InterPro domain IPR002777 (PFD_beta-like). This is consistent with the experimentally validated function and the IBA annotation for the same term. While redundant with the IBA and IDA annotations, it is not incorrect.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The IEA mapping from the PFD_beta-like domain to protein folding is appropriate and consistent with the experimentally determined function. Redundancy with other evidence codes is acceptable.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016272" target="_blank" class="term-link">
                                     GO:0016272
                                 </a>
                             </span>
                             <span class="term-label">prefoldin complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1230,97 +1241,97 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from InterPro domain IPR002777 (PFD_beta-like). Consistent with the well-established membership of PFDN6 in the prefoldin complex. Redundant with IBA and IDA annotations but not incorrect.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The IEA mapping from the prefoldin beta domain to prefoldin complex membership is appropriate and consistent with multiple other lines of evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
                                     GO:0032991
                                 </a>
                             </span>
                             <span class="term-label">protein-containing complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="O15212" data-a="GO:0032991" data-r="GO_REF:0000117" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="O15212" data-a="GO:0032991" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ARBA machine-learning-derived annotation placing PFDN6 in a protein-containing complex. While technically correct, this is extremely generic and adds no information beyond what is already captured by the more specific GO:0016272 prefoldin complex annotations.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> While overly broad, this IEA annotation is not incorrect. It is subsumed by the more specific prefoldin complex annotation. Keeping it as a broad IEA is acceptable since more informative annotations already exist.
+                            <strong>Reason:</strong> While not technically false, this IEA annotation is too broad to be useful for PFDN6 and is superseded by the more specific GO:0016272 prefoldin complex annotations already present.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1332,68 +1343,68 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from InterPro domain mapping. While prefoldin does bind unfolded proteins, GO:0051082 &#34;unfolded protein binding&#34; is a molecular function term that describes simple binding to unfolded proteins. The more accurate molecular function for prefoldin is GO:0044183 &#34;protein folding chaperone&#34; which captures the active chaperone role of binding to assist the protein folding process, rather than merely binding unfolded proteins.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Prefoldin does not merely bind unfolded proteins passively; it actively functions as a co-chaperone that captures non-native substrates and delivers them to TRiC/CCT. GO:0044183 &#34;protein folding chaperone&#34; (defined as &#34;Binding to a protein or a protein-containing complex to assist the protein folding process&#34;) better describes this active molecular function.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32296183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A reference map of the human binary protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1405,57 +1416,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> High-throughput binary interactome mapping study (HuRI). PFDN6 interacts with various proteins including MAGEB4, MBD3, CEBPG, FBXO2, KANK2, KIFC3, RPRD1B, AIMP2, and CCHCR1. While these interactions were detected in a systematic screen, protein binding is uninformative as a GO annotation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per curation guidelines, GO:0005515 protein binding is uninformative and should be avoided. The high-throughput interactome data does not provide specific enough functional insight to assign a more informative molecular function term. The known functional interactions (with TRiC/CCT, with other prefoldin subunits) are already captured by more specific annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32814053
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interactome Mapping Provides a Network of Neurodegenerative ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1467,57 +1478,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Interactome mapping in context of neurodegenerative disease proteins. PFDN6 interaction with FGFR3 detected. This is a high-throughput study and protein binding is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 protein binding is uninformative per curation guidelines. High-throughput interactome mapping does not provide sufficient context for a more specific annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                     GO:0050821
                                 </a>
                             </span>
                             <span class="term-label">protein stabilization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31738558" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31738558
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Upstream ORF-Encoded ASDURF Is a Novel Prefoldin-like Subuni...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1529,75 +1540,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NAS annotation from ComplexPortal referencing the PAQosome study. PMID:31738558 describes ASDURF as a novel prefoldin-like subunit of the PAQosome and shows that PFDN6 is part of the PAQosome prefoldin-like module. The PAQosome is involved in biogenesis of several protein complexes. While protein stabilization is a downstream consequence of chaperone activity, this annotation is reasonable given the role of prefoldin/PAQosome in preventing aggregation and promoting proper folding.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein stabilization is a legitimate downstream consequence of the prefoldin co-chaperone function. The prefoldin complex prevents aggregation of non-native proteins, which constitutes protein stabilization. The NAS evidence from ComplexPortal is appropriately inferred from the PAQosome characterization study.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/31738558" target="_blank" class="term-link">
                                         PMID:31738558
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The PAQosome is an 11-subunit chaperone involved in the biogenesis of several human protein complexes.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32699605
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The functions and mechanisms of prefoldin complex and prefol...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1609,57 +1620,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NAS annotation from ComplexPortal, citing a review on prefoldin functions and mechanisms. Consistent with the core function of prefoldin in protein folding. Redundant with IBA and IDA annotations but not incorrect.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The NAS annotation for protein folding is consistent with all other evidence. The review article cited comprehensively describes prefoldin&#39;s role in protein folding.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/34761191" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:34761191
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A comprehensive analysis of prefoldins and their implication...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1671,75 +1682,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NAS annotation from ComplexPortal citing Herranz-Montoya et al. 2021 comprehensive analysis of prefoldins. This review describes the canonical prefoldin function as escorting misfolded or non-native proteins to group II chaperonins for folding. Consistent with the core function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent with the well-established protein folding function of prefoldin.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/34761191" target="_blank" class="term-link">
                                         PMID:34761191
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">several reports indicate they act as co-chaperones escorting misfolded or non-native proteins to group II chaperonins</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                     GO:0050821
                                 </a>
                             </span>
                             <span class="term-label">protein stabilization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/34761191" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:34761191
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A comprehensive analysis of prefoldins and their implication...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1751,57 +1762,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NAS annotation from ComplexPortal citing Herranz-Montoya et al. 2021 review. Prefoldin prevents aggregation of non-native proteins, which constitutes protein stabilization. This is a legitimate aspect of the prefoldin function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein stabilization through prevention of aggregation is a well-documented aspect of prefoldin function, consistent with the co-chaperone holdase role.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                     GO:0050821
                                 </a>
                             </span>
                             <span class="term-label">protein stabilization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/29662061" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:29662061
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     RPAP3 provides a flexible scaffold for coupling HSP90 to the...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1813,75 +1824,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NAS annotation from ComplexPortal citing PMID:29662061 (Martino et al. 2018) about RPAP3 coupling HSP90 to the R2TP co-chaperone complex. PFDN6 is part of the PAQosome which includes the R2TP complex and prefoldin-like module. The PAQosome stabilizes client complexes during their assembly, so protein stabilization is a reasonable annotation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein stabilization is an appropriate annotation for PFDN6 as part of the PAQosome, which functions in biogenesis and stabilization of protein complexes.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/29662061" target="_blank" class="term-link">
                                         PMID:29662061
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">RPAP3 provides a flexible scaffold for coupling HSP90 to the human R2TP co-chaperone complex.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30955883
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Chaperonin TRiC/CCT Associates with Prefoldin through a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1893,75 +1904,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from Gestaut et al. 2019 (Cell), which used cryo-EM, crosslinking-mass spectrometry and biochemical approaches to characterize the structural and functional interplay between TRiC/CCT and prefoldin. The study showed that PFD can enhance the rate and yield of the TRiC folding reaction and that disrupting the TRiC-PFD interaction leads to accumulation of amyloid aggregates, demonstrating that the supra-chaperone assembly is essential for effective cellular proteostasis.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Strong experimental evidence from a high-quality Cell paper demonstrating that prefoldin cooperates with TRiC/CCT to promote protein folding and prevent toxic conformations.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles. Disrupting the TRiC-PFD interaction in vivo is strongly deleterious, leading to accumulation of amyloid aggregates.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016272" target="_blank" class="term-link">
                                     GO:0016272
                                 </a>
                             </span>
                             <span class="term-label">prefoldin complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30955883
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Chaperonin TRiC/CCT Associates with Prefoldin through a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1973,75 +1984,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from Gestaut et al. 2019, which directly visualized the prefoldin-TRiC complex by cryo-EM, confirming the defined architecture of the prefoldin heterohexamer including PFDN6 as a subunit.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct experimental demonstration of PFDN6 as part of the prefoldin complex through cryo-EM structural characterization.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">these hetero-oligomeric chaperones associate in a defined architecture, through a conserved interface of electrostatic contacts</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30955883
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Chaperonin TRiC/CCT Associates with Prefoldin through a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -2053,86 +2064,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from Gestaut et al. 2019. The study demonstrated that prefoldin captures unfolded substrates and transfers them to TRiC/CCT. However, the molecular function of prefoldin is better described as GO:0044183 &#34;protein folding chaperone&#34; rather than simple unfolded protein binding, because prefoldin actively assists in the folding process by transferring substrates to TRiC/CCT rather than merely binding unfolded proteins.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The prefoldin complex does not merely bind unfolded proteins; it functions as an active co-chaperone that captures non-native substrates and delivers them to TRiC/CCT. GO:0044183 &#34;protein folding chaperone&#34; better captures this molecular function.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFD alternates between an open &#34;latched&#34; conformation and a closed &#34;engaged&#34; conformation that aligns the PFD-TRiC substrate binding chambers. PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001540" target="_blank" class="term-link">
                                     GO:0001540
                                 </a>
                             </span>
                             <span class="term-label">amyloid-beta binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23614719
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human prefoldin inhibits amyloid-β (Aβ) fibrillation and con...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2144,75 +2155,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from Sorgjerd et al. 2013 (Biochemistry). The study demonstrated that recombinant human prefoldin (hPFD, the full heterohexameric complex) inhibits amyloid-beta (1-42) fibrillation and induces formation of soluble Abeta oligomers that are less toxic (30-40% less toxic than fibrils or archaeal PFD-formed oligomers). This demonstrates that the prefoldin complex as a whole binds amyloid-beta. However, the annotation is made at the level of individual subunits (PFDN6), whereas the binding is a property of the assembled hexamer complex, not of PFDN6 alone.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The amyloid-beta binding was demonstrated for the assembled prefoldin heterohexamer, not for PFDN6 individually. While technically each subunit participates in the complex that binds Abeta, this is not a core function of the gene product and may represent an in vitro property of the holo-complex rather than a physiological role of the individual subunit.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                                         PMID:23614719
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we investigated the effect of recombinant human PFD (hPFD) on Aβ(1-42) aggregation in vitro and found that hPFD inhibited Aβ fibrillation and induced formation of soluble Aβ oligomers.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016272" target="_blank" class="term-link">
                                     GO:0016272
                                 </a>
                             </span>
                             <span class="term-label">prefoldin complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23614719
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human prefoldin inhibits amyloid-β (Aβ) fibrillation and con...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2224,75 +2235,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from Sorgjerd et al. 2013. The study used recombinant human prefoldin (assembled as a heterohexamer) demonstrating that PFDN6 is part of the complex.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent with all other evidence for PFDN6 membership in the prefoldin complex.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                                         PMID:23614719
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin (PFD) is a molecular chaperone that prevents aggregation of misfolded proteins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905907" target="_blank" class="term-link">
                                     GO:1905907
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of amyloid fibril formation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23614719
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human prefoldin inhibits amyloid-β (Aβ) fibrillation and con...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2304,75 +2315,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from Sorgjerd et al. 2013. The study showed that the full recombinant human prefoldin complex inhibits amyloid-beta fibrillation in vitro, with Abeta oligomers formed in the presence of hPFD being 30-40% less toxic. This is a property of the assembled prefoldin complex, not specific to PFDN6 individually. While interesting, this represents an in vitro observation with the holo-complex rather than a core physiological function of the PFDN6 gene product.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The negative regulation of amyloid fibril formation was demonstrated for the full prefoldin heterohexameric complex in vitro. While potentially relevant to Alzheimer&#39;s disease biology, this is not a core evolved function of PFDN6 specifically. The annotation is kept as non-core because the evidence is valid but represents a property of the holo-complex.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                                         PMID:23614719
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">hPFD inhibited Aβ fibrillation and induced formation of soluble Aβ oligomers. Interestingly, cell viability measurements ... showed that Aβ oligomers formed by hPFD were 30-40% less toxic</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016272" target="_blank" class="term-link">
                                     GO:0016272
                                 </a>
                             </span>
                             <span class="term-label">prefoldin complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9630229
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Prefoldin, a chaperone that delivers unfolded proteins to cy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2384,75 +2395,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from the seminal Vainberg et al. 1998 (Cell) paper that first described the discovery of prefoldin as a heterohexameric chaperone. PFDN6 was identified as one of the six subunits of this complex.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Foundational experimental evidence from the original discovery of prefoldin.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We describe the discovery of a heterohexameric chaperone protein, prefoldin, based on its ability to capture unfolded actin.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9630229
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Prefoldin, a chaperone that delivers unfolded proteins to cy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -2464,86 +2475,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NAS annotation from the original Vainberg et al. 1998 paper. The paper demonstrated that prefoldin captures unfolded actin and delivers it to the chaperonin. However, the molecular function is better described as GO:0044183 &#34;protein folding chaperone&#34; since prefoldin actively assists in folding rather than merely binding unfolded proteins.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The original paper demonstrates that prefoldin&#39;s function goes beyond simple unfolded protein binding; it actively captures and transfers substrates to the chaperonin for productive folding. GO:0044183 &#34;protein folding chaperone&#34; is the more appropriate molecular function term.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it ... prefoldin promotes folding in an environment in which there are many competing pathways for nonnative proteins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9630229
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Prefoldin, a chaperone that delivers unfolded proteins to cy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2555,75 +2566,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from Vainberg et al. 1998. The paper directly demonstrated that prefoldin binds specifically to cytosolic chaperonin (c-CPN/TRiC/CCT) and transfers target proteins to it. This is strong direct experimental evidence for chaperonin binding.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct experimental demonstration that prefoldin binds specifically to the cytosolic chaperonin, which is the defining molecular interaction for prefoldin&#39;s function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051131" target="_blank" class="term-link">
                                     GO:0051131
                                 </a>
                             </span>
                             <span class="term-label">chaperone-mediated protein complex assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9630229
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Prefoldin, a chaperone that delivers unfolded proteins to cy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2635,75 +2646,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from Vainberg et al. 1998. The paper showed that deletion of a prefoldin subunit gene in yeast results in impaired functions of the actin and tubulin-based cytoskeleton, demonstrating prefoldin&#39;s role in chaperone-mediated assembly of cytoskeletal complexes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct experimental evidence from genetic studies showing that prefoldin is required for proper assembly of cytoskeletal protein complexes.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Deletion of the gene encoding a prefoldin subunit in S. cerevisiae results in a phenotype similar to those found when c-cpn is mutated, namely impaired functions of the actin and tubulin-based cytoskeleton.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9630229
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Prefoldin, a chaperone that delivers unfolded proteins to cy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2715,75 +2726,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NAS annotation from the original Vainberg et al. 1998 paper describing prefoldin&#39;s role in protein folding. The paper demonstrated that prefoldin promotes folding by directing target proteins to the chaperonin. Redundant with IDA and IBA annotations but consistent.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent with the well-established protein folding function of prefoldin, supported by the foundational paper.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we show that by directing target proteins to chaperonin, prefoldin promotes folding in an environment in which there are many competing pathways for nonnative proteins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     GO:0044183
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30955883
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Chaperonin TRiC/CCT Associates with Prefoldin through a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-new">
@@ -2795,63 +2806,63 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PFDN6, as a subunit of the prefoldin complex, functions as a protein folding chaperone that captures non-native substrates and delivers them to TRiC/CCT. This molecular function term is more appropriate than GO:0051082 &#34;unfolded protein binding&#34; because it captures the active co-chaperone role rather than passive binding. Gestaut et al. 2019 demonstrated that prefoldin alternates between conformations to align substrate binding chambers with TRiC/CCT and enhances the rate and yield of the folding reaction (PMID:30955883).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0044183 &#34;protein folding chaperone&#34; is the most appropriate molecular function term for prefoldin subunits. It is defined as &#34;Binding to a protein or a protein-containing complex to assist the protein folding process&#34; which exactly matches prefoldin&#39;s function. This annotation should replace the existing GO:0051082 annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFD alternates between an open &#34;latched&#34; conformation and a closed &#34;engaged&#34; conformation that aligns the PFD-TRiC substrate binding chambers. PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it ... prefoldin promotes folding in an environment in which there are many competing pathways for nonnative proteins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>PFDN6 is a beta-type subunit of the heterohexameric prefoldin co-chaperone complex that captures unfolded nascent polypeptides (primarily actin and tubulin) and delivers them to the TRiC/CCT chaperonin for ATP-dependent folding. PFDN6 contributes a coiled-coil tentacle with hydrophobic residues that engages exposed hydrophobic patches on non-native substrates. Deletion of prefoldin subunit genes impairs actin and tubulin cytoskeleton function.</h3>
                 <span class="vote-buttons" data-g="O15212" data-a="FUNCTION: PFDN6 is a beta-type subunit of the heterohexameri..." data-r="" data-act="CORE_FUNCTION">
@@ -2859,10 +2870,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -2871,45 +2882,45 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                 protein folding
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051131" target="_blank" class="term-link">
                                 chaperone-mediated protein complex assembly
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                 cytoplasm
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">In Complex:</div>
                     <span class="badge">
@@ -2918,266 +2929,291 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                 PMID:9630229
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">We describe the discovery of a heterohexameric chaperone protein, prefoldin, based on its ability to capture unfolded actin. Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                 PMID:30955883
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles.</div>
-                        
+
                     </li>
-                    
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PFDN6/PFDN6-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">PFDN6 functions as one beta subunit in the canonical prefoldin hexamer that captures non-native clients, for example nascent actin/tubulin, and delivers them to TRiC/CCT.</div>
+
+                    </li>
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/PFDN6/PFDN6-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for PFDN6</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                             PMID:23614719
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Human prefoldin inhibits amyloid-β (Aβ) fibrillation and contributes to formation of nontoxic Aβ aggregates.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/29662061" target="_blank" class="term-link">
                             PMID:29662061
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RPAP3 provides a flexible scaffold for coupling HSP90 to the human R2TP co-chaperone complex.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                             PMID:30955883
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The Chaperonin TRiC/CCT Associates with Prefoldin through a Conserved Electrostatic Interface Essential for Cellular Proteostasis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/31738558" target="_blank" class="term-link">
                             PMID:31738558
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Upstream ORF-Encoded ASDURF Is a Novel Prefoldin-like Subunit of the PAQosome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                             PMID:32296183
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A reference map of the human binary protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link">
                             PMID:32699605
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The functions and mechanisms of prefoldin complex and prefoldin-subunits.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
                             PMID:32814053
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/34761191" target="_blank" class="term-link">
                             PMID:34761191
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A comprehensive analysis of prefoldins and their implication in cancer.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                             PMID:9630229
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Prefoldin, a chaperone that delivers unfolded proteins to cytosolic chaperonin.</div>
-                
-                
+
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -3393,9 +3429,9 @@ this with annotations you find in gene/protein databases, but these can be outda
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -3407,7 +3443,7 @@ this with annotations you find in gene/protein databases, but these can be outda
                 <pre><code>id: O15212
 gene_symbol: PFDN6
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -3472,6 +3508,11 @@ existing_annotations:
         supporting_text: &gt;-
           The supra-chaperone assembly formed by PFD and TRiC is essential to prevent toxic
           conformations and ensure effective cellular proteostasis.
+      - reference_id: file:human/PFDN6/PFDN6-deep-research-falcon.md
+        supporting_text: &gt;-
+          PFDN6 functions as one beta subunit in the canonical prefoldin hexamer
+          that captures non-native clients, for example nascent actin/tubulin, and
+          delivers them to TRiC/CCT.
 - term:
     id: GO:0016272
     label: prefoldin complex
@@ -3581,11 +3622,11 @@ existing_annotations:
       ARBA machine-learning-derived annotation placing PFDN6 in a protein-containing complex.
       While technically correct, this is extremely generic and adds no information beyond what
       is already captured by the more specific GO:0016272 prefoldin complex annotations.
-    action: ACCEPT
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      While overly broad, this IEA annotation is not incorrect. It is subsumed by the more specific
-      prefoldin complex annotation. Keeping it as a broad IEA is acceptable since more informative
-      annotations already exist.
+      While not technically false, this IEA annotation is too broad to be useful
+      for PFDN6 and is superseded by the more specific GO:0016272 prefoldin
+      complex annotations already present.
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -4000,6 +4041,9 @@ existing_annotations:
           proteins to it ... prefoldin promotes folding in an environment in which there are
           many competing pathways for nonnative proteins.
 references:
+- id: file:human/PFDN6/PFDN6-deep-research-falcon.md
+  title: Falcon deep research report for PFDN6
+  findings: []
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
     terms
@@ -4073,13 +4117,18 @@ core_functions:
         supporting_text: &gt;-
           PFD can act after TRiC bound its substrates to enhance the rate and yield
           of the folding reaction, suppressing non-productive reaction cycles.
+      - reference_id: file:human/PFDN6/PFDN6-deep-research-falcon.md
+        supporting_text: &gt;-
+          PFDN6 functions as one beta subunit in the canonical prefoldin hexamer
+          that captures non-native clients, for example nascent actin/tubulin, and
+          delivers them to TRiC/CCT.
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/PFDN6/PFDN6-ai-review.yaml
+++ b/genes/human/PFDN6/PFDN6-ai-review.yaml
@@ -250,12 +250,12 @@ existing_annotations:
       complexes. While protein stabilization is a downstream consequence of chaperone activity,
       this annotation is reasonable given the role of prefoldin/PAQosome in preventing
       aggregation and promoting proper folding.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
-      Protein stabilization is a legitimate downstream consequence of the prefoldin co-chaperone
-      function. The prefoldin complex prevents aggregation of non-native proteins, which constitutes
-      protein stabilization. The NAS evidence from ComplexPortal is appropriately inferred from
-      the PAQosome characterization study.
+      Protein stabilization is a true downstream consequence of the prefoldin/PAQosome
+      chaperone context, but it is not the core molecular activity. The core role is
+      better captured by protein folding chaperone activity and chaperone-mediated
+      protein complex assembly.
     supported_by:
       - reference_id: PMID:31738558
         supporting_text: >-
@@ -304,10 +304,11 @@ existing_annotations:
       NAS annotation from ComplexPortal citing Herranz-Montoya et al. 2021 review. Prefoldin
       prevents aggregation of non-native proteins, which constitutes protein stabilization.
       This is a legitimate aspect of the prefoldin function.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
-      Protein stabilization through prevention of aggregation is a well-documented aspect
-      of prefoldin function, consistent with the co-chaperone holdase role.
+      Protein stabilization through prevention of aggregation is a documented consequence
+      of prefoldin holdase activity, but it is downstream of the core chaperone mechanism
+      rather than a primary molecular function for PFDN6.
 - term:
     id: GO:0050821
     label: protein stabilization
@@ -319,10 +320,12 @@ existing_annotations:
       coupling HSP90 to the R2TP co-chaperone complex. PFDN6 is part of the PAQosome which
       includes the R2TP complex and prefoldin-like module. The PAQosome stabilizes client
       complexes during their assembly, so protein stabilization is a reasonable annotation.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
-      Protein stabilization is an appropriate annotation for PFDN6 as part of the PAQosome,
-      which functions in biogenesis and stabilization of protein complexes.
+      Protein stabilization is appropriate as a downstream, non-core annotation for PFDN6
+      as part of the PAQosome. The core functional interpretation remains prefoldin-like
+      chaperone activity and client complex assembly rather than stabilization as the
+      primary role.
     supported_by:
       - reference_id: PMID:29662061
         supporting_text: >-
@@ -598,9 +601,40 @@ existing_annotations:
           Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target
           proteins to it ... prefoldin promotes folding in an environment in which there are
           many competing pathways for nonnative proteins.
+- term:
+    id: GO:1990062
+    label: RPAP3/R2TP/prefoldin-like complex
+  evidence_type: IPI
+  original_reference_id: PMID:29662061
+  review:
+    summary: >-
+      PFDN6 is part of the PAQosome/R2TP prefoldin-like module together with PFDN2,
+      URI1, UXT, and PDRG1. This NEW cellular component annotation captures the
+      PAQosome/PFDL complex membership separately from canonical prefoldin complex
+      membership.
+    action: NEW
+    reason: >-
+      GO:1990062 is the specific cellular component term for the RPAP3/R2TP/prefoldin-like
+      complex. UniProt and Martino et al. 2018 both support PFDN6 membership in
+      this PAQosome/PFDL module.
+    supported_by:
+      - reference_id: file:human/PFDN6/PFDN6-uniprot.txt
+        supporting_text: >-
+          Component of the PAQosome complex which is responsible for the biogenesis
+          of several protein complexes and which consists of R2TP complex members
+          RUVBL1, RUVBL2, RPAP3 and PIH1D1, URI complex members PFDN2, PFDN6,
+          PDRG1, UXT and URI1 as well as ASDURF, POLR2E and DNAAF10/WDR92.
+      - reference_id: PMID:29662061
+        supporting_text: >-
+          This PFDL module includes prefoldin and prefoldin-like proteins PFDN2,
+          PFDN6, URI1, UXT, PDRG1, and it associates with two additional components,
+          the RNA polymerase subunit POLR2E/RPB5 and WDR92/Monad5.
 references:
 - id: file:human/PFDN6/PFDN6-deep-research-falcon.md
   title: Falcon deep research report for PFDN6
+  findings: []
+- id: file:human/PFDN6/PFDN6-uniprot.txt
+  title: UniProt record for PFDN6
   findings: []
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO

--- a/genes/human/PFDN6/PFDN6-ai-review.yaml
+++ b/genes/human/PFDN6/PFDN6-ai-review.yaml
@@ -1,7 +1,7 @@
 id: O15212
 gene_symbol: PFDN6
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -66,6 +66,11 @@ existing_annotations:
         supporting_text: >-
           The supra-chaperone assembly formed by PFD and TRiC is essential to prevent toxic
           conformations and ensure effective cellular proteostasis.
+      - reference_id: file:human/PFDN6/PFDN6-deep-research-falcon.md
+        supporting_text: >-
+          PFDN6 functions as one beta subunit in the canonical prefoldin hexamer
+          that captures non-native clients, for example nascent actin/tubulin, and
+          delivers them to TRiC/CCT.
 - term:
     id: GO:0016272
     label: prefoldin complex
@@ -175,11 +180,11 @@ existing_annotations:
       ARBA machine-learning-derived annotation placing PFDN6 in a protein-containing complex.
       While technically correct, this is extremely generic and adds no information beyond what
       is already captured by the more specific GO:0016272 prefoldin complex annotations.
-    action: ACCEPT
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      While overly broad, this IEA annotation is not incorrect. It is subsumed by the more specific
-      prefoldin complex annotation. Keeping it as a broad IEA is acceptable since more informative
-      annotations already exist.
+      While not technically false, this IEA annotation is too broad to be useful
+      for PFDN6 and is superseded by the more specific GO:0016272 prefoldin
+      complex annotations already present.
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -594,6 +599,9 @@ existing_annotations:
           proteins to it ... prefoldin promotes folding in an environment in which there are
           many competing pathways for nonnative proteins.
 references:
+- id: file:human/PFDN6/PFDN6-deep-research-falcon.md
+  title: Falcon deep research report for PFDN6
+  findings: []
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
     terms
@@ -667,3 +675,8 @@ core_functions:
         supporting_text: >-
           PFD can act after TRiC bound its substrates to enhance the rate and yield
           of the folding reaction, suppressing non-productive reaction cycles.
+      - reference_id: file:human/PFDN6/PFDN6-deep-research-falcon.md
+        supporting_text: >-
+          PFDN6 functions as one beta subunit in the canonical prefoldin hexamer
+          that captures non-native clients, for example nascent actin/tubulin, and
+          delivers them to TRiC/CCT.


### PR DESCRIPTION
## Summary
Completes human review batch 05 for the prefoldin subunit set:

- PFDN1
- PFDN2
- PFDN4
- PFDN5
- PFDN6

All five reviews now have `status: COMPLETE`, Falcon deep-research support integrated into annotation evidence, and regenerated HTML pages. Review follow-up fixed PFDN2 PAQosome/R2TP handling by replacing generic URI1 protein-binding with the specific `GO:1990062` complex context, and fixed PFDN6's generic `protein-containing complex` annotation as over-annotated.

## Validation
- `just validate human PFDN1`
- `just validate human PFDN2`
- `just validate human PFDN4`
- `just validate human PFDN5`
- `just validate human PFDN6`
- `just render human PFDN1`
- `just render human PFDN2`
- `just render human PFDN4`
- `just render human PFDN5`
- `just render human PFDN6`
- `just pytest`
- `just mypy`
- `git diff --cached --check`

Each gene received read-only subagent review approval before publishing.