### PR TITLE
Fix pre-edit validation hook blocking all ai-review.yaml edits

### DIFF
--- a/.claude/hooks/validate_ai_review_pretool_hook.py
+++ b/.claude/hooks/validate_ai_review_pretool_hook.py
@@ -67,7 +67,10 @@ def validate_content(
         temp_path = Path(tmpdir) / original_path.name
         temp_path.write_text(content)
 
-        cmd = ["uv", "run", "ai-gene-review", "validate", str(temp_path)]
+        # Pass --no-goa: the temp dir holds only the simulated YAML, not the
+        # sibling <gene>-goa.tsv, so GOA cross-validation can't run here.
+        # GOA cross-validation already runs at PR time via `just validate-all`.
+        cmd = ["uv", "run", "ai-gene-review", "validate", "--no-goa", str(temp_path)]
 
         result = subprocess.run(
             cmd,


### PR DESCRIPTION
## Summary

- The PreToolUse hook (`.claude/hooks/validate_ai_review_pretool_hook.py`) is blocking **every** Edit/Write/MultiEdit on `*-ai-review.yaml` files — including no-op edits — with `GOA validation: GOA file not found`.
- Root cause: the hook simulates the edit by writing the YAML into a `tempfile.TemporaryDirectory()` and runs `ai-gene-review validate` against it. The validator's GOA cross-check looks for a sibling `<gene>-goa.tsv` and hard-fails when absent — which is always the case in the temp dir.
- The regression dates from #352 / 08915dbe9 (`Block NEW action for existing GOA terms`), which made the GOA validator surface the missing-file condition as a blocking error rather than a no-op.
- Fix: pass `--no-goa` to the validate command in `validate_content()`. The pre-edit hook's purpose is to catch schema/best-practices issues; GOA cross-validation already runs at PR time via `just validate-all` and can't meaningfully run from a temp dir anyway.

## Verification

| Scenario | Before | After |
|----------|--------|-------|
| No-op edit on `AGR2-ai-review.yaml` | exit 2 (blocked) | exit 0 (allowed) |
| Edit introducing an orphan `original_reference_id` | exit 2 (blocked) | exit 2 (blocked) — best-practices check still fires |

Reproduced and re-tested locally with crafted hook inputs piped to the script.

## Context

Discovered while attempting documentation enrichment on `genes/human/AGR2/AGR2-ai-review.yaml` for issue #306 — the prior scanner pass on that issue [flagged the bug and proposed this exact one-line fix](https://github.com/ai4curation/ai-gene-review/issues/306#issuecomment-4365572182) but couldn't apply it from the same blocked tool path. Verified the same failure on `AATF-ai-review.yaml` so it's not AGR2-specific.

This is a tooling fix, not a curation change. No `*-ai-review.yaml`, GOA, or publication files are touched.

## Test plan

- [x] No-op edit on a valid `*-ai-review.yaml` is allowed
- [x] Edit that introduces an orphan reference ID is still blocked
- [x] `--no-goa` is a valid flag on `ai-gene-review validate` (verified via `--help`)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)