### PR TITLE
[codex] Review human DNAJ chaperone batch

### DIFF
--- a/genes/human/DNAJA2/DNAJA2-ai-review.html
+++ b/genes/human/DNAJA2/DNAJA2-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>DNAJA2</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/O60884" target="_blank" class="term-link">
                         O60884
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>DNAJA2 (DnaJ homolog subfamily A member 2) is a class I J-domain protein (HSP40 co-chaperone) that functions as a co-chaperone for HSP70 family members. It contains an N-terminal J domain (with conserved HPD motif) that stimulates the ATPase activity of HSP70, a glycine/phenylalanine-rich region, a zinc-finger cysteine-rich domain (CR-type, with four CXXCXGXG repeats coordinating two zinc ions) involved in substrate recognition, and two C-terminal beta-barrel substrate-binding domains (CTDI and CTDII) plus a dimerization domain. DNAJA2 participates in the HSP70-mediated foldase pathway, delivering unfolded or misfolded protein substrates to HSP70 and stimulating ATP hydrolysis to promote productive protein refolding. It is farnesylated at Cys-409 and localized to the cytosol and membranes. DNAJA2 works in combination with specific nucleotide exchange factors (NEFs) to generate functionally distinct HSP70 chaperone complexes. A key structural feature is that DNAJA2 reversibly self-assembles into highly ordered tubular oligomers (~200 angstrom width, D5 symmetry disks of five dimers) that can dissociate into active dimers; this self-association equilibrium is temperature-sensitive (heat shock at 40 degrees C promotes dissociation with t1/2 ~2.3 min) and regulates its client-binding (&#34;holding&#34;) activity and productive interaction with Hsc70 (DOI:10.1038/s41467-023-41150-8). Beyond general protein refolding, DNAJA2 functions as a client-selective Hsc70 co-chaperone that can bias quality-control decisions toward degradation through ERAD (e.g., CFTR with CHIP, DOI:10.1371/journal.pone.0220984) or chaperone-mediated autophagy (CMA) of specific substrates such as PCM1/CEP290 at centrosomes (DOI:10.1038/s41467-023-40952-0) and CSB during transcription-coupled nucleotide excision repair (DOI:10.1038/s41421-023-00601-8). DNAJA2 also potently suppresses tau amyloid formation in vitro by binding both monomeric tau and preformed fibrils through distinct C-terminal domains (DOI:10.7554/elife.69601).</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,64 +795,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation of GO:0005829 (cytosol) inferred from phylogenetic analysis across DnaJ subfamily A orthologs (including S. pombe, S. cerevisiae, and multiple mammalian orthologs). DNAJA2 cytosolic localization is well supported by multiple lines of evidence: IDA from Hageman et al. (PMID:21231916), Reactome pathway data placing DNAJA2 in cytosolic HSP70 chaperone complexes, and UniProt subcellular location indicating cytosolic and membrane association via farnesylation. The IBA annotation is consistent with all available data.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosolic localization is core to DNAJA2 function as an HSP70 co-chaperone. This is confirmed by IDA evidence (PMID:21231916), Reactome pathway annotations, and UniProt records. The IBA phylogenetic inference is sound.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
                                     GO:0001671
                                 </a>
                             </span>
                             <span class="term-label">ATPase activator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -864,64 +864,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation of GO:0001671 (ATPase activator activity) inferred from phylogenetic analysis across DnaJ family orthologs including yeast (Ydj1, Sis1, Xdj1) and C. elegans (dnj-12). Stimulation of HSP70 ATPase activity via the J domain is the defining biochemical function of all DnaJ/HSP40 proteins. For DNAJA2 specifically, Rauch and Gestwicki (PMID:24318877) demonstrated ATPase stimulation activity in vitro using purified components. UniProt confirms DNAJA2 stimulates ATP hydrolysis mediated by HSPA1A/B (PubMed:24318877). This is a core molecular function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATPase activator activity is the defining core molecular function of all J-domain proteins. DNAJA2 contains a canonical J domain and has been directly shown to stimulate HSP70 ATPase activity in vitro (PMID:24318877). The IBA inference is strongly supported by direct experimental evidence (IDA) from the same gene.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24318877" target="_blank" class="term-link">
                                         PMID:24318877
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we combined the Hsp70-NEF pairs with cochaperones of the J protein family (DnaJA1, DnaJA2, DnaJB1, and DnaJB4) to generate 16 permutations. The activity of the combinations in ATPase and luciferase refolding assays were dependent on the identity and stoichiometry of both the J protein and NEF so that some combinations were potent chaperones, whereas others were inactive.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/DNAJA2/DNAJA2-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">DNAJA2 is an Hsp40/J-domain protein (JDP) that acts as a co-chaperone for Hsp70-family chaperones (including the constitutively expressed Hsc70/HSPA8), stimulating Hsp70 ATPase activity via the J-domain and contributing client specificity by binding particular unfolded/misfolded client proteins.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034605" target="_blank" class="term-link">
                                     GO:0034605
                                 </a>
                             </span>
                             <span class="term-label">cellular response to heat</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -933,64 +944,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation of GO:0034605 (cellular response to heat) inferred from phylogenetic analysis including S. pombe (mas5/SPBC1734.11) and S. cerevisiae (Ydj1) orthologs. DnaJ/HSP40 proteins are classically associated with the heat shock response; they function as co-chaperones of HSP70 to handle heat-denatured proteins. Hageman et al. (PMID:21231916) demonstrated that DNAJA2 supports refolding of heat-denatured luciferase, confirming its role in the cellular response to heat stress. The term GO:0034605 (cellular response to heat) is more specific than GO:0009408 (response to heat) and is appropriate for DNAJA2 given its direct role in handling heat-denatured proteins.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> DNAJA2 is an HSP40 co-chaperone that participates in the heat shock response pathway. Experimental evidence from Hageman et al. (PMID:21231916) directly demonstrates DNAJA2 supports refolding of heat-denatured substrates. The IBA inference from well-characterized yeast orthologs (Ydj1, mas5) is well supported.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1002,77 +1013,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation of GO:0042026 (protein refolding) inferred from phylogenetic analysis across DnaJ subfamily A orthologs including S. pombe (mas5), S. cerevisiae (Ydj1), DNAJA2 itself, and DNAJA4. Protein refolding is a core biological process of the HSP70/HSP40 foldase pathway. Hageman et al. (PMID:21231916) directly demonstrated that DNAJA2 supports luciferase refolding after heat denaturation. Rauch and Gestwicki (PMID:24318877) showed that DnaJA2 in combination with Hsp72 and NEFs promotes luciferase refolding in vitro. This is a core function of DNAJA2.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein refolding is a core biological process function of DNAJA2 as an HSP70 co-chaperone. Directly demonstrated by IDA evidence (PMID:21231916) and confirmed by in vitro reconstitution experiments (PMID:24318877). The IBA phylogenetic inference from yeast and mammalian orthologs is well supported.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24318877" target="_blank" class="term-link">
                                         PMID:24318877
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we combined the Hsp70-NEF pairs with cochaperones of the J protein family (DnaJA1, DnaJA2, DnaJB1, and DnaJB4) to generate 16 permutations. The activity of the combinations in ATPase and luciferase refolding assays were dependent on the identity and stoichiometry of both the J protein and NEF so that some combinations were potent chaperones, whereas others were inactive.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1084,88 +1095,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962) because it conflates the binding aspect with the functional chaperone activity. DNAJA2 is a class I J-domain protein that functions as a co-chaperone in the HSP70 foldase pathway. It binds unfolded substrates and delivers them to HSP70 for productive refolding, rather than simply binding unfolded proteins passively. Hageman et al. (PMID:21231916) showed that overexpression of class A J-domain proteins including DNAJA2 supported luciferase refolding, and Rauch and Gestwicki (PMID:24318877) demonstrated that DnaJA2 promoted refolding in combination with Hsp72. The correct replacement is GO:0044183 (protein folding chaperone), which captures the active role of DNAJA2 in assisting protein folding as a co-chaperone.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted per go-ontology#30962. DNAJA2 does not simply bind unfolded proteins; it actively participates in the HSP70-mediated foldase pathway by delivering substrates and stimulating ATP hydrolysis. GO:0044183 (protein folding chaperone) is the appropriate replacement, defined as binding to a protein or protein-containing complex to assist the protein folding process. This accurately describes DNAJA2&#39;s co-chaperone function with HSP70.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24318877" target="_blank" class="term-link">
                                         PMID:24318877
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we combined the Hsp70-NEF pairs with cochaperones of the J protein family (DnaJA1, DnaJA2, DnaJB1, and DnaJB4) to generate 16 permutations. The activity of the combinations in ATPase and luciferase refolding assays were dependent on the identity and stoichiometry of both the J protein and NEF so that some combinations were potent chaperones, whereas others were inactive.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1177,64 +1188,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation of GO:0051087 (protein-folding chaperone binding) inferred from phylogenetic analysis including DNAJA2 itself, DNAJA1 (P31689), and DNAJA4 (Q8WW22). DNAJA2 directly binds HSP70 family members (HSPA1A/B, HSPA8, HSPA6) via its J domain, which is the core mechanism for stimulating HSP70 ATPase activity and delivering substrates. Hageman et al. (PMID:21231916) demonstrated physical interaction between DNAJA2 and multiple HSP70 isoforms. This accurately captures the co-chaperone binding relationship.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein-folding chaperone binding is a core molecular function of DNAJA2. As a J-domain protein, DNAJA2 physically binds HSP70 chaperones to stimulate their ATPase activity and deliver substrates. IPI evidence from PMID:21231916 documents interactions with HSPA1A/B and HSPA6. The IBA inference is well supported.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
                                     GO:0001671
                                 </a>
                             </span>
                             <span class="term-label">ATPase activator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1246,46 +1257,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of GO:0001671 (ATPase activator activity) from ARBA machine learning models. This is consistent with the IBA and IDA annotations for the same term. DNAJA2 stimulates HSP70 ATPase activity via its J domain, as directly demonstrated by Rauch and Gestwicki (PMID:24318877). The ARBA prediction is correct.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The IEA annotation is concordant with both IBA (GO_REF:0000033) and IDA (PMID:24318877) evidence for the same term. ATPase activator activity is a core molecular function of DNAJA2.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
                                     GO:0005524
                                 </a>
                             </span>
                             <span class="term-label">ATP binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1297,46 +1308,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of GO:0005524 (ATP binding) inferred from InterPro domain IPR012724 (DnaJ). While DnaJ proteins interact with the HSP70 ATPase cycle, DnaJ/HSP40 proteins themselves do not bind ATP directly. The J domain stimulates the ATPase activity of HSP70, but it is HSP70 that binds and hydrolyzes ATP. DNAJA2 does not have its own ATPase domain or ATP binding site. This IEA annotation appears to be an artifact of the broad InterPro-to-GO mapping for the DnaJ family, which may conflate the ATP-dependent cycle of the HSP70 partner with ATP binding by the J-domain protein itself.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> DnaJ/HSP40 co-chaperones do not bind ATP themselves. They stimulate the ATPase activity of HSP70 proteins, but it is the HSP70 partner (e.g., HSPA1A/B) that binds and hydrolyzes ATP. DNAJA2 has no known ATP binding site. The InterPro mapping from IPR012724 (DnaJ) to GO:0005524 (ATP binding) is misleading for this protein family. UniProt does not annotate DNAJA2 with ATP binding activity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1348,46 +1359,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of GO:0006457 (protein folding) inferred from combined automated methods (ARBA and InterPro domains IPR008971, IPR012724, IPR044713). DNAJA2 participates in protein folding as a co-chaperone in the HSP70 foldase pathway. The more specific child term GO:0042026 (protein refolding) is annotated by both IBA and IDA evidence. GO:0006457 is the broader parent term and is acceptable as a general IEA annotation, even though the more specific term exists from higher-quality evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein folding is a legitimate biological process annotation for DNAJA2 as an HSP70 co-chaperone. While GO:0042026 (protein refolding) is the more specific term supported by IBA and IDA, the broader GO:0006457 from IEA is acceptable and not incorrect. DNAJA2 participates in both de novo folding and refolding pathways via its HSP70 co-chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
                                     GO:0008270
                                 </a>
                             </span>
                             <span class="term-label">zinc ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1399,46 +1410,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of GO:0008270 (zinc ion binding) inferred from UniProtKB keyword KW-0863 (Zinc). DNAJA2 contains a CR-type zinc finger domain (residues 130-214) with four CXXCXGXG repeat motifs that coordinate two zinc ions through eight cysteine residues. The zinc finger domain is a defining feature of class I (type A) DnaJ proteins and is involved in substrate recognition and binding. UniProt annotates eight zinc-binding cysteine residues (by similarity). This is a structural feature integral to DNAJA2 function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Zinc ion binding is a well-established structural feature of DNAJA2. The CR-type zinc finger domain with four CXXCXGXG repeats coordinates two zinc ions and is required for substrate binding function. UniProt documents eight zinc-binding residues. This is a core structural property of class I DnaJ proteins.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009408" target="_blank" class="term-link">
                                     GO:0009408
                                 </a>
                             </span>
                             <span class="term-label">response to heat</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1450,46 +1461,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of GO:0009408 (response to heat) inferred from InterPro domain IPR012724 (DnaJ). This is the broader parent term of GO:0034605 (cellular response to heat) which is annotated by IBA. DnaJ proteins are heat shock proteins that function in the cellular response to heat stress. The IEA annotation is consistent with but less specific than the IBA annotation for GO:0034605. It is acceptable as a broader IEA.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Response to heat is a legitimate biological process for DNAJA2 as an HSP40 co-chaperone. The more specific GO:0034605 (cellular response to heat) is annotated by IBA. The IEA annotation of the broader parent term GO:0009408 is acceptable and consistent.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
                                     GO:0016020
                                 </a>
                             </span>
                             <span class="term-label">membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1501,46 +1512,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of GO:0016020 (membrane) inferred from UniProtKB subcellular location vocabulary mapping. UniProt annotates DNAJA2 subcellular location as &#34;Membrane; Lipid-anchor&#34; based on its farnesylation at Cys-409 (PMID:15308774). The C-terminal CAHQ motif undergoes farnesylation, proteolytic processing, and carboxymethylation, tethering the mature protein to membranes. This is a legitimate secondary localization for DNAJA2, though the primary localization is cytosolic.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Membrane association via farnesylation at Cys-409 is experimentally confirmed (PMID:15308774). UniProt annotates DNAJA2 as lipid-anchored to membranes. While the primary localization is cytosolic, membrane association is a real secondary localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030544" target="_blank" class="term-link">
                                     GO:0030544
                                 </a>
                             </span>
                             <span class="term-label">Hsp70 protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1552,148 +1563,148 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of GO:0030544 (Hsp70 protein binding) inferred from InterPro domain IPR044713 (DNJA1/2-like). DNAJA2 directly binds HSP70 proteins via its J domain, as demonstrated by Hageman et al. (PMID:21231916) who showed physical interaction with HSPA1A/B and HSPA6, and by Rauch and Gestwicki (PMID:24318877) who used purified DNAJA2 with Hsp72. However, GO:0030544 is a child of GO:0005515 (protein binding) and essentially captures the binding aspect only. The more informative term GO:0051087 (protein-folding chaperone binding) is already annotated and better captures the functional context. Nevertheless, GO:0030544 is more specific than generic protein binding and is technically correct.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Hsp70 protein binding is experimentally demonstrated for DNAJA2 (PMID:21231916, PMID:24318877). The InterPro mapping from IPR044713 is correct. While GO:0051087 (protein-folding chaperone binding) is also annotated and captures the functional context, GO:0030544 specifically captures the HSP70-binding aspect and is technically accurate.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
                                     GO:0031072
                                 </a>
                             </span>
                             <span class="term-label">heat shock protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="O60884" data-a="GO:0031072" data-r="GO_REF:0000002" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="O60884" data-a="GO:0031072" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IEA annotation of GO:0031072 (heat shock protein binding) inferred from InterPro domain IPR001305 (HSP DnaJ cysteine-rich domain). This is a parent term of GO:0030544 (Hsp70 protein binding) which is also annotated. DNAJA2 binds HSP70 family members, so this broader term is technically correct but redundant with the more specific GO:0030544. As an IEA it is acceptable to have both the general and specific terms.
+                            <strong>Summary:</strong> IEA annotation of GO:0031072 (heat shock protein binding) inferred from InterPro domain IPR001305 (HSP DnaJ cysteine-rich domain). This is a parent term of GO:0030544 (Hsp70 protein binding) which is also annotated. DNAJA2 binds HSP70 family members, so this broader term is technically correct but redundant with the more specific GO:0030544.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Heat shock protein binding is correct for DNAJA2 as it binds HSP70 chaperones. The more specific GO:0030544 (Hsp70 protein binding) is also annotated from IEA. The broader IEA is acceptable and not incorrect.
+                            <strong>Reason:</strong> Heat shock protein binding is correct for DNAJA2 as it binds HSP70 chaperones. The more specific GO:0030544 (Hsp70 protein binding) is also annotated from IEA. Retaining the broader parent term as a core accepted annotation would obscure the more informative Hsp70-specific binding annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
                                     GO:0046872
                                 </a>
                             </span>
                             <span class="term-label">metal ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="O60884" data-a="GO:0046872" data-r="GO_REF:0000043" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="O60884" data-a="GO:0046872" data-r="GO_REF:0000043" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of GO:0046872 (metal ion binding) inferred from UniProtKB keyword KW-0479 (Metal-binding). This is the broader parent of GO:0008270 (zinc ion binding) which is also annotated by IEA. DNAJA2 coordinates two zinc ions in its CR-type zinc finger domain. The generic metal ion binding term is technically correct but less informative than the specific zinc ion binding term.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Metal ion binding is correct for DNAJA2 as it binds zinc ions in its cysteine-rich domain. The more specific GO:0008270 (zinc ion binding) is also annotated. As an IEA annotation of the broader parent term it is acceptable.
+                            <strong>Reason:</strong> Metal ion binding is technically correct but overly broad. DNAJA2 specifically binds zinc ions in its cysteine-rich domain, which is captured by GO:0008270 (zinc ion binding). The broader parent term adds no additional information and should not be treated as an accepted core molecular annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1705,57 +1716,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of GO:0051082 (unfolded protein binding) inferred from InterPro domain matches (IPR001305 cysteine-rich domain, IPR008971 HSP40/DnaJ peptide- binding domain, IPR012724 DnaJ). GO:0051082 is being obsoleted per go-ontology#30962 because it conflates passive binding with active chaperone function. DNAJA2 is a class I J-domain protein / HSP40 co-chaperone that actively assists protein folding through the HSP70 foldase pathway, not merely binding unfolded proteins. The InterPro domains correctly identify DNAJA2 as a DnaJ family member with substrate-binding capacity, but the appropriate molecular function term is GO:0044183 (protein folding chaperone).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted per go-ontology#30962. The InterPro-based inference correctly identifies DNAJA2 as having DnaJ domains with substrate binding capacity, but the term conflates binding with the active chaperone function. DNAJA2 functions as a protein folding chaperone in the HSP70 foldase pathway. GO:0044183 (protein folding chaperone) is the correct replacement.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1767,57 +1778,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of GO:0051087 (protein-folding chaperone binding) from ARBA machine learning models. This is concordant with IBA (GO_REF:0000033) and IPI (PMID:21231916) annotations for the same term. DNAJA2 binds HSP70 chaperones via its J domain. The ARBA prediction is correct.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The IEA annotation is concordant with IBA and IPI evidence for the same term. Protein-folding chaperone binding is a core molecular function of DNAJA2 as an HSP70 co-chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22085931" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22085931
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Optimal functional levels of activation-induced deaminase sp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1829,75 +1840,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation of GO:0005515 (protein binding) based on interaction with AICDA (Q9GZX7, activation-induced cytidine deaminase) from Orthwein et al. (PMID:22085931). This study focused on the specific functional interaction between AID and DnaJa1, and explicitly showed that &#34;both major cytoplasmic type I Hsp40s, DnaJa1 and DnaJa2, are induced upon B-cell activation and interact with AID in vitro, only DnaJa1 overexpression increases AID levels and biological activity in cell lines.&#34; Thus DNAJA2 interacts with AID but does NOT functionally stabilize it (that is DNAJA1-specific). The interaction is real but the generic protein binding term is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The study specifically demonstrates that while DNAJA2 can interact with AID in vitro, the functional interaction is specific to DNAJA1, not DNAJA2. The generic protein binding term does not convey this important distinction. The interaction with AID appears to lack functional consequence for DNAJA2.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22085931" target="_blank" class="term-link">
                                         PMID:22085931
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Although both major cytoplasmic type I Hsp40s, DnaJa1 and DnaJa2, are induced upon B-cell activation and interact with AID in vitro, only DnaJa1 overexpression increases AID levels and biological activity in cell lines.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25036637
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A quantitative chaperone interaction network reveals the arc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1909,75 +1920,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation of GO:0005515 (protein binding) from Taipale et al. (PMID:25036637), a large-scale systematic chaperone interaction network study. Interacting partners are DNAJA4 (Q8WW22) and NUDC (Q9Y266). DNAJA4 interaction represents homo-/hetero- oligomeric interactions among DnaJ family members, which is expected. NUDC interaction is notable as NUDC family cochaperones specifically associate with beta-propeller folds per this study. However, the generic GO:0005515 term is uninformative for a co-chaperone that interacts with many proteins as part of its chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for DNAJA2, which is a co-chaperone that by definition interacts with many proteins. The specific interactions from this study (DNAJA4, NUDC) are part of the chaperone interaction network but the generic term does not capture any specific functional insight.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link">
                                         PMID:25036637
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We have combined mass spectrometry and quantitative high-throughput LUMIER assays to systematically characterize the chaperone/co-chaperone/client interaction network in human cells. We uncover hundreds of novel chaperone clients, delineate their participation in specific co-chaperone complexes, and establish a surprisingly distinct network of protein/protein interactions for co-chaperones.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32296183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A reference map of the human binary protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1989,75 +2000,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation of GO:0005515 (protein binding) from Luck et al. (PMID:32296183), the HuRI reference map of the human binary protein interactome. The interacting partner is DYNLT1 (P63172, dynein light chain Tctex-type 1). This is a large-scale Y2H interaction screen. The interaction with DYNLT1 is also documented in IntAct with 3 experiments (per UniProt). While the interaction may be real, the generic protein binding term is uninformative for a co-chaperone.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for DNAJA2. The specific interaction with DYNLT1 from the HuRI large-scale screen may reflect a chaperone-client relationship rather than a functional partnership, and the generic term does not capture any meaningful functional insight.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                                         PMID:32296183
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Here we present a human &#39;all-by-all&#39; reference interactome map of human binary protein interactions, or &#39;HuRI&#39;. With approximately 53,000 protein-protein interactions, HuRI has approximately four times as many such interactions as there are high-quality curated interactions from small-scale studies.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2069,75 +2080,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation of GO:0005515 (protein binding) from Huttlin et al. (PMID:33961781), the BioPlex 3.0 proteome-scale network. Interacting partners are DCAF10 (Q5QP82), DNAJA4 (Q8WW22), and NUDC (Q9Y266). BioPlex uses AP-MS in 293T and HCT116 cells. The DNAJA4 and NUDC interactions are replicated across multiple studies (PMID:25036637, PMID:40205054). Generic protein binding is uninformative for a co-chaperone that by nature interacts with many cellular proteins.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for DNAJA2. While the AP-MS interactions are high-quality, the generic term does not capture the co-chaperone functional context. The DNAJA4 and NUDC interactions likely reflect co-chaperone network associations rather than informative functional insights beyond what is captured by GO:0051087 (protein-folding chaperone binding).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                                         PMID:33961781
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Thousands of interactions assemble proteins into modules that impart spatial and functional organization to the cellular proteome. Through affinity-purification mass spectrometry, we have created two proteome-scale, cell-line-specific interaction networks.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:40205054
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Multimodal cell maps as a foundation for structural and func...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2149,75 +2160,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation of GO:0005515 (protein binding) from Schaffer et al. (PMID:40205054), multimodal cell maps. Interacting partners are DCAF10 (Q5QP82), DNAJA4 (Q8WW22), and NUDC (Q9Y266), the same set as in BioPlex 3.0 (PMID:33961781). This replication across independent studies strengthens confidence in these interactions but the generic protein binding term remains uninformative for a co-chaperone.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for DNAJA2. These interactions are replicated from BioPlex 3.0 and reflect co-chaperone network topology. The generic term does not capture meaningful functional insight.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
                                         PMID:40205054
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Here we construct a global map of human subcellular architecture through joint measurement of biophysical interactions and immunofluorescence images for over 5,100 proteins in U2OS osteosarcoma cells.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2229,75 +2240,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation of GO:0051087 (protein-folding chaperone binding) based on Hageman et al. (PMID:21231916). The with/from column indicates interactions with HSPA1A (P0DMV8), HSPA1B (P0DMV9), and HSPA6 (P17066), all HSP70 family chaperones. This study systematically assessed HSP70/HSP40 functional interactions and demonstrated that DNAJA2 physically interacts with and functionally cooperates with multiple HSP70 isoforms in the foldase pathway. This is a core molecular function annotation that accurately captures DNAJA2&#39;s interaction with HSP70 chaperones.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein-folding chaperone binding is a core molecular function of DNAJA2. The IPI evidence from PMID:21231916 documents direct physical interaction with HSP70 chaperones HSPA1A, HSPA1B, and HSPA6. This is a much more informative term than generic protein binding and accurately captures the co-chaperone binding function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol. To test for possible functional differences and/or substrate specificity, we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
                                     GO:0001671
                                 </a>
                             </span>
                             <span class="term-label">ATPase activator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24318877" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24318877
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Binding of human nucleotide exchange factors to heat shock p...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2309,64 +2320,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation of GO:0001671 (ATPase activator activity) based on Rauch and Gestwicki (PMID:24318877). This study directly measured DNAJA2&#39;s ability to stimulate ATPase activity of Hsp72 (HSPA1A) in vitro using purified recombinant proteins. DnaJA2 was combined with Hsp70-NEF pairs to generate 16 permutations, and ATPase activity was measured for each combination. UniProt confirms this function: &#34;Stimulates ATP hydrolysis and the folding of unfolded proteins mediated by HSPA1A/B.&#34; This is the defining molecular function of all J-domain proteins and a core function of DNAJA2.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATPase activator activity is the core molecular function of DNAJA2 as a J-domain protein. Directly demonstrated in vitro using purified components (PMID:24318877). Confirmed by UniProt functional description. This represents the strongest possible evidence type (IDA) for the most central function of this protein.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24318877" target="_blank" class="term-link">
                                         PMID:24318877
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we combined the Hsp70-NEF pairs with cochaperones of the J protein family (DnaJA1, DnaJA2, DnaJB1, and DnaJB4) to generate 16 permutations. The activity of the combinations in ATPase and luciferase refolding assays were dependent on the identity and stoichiometry of both the J protein and NEF so that some combinations were potent chaperones, whereas others were inactive.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371422
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2378,46 +2389,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation of GO:0005829 (cytosol) from Reactome pathway R-HSA-3371422 (ATP hydrolysis by HSP70). DNAJA2 is placed in the cytosol as part of the HSP70 chaperone cycle where J domain co-chaperones stimulate HSP70 ATPase activity. This is consistent with all other evidence for cytosolic localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosolic localization is well established for DNAJA2. The Reactome pathway correctly places DNAJA2 in the cytosol for the HSP70 chaperone cycle. Concordant with IBA, IDA, and other TAS evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371503
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2429,46 +2440,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation of GO:0005829 (cytosol) from Reactome pathway R-HSA-3371503 (STIP1 (HOP) binds HSP90 and HSP70:HSP40:nascent protein). DNAJA2 is placed in the cytosol as part of the HSP70:HSP40:nascent protein complex that is bridged to HSP90 by STIP1/HOP. Consistent with all other evidence for cytosolic localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosolic localization is well established. The Reactome pathway places DNAJA2 in the HSP70-HSP90 client transfer pathway in the cytosol. Concordant with other evidence lines.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371590
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2480,57 +2491,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation of GO:0005829 (cytosol) from Reactome pathway R-HSA-3371590 (HSP70 binds to HSP40:nascent protein). DNAJA2 is placed in the cytosol as the HSP40 co-chaperone that first binds nascent/unfolded client proteins before delivering them to HSP70. Consistent with all other evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosolic localization is well established. The Reactome pathway correctly places DNAJA2 in the cytosol for the HSP70:HSP40 substrate delivery step. Concordant with IBA, IDA, and other TAS evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2542,75 +2553,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation of GO:0005829 (cytosol) based on Hageman et al. (PMID:21231916). This study assessed HSP70 and HSP40 family members, most of which are localized in the cytosol. DNAJA2 was shown to be cytosolic as part of the experimental characterization. This is the strongest evidence line for DNAJA2 cytosolic localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosolic localization directly demonstrated (IDA) in the study by Hageman et al. This is concordant with IBA, TAS (Reactome), and IEA evidence. Cytosol is the primary subcellular localization for DNAJA2.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2622,88 +2633,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation of GO:0042026 (protein refolding) based on Hageman et al. (PMID:21231916). This study directly demonstrated that overexpression of DNAJA2 supports refolding of heat-denatured luciferase, placing it in the HSP70-mediated foldase pathway. The study distinguished foldase activity (luciferase refolding) from holdase activity (polyQ aggregation suppression), and classified DnaJ subfamily A members as supporting the foldase pathway. This is a core biological process function of DNAJA2.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein refolding is directly demonstrated for DNAJA2 by the luciferase refolding assay (PMID:21231916). DNAJA2 participates in the HSP70-mediated foldase pathway. This is confirmed by in vitro reconstitution (PMID:24318877). Core biological process function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment. Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24318877" target="_blank" class="term-link">
                                         PMID:24318877
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we combined the Hsp70-NEF pairs with cochaperones of the J protein family (DnaJA1, DnaJA2, DnaJB1, and DnaJB4) to generate 16 permutations. The activity of the combinations in ATPase and luciferase refolding assays were dependent on the identity and stoichiometry of both the J protein and NEF so that some combinations were potent chaperones, whereas others were inactive.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -2715,99 +2726,99 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation of GO:0051082 (unfolded protein binding) based on Hageman et al. (PMID:21231916), which assessed functional differences among HSP70 and HSP40 family members. The study tested overexpression of HSP70/HSPA and HSP40/DNAJ proteins on refolding of heat-denatured luciferase and suppression of polyQ aggregation. DNAJA2 was shown to participate in the foldase pathway, supporting luciferase refolding. GO:0051082 is being obsoleted per go-ontology#30962. DNAJA2 does not simply bind unfolded proteins passively; it functions as a co-chaperone in the HSP70-mediated protein folding pathway. UniProt describes DNAJA2 as a co-chaperone of Hsc70 that stimulates ATP hydrolysis and the folding of unfolded proteins mediated by HSPA1A/B. The correct replacement is GO:0044183 (protein folding chaperone).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted per go-ontology#30962. The experimental evidence from Hageman et al. (PMID:21231916) demonstrates that DNAJA2 functions in the HSP70-mediated foldase pathway, supporting luciferase refolding rather than merely binding unfolded proteins. UniProt confirms DNAJA2 is a co-chaperone of Hsc70 that stimulates ATP hydrolysis and folding. GO:0044183 (protein folding chaperone), defined as binding to a protein or protein-containing complex to assist the protein folding process, accurately captures this function.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24318877" target="_blank" class="term-link">
                                         PMID:24318877
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we combined the Hsp70-NEF pairs with cochaperones of the J protein family (DnaJA1, DnaJA2, DnaJB1, and DnaJB4) to generate 16 permutations. The activity of the combinations in ATPase and luciferase refolding assays were dependent on the identity and stoichiometry of both the J protein and NEF so that some combinations were potent chaperones, whereas others were inactive.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
                                     GO:0070062
                                 </a>
                             </span>
                             <span class="term-label">extracellular exosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19056867
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Large-scale proteomics and phosphoproteomics of urinary exos...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2819,75 +2830,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HDA annotation of GO:0070062 (extracellular exosome) based on Gonzales et al. (PMID:19056867), a large-scale proteomics study of urinary exosomes that identified 1132 proteins. DNAJA2 was among the many proteins detected in urinary exosomes by LC-MS/MS. While this is a high-throughput proteomic detection, being found in exosomes is likely a consequence of the general abundance of cytosolic proteins in exosome preparations rather than a specific functional localization for DNAJA2. Exosome detection does not represent a core localization for this co-chaperone.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Detection in urinary exosomes via large-scale proteomics (PMID:19056867) is technically valid but represents a secondary observation rather than a core functional localization. Many abundant cytosolic proteins are detected in exosome preparations. DNAJA2&#39;s primary function is as a cytosolic HSP70 co-chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link">
                                         PMID:19056867
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overall, the analysis identified 1132 proteins unambiguously, including 177 that are represented on the Online Mendelian Inheritance in Man database of disease-related genes, suggesting that exosome analysis is a potential approach to discover urinary biomarkers</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008284" target="_blank" class="term-link">
                                     GO:0008284
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of cell population proliferation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9383053" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9383053
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human CPR (cell cycle progression restoration) genes impart ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2899,61 +2910,61 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation of GO:0008284 (positive regulation of cell population proliferation) based on Edwards et al. (PMID:9383053). This study identified human CPR (cell cycle progression restoration) genes that when overexpressed could overcome G1 arrest signals in yeast. DNAJA2 (then called CPR3) was one of 13 human genes identified in this screen. The study described CPR genes as representing &#34;a variety of biochemical functions including a new cyclin, a tumor suppressor binding protein, chaperones, transcription factors, translation factors, RNA-binding proteins.&#34; However, the ability to overcome pheromone-induced G1 arrest in yeast when overexpressed does not directly demonstrate a role in positive regulation of cell proliferation in human cells. This is an indirect inference from a heterologous overexpression system, and likely reflects general chaperone activity facilitating cell cycle protein folding rather than a specific proliferation-regulatory function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The CPR screen (PMID:9383053) identified DNAJA2 as a gene that overcomes G1 arrest in yeast when overexpressed. This is a heterologous overexpression assay in yeast and does not demonstrate a specific role in positive regulation of cell proliferation in human cells. The effect is most likely attributable to general HSP40 chaperone activity assisting cell cycle protein homeostasis rather than a direct proliferation-regulatory function. No subsequent studies have established DNAJA2 as a specific regulator of cell proliferation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9383053" target="_blank" class="term-link">
                                         PMID:9383053
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We have identified 13 human CPR (cell cycle progression restoration) genes and 11 yeast OPY (overproduction-induced pheromone-resistant yeast) genes that specifically block the G1 arrest by mating pheromone. The CPR genes represent a variety of biochemical functions including a new cyclin, a tumor suppressor binding protein, chaperones, transcription factors, translation factors, RNA-binding proteins, as well as novel proteins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>DNAJA2 is a class I J-domain co-chaperone (foldase-type) that delivers unfolded or misfolded protein substrates to HSP70 for productive ATP-dependent refolding. Its domain architecture includes an N-terminal J domain (HPD motif), a Gly/Phe-rich region, a zinc-finger cysteine-rich domain (four CXXCXGXG repeats coordinating two zinc ions) for substrate recognition, two C-terminal beta-barrel substrate-binding domains (CTDI and CTDII), and a dimerization domain. DNAJA2 reversibly self-assembles into highly ordered tubular oligomers (~200 angstrom width, D5 symmetry disks of five dimers) that serve as a storage form; heat shock (40 degrees C) drives rapid dissociation into active dimers (t1/2 ~2.3 min), and Hsc70 ATPase cycling coupled to J-domain interaction triggers oligomer disassembly (DOI:10.1038/s41467-023-41150-8). Beyond general protein refolding, DNAJA2 acts as a client-selective Hsc70 co-chaperone that can bias quality-control decisions toward degradation through ERAD (e.g., CFTR with Hsc70/CHIP, DOI:10.1371/journal.pone.0220984) or chaperone-mediated autophagy (CMA) of specific substrates such as PCM1/CEP290 at centrosomes (DOI:10.1038/s41467-023-40952-0) and CSB during TC-NER (DOI:10.1038/s41421-023-00601-8). DNAJA2 also potently suppresses tau amyloid formation using distinct CTDI (monomer-binding) and CTDII (fibril-binding) sites, achieving 88% reduction in fibril mass at sub-stoichiometric ratios (DOI:10.7554/elife.69601). DNAJA2 works in combination with specific nucleotide exchange factors (NEFs) to generate functionally distinct HSP70 chaperone complexes with varying foldase potency.</h3>
+                <h3>DNAJA2 is a class I J-domain co-chaperone (foldase-type) that delivers unfolded or misfolded protein substrates to HSP70 for productive ATP-dependent refolding. Its domain architecture includes an N-terminal J domain (HPD motif), a Gly/Phe-rich region, a zinc-finger cysteine-rich domain (four CXXCXGXG repeats coordinating two zinc ions) for substrate recognition, two C-terminal beta-barrel substrate-binding domains (CTDI and CTDII), and a dimerization domain. DNAJA2 reversibly self-assembles into highly ordered tubular oligomers (~200 angstrom width, D5 symmetry disks of five dimers) that serve as a storage form; heat shock (40 degrees C) drives rapid dissociation into active dimers (t1/2 ~2.3 min), and Hsc70 ATPase cycling coupled to J-domain interaction triggers oligomer disassembly (DOI:10.1038/s41467-023-41150-8). DNAJA2 also appears in client- and context-specific quality-control settings including ERAD, chaperone-mediated autophagy, centrosome- associated client handling, and tau anti-aggregation. Those findings are useful biological context, but they are not proposed here as core GO annotations because the evidence maps to specific substrates or pathways rather than to a conserved primary function of DNAJA2. The core function retained in this review is the foldase-type HSP70 co-chaperone activity, with client-selective degradation and anti-aggregation outcomes treated as downstream contexts unless directly represented in GOA.</h3>
                 <span class="vote-buttons" data-g="O60884" data-a="FUNCTION: DNAJA2 is a class I J-domain co-chaperone (foldase..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -2962,93 +2973,93 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                 protein refolding
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                 protein folding
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034605" target="_blank" class="term-link">
                                 cellular response to heat
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                 PMID:21231916
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24318877" target="_blank" class="term-link">
                                 PMID:24318877
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">we combined the Hsp70-NEF pairs with cochaperones of the J protein family (DnaJA1, DnaJA2, DnaJB1, and DnaJB4) to generate 16 permutations. The activity of the combinations in ATPase and luciferase refolding assays were dependent on the identity and stoichiometry of both the J protein and NEF so that some combinations were potent chaperones, whereas others were inactive.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>DNAJA2 stimulates the intrinsic ATPase activity of HSP70 (HSPA1A/B, HSPA8/Hsc70) through its conserved J-domain HPD motif, driving the HSP70 chaperone cycle for substrate binding, folding, and release. Directly demonstrated in vitro with purified recombinant DNAJA2, Hsp72, and nucleotide exchange factors (PMID:24318877). The J-domain interaction is also critical for DNAJA2 oligomer regulation: an HPD-to-QPN mutation prevents productive Hsc70 engagement and impairs ATP-dependent oligomer disassembly, supporting the model that J-domain- stimulated ATPase cycling triggers release of active DNAJA2 dimers from the tubular storage form (DOI:10.1038/s41467-023-41150-8). ATPase stimulation is also required for DNAJA2-dependent degradation functions, as the J-domain deletion mutant (DJA2-deltaJ) fails to promote CFTR ERAD (DOI:10.1371/journal.pone.0220984).</h3>
                 <span class="vote-buttons" data-g="O60884" data-a="FUNCTION: DNAJA2 stimulates the intrinsic ATPase activity of..." data-r="" data-act="CORE_FUNCTION">
@@ -3056,10 +3067,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -3068,594 +3079,608 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                 protein folding
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24318877" target="_blank" class="term-link">
                                 PMID:24318877
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">we combined the Hsp70-NEF pairs with cochaperones of the J protein family (DnaJA1, DnaJA2, DnaJB1, and DnaJB4) to generate 16 permutations. The activity of the combinations in ATPase and luciferase refolding assays were dependent on the identity and stoichiometry of both the J protein and NEF so that some combinations were potent chaperones, whereas others were inactive.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/DNAJA2/DNAJA2-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for DNAJA2</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link">
                             PMID:19056867
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Large-scale proteomics and phosphoproteomics of urinary exosomes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                             PMID:21231916
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The diverse members of the mammalian HSP70 machine show distinct chaperone-like activities.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22085931" target="_blank" class="term-link">
                             PMID:22085931
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Optimal functional levels of activation-induced deaminase specifically require the Hsp40 DnaJa1.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24318877" target="_blank" class="term-link">
                             PMID:24318877
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Binding of human nucleotide exchange factors to heat shock protein 70 (Hsp70) generates functionally distinct complexes in vitro.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link">
                             PMID:25036637
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A quantitative chaperone interaction network reveals the architecture of cellular protein homeostasis pathways.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                             PMID:32296183
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A reference map of the human binary protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
                             PMID:40205054
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9383053" target="_blank" class="term-link">
                             PMID:9383053
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Human CPR (cell cycle progression restoration) genes impart a Far- phenotype on yeast cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371422
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ATP hydrolysis by HSP70</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371503
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">STIP1(HOP) binds HSP90 and HSP70:HSP40:nascent protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371590
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP70 binds to HSP40:nascent protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1038/s41467-023-41150-8
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The self-association equilibrium of DNAJA2 regulates its interaction with unfolded substrate proteins and with Hsc70.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">DNAJA2 reversibly self-assembles into highly ordered tubular oligomers (~200 angstrom width, D5 symmetry disks of five dimers) that can dissociate into active dimers; heat shock at 40 degrees C promotes dissociation with t1/2 ~2.3 min.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">The intrinsically disordered C-terminal tail (V361-Q412) regulates holding activity and productive Hsc70 interaction.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Hsc70 drives DNAJA2 oligomer disassembly in an ATP-dependent manner via J-domain engagement.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1371/journal.pone.0220984
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Hsp70 and DNAJA2 limit CFTR levels through degradation.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">DNAJA2 overexpression reduces CFTR maturation, consistent with increased ERAD of immature CFTR, in a J-domain-dependent manner.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">DNAJA2 acts with Hsc70/Hsp70 and the E3 ubiquitin ligase CHIP to promote CFTR degradation at the ER.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1038/s41467-023-40952-0
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">DNAJA2 deficiency activates cGAS-STING pathway via the induction of aberrant mitosis and chromosome instability.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">DNAJA2 localizes to centrosomes and promotes CMA-dependent degradation of PCM1 and CEP290 via Hsc70/LAMP2A.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Loss of DNAJA2 causes abnormal mitosis (~50% abnormal spindles), chromosome instability, and micronuclei formation activating cGAS-STING innate immunity.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1038/s41421-023-00601-8
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Heat shock protein DNAJA2 regulates transcription-coupled repair by triggering CSB degradation via chaperone-mediated autophagy.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">DNAJA2 facilitates Hsc70-dependent CMA to degrade CSB during transcription-coupled nucleotide excision repair.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">CSB must translocate from nucleus to cytosol for LAMP2A-dependent lysosomal degradation.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.7554/elife.69601
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Hsp40s play complementary roles in the prevention of tau amyloid formation.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">DNAJA2 potently suppresses tau amyloid formation using at least two binding sites; CTDI recognizes monomeric tau while CTDII binds aggregation-prone species and mature fibrils.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">At sub-stoichiometric DNAJA2:tau ratios (0.5:1), 88% reduction in fibril mass was observed.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1038/s41594-018-0057-1
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Mapping interactions with the chaperone network reveals factors that protect against tau aggregation.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Systems-level chaperone-tau interaction survey identified DNAJA2 as a potent tau aggregation inhibitor across ~600 combinations.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">DNAJA2 levels correlated with tau pathology in human brain samples.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1128/mcb.01592-06
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Definition of pRb- and p53-dependent and -independent steps in HIRA/ASF1a-mediated formation of senescence-associated heterochromatin foci.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">DNAJA2 (as HIRIP4) interacts with HIRA and pRb in the context of senescence-associated heterochromatin foci (SAHF) formation.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.3390/ijms222413527
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Regulation of p53 and cancer signaling by heat shock protein 40/J-domain protein family members.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Review of J-domain protein family including DNAJA2, emphasizing role as specificity determinants for Hsp70 functional outcomes including client triage between folding and degradation.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -3981,9 +4006,9 @@ DNAJA2 is experimentally linked to multiple cellular locales consistent with its
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -3995,7 +4020,7 @@ DNAJA2 is experimentally linked to multiple cellular locales consistent with its
                 <pre><code>id: O60884
 gene_symbol: DNAJA2
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -4078,6 +4103,13 @@ existing_annotations:
           activity of the combinations in ATPase and luciferase refolding assays were
           dependent on the identity and stoichiometry of both the J protein and NEF so
           that some combinations were potent chaperones, whereas others were inactive.
+      - reference_id: file:human/DNAJA2/DNAJA2-deep-research-falcon.md
+        supporting_text: &gt;-
+          DNAJA2 is an Hsp40/J-domain protein (JDP) that acts as a co-chaperone
+          for Hsp70-family chaperones (including the constitutively expressed
+          Hsc70/HSPA8), stimulating Hsp70 ATPase activity via the J-domain and
+          contributing client specificity by binding particular unfolded/misfolded
+          client proteins.
 - term:
     id: GO:0034605
     label: cellular response to heat
@@ -4359,13 +4391,13 @@ existing_annotations:
       domain IPR001305 (HSP DnaJ cysteine-rich domain). This is a parent term of
       GO:0030544 (Hsp70 protein binding) which is also annotated. DNAJA2 binds HSP70
       family members, so this broader term is technically correct but redundant with the
-      more specific GO:0030544. As an IEA it is acceptable to have both the general
-      and specific terms.
-    action: ACCEPT
+      more specific GO:0030544.
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       Heat shock protein binding is correct for DNAJA2 as it binds HSP70 chaperones.
       The more specific GO:0030544 (Hsp70 protein binding) is also annotated from IEA.
-      The broader IEA is acceptable and not incorrect.
+      Retaining the broader parent term as a core accepted annotation would obscure the
+      more informative Hsp70-specific binding annotation.
 - term:
     id: GO:0046872
     label: metal ion binding
@@ -4378,11 +4410,12 @@ existing_annotations:
       binding) which is also annotated by IEA. DNAJA2 coordinates two zinc ions in its
       CR-type zinc finger domain. The generic metal ion binding term is technically
       correct but less informative than the specific zinc ion binding term.
-    action: ACCEPT
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      Metal ion binding is correct for DNAJA2 as it binds zinc ions in its cysteine-rich
-      domain. The more specific GO:0008270 (zinc ion binding) is also annotated. As an
-      IEA annotation of the broader parent term it is acceptable.
+      Metal ion binding is technically correct but overly broad. DNAJA2 specifically
+      binds zinc ions in its cysteine-rich domain, which is captured by GO:0008270
+      (zinc ion binding). The broader parent term adds no additional information and
+      should not be treated as an accepted core molecular annotation.
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -4847,18 +4880,14 @@ core_functions:
       five dimers) that serve as a storage form; heat shock (40 degrees C) drives rapid
       dissociation into active dimers (t1/2 ~2.3 min), and Hsc70 ATPase cycling coupled
       to J-domain interaction triggers oligomer disassembly
-      (DOI:10.1038/s41467-023-41150-8). Beyond general protein refolding, DNAJA2 acts
-      as a client-selective Hsc70 co-chaperone that can bias quality-control decisions
-      toward degradation through ERAD (e.g., CFTR with Hsc70/CHIP,
-      DOI:10.1371/journal.pone.0220984) or chaperone-mediated autophagy (CMA) of
-      specific substrates such as PCM1/CEP290 at centrosomes
-      (DOI:10.1038/s41467-023-40952-0) and CSB during TC-NER
-      (DOI:10.1038/s41421-023-00601-8). DNAJA2 also potently suppresses tau amyloid
-      formation using distinct CTDI (monomer-binding) and CTDII (fibril-binding)
-      sites, achieving 88% reduction in fibril mass at sub-stoichiometric ratios
-      (DOI:10.7554/elife.69601). DNAJA2 works in combination with specific nucleotide
-      exchange factors (NEFs) to generate functionally distinct HSP70 chaperone complexes
-      with varying foldase potency.
+      (DOI:10.1038/s41467-023-41150-8). DNAJA2 also appears in client- and context-specific
+      quality-control settings including ERAD, chaperone-mediated autophagy, centrosome-
+      associated client handling, and tau anti-aggregation. Those findings are useful
+      biological context, but they are not proposed here as core GO annotations because the
+      evidence maps to specific substrates or pathways rather than to a conserved primary
+      function of DNAJA2. The core function retained in this review is the foldase-type
+      HSP70 co-chaperone activity, with client-selective degradation and anti-aggregation
+      outcomes treated as downstream contexts unless directly represented in GOA.
     supported_by:
       - reference_id: PMID:21231916
         supporting_text: &gt;-
@@ -4913,6 +4942,9 @@ core_functions:
       - id: GO:0005829
         label: cytosol
 references:
+- id: file:human/DNAJA2/DNAJA2-deep-research-falcon.md
+  title: Falcon deep research report for DNAJA2
+  findings: []
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
     terms
@@ -5060,7 +5092,7 @@ references:
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/DNAJA2/DNAJA2-ai-review.yaml
+++ b/genes/human/DNAJA2/DNAJA2-ai-review.yaml
@@ -1,7 +1,7 @@
 id: O60884
 gene_symbol: DNAJA2
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -84,6 +84,13 @@ existing_annotations:
           activity of the combinations in ATPase and luciferase refolding assays were
           dependent on the identity and stoichiometry of both the J protein and NEF so
           that some combinations were potent chaperones, whereas others were inactive.
+      - reference_id: file:human/DNAJA2/DNAJA2-deep-research-falcon.md
+        supporting_text: >-
+          DNAJA2 is an Hsp40/J-domain protein (JDP) that acts as a co-chaperone
+          for Hsp70-family chaperones (including the constitutively expressed
+          Hsc70/HSPA8), stimulating Hsp70 ATPase activity via the J-domain and
+          contributing client specificity by binding particular unfolded/misfolded
+          client proteins.
 - term:
     id: GO:0034605
     label: cellular response to heat
@@ -365,13 +372,13 @@ existing_annotations:
       domain IPR001305 (HSP DnaJ cysteine-rich domain). This is a parent term of
       GO:0030544 (Hsp70 protein binding) which is also annotated. DNAJA2 binds HSP70
       family members, so this broader term is technically correct but redundant with the
-      more specific GO:0030544. As an IEA it is acceptable to have both the general
-      and specific terms.
-    action: ACCEPT
+      more specific GO:0030544.
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
       Heat shock protein binding is correct for DNAJA2 as it binds HSP70 chaperones.
       The more specific GO:0030544 (Hsp70 protein binding) is also annotated from IEA.
-      The broader IEA is acceptable and not incorrect.
+      Retaining the broader parent term as a core accepted annotation would obscure the
+      more informative Hsp70-specific binding annotation.
 - term:
     id: GO:0046872
     label: metal ion binding
@@ -384,11 +391,12 @@ existing_annotations:
       binding) which is also annotated by IEA. DNAJA2 coordinates two zinc ions in its
       CR-type zinc finger domain. The generic metal ion binding term is technically
       correct but less informative than the specific zinc ion binding term.
-    action: ACCEPT
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      Metal ion binding is correct for DNAJA2 as it binds zinc ions in its cysteine-rich
-      domain. The more specific GO:0008270 (zinc ion binding) is also annotated. As an
-      IEA annotation of the broader parent term it is acceptable.
+      Metal ion binding is technically correct but overly broad. DNAJA2 specifically
+      binds zinc ions in its cysteine-rich domain, which is captured by GO:0008270
+      (zinc ion binding). The broader parent term adds no additional information and
+      should not be treated as an accepted core molecular annotation.
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -853,18 +861,14 @@ core_functions:
       five dimers) that serve as a storage form; heat shock (40 degrees C) drives rapid
       dissociation into active dimers (t1/2 ~2.3 min), and Hsc70 ATPase cycling coupled
       to J-domain interaction triggers oligomer disassembly
-      (DOI:10.1038/s41467-023-41150-8). Beyond general protein refolding, DNAJA2 acts
-      as a client-selective Hsc70 co-chaperone that can bias quality-control decisions
-      toward degradation through ERAD (e.g., CFTR with Hsc70/CHIP,
-      DOI:10.1371/journal.pone.0220984) or chaperone-mediated autophagy (CMA) of
-      specific substrates such as PCM1/CEP290 at centrosomes
-      (DOI:10.1038/s41467-023-40952-0) and CSB during TC-NER
-      (DOI:10.1038/s41421-023-00601-8). DNAJA2 also potently suppresses tau amyloid
-      formation using distinct CTDI (monomer-binding) and CTDII (fibril-binding)
-      sites, achieving 88% reduction in fibril mass at sub-stoichiometric ratios
-      (DOI:10.7554/elife.69601). DNAJA2 works in combination with specific nucleotide
-      exchange factors (NEFs) to generate functionally distinct HSP70 chaperone complexes
-      with varying foldase potency.
+      (DOI:10.1038/s41467-023-41150-8). DNAJA2 also appears in client- and context-specific
+      quality-control settings including ERAD, chaperone-mediated autophagy, centrosome-
+      associated client handling, and tau anti-aggregation. Those findings are useful
+      biological context, but they are not proposed here as core GO annotations because the
+      evidence maps to specific substrates or pathways rather than to a conserved primary
+      function of DNAJA2. The core function retained in this review is the foldase-type
+      HSP70 co-chaperone activity, with client-selective degradation and anti-aggregation
+      outcomes treated as downstream contexts unless directly represented in GOA.
     supported_by:
       - reference_id: PMID:21231916
         supporting_text: >-
@@ -919,6 +923,9 @@ core_functions:
       - id: GO:0005829
         label: cytosol
 references:
+- id: file:human/DNAJA2/DNAJA2-deep-research-falcon.md
+  title: Falcon deep research report for DNAJA2
+  findings: []
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
     terms

--- a/genes/human/DNAJA4/DNAJA4-ai-review.html
+++ b/genes/human/DNAJA4/DNAJA4-ai-review.html
@@ -1652,10 +1652,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q8WW22" data-a="GO:0031072" data-r="GO_REF:0000002" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q8WW22" data-a="GO:0031072" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1668,7 +1668,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Heat shock protein binding is a broad but correct annotation. DNAJA4 binds HSP70 partners and participates in the HSP90 chaperone cycle. More specific terms are already annotated (GO:0030544, GO:0051087), but this broader IEA is acceptable.
+                            <strong>Reason:</strong> Heat shock protein binding is correct for DNAJA4 as it binds HSP70 chaperones. The more specific GO:0030544 (Hsp70 protein binding) is also annotated from IEA, and GO:0051087 captures the functional chaperone-binding context. Retaining this broader parent term as accepted would obscure the more informative Hsp70-specific and chaperone-binding annotations.
                         </div>
 
 
@@ -1703,10 +1703,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q8WW22" data-a="GO:0046872" data-r="GO_REF:0000043" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q8WW22" data-a="GO:0046872" data-r="GO_REF:0000043" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1719,7 +1719,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Metal ion binding is correct but overly broad compared to the already annotated GO:0008270 (zinc ion binding). As an IEA annotation it is acceptable even though it provides less specificity.
+                            <strong>Reason:</strong> Metal ion binding is correct but overly broad compared to the already annotated GO:0008270 (zinc ion binding). DNAJA4 specifically binds zinc ions in its cysteine-rich domain, and the broader parent term adds no additional information beyond the more specific zinc ion binding annotation.
                         </div>
 
 
@@ -4111,12 +4111,13 @@ existing_annotations:
       evidence. As a J-domain co-chaperone, DNAJA4 binds HSP70 (and participates
       in the HSP90 chaperone cycle via HOP). This annotation is not incorrect but
       is less informative than the existing more specific annotations.
-    action: ACCEPT
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      Heat shock protein binding is a broad but correct annotation. DNAJA4 binds
-      HSP70 partners and participates in the HSP90 chaperone cycle. More specific
-      terms are already annotated (GO:0030544, GO:0051087), but this broader IEA
-      is acceptable.
+      Heat shock protein binding is correct for DNAJA4 as it binds HSP70
+      chaperones. The more specific GO:0030544 (Hsp70 protein binding) is also
+      annotated from IEA, and GO:0051087 captures the functional chaperone-binding
+      context. Retaining this broader parent term as accepted would obscure the
+      more informative Hsp70-specific and chaperone-binding annotations.
 - term:
     id: GO:0046872
     label: metal ion binding
@@ -4129,11 +4130,12 @@ existing_annotations:
       coordinating two zinc ions. The more specific term GO:0008270 (zinc ion
       binding) is already annotated with the same evidence type (IEA). This
       broader term is redundant but not incorrect.
-    action: ACCEPT
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       Metal ion binding is correct but overly broad compared to the already
-      annotated GO:0008270 (zinc ion binding). As an IEA annotation it is
-      acceptable even though it provides less specificity.
+      annotated GO:0008270 (zinc ion binding). DNAJA4 specifically binds zinc
+      ions in its cysteine-rich domain, and the broader parent term adds no
+      additional information beyond the more specific zinc ion binding annotation.
 - term:
     id: GO:0051082
     label: unfolded protein binding

--- a/genes/human/DNAJA4/DNAJA4-ai-review.html
+++ b/genes/human/DNAJA4/DNAJA4-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>DNAJA4</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/Q8WW22" target="_blank" class="term-link">
                         Q8WW22
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -737,15 +737,15 @@
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>DNAJA4 is a class I J-domain protein (HSP40 co-chaperone) belonging to the DNAJA subfamily. It contains an N-terminal J-domain (with conserved HPD motif) that stimulates the ATPase activity of HSP70 family members, a glycine/phenylalanine-rich region, a cysteine-rich zinc finger domain (CR-type, with four CXXCXGXG repeats coordinating two zinc ions) involved in substrate recognition, two C-terminal beta-barrel substrate-binding domains (CTDI and CTDII), and a dimerization domain. As a co-chaperone, DNAJA4 binds unfolded or misfolded client proteins and delivers them to HSP70 (HSPA) partners for ATP-dependent protein folding. Hageman et al. (2011) demonstrated that DNAJA4 supports luciferase refolding and suppresses polyQ aggregation when co-expressed with HSP70 partners (PMID:21231916). Systematic interactome profiling of the human Hsp70 network (AP-MS and BioID) places DNAJA4 in the densely connected cytoplasmic class A JDP core, with robust interactions with DNAJA1, DNAJA2, and DNAJB1 (DOI:10.1016/j.molcel.2021.04.012). DNAJA4 is farnesylated and membrane-associated, and is also found in the cytosol. It participates in the HSP90 chaperone cycle for steroid hormone receptors via the HSP70-HSP40-HOP-HSP90 relay pathway. DNAJA4 is transcriptionally upregulated during heat stress in human neuronal models (log2 fold-change 1.5-5 at 1 h post-heat shock; DOI:10.3390/biology12030416). Beyond generic chaperoning, DNAJA4 has a specific role in suppressing epithelial-mesenchymal transition (EMT) and metastasis in nasopharyngeal carcinoma (NPC) by promoting PSMD2-mediated ubiquitin-proteasome degradation of MYH9, an interaction requiring the DnaJ domain (DOI:10.1038/s41419-023-06225-w). DNAJA4 promoter hypermethylation and silencing is observed in multiple cancers including NPC, stomach adenocarcinoma, and rhabdomyosarcoma (DOI:10.3390/ijms222413527).</p>
+        <p>DNAJA4 is a class I J-domain protein (HSP40 co-chaperone) belonging to the DNAJA subfamily. It contains an N-terminal J-domain (with conserved HPD motif) that stimulates the ATPase activity of HSP70 family members, a glycine/phenylalanine-rich region, a cysteine-rich zinc finger domain (CR-type, with four CXXCXGXG repeats coordinating two zinc ions) involved in substrate recognition, two C-terminal beta-barrel substrate-binding domains (CTDI and CTDII), and a dimerization domain. As a co-chaperone, DNAJA4 is expected to bind unfolded or misfolded client proteins and deliver them to HSP70 (HSPA) partners for ATP-dependent client processing. Systematic interactome profiling of the human Hsp70 network (AP-MS and BioID) places DNAJA4 in the densely connected cytoplasmic class A JDP core, with robust interactions with DNAJA1, DNAJA2, and DNAJB1 (DOI:10.1016/j.molcel.2021.04.012). DNAJA4 is farnesylated and membrane-associated, and is also found in the cytosol. It participates in the HSP90 chaperone cycle for steroid hormone receptors via the HSP70-HSP40-HOP-HSP90 relay pathway. DNAJA4 is transcriptionally upregulated during heat stress in human neuronal models (log2 fold-change 1.5-5 at 1 h post-heat shock; DOI:10.3390/biology12030416). In nasopharyngeal carcinoma, DNAJA4 has a cancer-context role in suppressing epithelial-mesenchymal transition (EMT) and metastasis by promoting PSMD2-mediated ubiquitin-proteasome degradation of MYH9 (DOI:10.1038/s41419-023-06225-w). DNAJA4 promoter hypermethylation and silencing is observed in multiple cancers including NPC, stomach adenocarcinoma, and rhabdomyosarcoma (DOI:10.3390/ijms222413527).</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,64 +795,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for cytosol localization propagated from orthologs including yeast Ydj1 (SGD:S000005008), S. pombe Mas5 (PomBase:SPBC1734.11), DNAJA2 (UniProtKB:O60884), and DNAJA4 itself. This is well supported by direct experimental evidence: Hageman et al. (2011) showed that DNAJA4 is localized in the cytosol (PMID:21231916). The IDA annotation from the same paper (see below) independently confirms this localization. Cytosolic localization is consistent with DNAJA4&#39;s role as a cytosolic HSP70 co-chaperone.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization is a core localization for DNAJA4 as a cytosolic J-domain co-chaperone. This IBA annotation is independently confirmed by IDA evidence from PMID:21231916.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
                                     GO:0001671
                                 </a>
                             </span>
                             <span class="term-label">ATPase activator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -864,77 +864,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for ATPase activator activity propagated from orthologs including yeast Ydj1 (SGD:S000005008), Sis1 (SGD:S000005021), DNAJA2 (UniProtKB:O60884), and others. All class I J-domain proteins stimulate HSP70 ATPase activity through their conserved J-domain, which directly contacts the HSP70 ATPase domain and accelerates ATP hydrolysis. Kampinga and Craig (2010) describe that J-domain cochaperones stimulate &#34;the ATPase activity of HSP70&#34; (PMID:20651708). Hageman et al. (2011) confirmed that J-proteins including DNAJA4 stimulate the intrinsic ATPase activity of HSP70 family members (PMID:21231916). The Reactome entry R-HSA-3371422 (ATP hydrolysis by HSP70) explicitly describes that &#34;This ATPase activity of HSP70 is stimulated by protein substrates in synergism with J domain cochaperones (HSP40s).&#34; This is a core molecular function of all J-domain proteins.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATPase activator activity is a fundamental and well-established molecular function of J-domain proteins. DNAJA4 contains a conserved J-domain that stimulates HSP70 ATPase activity. This IBA annotation is phylogenetically sound and supported by the general biochemistry of J-domain proteins.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20651708" target="_blank" class="term-link">
                                         PMID:20651708
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Much of the functional diversity of the HSP70s is driven by a diverse class of cofactors: J proteins</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSPA6 has a functional substrate-binding domain and possesses intrinsic ATPase activity that is as high as that of the canonical HSPA1A when stimulated by J-proteins</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/DNAJA4/DNAJA4-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">DNAJA4 is a class A HSP40/J-domain protein (JDP). Class A JDPs are characterized by the canonical domain architecture: an N-terminal J-domain (containing the conserved HPD motif that stimulates Hsp70 ATPase activity), a Gly/Phe-rich region, C-terminal substrate-binding beta-barrel domains, a dimerization region, and a class-A-specific zinc-finger insertion.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034605" target="_blank" class="term-link">
                                     GO:0034605
                                 </a>
                             </span>
                             <span class="term-label">cellular response to heat</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -946,64 +957,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for cellular response to heat propagated from orthologs including yeast Ydj1 (SGD:S000005008) and S. pombe Mas5 (PomBase:SPBC1734.11). HSP40/DNAJ proteins are heat shock proteins by definition -- they are induced by and function during heat stress to assist in protein folding and prevent aggregation. Hageman et al. (2011) specifically tested DNAJA4 in the context of heat-denatured substrates, showing it supports refolding of heat-denatured luciferase (PMID:21231916). The IEA annotation for response to heat (GO:0009408, a parent term) via InterPro also supports this. This is a broader but appropriate term given the IBA evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cellular response to heat is an appropriate annotation for a heat shock co-chaperone. DNAJA4 functions in protein refolding after heat denaturation, which is a core aspect of the cellular heat stress response. The IBA annotation is phylogenetically well supported.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1015,64 +1026,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for protein refolding propagated from orthologs including yeast Ydj1 (SGD:S000005008), S. pombe Mas5 (PomBase:SPBC1734.11), DNAJA2 (UniProtKB:O60884), and DNAJA4 itself. Hageman et al. (2011) directly demonstrated that DNAJA4 supports HSP70-dependent refolding of heat-denatured luciferase (PMID:21231916). This is a core biological process for J-domain co-chaperones that assist HSP70 in the ATP-dependent refolding cycle.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein refolding is a core function of J-domain co-chaperones working with HSP70. This IBA is directly confirmed by experimental evidence from Hageman et al. (2011) showing DNAJA4 supports luciferase refolding.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1084,88 +1095,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962). This IBA annotation was propagated via phylogenetic inference from orthologs including yeast Ydj1 (SGD:S000005008, S000005021), DNAJA2 (UniProtKB:O60884), and DNAJA4 itself (UniProtKB:Q8WW22). While it is true that class I J-domain proteins like DNAJA4 bind unfolded substrates, the term &#34;unfolded protein binding&#34; is being replaced because it does not capture the functional role of the protein as a chaperone. DNAJA4 functions as an HSP70 co-chaperone: it binds client proteins and delivers them to HSP70, stimulating HSP70 ATPase activity via its J-domain (PMID:21231916). Kampinga and Craig (2010) describe how J proteins &#34;bind client proteins directly, thereby delivering specific clients to HSP70 and directly determining their fate&#34; (PMID:20651708). The correct replacement term is GO:0044183 (protein folding chaperone), defined as &#34;Binding to a protein or a protein-containing complex to assist the protein folding process.&#34;
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. DNAJA4 is a class I J-domain protein that functions as a protein folding chaperone, not merely as an unfolded protein binder. The replacement term GO:0044183 (protein folding chaperone) accurately captures the functional role of DNAJA4 in binding client proteins and delivering them to HSP70 for ATP-dependent refolding.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20651708" target="_blank" class="term-link">
                                         PMID:20651708
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">others bind client proteins directly, thereby delivering specific clients to HSP70 and directly determining their fate</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1177,77 +1188,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for protein-folding chaperone binding propagated from orthologs including DNAJA2 (UniProtKB:O60884), DNAJA1 (UniProtKB:P31689), and DNAJA4 itself. This term captures the binding of DNAJA4 to HSP70 chaperone partners. Hageman et al. (2011) demonstrated that DNAJA4 physically interacts with multiple HSP70 family members including HSPA1A (P0DMV8), HSPA1B (P0DMV9), and HSPA6 (P17066) (PMID:21231916). The IPI annotations from the same paper independently confirm this interaction. Binding to HSP70 chaperones is a core molecular function of all J-domain proteins, mediated through the J-domain interaction with the HSP70 ATPase domain.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein-folding chaperone binding (i.e., binding to HSP70 partners) is a core function of J-domain co-chaperones. DNAJA4 has been experimentally shown to interact with multiple HSP70 family members. This IBA is well supported by direct experimental evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20651708" target="_blank" class="term-link">
                                         PMID:20651708
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Some target HSP70 activity to clients at precise locations in cells and others bind client proteins directly, thereby delivering specific clients to HSP70 and directly determining their fate</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
                                     GO:0005524
                                 </a>
                             </span>
                             <span class="term-label">ATP binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1259,64 +1270,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for ATP binding inferred from InterPro domain IPR012724 (DnaJ). While the DnaJ/J-domain does interact with the HSP70 ATPase domain and stimulates its ATPase activity, the J-domain protein itself does not bind ATP. It is the HSP70 partner that binds and hydrolyzes ATP. DNAJA4 does not have an ATPase domain or ATP-binding domain. The InterPro2GO mapping from IPR012724 to GO:0005524 appears to be an incorrect transitive annotation -- the DnaJ domain stimulates the ATPase of HSP70, but does not itself bind ATP.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> J-domain proteins like DNAJA4 do not bind ATP themselves. The J-domain stimulates the ATPase activity of HSP70 partners, but it is the HSP70 that binds ATP, not the co-chaperone. This IEA annotation based on the DnaJ InterPro domain is an incorrect transitive inference.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20651708" target="_blank" class="term-link">
                                         PMID:20651708
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Heat shock 70 kDa proteins (HSP70s) are ubiquitous molecular chaperones that function in a myriad of biological processes, modulating polypeptide folding, degradation and translocation across membranes, and protein-protein interactions. This multitude of roles is not easily reconciled with the universality of the activity of HSP70s in ATP-dependent client protein-binding and release cycles</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1328,64 +1339,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for protein folding inferred from multiple sources (ARBA, InterPro IPR008971 HSP40/DnaJ_pept-bd, IPR012724 DnaJ, IPR044713 DNJA1/2-like). As a J-domain co-chaperone, DNAJA4 participates in protein folding by binding client proteins and delivering them to HSP70 for ATP-dependent folding. Hageman et al. (2011) showed DNAJA4 supports refolding of heat-denatured luciferase (PMID:21231916). The more specific term GO:0042026 (protein refolding) is already annotated with IDA and IBA evidence. This broader term is acceptable as a parent-level IEA annotation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein folding is an appropriate broad process annotation for DNAJA4. The more specific child term protein refolding (GO:0042026) is already annotated with experimental evidence. This IEA correctly captures the general biological process in which DNAJA4 participates.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
                                     GO:0008270
                                 </a>
                             </span>
                             <span class="term-label">zinc ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1397,46 +1408,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for zinc ion binding inferred from UniProtKB keyword KW-0863 (Zinc). DNAJA4 contains a CR-type zinc finger domain (residues 122-206) with four CXXCXGXG repeats that coordinate two zinc ions. This is confirmed by the UniProt feature annotations showing eight cysteine residues that bind Zn(2+) ions (positions 135, 138, 151, 154, 178, 181, 194, 197). The zinc finger domain is characteristic of class I J-domain proteins and is important for client protein recognition and binding.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Zinc ion binding is structurally confirmed for DNAJA4 via its CR-type zinc finger domain with four CXXCXGXG repeats coordinating two zinc ions. This is a well-characterized structural feature of class I J-domain proteins.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009408" target="_blank" class="term-link">
                                     GO:0009408
                                 </a>
                             </span>
                             <span class="term-label">response to heat</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1448,64 +1459,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for response to heat inferred from InterPro domain IPR012724 (DnaJ). This is a broader parent term of GO:0034605 (cellular response to heat), which is already annotated by IBA evidence. As a heat shock co-chaperone, DNAJA4 is involved in the cellular response to heat stress through its role in protein refolding and prevention of aggregation. Hageman et al. (2011) tested DNAJA4 function using heat-denatured substrates (PMID:21231916). This broader IEA annotation is acceptable alongside the more specific IBA annotation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Response to heat is an appropriate broad annotation for a heat shock co-chaperone. The more specific child term cellular response to heat (GO:0034605) is already annotated by IBA. This broader IEA is acceptable.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
                                     GO:0016020
                                 </a>
                             </span>
                             <span class="term-label">membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1517,46 +1528,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for membrane localization inferred from UniProt subcellular location vocabulary (SL-0162). DNAJA4 is farnesylated at Cys-394 (S-farnesyl cysteine, by sequence similarity) and is annotated as membrane-associated via lipid anchor in UniProt. Hageman et al. (2011) provided IDA evidence for membrane localization (PMID:21231916), independently confirming this IEA. The lipid anchor (farnesylation) is a distinctive feature of DNAJA4 among the DNAJA subfamily members and mediates its membrane association.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Membrane localization is supported by the farnesylation of DNAJA4 at Cys-394 and is independently confirmed by IDA evidence from PMID:21231916. This is a valid localization for DNAJA4.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030544" target="_blank" class="term-link">
                                     GO:0030544
                                 </a>
                             </span>
                             <span class="term-label">Hsp70 protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1568,77 +1579,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for Hsp70 protein binding inferred from InterPro domain IPR044713 (DNJA1/2-like). DNAJA4 is a J-domain co-chaperone whose primary molecular function involves binding HSP70 family members via its J-domain. Hageman et al. (2011) demonstrated that DNAJA4 physically interacts with HSP70 family members HSPA1A, HSPA1B, and HSPA6 (PMID:21231916). However, GO:0030544 (Hsp70 protein binding) is a less informative term than GO:0051087 (protein-folding chaperone binding), which is already annotated with IBA and IPI evidence. The term GO:0030544 simply describes binding without capturing the functional context. Nevertheless, as an IEA annotation it is not incorrect and can be accepted alongside the more specific IBA/IPI annotations.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Hsp70 protein binding is correct -- DNAJA4 binds HSP70 partners via its J-domain. While the more informative term protein-folding chaperone binding (GO:0051087) is already annotated, this IEA is not incorrect and reflects the InterPro domain-based inference.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20651708" target="_blank" class="term-link">
                                         PMID:20651708
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Often, multiple J proteins function with a single HSP70</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
                                     GO:0031072
                                 </a>
                             </span>
                             <span class="term-label">heat shock protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1650,46 +1661,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for heat shock protein binding inferred from InterPro domain IPR001305 (HSP_DnaJ_Cys-rich_dom). This is a broader parent of GO:0030544 (Hsp70 protein binding) and a broader relative of GO:0051087 (protein-folding chaperone binding), both of which are already annotated with higher-quality evidence. As a J-domain co-chaperone, DNAJA4 binds HSP70 (and participates in the HSP90 chaperone cycle via HOP). This annotation is not incorrect but is less informative than the existing more specific annotations.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Heat shock protein binding is a broad but correct annotation. DNAJA4 binds HSP70 partners and participates in the HSP90 chaperone cycle. More specific terms are already annotated (GO:0030544, GO:0051087), but this broader IEA is acceptable.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
                                     GO:0046872
                                 </a>
                             </span>
                             <span class="term-label">metal ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1701,46 +1712,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for metal ion binding inferred from UniProtKB keyword KW-0479 (Metal-binding). DNAJA4 contains a CR-type zinc finger domain coordinating two zinc ions. The more specific term GO:0008270 (zinc ion binding) is already annotated with the same evidence type (IEA). This broader term is redundant but not incorrect.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Metal ion binding is correct but overly broad compared to the already annotated GO:0008270 (zinc ion binding). As an IEA annotation it is acceptable even though it provides less specificity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1752,88 +1763,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962). This IEA annotation was inferred from InterPro domain matches (IPR001305 HSP_DnaJ_Cys-rich_dom, IPR008971 HSP40/DnaJ_pept-bd, IPR012724 DnaJ). These domains are characteristic of class I J-domain proteins that function as HSP70 co-chaperones. The InterPro domains correctly identify DNAJA4 as a DnaJ family member with substrate-binding capability, but the GO term &#34;unfolded protein binding&#34; is being replaced because it fails to convey the chaperone function. Kampinga and Craig (2010) explain that J proteins function with HSP70 through &#34;ATP-dependent client protein-binding and release cycles&#34; and that some J proteins &#34;bind client proteins directly, thereby delivering specific clients to HSP70&#34; (PMID:20651708). The correct replacement is GO:0044183 (protein folding chaperone).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. The InterPro-based annotation correctly identifies DNAJA4 as having substrate-binding domains characteristic of J-domain protein co-chaperones, but the term should be replaced with GO:0044183 (protein folding chaperone) which properly captures the functional role of binding client proteins to assist in the protein folding process.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20651708" target="_blank" class="term-link">
                                         PMID:20651708
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Much of the functional diversity of the HSP70s is driven by a diverse class of cofactors: J proteins</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20651708" target="_blank" class="term-link">
                                         PMID:20651708
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">others bind client proteins directly, thereby delivering specific clients to HSP70 and directly determining their fate</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1845,75 +1856,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for protein-folding chaperone binding inferred by ARBA machine learning model (ARBA:ARBA00088077). This is consistent with DNAJA4&#39;s well-established role as a J-domain co-chaperone that binds HSP70 chaperone partners. This annotation is independently confirmed by IBA (GO_REF:0000033) and IPI (PMID:21231916) evidence for the same GO term. Hageman et al. (2011) showed DNAJA4 interacts with HSPA1A, HSPA1B, and HSPA6 (PMID:21231916).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein-folding chaperone binding is a core function of J-domain co-chaperones. This IEA annotation is independently confirmed by both IBA and IPI evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25036637
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A quantitative chaperone interaction network reveals the arc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1925,57 +1936,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from Taipale et al. (2014), a large-scale quantitative chaperone interaction network study. The GOA data shows interactions with DNAJA2 (UniProtKB:O60884) and ENDOG (UniProtKB:Q14249). The DNAJA2 interaction (homodimerization/heterodimerization between DNAJA family members) is plausible for co-chaperone function. The ENDOG interaction is from a high-throughput screen. However, &#34;protein binding&#34; (GO:0005515) is uninformative -- the DNAJA2 interaction could be more accurately captured by a more specific binding term, and the interaction with ENDOG lacks functional context.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative and does not convey the functional significance of the interactions. The DNAJA2 interaction is better captured by existing annotations for protein-folding chaperone binding. Per curation guidelines, protein binding should be avoided in favor of more specific MF terms.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1987,57 +1998,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from Huttlin et al. (2021), a dual proteome-scale interaction network study. The GOA data shows an interaction with DNAJA2 (UniProtKB:O60884). This DNAJA4-DNAJA2 interaction is also supported by the UniProt interaction data (4 experiments in IntAct). While the interaction may be real, &#34;protein binding&#34; is uninformative and the interaction between DNAJA co-chaperones is better captured by existing chaperone binding annotations.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative. The DNAJA4-DNAJA2 interaction detected in this high-throughput study does not add functional information beyond what is captured by the existing protein-folding chaperone binding annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:40205054
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Multimodal cell maps as a foundation for structural and func...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2049,57 +2060,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from a multimodal cell maps study. The GOA data shows an interaction with DNAJA2 (UniProtKB:O60884). This is the third independent detection of the DNAJA4-DNAJA2 interaction (also seen in PMID:25036637 and PMID:33961781), suggesting it is a robust interaction. However, &#34;protein binding&#34; remains uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative. While the DNAJA4-DNAJA2 interaction is robustly detected across multiple studies, the functional significance is better captured by existing chaperone binding annotations. Per curation guidelines, protein binding should be avoided.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010596" target="_blank" class="term-link">
                                     GO:0010596
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of endothelial cell migration</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23142051" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23142051
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Convergent multi-miRNA targeting of ApoE drives LRP1/LRP8-de...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2111,75 +2122,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IMP annotation from Pencheva et al. (2012), which studied miRNA-mediated regulation of melanoma metastasis. The study found that miR-1908, miR-199a-5p, and miR-199a-3p convergently target DNAJA4 and ApoE. DNAJA4 was shown to promote ApoE expression, and ApoE suppresses metastatic endothelial recruitment (MER). The negative regulation of endothelial cell migration is an indirect downstream consequence of DNAJA4 promoting ApoE expression, rather than a direct molecular function of DNAJA4 as a co-chaperone. This is a context-specific phenotypic observation in melanoma cells, not a core function of DNAJA4.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The negative regulation of endothelial cell migration is a downstream phenotypic consequence observed in the specific context of melanoma metastasis. DNAJA4 promotes ApoE expression, and ApoE is the effector that suppresses endothelial migration. This is not a core evolved function of DNAJA4 as a J-domain co-chaperone, but the IMP evidence from PMID:23142051 supports the annotation in this specific biological context.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23142051" target="_blank" class="term-link">
                                         PMID:23142051
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Cancer-secreted ApoE suppresses invasion and metastatic endothelial recruitment (MER) by engaging melanoma cell LRP1 and endothelial cell LRP8 receptors, respectively, while DNAJA4 promotes ApoE expression</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010628" target="_blank" class="term-link">
                                     GO:0010628
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of gene expression</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23142051" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23142051
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Convergent multi-miRNA targeting of ApoE drives LRP1/LRP8-de...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2191,157 +2202,157 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IMP annotation from Pencheva et al. (2012) showing that DNAJA4 promotes ApoE expression. The study demonstrated that miRNAs targeting DNAJA4 reduce ApoE expression, and DNAJA4 promotes ApoE expression. However, GO:0010628 (positive regulation of gene expression) is extremely broad and does not specify what gene expression is being regulated. The mechanism by which a J-domain co-chaperone regulates gene expression is unclear -- it could be through chaperoning a transcription factor or signaling protein. The annotation is overly vague and the mechanism is indirect.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0010628 (positive regulation of gene expression) is overly broad and does not capture the specificity of what was observed. DNAJA4 promotes ApoE expression, but the mechanism is not well characterized and could involve chaperoning of upstream regulators. This vague process annotation does not add meaningful information about DNAJA4&#39;s function. The connection to ApoE regulation in melanoma is a context-specific observation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23142051" target="_blank" class="term-link">
                                         PMID:23142051
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">DNAJA4 promotes ApoE expression</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="Q8WW22" data-a="GO:0051087" data-r="PMID:21231916" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q8WW22" data-a="GO:0051087" data-r="PMID:21231916" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IPI annotation for protein-folding chaperone binding based on physical interaction evidence from Hageman et al. (2011). The GOA data shows three separate IPI entries from this paper with different interactors: HSPA1A (UniProtKB:P0DMV8), HSPA1B (UniProtKB:P0DMV9), and HSPA6 (UniProtKB:P17066). This annotation entry corresponds to the interaction with HSPA1A. DNAJA4 binds HSP70 chaperone partners through its J-domain, which is a core molecular function of all J-domain co-chaperones. Hageman et al. systematically tested interactions between mammalian HSP40 and HSP70 family members and found that DNAJA4 functionally interacts with these HSP70 partners to support protein refolding.
+                            <strong>Summary:</strong> IPI annotation for protein-folding chaperone binding based on physical interaction evidence from Hageman et al. (2011). The GOA data shows three separate IPI entries from this paper with different interactors: HSPA1A (UniProtKB:P0DMV8), HSPA1B (UniProtKB:P0DMV9), and HSPA6 (UniProtKB:P17066). This annotation entry corresponds to the interaction with HSPA1A. DNAJA4 binds HSP70 chaperone partners through its J-domain, which is a core molecular function of all J-domain co-chaperones. The cached PMID:21231916 text available in this repository is abstract-only and provides class-level HSP70/HSP40 statements rather than DNAJA4-specific interactor evidence.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Protein-folding chaperone binding is a core molecular function of DNAJA4. The IPI evidence from Hageman et al. (2011) directly demonstrates physical interaction between DNAJA4 and HSP70 family member HSPA1A.
+                            <strong>Reason:</strong> Protein-folding chaperone binding is biologically plausible for DNAJA4, but this source-specific IPI annotation cannot be verified from the accessible cached text. The review should not treat PMID:21231916 as direct DNAJA4-specific support without accessible source details.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20651708" target="_blank" class="term-link">
                                         PMID:20651708
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Often, multiple J proteins function with a single HSP70</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371422
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2353,46 +2364,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for cytosol localization from Reactome pathway R-HSA-3371422 (ATP hydrolysis by HSP70). The Reactome entry describes the HSP70 chaperone cycle in which HSP40 co-chaperones (including DNAJA4) stimulate HSP70 ATPase activity in the cytosol. This localization is independently confirmed by IDA evidence from PMID:21231916 and IBA evidence from GO_REF:0000033.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization is well supported for DNAJA4 by multiple independent evidence sources. This Reactome TAS annotation is consistent with the IDA and IBA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371503
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2404,46 +2415,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for cytosol localization from Reactome pathway R-HSA-3371503 (STIP1/HOP binds HSP90 and HSP70:HSP40:nascent protein). The Reactome entry describes the HSP70-HSP40-HOP-HSP90 relay pathway in the cytosol, in which DNAJA4 participates as a HSP40 co-chaperone. This localization is independently confirmed by IDA (PMID:21231916) and IBA evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization is well established. This Reactome TAS annotation is consistent with the HSP90 chaperone cycle in which DNAJA4 participates as part of the HSP70-HSP40-HOP-HSP90 relay.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371590
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2455,480 +2466,469 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for cytosol localization from Reactome pathway R-HSA-3371590 (HSP70 binds to HSP40:nascent protein). The Reactome entry describes the initial step of client protein binding by HSP40 co-chaperones followed by HSP70 recruitment in the cytosol. DNAJA4 is included as one of the HSP40 family members. This localization is independently confirmed by IDA and IBA evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization is well established for DNAJA4 as a cytosolic HSP70 co-chaperone. This is the third Reactome TAS annotation for the same localization, all consistent with experimental evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="Q8WW22" data-a="GO:0005829" data-r="PMID:21231916" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q8WW22" data-a="GO:0005829" data-r="PMID:21231916" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IDA annotation for cytosol localization from Hageman et al. (2011). The study included subcellular localization analysis of mammalian HSP70 and HSP40 family members, reporting that &#34;most of the corresponding proteins are localized in the cytosol&#34; (PMID:21231916). This direct experimental evidence confirms the cytosolic localization of DNAJA4, consistent with its role as a cytosolic co-chaperone.
+                            <strong>Summary:</strong> IDA annotation for cytosol localization from Hageman et al. (2011). The study included subcellular localization analysis of mammalian HSP70 and HSP40 family members, reporting that &#34;most of the corresponding proteins are localized in the cytosol&#34; (PMID:21231916). The cached source does not provide DNAJA4-specific localization evidence beyond this class-level statement.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Direct experimental evidence (IDA) confirms cytosol localization. This is the strongest evidence for DNAJA4&#39;s cytosolic localization and is consistent with its function as a cytosolic HSP70 co-chaperone.
+                            <strong>Reason:</strong> Cytosol localization is plausible and supported elsewhere in the review, but this PMID:21231916-specific IDA cannot be confirmed from the accessible abstract-only source. Mark as undecided rather than accepting an unsupported direct-evidence claim.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
                                     GO:0016020
                                 </a>
                             </span>
                             <span class="term-label">membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="Q8WW22" data-a="GO:0016020" data-r="PMID:21231916" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q8WW22" data-a="GO:0016020" data-r="PMID:21231916" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IDA annotation for membrane localization from Hageman et al. (2011). DNAJA4 is farnesylated at Cys-394 (S-farnesyl cysteine), which anchors it to cellular membranes. UniProt annotates the subcellular location as &#34;Membrane; Lipid-anchor.&#34; Hageman et al. (2011) provided direct assay evidence confirming membrane association (PMID:21231916). This dual localization (cytosol and membrane) is distinctive for DNAJA4 among DNAJA subfamily members and may reflect regulation of its availability for different substrates.
+                            <strong>Summary:</strong> IDA annotation for membrane localization from Hageman et al. (2011). DNAJA4 is farnesylated at Cys-394 (S-farnesyl cysteine), which anchors it to cellular membranes. UniProt annotates the subcellular location as &#34;Membrane; Lipid-anchor.&#34; The cached PMID:21231916 text does not provide DNAJA4-specific membrane-localization details. This dual localization (cytosol and membrane) is distinctive for DNAJA4 among DNAJA subfamily members and may reflect regulation of its availability for different substrates.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Membrane localization is directly supported by IDA evidence and is consistent with the farnesylation of DNAJA4 at Cys-394. This is a distinctive and functionally relevant localization for this co-chaperone.
+                            <strong>Reason:</strong> Membrane localization is consistent with DNAJA4 farnesylation and UniProt-style localization summaries, but the PMID:21231916-specific IDA evidence is not verifiable from the cached source text.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="Q8WW22" data-a="GO:0042026" data-r="PMID:21231916" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q8WW22" data-a="GO:0042026" data-r="PMID:21231916" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IDA annotation for protein refolding from Hageman et al. (2011). The study directly demonstrated that overexpression of DNAJA4 with HSP70 partners supports refolding of heat-denatured luciferase. The authors &#34;assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase&#34; (PMID:21231916). This is a core function of J-domain co-chaperones that assist HSP70 in the ATP-dependent protein refolding cycle.
+                            <strong>Summary:</strong> IDA annotation for protein refolding from Hageman et al. (2011). The study directly demonstrated that overexpression of DNAJA4 with HSP70 partners supports refolding of heat-denatured luciferase. The authors &#34;assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase&#34; (PMID:21231916). The cached source does not show which HSP40/HSP70 combinations correspond to DNAJA4, so the DNAJA4-specific direct evidence cannot be confirmed here.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Protein refolding is a core biological process for J-domain co-chaperones. Hageman et al. (2011) directly demonstrated DNAJA4&#39;s ability to support luciferase refolding with HSP70 partners. This IDA annotation represents strong experimental evidence for a fundamental function.
+                            <strong>Reason:</strong> Protein refolding is a plausible class A JDP function, but this source-specific IDA annotation should not be accepted from an abstract-only cached source that lacks DNAJA4-specific assay details.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="Q8WW22" data-a="GO:0051082" data-r="PMID:21231916" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="Q8WW22" data-a="GO:0051082" data-r="PMID:21231916" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962). This IDA annotation from PMID:21231916 (Hageman et al. 2011) is based on direct experimental evidence showing that DNAJA4 functions as an HSP70 co-chaperone. The study demonstrated that DNAJA4 supports HSP70-dependent luciferase refolding and suppresses polyQ aggregation, activities that reflect its role as a protein folding chaperone rather than simply binding unfolded proteins. The authors &#34;assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment&#34; (PMID:21231916). The same paper provides evidence for DNAJA4 interacting with multiple HSP70 family members (HSPA1A/P0DMV8, HSPA1B/P0DMV9, HSPA6/P17066) as IPI evidence for GO:0051087 (protein-folding chaperone binding). The correct replacement term is GO:0044183 (protein folding chaperone), which captures the functional role of DNAJA4 as a co-chaperone that binds client proteins and delivers them to HSP70 for ATP-dependent refolding.
+                            <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962). This IDA annotation from PMID:21231916 (Hageman et al. 2011) is based on direct experimental evidence showing that DNAJA4 functions as an HSP70 co-chaperone. The study demonstrated that DNAJA4 supports HSP70-dependent luciferase refolding and suppresses polyQ aggregation, activities that reflect its role as a protein folding chaperone rather than simply binding unfolded proteins. The authors &#34;assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment&#34; (PMID:21231916). The same paper provides evidence for DNAJA4 interacting with multiple HSP70 family members (HSPA1A/P0DMV8, HSPA1B/P0DMV9, HSPA6/P17066) as IPI evidence for GO:0051087 (protein-folding chaperone binding). The cached PMID:21231916 text does not make the DNAJA4-specific client-binding evidence accessible.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> GO:0051082 is being obsoleted. The experimental evidence from Hageman et al. (2011) demonstrates that DNAJA4 functions as a protein folding chaperone -- it supports luciferase refolding and suppresses polyQ aggregation in cooperation with HSP70 partners. This is consistent with the well-established role of class I J-domain proteins as co-chaperones that bind unfolded substrates and deliver them to HSP70. The replacement term GO:0044183 (protein folding chaperone) accurately describes this molecular function.
+                            <strong>Reason:</strong> GO:0051082 is being obsoleted, and GO:0044183 is the likely better term for a class A JDP. However, the PMID:21231916-specific IDA evidence cannot be verified from the accessible cached text, so this annotation remains undecided rather than converted to an accepted replacement.
                         </div>
-                        
-                        
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-                            
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
-                                </a>
-                            </span>
-                            
-                        </div>
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20651708" target="_blank" class="term-link">
                                         PMID:20651708
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">others bind client proteins directly, thereby delivering specific clients to HSP70 and directly determining their fate</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090084" target="_blank" class="term-link">
                                     GO:0090084
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of inclusion body assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="Q8WW22" data-a="GO:0090084" data-r="PMID:21231916" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q8WW22" data-a="GO:0090084" data-r="PMID:21231916" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IDA annotation for negative regulation of inclusion body assembly from Hageman et al. (2011). The study demonstrated that DNAJA4 suppresses aggregation of polyQ-expanded Huntingtin fragments, which form inclusion bodies. The authors specifically tested &#34;suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment&#34; (PMID:21231916). This is a direct experimental observation and reflects DNAJA4&#39;s anti-aggregation chaperone activity. However, it is worth noting that this is a specific experimental readout rather than a primary evolved function, as polyQ expansion is a pathological context. The ability to suppress aggregation is a general property of chaperones that bind misfolded substrates.
+                            <strong>Summary:</strong> IDA annotation for negative regulation of inclusion body assembly from Hageman et al. (2011). The study demonstrated that DNAJA4 suppresses aggregation of polyQ-expanded Huntingtin fragments, which form inclusion bodies. The authors specifically tested &#34;suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment&#34; (PMID:21231916). The cached source does not provide DNAJA4-specific data for this assay, and this polyQ inclusion-body readout is a pathological model rather than a primary conserved DNAJA4 function.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> The IDA evidence directly demonstrates that DNAJA4 suppresses polyQ inclusion body formation. While this is tested in a pathological context (polyQ-expanded Huntingtin), it reflects the genuine anti-aggregation chaperone activity of DNAJA4. Suppression of protein aggregation is a core function of J-domain co-chaperones.
+                            <strong>Reason:</strong> Without accessible DNAJA4-specific source text, the review should not accept this IDA annotation as direct evidence. The term may reflect a real anti-aggregation assay outcome, but the source support is not sufficient here.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>DNAJA4 functions as a cytoplasmic class A HSP70 co-chaperone (J-domain protein) that stimulates the ATPase activity of HSP70 family members via its conserved J-domain HPD motif, binds unfolded client proteins through its zinc finger cysteine-rich domain and C-terminal beta-barrel substrate-binding domains (CTDI and CTDII), and delivers them to HSP70 for ATP-dependent refolding. It supports refolding of heat-denatured substrates and suppresses protein aggregation (PMID:21231916). Systematic Hsp70 network profiling places DNAJA4 in the densely connected cytoplasmic JDP core (DOI:10.1016/j.molcel.2021.04.012), and it is acutely upregulated during heat stress in human neuronal models (DOI:10.3390/biology12030416). DNAJA4 also has a specific role in promoting PSMD2-mediated ubiquitin-proteasome degradation of MYH9, linking its co-chaperone function to cytoskeletal remodeling and EMT suppression in NPC (DOI:10.1038/s41419-023-06225-w). DNAJA4 is farnesylated at Cys-394, providing dual cytosol/membrane localization.</h3>
+                <h3>DNAJA4 functions as a cytoplasmic class A HSP70 co-chaperone (J-domain protein) that stimulates the ATPase activity of HSP70 family members via its conserved J-domain HPD motif, binds unfolded client proteins through its zinc finger cysteine-rich domain and C-terminal beta-barrel substrate-binding domains (CTDI and CTDII), and delivers them to HSP70 for ATP-dependent client processing. Systematic Hsp70 network profiling places DNAJA4 in the densely connected cytoplasmic JDP core (DOI:10.1016/j.molcel.2021.04.012), and it is acutely upregulated during heat stress in human neuronal models (DOI:10.3390/biology12030416). The reported PSMD2/MYH9 axis in nasopharyngeal carcinoma is treated as a cancer-context client pathway rather than a core conserved molecular function. DNAJA4 is farnesylated at Cys-394, providing dual cytosol/membrane localization.</h3>
                 <span class="vote-buttons" data-g="Q8WW22" data-a="FUNCTION: DNAJA4 functions as a cytoplasmic class A HSP70 co..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -2937,472 +2937,484 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                 protein refolding
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034605" target="_blank" class="term-link">
                                 cellular response to heat
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
                                 membrane
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
-                                PMID:21231916
-                            </a>
-                            
+
+                            file:human/DNAJA4/DNAJA4-deep-research-falcon.md
+
                         </span>
-                        
-                        <div class="finding-text">assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment</div>
-                        
+
+                        <div class="finding-text">DNAJA4 is a class A HSP40/J-domain protein that helps recruit substrates to Hsp70 and stimulates the Hsp70 ATPase cycle to drive client binding and processing.</div>
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20651708" target="_blank" class="term-link">
                                 PMID:20651708
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">others bind client proteins directly, thereby delivering specific clients to HSP70 and directly determining their fate</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/DNAJA4/DNAJA4-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for DNAJA4</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20651708" target="_blank" class="term-link">
                             PMID:20651708
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The HSP70 chaperone machinery: J proteins as drivers of functional specificity.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                             PMID:21231916
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The diverse members of the mammalian HSP70 machine show distinct chaperone-like activities.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23142051" target="_blank" class="term-link">
                             PMID:23142051
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Convergent multi-miRNA targeting of ApoE drives LRP1/LRP8-dependent melanoma metastasis and angiogenesis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link">
                             PMID:25036637
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A quantitative chaperone interaction network reveals the architecture of cellular protein homeostasis pathways.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
                             PMID:40205054
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371422
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ATP hydrolysis by HSP70</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371503
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">STIP1(HOP) binds HSP90 and HSP70:HSP40:nascent protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371590
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP70 binds to HSP40:nascent protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1016/j.molcel.2021.04.012
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Comprehensive interactome profiling of the human Hsp70 network highlights functional differentiation of J domains.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">DNAJA4 is positioned in the densely connected cytoplasmic class A JDP core of the human Hsp70 network, with robust interactions with DNAJA1, DNAJA2, and DNAJB1.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.3390/biology12030416
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Profiling the Hsp70 chaperone network in heat-induced proteotoxic stress models of human neurons.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">DNAJA4 is among the chaperone/co-chaperone genes commonly upregulated across three neuronal models after heat stress (log2 fold-change 1.5-5 at 1 h post-heat shock).</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1038/s41419-023-06225-w
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">DNAJA4 suppresses epithelial-mesenchymal transition and metastasis in nasopharyngeal carcinoma via PSMD2-mediated MYH9 degradation.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">DNAJA4 promotes ubiquitin-proteasome-dependent degradation of MYH9 via PSMD2 recruitment, suppressing EMT and metastasis in NPC.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">DNAJA4 promoter hypermethylation and downregulation in NPC; DAC demethylation restores DNAJA4 levels at least 15-fold in NPC cell lines.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.3390/ijms222413527
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Regulation of p53 and cancer signaling by heat shock protein 40/J-domain protein family members.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">DNAJA4 can be epigenetically silenced in cancers; reduced DNAJA4 expression due to promoter methylation correlates with poorer disease-free survival in stomach adenocarcinoma, and hypermethylation is observed in rhabdomyosarcoma.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1098/rstb.2016.0534
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">DNAJ proteins in neurodegeneration - essential and protective factors.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Review situating DNAJA4 within the DNAJA subfamily with canonical class A JDP domain composition (J-domain, G/F region, Zn-binding region, and C-terminal client-binding/dimerization region).</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -3687,9 +3699,9 @@ this with annotations you find in gene/protein databases, but these can be outda
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -3701,7 +3713,7 @@ this with annotations you find in gene/protein databases, but these can be outda
                 <pre><code>id: Q8WW22
 gene_symbol: DNAJA4
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -3712,10 +3724,8 @@ description: &gt;-
   region, a cysteine-rich zinc finger domain (CR-type, with four CXXCXGXG repeats
   coordinating two zinc ions) involved in substrate recognition, two C-terminal
   beta-barrel substrate-binding domains (CTDI and CTDII), and a dimerization domain.
-  As a co-chaperone, DNAJA4 binds unfolded or misfolded client proteins and delivers
-  them to HSP70 (HSPA) partners for ATP-dependent protein folding. Hageman et al.
-  (2011) demonstrated that DNAJA4 supports luciferase refolding and suppresses polyQ
-  aggregation when co-expressed with HSP70 partners (PMID:21231916). Systematic
+  As a co-chaperone, DNAJA4 is expected to bind unfolded or misfolded client proteins
+  and deliver them to HSP70 (HSPA) partners for ATP-dependent client processing. Systematic
   interactome profiling of the human Hsp70 network (AP-MS and BioID) places DNAJA4
   in the densely connected cytoplasmic class A JDP core, with robust interactions
   with DNAJA1, DNAJA2, and DNAJB1 (DOI:10.1016/j.molcel.2021.04.012). DNAJA4 is
@@ -3723,11 +3733,10 @@ description: &gt;-
   participates in the HSP90 chaperone cycle for steroid hormone receptors via the
   HSP70-HSP40-HOP-HSP90 relay pathway. DNAJA4 is transcriptionally upregulated
   during heat stress in human neuronal models (log2 fold-change 1.5-5 at 1 h
-  post-heat shock; DOI:10.3390/biology12030416). Beyond generic chaperoning, DNAJA4
-  has a specific role in suppressing epithelial-mesenchymal transition (EMT) and
-  metastasis in nasopharyngeal carcinoma (NPC) by promoting PSMD2-mediated
-  ubiquitin-proteasome degradation of MYH9, an interaction requiring the DnaJ domain
-  (DOI:10.1038/s41419-023-06225-w). DNAJA4 promoter hypermethylation and silencing
+  post-heat shock; DOI:10.3390/biology12030416). In nasopharyngeal carcinoma,
+  DNAJA4 has a cancer-context role in suppressing epithelial-mesenchymal transition
+  (EMT) and metastasis by promoting PSMD2-mediated ubiquitin-proteasome degradation
+  of MYH9 (DOI:10.1038/s41419-023-06225-w). DNAJA4 promoter hypermethylation and silencing
   is observed in multiple cancers including NPC, stomach adenocarcinoma, and
   rhabdomyosarcoma (DOI:10.3390/ijms222413527).
 alternative_products:
@@ -3800,6 +3809,13 @@ existing_annotations:
         HSPA6 has a functional substrate-binding domain and possesses intrinsic
         ATPase activity that is as high as that of the canonical HSPA1A when
         stimulated by J-proteins
+    - reference_id: file:human/DNAJA4/DNAJA4-deep-research-falcon.md
+      supporting_text: &gt;-
+        DNAJA4 is a class A HSP40/J-domain protein (JDP). Class A JDPs are
+        characterized by the canonical domain architecture: an N-terminal J-domain
+        (containing the conserved HPD motif that stimulates Hsp70 ATPase activity),
+        a Gly/Phe-rich region, C-terminal substrate-binding beta-barrel domains,
+        a dimerization region, and a class-A-specific zinc-finger insertion.
 - term:
     id: GO:0034605
     label: cellular response to heat
@@ -4313,14 +4329,15 @@ existing_annotations:
       (UniProtKB:P17066). This annotation entry corresponds to the interaction
       with HSPA1A. DNAJA4 binds HSP70 chaperone partners through its J-domain,
       which is a core molecular function of all J-domain co-chaperones.
-      Hageman et al. systematically tested interactions between mammalian
-      HSP40 and HSP70 family members and found that DNAJA4 functionally
-      interacts with these HSP70 partners to support protein refolding.
-    action: ACCEPT
+      The cached PMID:21231916 text available in this repository is abstract-only
+      and provides class-level HSP70/HSP40 statements rather than DNAJA4-specific
+      interactor evidence.
+    action: UNDECIDED
     reason: &gt;-
-      Protein-folding chaperone binding is a core molecular function of DNAJA4.
-      The IPI evidence from Hageman et al. (2011) directly demonstrates physical
-      interaction between DNAJA4 and HSP70 family member HSPA1A.
+      Protein-folding chaperone binding is biologically plausible for DNAJA4, but this
+      source-specific IPI annotation cannot be verified from the accessible cached text.
+      The review should not treat PMID:21231916 as direct DNAJA4-specific support without
+      accessible source details.
     supported_by:
     - reference_id: PMID:21231916
       supporting_text: &gt;-
@@ -4393,14 +4410,13 @@ existing_annotations:
       IDA annotation for cytosol localization from Hageman et al. (2011).
       The study included subcellular localization analysis of mammalian HSP70
       and HSP40 family members, reporting that &#34;most of the corresponding
-      proteins are localized in the cytosol&#34; (PMID:21231916). This direct
-      experimental evidence confirms the cytosolic localization of DNAJA4,
-      consistent with its role as a cytosolic co-chaperone.
-    action: ACCEPT
+      proteins are localized in the cytosol&#34; (PMID:21231916). The cached source does
+      not provide DNAJA4-specific localization evidence beyond this class-level statement.
+    action: UNDECIDED
     reason: &gt;-
-      Direct experimental evidence (IDA) confirms cytosol localization.
-      This is the strongest evidence for DNAJA4&#39;s cytosolic localization
-      and is consistent with its function as a cytosolic HSP70 co-chaperone.
+      Cytosol localization is plausible and supported elsewhere in the review, but this
+      PMID:21231916-specific IDA cannot be confirmed from the accessible abstract-only
+      source. Mark as undecided rather than accepting an unsupported direct-evidence claim.
     supported_by:
     - reference_id: PMID:21231916
       supporting_text: &gt;-
@@ -4416,16 +4432,16 @@ existing_annotations:
       IDA annotation for membrane localization from Hageman et al. (2011).
       DNAJA4 is farnesylated at Cys-394 (S-farnesyl cysteine), which anchors
       it to cellular membranes. UniProt annotates the subcellular location
-      as &#34;Membrane; Lipid-anchor.&#34; Hageman et al. (2011) provided direct
-      assay evidence confirming membrane association (PMID:21231916). This
-      dual localization (cytosol and membrane) is distinctive for DNAJA4
+      as &#34;Membrane; Lipid-anchor.&#34; The cached PMID:21231916 text does not provide
+      DNAJA4-specific membrane-localization details. This dual localization
+      (cytosol and membrane) is distinctive for DNAJA4
       among DNAJA subfamily members and may reflect regulation of its
       availability for different substrates.
-    action: ACCEPT
+    action: UNDECIDED
     reason: &gt;-
-      Membrane localization is directly supported by IDA evidence and is
-      consistent with the farnesylation of DNAJA4 at Cys-394. This is a
-      distinctive and functionally relevant localization for this co-chaperone.
+      Membrane localization is consistent with DNAJA4 farnesylation and UniProt-style
+      localization summaries, but the PMID:21231916-specific IDA evidence is not
+      verifiable from the cached source text.
     supported_by:
     - reference_id: PMID:21231916
       supporting_text: &gt;-
@@ -4442,15 +4458,14 @@ existing_annotations:
       study directly demonstrated that overexpression of DNAJA4 with HSP70
       partners supports refolding of heat-denatured luciferase. The authors
       &#34;assessed the effect of overexpression of each of these HSPs on refolding
-      of heat-denatured luciferase&#34; (PMID:21231916). This is a core function
-      of J-domain co-chaperones that assist HSP70 in the ATP-dependent
-      protein refolding cycle.
-    action: ACCEPT
+      of heat-denatured luciferase&#34; (PMID:21231916). The cached source does not show
+      which HSP40/HSP70 combinations correspond to DNAJA4, so the DNAJA4-specific
+      direct evidence cannot be confirmed here.
+    action: UNDECIDED
     reason: &gt;-
-      Protein refolding is a core biological process for J-domain co-chaperones.
-      Hageman et al. (2011) directly demonstrated DNAJA4&#39;s ability to support
-      luciferase refolding with HSP70 partners. This IDA annotation represents
-      strong experimental evidence for a fundamental function.
+      Protein refolding is a plausible class A JDP function, but this source-specific
+      IDA annotation should not be accepted from an abstract-only cached source that
+      lacks DNAJA4-specific assay details.
     supported_by:
     - reference_id: PMID:21231916
       supporting_text: &gt;-
@@ -4475,22 +4490,14 @@ existing_annotations:
       polyQ (polyglutamine)-expanded Huntingtin fragment&#34; (PMID:21231916). The same
       paper provides evidence for DNAJA4 interacting with multiple HSP70 family members
       (HSPA1A/P0DMV8, HSPA1B/P0DMV9, HSPA6/P17066) as IPI evidence for GO:0051087
-      (protein-folding chaperone binding). The correct replacement term is GO:0044183
-      (protein folding chaperone), which captures the functional role of DNAJA4 as a
-      co-chaperone that binds client proteins and delivers them to HSP70 for
-      ATP-dependent refolding.
-    action: MODIFY
+      (protein-folding chaperone binding). The cached PMID:21231916 text does not make
+      the DNAJA4-specific client-binding evidence accessible.
+    action: UNDECIDED
     reason: &gt;-
-      GO:0051082 is being obsoleted. The experimental evidence from Hageman et al.
-      (2011) demonstrates that DNAJA4 functions as a protein folding chaperone --
-      it supports luciferase refolding and suppresses polyQ aggregation in cooperation
-      with HSP70 partners. This is consistent with the well-established role of class I
-      J-domain proteins as co-chaperones that bind unfolded substrates and deliver them
-      to HSP70. The replacement term GO:0044183 (protein folding chaperone) accurately
-      describes this molecular function.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+      GO:0051082 is being obsoleted, and GO:0044183 is the likely better term for a
+      class A JDP. However, the PMID:21231916-specific IDA evidence cannot be verified
+      from the accessible cached text, so this annotation remains undecided rather than
+      converted to an accepted replacement.
     additional_reference_ids:
     - PMID:20651708
     supported_by:
@@ -4519,19 +4526,14 @@ existing_annotations:
       aggregation of polyQ-expanded Huntingtin fragments, which form inclusion
       bodies. The authors specifically tested &#34;suppression of aggregation of a
       non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment&#34;
-      (PMID:21231916). This is a direct experimental observation and reflects
-      DNAJA4&#39;s anti-aggregation chaperone activity. However, it is worth noting
-      that this is a specific experimental readout rather than a primary evolved
-      function, as polyQ expansion is a pathological context. The ability to
-      suppress aggregation is a general property of chaperones that bind
-      misfolded substrates.
-    action: ACCEPT
+      (PMID:21231916). The cached source does not provide DNAJA4-specific data for this
+      assay, and this polyQ inclusion-body readout is a pathological model rather than
+      a primary conserved DNAJA4 function.
+    action: UNDECIDED
     reason: &gt;-
-      The IDA evidence directly demonstrates that DNAJA4 suppresses polyQ
-      inclusion body formation. While this is tested in a pathological context
-      (polyQ-expanded Huntingtin), it reflects the genuine anti-aggregation
-      chaperone activity of DNAJA4. Suppression of protein aggregation is a
-      core function of J-domain co-chaperones.
+      Without accessible DNAJA4-specific source text, the review should not accept this
+      IDA annotation as direct evidence. The term may reflect a real anti-aggregation
+      assay outcome, but the source support is not sufficient here.
     supported_by:
     - reference_id: PMID:21231916
       supporting_text: &gt;-
@@ -4539,6 +4541,9 @@ existing_annotations:
         heat-denatured luciferase and on the suppression of aggregation of a
         non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment
 references:
+- id: file:human/DNAJA4/DNAJA4-deep-research-falcon.md
+  title: Falcon deep research report for DNAJA4
+  findings: []
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
     terms
@@ -4638,15 +4643,13 @@ core_functions:
       that stimulates the ATPase activity of HSP70 family members via its conserved
       J-domain HPD motif, binds unfolded client proteins through its zinc finger
       cysteine-rich domain and C-terminal beta-barrel substrate-binding domains (CTDI
-      and CTDII), and delivers them to HSP70 for ATP-dependent refolding. It supports
-      refolding of heat-denatured substrates and suppresses protein aggregation
-      (PMID:21231916). Systematic Hsp70 network profiling places DNAJA4 in the densely
+      and CTDII), and delivers them to HSP70 for ATP-dependent client processing. Systematic
+      Hsp70 network profiling places DNAJA4 in the densely
       connected cytoplasmic JDP core (DOI:10.1016/j.molcel.2021.04.012), and it is
       acutely upregulated during heat stress in human neuronal models
-      (DOI:10.3390/biology12030416). DNAJA4 also has a specific role in promoting
-      PSMD2-mediated ubiquitin-proteasome degradation of MYH9, linking its co-chaperone
-      function to cytoskeletal remodeling and EMT suppression in NPC
-      (DOI:10.1038/s41419-023-06225-w). DNAJA4 is farnesylated at Cys-394, providing
+      (DOI:10.3390/biology12030416). The reported PSMD2/MYH9 axis in nasopharyngeal
+      carcinoma is treated as a cancer-context client pathway rather than a core
+      conserved molecular function. DNAJA4 is farnesylated at Cys-394, providing
       dual cytosol/membrane localization.
     molecular_function:
       id: GO:0044183
@@ -4662,11 +4665,11 @@ core_functions:
       - id: GO:0016020
         label: membrane
     supported_by:
-      - reference_id: PMID:21231916
+      - reference_id: file:human/DNAJA4/DNAJA4-deep-research-falcon.md
         supporting_text: &gt;-
-          assessed the effect of overexpression of each of these HSPs on refolding of
-          heat-denatured luciferase and on the suppression of aggregation of a
-          non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment
+          DNAJA4 is a class A HSP40/J-domain protein that helps recruit substrates to
+          Hsp70 and stimulates the Hsp70 ATPase cycle to drive client binding and
+          processing.
       - reference_id: PMID:20651708
         supporting_text: &gt;-
           others bind client proteins directly, thereby delivering specific clients to
@@ -4677,7 +4680,7 @@ core_functions:
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/DNAJA4/DNAJA4-ai-review.yaml
+++ b/genes/human/DNAJA4/DNAJA4-ai-review.yaml
@@ -1,7 +1,7 @@
 id: Q8WW22
 gene_symbol: DNAJA4
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -12,10 +12,8 @@ description: >-
   region, a cysteine-rich zinc finger domain (CR-type, with four CXXCXGXG repeats
   coordinating two zinc ions) involved in substrate recognition, two C-terminal
   beta-barrel substrate-binding domains (CTDI and CTDII), and a dimerization domain.
-  As a co-chaperone, DNAJA4 binds unfolded or misfolded client proteins and delivers
-  them to HSP70 (HSPA) partners for ATP-dependent protein folding. Hageman et al.
-  (2011) demonstrated that DNAJA4 supports luciferase refolding and suppresses polyQ
-  aggregation when co-expressed with HSP70 partners (PMID:21231916). Systematic
+  As a co-chaperone, DNAJA4 is expected to bind unfolded or misfolded client proteins
+  and deliver them to HSP70 (HSPA) partners for ATP-dependent client processing. Systematic
   interactome profiling of the human Hsp70 network (AP-MS and BioID) places DNAJA4
   in the densely connected cytoplasmic class A JDP core, with robust interactions
   with DNAJA1, DNAJA2, and DNAJB1 (DOI:10.1016/j.molcel.2021.04.012). DNAJA4 is
@@ -23,11 +21,10 @@ description: >-
   participates in the HSP90 chaperone cycle for steroid hormone receptors via the
   HSP70-HSP40-HOP-HSP90 relay pathway. DNAJA4 is transcriptionally upregulated
   during heat stress in human neuronal models (log2 fold-change 1.5-5 at 1 h
-  post-heat shock; DOI:10.3390/biology12030416). Beyond generic chaperoning, DNAJA4
-  has a specific role in suppressing epithelial-mesenchymal transition (EMT) and
-  metastasis in nasopharyngeal carcinoma (NPC) by promoting PSMD2-mediated
-  ubiquitin-proteasome degradation of MYH9, an interaction requiring the DnaJ domain
-  (DOI:10.1038/s41419-023-06225-w). DNAJA4 promoter hypermethylation and silencing
+  post-heat shock; DOI:10.3390/biology12030416). In nasopharyngeal carcinoma,
+  DNAJA4 has a cancer-context role in suppressing epithelial-mesenchymal transition
+  (EMT) and metastasis by promoting PSMD2-mediated ubiquitin-proteasome degradation
+  of MYH9 (DOI:10.1038/s41419-023-06225-w). DNAJA4 promoter hypermethylation and silencing
   is observed in multiple cancers including NPC, stomach adenocarcinoma, and
   rhabdomyosarcoma (DOI:10.3390/ijms222413527).
 alternative_products:
@@ -100,6 +97,13 @@ existing_annotations:
         HSPA6 has a functional substrate-binding domain and possesses intrinsic
         ATPase activity that is as high as that of the canonical HSPA1A when
         stimulated by J-proteins
+    - reference_id: file:human/DNAJA4/DNAJA4-deep-research-falcon.md
+      supporting_text: >-
+        DNAJA4 is a class A HSP40/J-domain protein (JDP). Class A JDPs are
+        characterized by the canonical domain architecture: an N-terminal J-domain
+        (containing the conserved HPD motif that stimulates Hsp70 ATPase activity),
+        a Gly/Phe-rich region, C-terminal substrate-binding beta-barrel domains,
+        a dimerization region, and a class-A-specific zinc-finger insertion.
 - term:
     id: GO:0034605
     label: cellular response to heat
@@ -613,14 +617,15 @@ existing_annotations:
       (UniProtKB:P17066). This annotation entry corresponds to the interaction
       with HSPA1A. DNAJA4 binds HSP70 chaperone partners through its J-domain,
       which is a core molecular function of all J-domain co-chaperones.
-      Hageman et al. systematically tested interactions between mammalian
-      HSP40 and HSP70 family members and found that DNAJA4 functionally
-      interacts with these HSP70 partners to support protein refolding.
-    action: ACCEPT
+      The cached PMID:21231916 text available in this repository is abstract-only
+      and provides class-level HSP70/HSP40 statements rather than DNAJA4-specific
+      interactor evidence.
+    action: UNDECIDED
     reason: >-
-      Protein-folding chaperone binding is a core molecular function of DNAJA4.
-      The IPI evidence from Hageman et al. (2011) directly demonstrates physical
-      interaction between DNAJA4 and HSP70 family member HSPA1A.
+      Protein-folding chaperone binding is biologically plausible for DNAJA4, but this
+      source-specific IPI annotation cannot be verified from the accessible cached text.
+      The review should not treat PMID:21231916 as direct DNAJA4-specific support without
+      accessible source details.
     supported_by:
     - reference_id: PMID:21231916
       supporting_text: >-
@@ -693,14 +698,13 @@ existing_annotations:
       IDA annotation for cytosol localization from Hageman et al. (2011).
       The study included subcellular localization analysis of mammalian HSP70
       and HSP40 family members, reporting that "most of the corresponding
-      proteins are localized in the cytosol" (PMID:21231916). This direct
-      experimental evidence confirms the cytosolic localization of DNAJA4,
-      consistent with its role as a cytosolic co-chaperone.
-    action: ACCEPT
+      proteins are localized in the cytosol" (PMID:21231916). The cached source does
+      not provide DNAJA4-specific localization evidence beyond this class-level statement.
+    action: UNDECIDED
     reason: >-
-      Direct experimental evidence (IDA) confirms cytosol localization.
-      This is the strongest evidence for DNAJA4's cytosolic localization
-      and is consistent with its function as a cytosolic HSP70 co-chaperone.
+      Cytosol localization is plausible and supported elsewhere in the review, but this
+      PMID:21231916-specific IDA cannot be confirmed from the accessible abstract-only
+      source. Mark as undecided rather than accepting an unsupported direct-evidence claim.
     supported_by:
     - reference_id: PMID:21231916
       supporting_text: >-
@@ -716,16 +720,16 @@ existing_annotations:
       IDA annotation for membrane localization from Hageman et al. (2011).
       DNAJA4 is farnesylated at Cys-394 (S-farnesyl cysteine), which anchors
       it to cellular membranes. UniProt annotates the subcellular location
-      as "Membrane; Lipid-anchor." Hageman et al. (2011) provided direct
-      assay evidence confirming membrane association (PMID:21231916). This
-      dual localization (cytosol and membrane) is distinctive for DNAJA4
+      as "Membrane; Lipid-anchor." The cached PMID:21231916 text does not provide
+      DNAJA4-specific membrane-localization details. This dual localization
+      (cytosol and membrane) is distinctive for DNAJA4
       among DNAJA subfamily members and may reflect regulation of its
       availability for different substrates.
-    action: ACCEPT
+    action: UNDECIDED
     reason: >-
-      Membrane localization is directly supported by IDA evidence and is
-      consistent with the farnesylation of DNAJA4 at Cys-394. This is a
-      distinctive and functionally relevant localization for this co-chaperone.
+      Membrane localization is consistent with DNAJA4 farnesylation and UniProt-style
+      localization summaries, but the PMID:21231916-specific IDA evidence is not
+      verifiable from the cached source text.
     supported_by:
     - reference_id: PMID:21231916
       supporting_text: >-
@@ -742,15 +746,14 @@ existing_annotations:
       study directly demonstrated that overexpression of DNAJA4 with HSP70
       partners supports refolding of heat-denatured luciferase. The authors
       "assessed the effect of overexpression of each of these HSPs on refolding
-      of heat-denatured luciferase" (PMID:21231916). This is a core function
-      of J-domain co-chaperones that assist HSP70 in the ATP-dependent
-      protein refolding cycle.
-    action: ACCEPT
+      of heat-denatured luciferase" (PMID:21231916). The cached source does not show
+      which HSP40/HSP70 combinations correspond to DNAJA4, so the DNAJA4-specific
+      direct evidence cannot be confirmed here.
+    action: UNDECIDED
     reason: >-
-      Protein refolding is a core biological process for J-domain co-chaperones.
-      Hageman et al. (2011) directly demonstrated DNAJA4's ability to support
-      luciferase refolding with HSP70 partners. This IDA annotation represents
-      strong experimental evidence for a fundamental function.
+      Protein refolding is a plausible class A JDP function, but this source-specific
+      IDA annotation should not be accepted from an abstract-only cached source that
+      lacks DNAJA4-specific assay details.
     supported_by:
     - reference_id: PMID:21231916
       supporting_text: >-
@@ -775,22 +778,14 @@ existing_annotations:
       polyQ (polyglutamine)-expanded Huntingtin fragment" (PMID:21231916). The same
       paper provides evidence for DNAJA4 interacting with multiple HSP70 family members
       (HSPA1A/P0DMV8, HSPA1B/P0DMV9, HSPA6/P17066) as IPI evidence for GO:0051087
-      (protein-folding chaperone binding). The correct replacement term is GO:0044183
-      (protein folding chaperone), which captures the functional role of DNAJA4 as a
-      co-chaperone that binds client proteins and delivers them to HSP70 for
-      ATP-dependent refolding.
-    action: MODIFY
+      (protein-folding chaperone binding). The cached PMID:21231916 text does not make
+      the DNAJA4-specific client-binding evidence accessible.
+    action: UNDECIDED
     reason: >-
-      GO:0051082 is being obsoleted. The experimental evidence from Hageman et al.
-      (2011) demonstrates that DNAJA4 functions as a protein folding chaperone --
-      it supports luciferase refolding and suppresses polyQ aggregation in cooperation
-      with HSP70 partners. This is consistent with the well-established role of class I
-      J-domain proteins as co-chaperones that bind unfolded substrates and deliver them
-      to HSP70. The replacement term GO:0044183 (protein folding chaperone) accurately
-      describes this molecular function.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+      GO:0051082 is being obsoleted, and GO:0044183 is the likely better term for a
+      class A JDP. However, the PMID:21231916-specific IDA evidence cannot be verified
+      from the accessible cached text, so this annotation remains undecided rather than
+      converted to an accepted replacement.
     additional_reference_ids:
     - PMID:20651708
     supported_by:
@@ -819,19 +814,14 @@ existing_annotations:
       aggregation of polyQ-expanded Huntingtin fragments, which form inclusion
       bodies. The authors specifically tested "suppression of aggregation of a
       non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment"
-      (PMID:21231916). This is a direct experimental observation and reflects
-      DNAJA4's anti-aggregation chaperone activity. However, it is worth noting
-      that this is a specific experimental readout rather than a primary evolved
-      function, as polyQ expansion is a pathological context. The ability to
-      suppress aggregation is a general property of chaperones that bind
-      misfolded substrates.
-    action: ACCEPT
+      (PMID:21231916). The cached source does not provide DNAJA4-specific data for this
+      assay, and this polyQ inclusion-body readout is a pathological model rather than
+      a primary conserved DNAJA4 function.
+    action: UNDECIDED
     reason: >-
-      The IDA evidence directly demonstrates that DNAJA4 suppresses polyQ
-      inclusion body formation. While this is tested in a pathological context
-      (polyQ-expanded Huntingtin), it reflects the genuine anti-aggregation
-      chaperone activity of DNAJA4. Suppression of protein aggregation is a
-      core function of J-domain co-chaperones.
+      Without accessible DNAJA4-specific source text, the review should not accept this
+      IDA annotation as direct evidence. The term may reflect a real anti-aggregation
+      assay outcome, but the source support is not sufficient here.
     supported_by:
     - reference_id: PMID:21231916
       supporting_text: >-
@@ -839,6 +829,9 @@ existing_annotations:
         heat-denatured luciferase and on the suppression of aggregation of a
         non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment
 references:
+- id: file:human/DNAJA4/DNAJA4-deep-research-falcon.md
+  title: Falcon deep research report for DNAJA4
+  findings: []
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
     terms
@@ -938,15 +931,13 @@ core_functions:
       that stimulates the ATPase activity of HSP70 family members via its conserved
       J-domain HPD motif, binds unfolded client proteins through its zinc finger
       cysteine-rich domain and C-terminal beta-barrel substrate-binding domains (CTDI
-      and CTDII), and delivers them to HSP70 for ATP-dependent refolding. It supports
-      refolding of heat-denatured substrates and suppresses protein aggregation
-      (PMID:21231916). Systematic Hsp70 network profiling places DNAJA4 in the densely
+      and CTDII), and delivers them to HSP70 for ATP-dependent client processing. Systematic
+      Hsp70 network profiling places DNAJA4 in the densely
       connected cytoplasmic JDP core (DOI:10.1016/j.molcel.2021.04.012), and it is
       acutely upregulated during heat stress in human neuronal models
-      (DOI:10.3390/biology12030416). DNAJA4 also has a specific role in promoting
-      PSMD2-mediated ubiquitin-proteasome degradation of MYH9, linking its co-chaperone
-      function to cytoskeletal remodeling and EMT suppression in NPC
-      (DOI:10.1038/s41419-023-06225-w). DNAJA4 is farnesylated at Cys-394, providing
+      (DOI:10.3390/biology12030416). The reported PSMD2/MYH9 axis in nasopharyngeal
+      carcinoma is treated as a cancer-context client pathway rather than a core
+      conserved molecular function. DNAJA4 is farnesylated at Cys-394, providing
       dual cytosol/membrane localization.
     molecular_function:
       id: GO:0044183
@@ -962,11 +953,11 @@ core_functions:
       - id: GO:0016020
         label: membrane
     supported_by:
-      - reference_id: PMID:21231916
+      - reference_id: file:human/DNAJA4/DNAJA4-deep-research-falcon.md
         supporting_text: >-
-          assessed the effect of overexpression of each of these HSPs on refolding of
-          heat-denatured luciferase and on the suppression of aggregation of a
-          non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment
+          DNAJA4 is a class A HSP40/J-domain protein that helps recruit substrates to
+          Hsp70 and stimulates the Hsp70 ATPase cycle to drive client binding and
+          processing.
       - reference_id: PMID:20651708
         supporting_text: >-
           others bind client proteins directly, thereby delivering specific clients to

--- a/genes/human/DNAJA4/DNAJA4-ai-review.yaml
+++ b/genes/human/DNAJA4/DNAJA4-ai-review.yaml
@@ -399,12 +399,13 @@ existing_annotations:
       evidence. As a J-domain co-chaperone, DNAJA4 binds HSP70 (and participates
       in the HSP90 chaperone cycle via HOP). This annotation is not incorrect but
       is less informative than the existing more specific annotations.
-    action: ACCEPT
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      Heat shock protein binding is a broad but correct annotation. DNAJA4 binds
-      HSP70 partners and participates in the HSP90 chaperone cycle. More specific
-      terms are already annotated (GO:0030544, GO:0051087), but this broader IEA
-      is acceptable.
+      Heat shock protein binding is correct for DNAJA4 as it binds HSP70
+      chaperones. The more specific GO:0030544 (Hsp70 protein binding) is also
+      annotated from IEA, and GO:0051087 captures the functional chaperone-binding
+      context. Retaining this broader parent term as accepted would obscure the
+      more informative Hsp70-specific and chaperone-binding annotations.
 - term:
     id: GO:0046872
     label: metal ion binding
@@ -417,11 +418,12 @@ existing_annotations:
       coordinating two zinc ions. The more specific term GO:0008270 (zinc ion
       binding) is already annotated with the same evidence type (IEA). This
       broader term is redundant but not incorrect.
-    action: ACCEPT
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
       Metal ion binding is correct but overly broad compared to the already
-      annotated GO:0008270 (zinc ion binding). As an IEA annotation it is
-      acceptable even though it provides less specificity.
+      annotated GO:0008270 (zinc ion binding). DNAJA4 specifically binds zinc
+      ions in its cysteine-rich domain, and the broader parent term adds no
+      additional information beyond the more specific zinc ion binding annotation.
 - term:
     id: GO:0051082
     label: unfolded protein binding

--- a/genes/human/DNAJB1/DNAJB1-ai-review.html
+++ b/genes/human/DNAJB1/DNAJB1-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>DNAJB1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P25685" target="_blank" class="term-link">
                         P25685
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>DNAJB1 (also known as HSP40, HDJ1) is a class II (class B) J-domain protein that functions as a co-chaperone for HSP70 family members. Its domain architecture comprises an N-terminal J-domain (with conserved HPD motif), a glycine/phenylalanine-rich (G/F) region, and C-terminal beta-sandwich client-binding domains (CTD-I and CTD-II) plus a dimerization domain; notably, class B JDPs lack the zinc-finger-like region present in class A members (DOI:10.1016/j.tcb.2022.05.004). DNAJB1 stimulates the ATPase activity of HSP70 and delivers substrates to the HSP70 chaperone machinery, promoting protein folding (foldase-type activity). A key regulatory mechanism is G/F-mediated autoinhibition of the J-domain, which is relieved by a secondary contact between the Hsp70 C-terminal EEVD motif and a positively charged groove in DNAJB1 CTD-I, enabling productive Hsp70 engagement (DOI:10.1016/j.tcb.2022.05.004). Beyond simple refolding, DNAJB1 participates in JDP scaffolding and hetero-oligomerization to create potent Hsp70-based disaggregases, remaining associated with aggregates to recruit multiple Hsp70 molecules (DOI:10.1016/j.tcb.2022.05.004). DNAJB1 also negatively regulates HSF1 transcriptional activity during the attenuation phase of the heat shock response by binding HSF1 in complex with HSP70. It can modulate the p53/MDM2 axis by binding and stabilizing MDM2 and destabilizing PDCD5, with context-dependent effects on p53 signaling (DOI:10.3390/ijms222413527). DNAJB1 is stress-inducible and translocates from the cytoplasm to the nucleus and nucleolus upon heat shock. Notably, the DNAJB1-PRKACA gene fusion drives fibrolamellar carcinoma and is a distinct chimeric oncoprotein that should not be conflated with wild-type DNAJB1 co-chaperone function.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,77 +795,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> DNAJB1 is a class II J-domain co-chaperone that promotes protein folding through the HSP70 chaperone machinery. Rauch and Gestwicki (PMID:24318877) showed that combinations of J proteins including DnaJB1 with NEFs and HSP70 produce potent chaperone activities in luciferase refolding assays. Hageman et al. (PMID:21231916) showed that DNAJB1 supports luciferase refolding when paired with HSP70, classifying it as a foldase-type co-chaperone. The IBA annotation for protein folding is well supported by phylogenetic inference and experimental data.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein folding is the core biological process of DNAJB1. As a class II J-domain co-chaperone, DNAJB1 delivers substrates to HSP70 and stimulates the ATPase-dependent folding cycle (PMID:24318877, PMID:21231916). This IBA annotation is consistent with extensive experimental evidence and phylogenetic conservation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24318877" target="_blank" class="term-link">
                                         PMID:24318877
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we combined the Hsp70-NEF pairs with cochaperones of the J protein family (DnaJA1, DnaJA2, DnaJB1, and DnaJB4) to generate 16 permutations. The activity of the combinations in ATPase and luciferase refolding assays were dependent on the identity and stoichiometry of both the J protein and NEF</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/DNAJB1/DNAJB1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">DNAJB1 stimulates the ATPase activity of HSP70 and delivers substrates to the HSP70 chaperone machinery, promoting protein folding (foldase-type activity).</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -877,64 +888,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> DNAJB1 is primarily a cytosolic protein. Hageman et al. (PMID:21231916) stated that most HSP70/HSPA and HSP40/DNAJ proteins are localized in the cytosol. UniProt confirms cytoplasmic localization. The IBA annotation for cytosol is well supported.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol is the primary localization of DNAJB1 under normal conditions, consistent with its role as a cytosolic co-chaperone for HSP70. Phylogenetic inference and direct experimental evidence (immunofluorescence, PMID:21231916) support this.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000122" target="_blank" class="term-link">
                                     GO:0000122
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of transcription by RNA polymerase II</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -946,64 +957,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> DNAJB1 negatively regulates HSF1-driven transcription during the attenuation phase of the heat shock response. Shi et al. (PMID:9499401) demonstrated that Hsp70 and the cochaperone Hdj1 (DNAJB1) interact directly with the transactivation domain of HSF1 and repress heat shock gene transcription. The IBA annotation is well supported.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While experimentally validated (PMID:9499401), negative regulation of transcription is not a core molecular function of DNAJB1 but rather a downstream consequence of its co-chaperone activity in the HSP70 complex. DNAJB1 represses HSF1 transcription as part of the heat shock attenuation mechanism, which is a secondary regulatory role. The IBA annotation is phylogenetically sound.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9499401" target="_blank" class="term-link">
                                         PMID:9499401
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the molecular chaperone Hsp70 and the cochaperone Hdj1 interact directly with the transactivation domain of HSF1 and repress heat shock gene transcription.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003714" target="_blank" class="term-link">
                                     GO:0003714
                                 </a>
                             </span>
                             <span class="term-label">transcription corepressor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1015,64 +1026,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Shi et al. (PMID:9499401) showed that overexpression of Hdj1 (DNAJB1) represses the transcriptional activity of HSF1, including a transfected GAL4-HSF1 activation domain fusion protein. This demonstrates transcription corepressor activity. The IBA annotation is phylogenetically consistent.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Transcription corepressor activity is a real but non-core function of DNAJB1. It acts as a corepressor specifically in the context of HSF1-mediated heat shock gene transcription, working together with HSP70 to repress the HSF1 transactivation domain (PMID:9499401). This is a secondary regulatory role dependent on its primary co-chaperone activity, not a general transcription corepressor function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9499401" target="_blank" class="term-link">
                                         PMID:9499401
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpression of either chaperone represses the transcriptional activity of a transfected GAL4-HSF1 activation domain fusion protein and endogenous HSF1.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030544" target="_blank" class="term-link">
                                     GO:0030544
                                 </a>
                             </span>
                             <span class="term-label">Hsp70 protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1084,46 +1095,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> DNAJB1 is a J-domain co-chaperone that physically binds HSP70 family members through its J-domain. UniProt records interactions with HSP70/HSPA1A (PMID:14503850) and this is a defining feature of all J-domain proteins. The IBA annotation accurately reflects the core molecular function of DNAJB1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSP70 binding via the J-domain is the core molecular function of DNAJB1 as a J-domain co-chaperone. This is the defining feature of the DnaJ family and is essential for DNAJB1&#39;s ability to stimulate HSP70 ATPase activity and deliver substrates. Phylogenetically well-conserved and experimentally validated.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1135,75 +1146,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962). DNAJB1 is a class II J-domain protein that functions as a foldase-type co-chaperone for HSP70, not as an independent holdase. Hageman et al. (PMID:21231916) showed that DNAJB1 promotes efficient luciferase refolding when paired with HSP70, placing it in the foldase category. UniProt describes DNAJB1 as stimulating ATP hydrolysis and the folding of unfolded proteins mediated by HSPA1A/B. The correct replacement term is GO:0044183 (protein folding chaperone), which accurately describes DNAJB1&#39;s role in binding to proteins to assist the protein folding process as part of the HSP70 chaperone machinery.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is scheduled for obsoletion. The obsolescence notice (go-ontology#30962) specifies that annotations should be migrated to either holdase chaperone activity or GO:0044183 (protein folding chaperone, i.e. foldase). DNAJB1 is definitively a foldase-type co-chaperone, not a holdase. Hageman et al. (PMID:21231916) demonstrated that chaperones supporting luciferase refolding (foldase activity) were poor suppressors of polyQ aggregation (holdase activity), and vice versa. DNAJB1 promotes refolding when paired with HSP70, classifying it as a foldase. This IBA annotation by phylogenetic inference correctly identified the general chaperone activity of DNAJB1, but the term needs updating to GO:0044183 to reflect the foldase function and the obsolescence of GO:0051082.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1215,46 +1226,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> DNAJB1 translocates from the cytoplasm to the nucleus upon heat shock. UniProt subcellular location annotation confirms nuclear localization under stress conditions, supported by Hattori et al. (PubMed:1586970). This IEA annotation from UniProtKB subcellular location vocabulary mapping is consistent with known biology.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear localization of DNAJB1 upon heat shock is well-documented. UniProt states that DNAJB1 translocates rapidly from the cytoplasm to the nucleus upon heat shock. The IEA mapping from UniProt subcellular location is appropriate.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005730" target="_blank" class="term-link">
                                     GO:0005730
                                 </a>
                             </span>
                             <span class="term-label">nucleolus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1266,46 +1277,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> DNAJB1 translocates to the nucleolus upon heat shock. UniProt subcellular location confirms nucleolar localization under stress, supported by Hattori et al. (PubMed:1586970). The IEA annotation is consistent with known stress-induced translocation behavior.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleolar localization of DNAJB1 upon heat shock is documented in UniProt based on Hattori et al. The IEA mapping from UniProt subcellular location vocabulary is appropriate. DNAJB1 translocates to the nucleolus under heat shock stress.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1317,46 +1328,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> DNAJB1 is primarily cytoplasmic under normal conditions. UniProt subcellular location lists cytoplasm as a primary location. This is broader than the cytosol annotation but acceptable as an IEA annotation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization of DNAJB1 is well-established. While the cytosol annotation is more specific, cytoplasm is a valid broader term from the UniProt mapping. Both are correct.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1368,46 +1379,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein folding is a core process for DNAJB1 as a J-domain co-chaperone. This IEA annotation from combined automated methods is consistent with the IBA annotation and experimental evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Redundant with the IBA annotation for the same term, but the IEA is independently valid. Protein folding is a core function of DNAJB1 through its HSP70 co-chaperone activity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006986" target="_blank" class="term-link">
                                     GO:0006986
                                 </a>
                             </span>
                             <span class="term-label">response to unfolded protein</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1419,46 +1430,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> DNAJB1 is a heat shock-inducible co-chaperone that participates in the cellular response to unfolded proteins. As a J-domain protein that delivers substrates to HSP70, it is involved in the response to unfolded protein. This IEA annotation from ARBA machine learning is reasonable.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> DNAJB1 is indeed involved in the response to unfolded protein as a heat shock-inducible J-domain co-chaperone. While the term is broad, it is appropriate for an IEA annotation. It is consistent with the TAS annotation for the same term (PMID:8975727).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1470,75 +1481,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962). This IEA annotation was inferred from the InterPro domain IPR008971 (HSP40/DnaJ peptide-binding domain) mapping to GO:0051082. While the DnaJ peptide-binding domain does indeed interact with substrates, the function of DNAJB1 is best described as protein folding chaperone activity (GO:0044183), as DNAJB1 acts as a foldase-type co-chaperone for HSP70. DNAJB1 does not independently hold unfolded proteins; it delivers substrates to HSP70 and stimulates the ATPase-dependent folding cycle.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is scheduled for obsoletion (go-ontology#30962). This IEA annotation derives from the InterPro domain mapping (IPR008971, HSP40/DnaJ peptide-binding domain). The InterPro2GO mapping will need to be updated when GO:0051082 is obsoleted. For DNAJB1 specifically, the correct replacement is GO:0044183 (protein folding chaperone), since DNAJB1 is a foldase-type J-domain protein that promotes protein refolding in concert with HSP70 (PMID:21231916).
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1550,57 +1561,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> DNAJB1 binds HSP70 family members (protein-folding chaperones) through its J-domain. This IEA annotation from ARBA machine learning is consistent with the known interaction between DNAJB1 and HSP70 chaperones (PMID:9499401, PMID:24318877).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> DNAJB1 is a co-chaperone that physically binds protein-folding chaperones (HSP70 family members). This IEA annotation is appropriate and consistent with the more specific Hsp70 protein binding annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17024176" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17024176
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A novel HSF1-mediated death pathway that is suppressed by he...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1612,75 +1623,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Hayashida et al. (PMID:17024176) studied a novel HSF1-mediated death pathway suppressed by heat shock proteins. The paper reports that Hsps bound directly to the N-terminal pleckstrin-homology like domain of Tdag51 and suppressed death activity. DNAJB1 binding was detected in this context.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative as a GO annotation. The interaction described in PMID:17024176 between HSPs and Tdag51 is tangential to DNAJB1 core function. More specific terms such as Hsp70 protein binding or protein-folding chaperone binding already capture the meaningful interactions of DNAJB1.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17024176" target="_blank" class="term-link">
                                         PMID:17024176
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Hsps bound directly to the N-terminal pleckstrin-homology like (PHL) domain of Tdag51, and suppressed death activity of the C-terminal proline/glutamine/histidine-rich domain.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21044950" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21044950
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Genome-wide YFP fluorescence complementation screen identifi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1692,57 +1703,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:21044950 is a genome-wide YFP fluorescence complementation screen for telomere signaling regulators. This is a large-scale screen and the protein binding annotation is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. This large-scale screen result does not provide specific functional insight into DNAJB1&#39;s molecular function. More informative MF terms such as Hsp70 protein binding already exist.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21163940" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21163940
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interactome mapping suggests new mechanistic details underly...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1754,57 +1765,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:21163940 is an interactome mapping study related to Alzheimer&#39;s disease. The protein binding annotation from this large-scale study is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. Large-scale interactome mapping does not provide specific functional insight for DNAJB1 curation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25036637
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A quantitative chaperone interaction network reveals the arc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1816,57 +1827,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:25036637 describes a quantitative chaperone interaction network. While relevant to understanding DNAJB1 as a chaperone, the protein binding annotation is uninformative. The interactions are better captured by Hsp70 protein binding and protein-folding chaperone binding terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. The chaperone interaction network data is better captured by the more specific Hsp70 protein binding and protein-folding chaperone binding annotations already present.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27173435" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27173435
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An organelle-specific protein landscape identifies novel dis...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1878,57 +1889,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:27173435 describes an organelle-specific protein landscape. The protein binding annotation is uninformative for DNAJB1 curation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. Large-scale proteomics does not provide specific functional insight for DNAJB1.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28514442
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Architecture of the human interactome defines protein commun...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1940,57 +1951,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:28514442 describes architecture of the human interactome. The protein binding annotation from this large-scale interactome study is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. Large-scale interactome mapping does not provide specific functional insight for DNAJB1.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32296183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A reference map of the human binary protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -2002,57 +2013,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:32296183 is a reference map of the human binary protein interactome. The protein binding annotation is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. Large-scale interactome mapping does not provide specific functional insight for DNAJB1.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32814053
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interactome Mapping Provides a Network of Neurodegenerative ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -2064,57 +2075,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:32814053 is an interactome mapping study of neurodegenerative disease proteins. The protein binding annotation is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. Interactome mapping for neurodegenerative disease does not provide specific functional insight for DNAJB1.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -2126,57 +2137,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:33961781 describes dual proteome-scale networks of the human interactome. The protein binding annotation is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. Large-scale interactome mapping does not provide specific functional insight for DNAJB1.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:35271311
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     OpenCell: Endogenous tagging for the cartography of human ce...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -2188,57 +2199,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:35271311 (OpenCell) is an endogenous tagging study for cellular organization cartography. The protein binding annotation is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. Large-scale cellular organization studies do not provide specific functional insight for DNAJB1.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/36931259" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:36931259
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A central chaperone-like role for 14-3-3 proteins in human c...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -2250,46 +2261,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:36931259 describes a chaperone-like role for 14-3-3 proteins. The protein binding annotation is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. The interaction with 14-3-3 proteins may be interesting but the generic protein binding term does not capture any specific functional relationship.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0014069" target="_blank" class="term-link">
                                     GO:0014069
                                 </a>
                             </span>
                             <span class="term-label">postsynaptic density</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2301,46 +2312,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation was transferred from an ortholog by Ensembl Compara. DNAJB1 is a ubiquitous co-chaperone without specific synaptic function. While chaperones may be present at the postsynaptic density for proteostasis, there is no evidence that postsynaptic density is a primary or functionally significant localization for DNAJB1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> DNAJB1 is a ubiquitously expressed co-chaperone. Its presence at the postsynaptic density likely reflects general proteostasis rather than a specific synaptic function. This ortholog transfer may over-annotate a non-specific localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030900" target="_blank" class="term-link">
                                     GO:0030900
                                 </a>
                             </span>
                             <span class="term-label">forebrain development</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2352,46 +2363,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation was transferred from an ortholog by Ensembl Compara. DNAJB1 is a ubiquitous co-chaperone, and there is no specific evidence linking it to forebrain development as a core function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> DNAJB1 is ubiquitously expressed and functions as a general co-chaperone for HSP70. Forebrain development likely reflects pleiotropic developmental consequences of general protein folding activity rather than a specific role for DNAJB1 in forebrain development. This is likely an over-annotation from ortholog transfer.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043025" target="_blank" class="term-link">
                                     GO:0043025
                                 </a>
                             </span>
                             <span class="term-label">neuronal cell body</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2403,46 +2414,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation was transferred from an ortholog by Ensembl Compara. DNAJB1 is a ubiquitous cytosolic co-chaperone. Its presence in neuronal cell bodies reflects general cytoplasmic/cytosolic localization rather than specific neuronal enrichment.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> DNAJB1 is ubiquitously expressed. Neuronal cell body localization likely reflects general cytosolic presence rather than specific neuronal targeting. This is an over-annotation from ortholog transfer.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043197" target="_blank" class="term-link">
                                     GO:0043197
                                 </a>
                             </span>
                             <span class="term-label">dendritic spine</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2454,46 +2465,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation was transferred from an ortholog by Ensembl Compara. DNAJB1 is a ubiquitous co-chaperone without known specific dendritic spine function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> DNAJB1 is a ubiquitous co-chaperone. Dendritic spine localization from ortholog transfer likely represents general proteostasis rather than specific synaptic function. This is an over-annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     GO:0044183
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2505,64 +2516,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> DNAJB1 functions as a protein folding chaperone (foldase-type) as part of the HSP70 machinery. Hageman et al. (PMID:21231916) demonstrated that DNAJB1 supports luciferase refolding when paired with HSP70. This IEA annotation from Ensembl Compara ortholog transfer is accurate.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein folding chaperone is the correct MF term for DNAJB1 as a foldase-type J-domain co-chaperone. This is consistent with the proposed replacement for the obsolete GO:0051082 annotations and accurately reflects DNAJB1 core function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061827" target="_blank" class="term-link">
                                     GO:0061827
                                 </a>
                             </span>
                             <span class="term-label">sperm head</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2574,46 +2585,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation was transferred from an ortholog by Ensembl Compara. While PMID:21630459 (HDA) independently identifies DNAJB1 in the sperm nucleus proteome, sperm head localization is likely a reflection of general chaperone presence rather than specific function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Sperm head localization is not a core annotation for DNAJB1 but is supported by independent proteomic evidence (PMID:21630459, HDA for nucleus). Chaperones are expected to be present in spermatozoa for proteostasis. Keep as non-core.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098794" target="_blank" class="term-link">
                                     GO:0098794
                                 </a>
                             </span>
                             <span class="term-label">postsynapse</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2625,46 +2636,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation was transferred from an ortholog by Ensembl Compara. DNAJB1 is a ubiquitous co-chaperone; postsynaptic localization is not specific to DNAJB1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> DNAJB1 is ubiquitously expressed. Postsynapse localization from ortholog transfer likely represents general proteostasis presence rather than specific synaptic function. Over-annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098978" target="_blank" class="term-link">
                                     GO:0098978
                                 </a>
                             </span>
                             <span class="term-label">glutamatergic synapse</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2676,46 +2687,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation was transferred from an ortholog by Ensembl Compara. DNAJB1 is a ubiquitous co-chaperone without known specific glutamatergic synapse function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> DNAJB1 is ubiquitously expressed. Glutamatergic synapse localization from ortholog transfer likely represents general proteostasis rather than specific synaptic function. Over-annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2727,46 +2738,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> DNAJB1 is detected in the nucleoplasm by HPA immunofluorescence (GO_REF:0000052). This is consistent with the known translocation of DNAJB1 to the nucleus upon heat shock (UniProt) and its role in HSF1 regulation in the nucleus (PMID:9499401).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization is consistent with DNAJB1&#39;s known nuclear translocation under stress and its role in repressing HSF1 transcriptional activity in the nucleus. HPA immunofluorescence data provides direct evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2778,46 +2789,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> DNAJB1 is detected in the cytosol by HPA immunofluorescence (GO_REF:0000052). Consistent with its primary cytosolic localization and role as a cytosolic co-chaperone for HSP70.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol is the primary localization of DNAJB1 under normal conditions. HPA immunofluorescence confirms this well-established localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1900034" target="_blank" class="term-link">
                                     GO:1900034
                                 </a>
                             </span>
                             <span class="term-label">regulation of cellular response to heat</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371453
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2829,199 +2840,199 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Reactome R-HSA-3371453 models the regulation of HSF1-mediated heat shock response. DNAJB1 participates in this pathway by repressing HSF1 transcriptional activity together with HSP70 during the attenuation phase (PMID:9499401).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> DNAJB1 is a key regulator of the cellular response to heat. It participates in the attenuation of the HSF1-mediated heat shock response by binding HSF1 with HSP70 and repressing transcription (PMID:9499401, Reactome:R-HSA-5082384). This is a well- supported annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
                                     GO:0001671
                                 </a>
                             </span>
                             <span class="term-label">ATPase activator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23921388
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of a novel human methylt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="P25685" data-a="GO:0001671" data-r="PMID:23921388" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P25685" data-a="GO:0001671" data-r="PMID:23921388" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Jakobsson et al. (PMID:23921388) characterized METTL21A methyltransferase and its effects on HSP70. The paper mentions that J-proteins stimulate intrinsic ATPase activity of HSP70s, consistent with DNAJB1 function. However, this paper primarily studies METTL21A, not DNAJB1 directly.
+                            <strong>Summary:</strong> Jakobsson et al. (PMID:23921388) characterized METTL21A methyltransferase and its effects on HSP70. The paper mentions that J-proteins stimulate intrinsic ATPase activity of HSP70s, but this paper primarily studies METTL21A rather than DNAJB1 directly.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> ATPase activator activity is a core molecular function of DNAJB1. As a J-domain co-chaperone, DNAJB1 stimulates the intrinsic ATPase activity of HSP70 family members. While PMID:23921388 focuses on METTL21A, DNAJB1 ATPase activation is extensively documented (PMID:24318877, Reactome:R-HSA-5251959). Multiple independent lines of evidence support this annotation.
+                            <strong>Reason:</strong> ATPase activator activity is a core molecular function of DNAJB1. As a J-domain co-chaperone, DNAJB1 stimulates the intrinsic ATPase activity of HSP70 family members. However, PMID:23921388 is a METTL21A/HSP70 methylation paper and the cached text does not provide DNAJB1-specific direct evidence for this annotation. Direct support is captured separately from PMID:24318877 and Reactome.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link">
                                         PMID:23921388
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Hsp70 proteins constitute an evolutionarily conserved protein family of ATP-dependent molecular chaperones involved in a wide range of biological processes.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1903334" target="_blank" class="term-link">
                                     GO:1903334
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23921388
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of a novel human methylt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="P25685" data-a="GO:1903334" data-r="PMID:23921388" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P25685" data-a="GO:1903334" data-r="PMID:23921388" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Jakobsson et al. (PMID:23921388) studied methylation effects on HSP70 chaperone function. DNAJB1 positively regulates protein folding by stimulating HSP70 ATPase activity and promoting the HSP70 folding cycle. This is consistent with DNAJB1&#39;s well-established foldase co-chaperone role.
+                            <strong>Summary:</strong> Jakobsson et al. (PMID:23921388) studied methylation effects on HSP70 chaperone function. DNAJB1 positively regulates protein folding through its HSP70 co-chaperone role, but this source does not directly establish that activity for DNAJB1.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Positive regulation of protein folding accurately describes DNAJB1&#39;s role as a co-chaperone that stimulates HSP70-mediated folding. This is a core function.
+                            <strong>Reason:</strong> Positive regulation of protein folding is a sound DNAJB1 function, but PMID:23921388 is not usable as direct DNAJB1-specific evidence from the cached source. Keep the source-specific annotation undecided.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000122" target="_blank" class="term-link">
                                     GO:0000122
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of transcription by RNA polymerase II</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9499401" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9499401
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular chaperones as HSF1-specific transcriptional repres...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3033,75 +3044,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Shi et al. (PMID:9499401) directly demonstrated that Hdj1 (DNAJB1) interacts with the transactivation domain of HSF1 and represses heat shock gene transcription. Overexpression of DNAJB1 represses HSF1-driven transcription.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Directly demonstrated by Shi et al. (PMID:9499401) using overexpression of Hdj1 repressing GAL4-HSF1 activation domain fusion and endogenous HSF1. While experimentally valid, this transcriptional repression is specific to the heat shock attenuation context and is a secondary consequence of co-chaperone activity, not a core function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9499401" target="_blank" class="term-link">
                                         PMID:9499401
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpression of either chaperone represses the transcriptional activity of a transfected GAL4-HSF1 activation domain fusion protein and endogenous HSF1.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034605" target="_blank" class="term-link">
                                     GO:0034605
                                 </a>
                             </span>
                             <span class="term-label">cellular response to heat</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9499401" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9499401
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular chaperones as HSF1-specific transcriptional repres...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3113,75 +3124,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Shi et al. (PMID:9499401) demonstrated that DNAJB1 (Hdj1) participates in the cellular response to heat by interacting with HSF1 during the attenuation phase of the heat shock response. The heat shock response involves DNAJB1 acting with HSP70 to repress HSF1 transcriptional activity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> DNAJB1 is heat shock-inducible and plays a direct role in the cellular response to heat by participating in the attenuation of HSF1-mediated transcription (PMID:9499401). This is well-supported by direct experimental evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9499401" target="_blank" class="term-link">
                                         PMID:9499401
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the molecular chaperone Hsp70 and the cochaperone Hdj1 interact directly with the transactivation domain of HSF1 and repress heat shock gene transcription.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140416" target="_blank" class="term-link">
                                     GO:0140416
                                 </a>
                             </span>
                             <span class="term-label">transcription regulator inhibitor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9499401" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9499401
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular chaperones as HSF1-specific transcriptional repres...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3193,64 +3204,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Shi et al. (PMID:9499401) showed that DNAJB1 (Hdj1) directly inhibits HSF1 transcriptional activity by binding to the HSF1 transactivation domain. This constitutes transcription regulator inhibitor activity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> DNAJB1 inhibits HSF1 transcriptional activity during heat shock attenuation (PMID:9499401). While the annotation is accurate, this is not a core molecular function of DNAJB1 but rather a specialized regulatory activity in the HSF1 heat shock response pathway. Its primary role is as a co-chaperone for HSP70.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9499401" target="_blank" class="term-link">
                                         PMID:9499401
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the molecular chaperone Hsp70 and the cochaperone Hdj1 interact directly with the transactivation domain of HSF1 and repress heat shock gene transcription.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
                                     GO:0001671
                                 </a>
                             </span>
                             <span class="term-label">ATPase activator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5251955
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3262,46 +3273,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Reactome R-HSA-5251955 models HSP40s activating intrinsic ATPase activity of HSP70s in the nucleoplasm. DNAJB1 translocates to the nucleus under heat shock and activates HSP70 ATPase activity there.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATPase activator activity is a core molecular function of DNAJB1. The Reactome annotation for nucleoplasmic ATPase activation is consistent with DNAJB1&#39;s known nuclear translocation under heat shock and its ability to stimulate HSP70 ATPase.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
                                     GO:0001671
                                 </a>
                             </span>
                             <span class="term-label">ATPase activator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5251959
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3313,57 +3324,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Reactome R-HSA-5251959 models HSP40s activating intrinsic ATPase activity of HSP70s in the cytosol. DNAJB1 is explicitly listed as one of the HSP40s that modulates intrinsic ATPase activity of HSP70s.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATPase activator activity in the cytosol is a core function of DNAJB1. The Reactome pathway explicitly lists DNAJB1 as an HSP40 that activates HSP70 ATPase activity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045296" target="_blank" class="term-link">
                                     GO:0045296
                                 </a>
                             </span>
                             <span class="term-label">cadherin binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25468996" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25468996
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     E-cadherin interactome complexity and robustness resolved by...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -3375,57 +3386,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:25468996 describes an E-cadherin interactome study using quantitative proteomics. DNAJB1 was identified in the cadherin interactome by high-throughput proteomics. This is likely a non-specific interaction due to DNAJB1&#39;s general chaperone activity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cadherin binding is not a known or expected function of DNAJB1. As a general co-chaperone, DNAJB1 may associate with many cellular protein complexes for proteostasis without specific binding activity. The HDA evidence from a proteomics screen is not sufficient to establish specific cadherin binding as a function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3437,75 +3448,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Hageman et al. (PMID:21231916) systematically assessed functional differences among HSP70/HSPA and HSP40/DNAJ family members. DNAJB1 was shown to interact with and modulate HSP70 chaperone activity, directly demonstrating protein-folding chaperone binding.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> DNAJB1 binds HSP70 chaperones through its J-domain, which is central to its function. PMID:21231916 provides direct evidence of functional DNAJB1-HSP70 interaction in luciferase refolding and polyQ aggregation assays.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol. To test for possible functional differences and/or substrate specificity, we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
                                     GO:0001671
                                 </a>
                             </span>
                             <span class="term-label">ATPase activator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24318877" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24318877
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Binding of human nucleotide exchange factors to heat shock p...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3517,75 +3528,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Rauch and Gestwicki (PMID:24318877) combined Hsp70-NEF pairs with J proteins including DnaJB1 and measured ATPase and luciferase refolding activities. DNAJB1 was directly shown to stimulate HSP70 ATPase activity in these in vitro assays.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATPase activator activity is a core molecular function of DNAJB1. PMID:24318877 provides direct biochemical evidence of DNAJB1 stimulating HSP70 ATPase activity in vitro.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24318877" target="_blank" class="term-link">
                                         PMID:24318877
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we combined the Hsp70-NEF pairs with cochaperones of the J protein family (DnaJA1, DnaJA2, DnaJB1, and DnaJB4) to generate 16 permutations. The activity of the combinations in ATPase and luciferase refolding assays were dependent on the identity and stoichiometry of both the J protein and NEF</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003714" target="_blank" class="term-link">
                                     GO:0003714
                                 </a>
                             </span>
                             <span class="term-label">transcription corepressor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9499401" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9499401
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular chaperones as HSF1-specific transcriptional repres...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3597,75 +3608,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Shi et al. (PMID:9499401) demonstrated that Hdj1 (DNAJB1) represses HSF1 transcriptional activity. Overexpression of DNAJB1 represses both GAL4-HSF1 fusion and endogenous HSF1, functioning as a transcription corepressor in the heat shock response context.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The IDA evidence from PMID:9499401 directly demonstrates corepressor activity on HSF1. This is a duplicate of the IBA annotation for the same term, both supported by the same mechanism. Keep as non-core since transcription corepression is secondary to the primary co-chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9499401" target="_blank" class="term-link">
                                         PMID:9499401
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpression of either chaperone represses the transcriptional activity of a transfected GAL4-HSF1 activation domain fusion protein and endogenous HSF1.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9499401" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9499401
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular chaperones as HSF1-specific transcriptional repres...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -3677,57 +3688,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Shi et al. (PMID:9499401) showed that Hdj1 (DNAJB1) interacts directly with the transactivation domain of HSF1. This interaction is real but better described by more specific terms (transcription regulator inhibitor activity, protein-folding chaperone binding).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. The specific interaction with HSF1 described in PMID:9499401 is already captured by the transcription regulator inhibitor activity and transcription corepressor activity annotations. The generic protein binding term adds no additional information.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27120771" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27120771
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Polyhydramnios, Transient Antenatal Bartter&#39;s Syndrome, and ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -3739,57 +3750,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:27120771 concerns MAGED2 mutations and Bartter&#39;s syndrome. The paper mentions interaction with a cytoplasmic heat-shock protein but DNAJB1 is not the focus. This protein binding annotation is tangential to DNAJB1 function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. PMID:27120771 is primarily about MAGED2 and Bartter&#39;s syndrome. Any interaction with DNAJB1 described here is tangential and the generic protein binding term adds no useful information about DNAJB1 function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25468996" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25468996
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     E-cadherin interactome complexity and robustness resolved by...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3801,268 +3812,268 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:25468996 is an E-cadherin interactome study. DNAJB1 being detected in the cytoplasm is consistent with its known primary cytoplasmic localization. However, the IDA evidence code from a proteomics study is appropriate.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization of DNAJB1 is well-established and consistent with UniProt subcellular location data. Acceptable as independent confirmation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
                                     GO:0001671
                                 </a>
                             </span>
                             <span class="term-label">ATPase activator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20060297" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20060297
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Chaperone-assisted selective autophagy is essential for musc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="P25685" data-a="GO:0001671" data-r="PMID:20060297" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P25685" data-a="GO:0001671" data-r="PMID:20060297" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Arndt et al. (PMID:20060297) described chaperone-assisted selective autophagy (CASA) for muscle maintenance. The paper focuses on BAG-3 coordinating Hsc70 and HspB8 during degradation of damaged Z disk components. DNAJB1 ATPase activator activity may be referenced in the context of the HSP70 chaperone cycle but this paper primarily studies the BAG3/CASA pathway.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> ATPase activator activity is a core function of DNAJB1. While PMID:20060297 focuses on CASA, DNAJB1&#39;s role in activating HSP70 ATPase is well-established across multiple independent studies (PMID:24318877, PMID:23921388, Reactome). The annotation is valid regardless of the specific reference context.
+                            <strong>Reason:</strong> ATPase activator activity is a core function of DNAJB1. While PMID:20060297 focuses on CASA, the cached text does not provide DNAJB1-specific ATPase activation evidence. Direct support is already represented by PMID:24318877 and Reactome, so this particular IDA annotation should not be accepted on the basis of a mismatched source.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20060297" target="_blank" class="term-link">
                                         PMID:20060297
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Stv and its mammalian ortholog BAG-3 coordinate the activity of Hsc70 and the small heat shock protein HspB8 during disposal that is initiated by the chaperone-associated ubiquitin ligase CHIP and the autophagic ubiquitin adaptor p62.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030544" target="_blank" class="term-link">
                                     GO:0030544
                                 </a>
                             </span>
                             <span class="term-label">Hsp70 protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23921388
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of a novel human methylt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="P25685" data-a="GO:0030544" data-r="PMID:23921388" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P25685" data-a="GO:0030544" data-r="PMID:23921388" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Jakobsson et al. (PMID:23921388) studied METTL21A methyltransferase effects on HSP70. The study demonstrates DNAJB1 interaction with HSP70 family members in the context of methylation modulation of chaperone function. HSP70 binding is a core interaction for DNAJB1.
+                            <strong>Summary:</strong> Jakobsson et al. (PMID:23921388) studied METTL21A methyltransferase effects on HSP70. HSP70 binding is a core interaction for DNAJB1, but this source focuses on METTL21A and does not provide accessible DNAJB1-specific interaction evidence in the cached text.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Hsp70 protein binding is a core molecular function of DNAJB1 as a J-domain co-chaperone. The J-domain of DNAJB1 directly binds HSP70 to stimulate ATPase activity. This annotation is well-supported by multiple studies.
+                            <strong>Reason:</strong> Hsp70 protein binding is a core molecular function of DNAJB1 as a J-domain co-chaperone. The J-domain of DNAJB1 directly binds HSP70 to stimulate ATPase activity, but PMID:23921388 is not the supporting source to establish that specific DNAJB1 interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link">
                                         PMID:23921388
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Hsp70 proteins constitute an evolutionarily conserved protein family of ATP-dependent molecular chaperones involved in a wide range of biological processes.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051117" target="_blank" class="term-link">
                                     GO:0051117
                                 </a>
                             </span>
                             <span class="term-label">ATPase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23921388
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of a novel human methylt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="P25685" data-a="GO:0051117" data-r="PMID:23921388" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P25685" data-a="GO:0051117" data-r="PMID:23921388" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> DNAJB1 binds to the ATPase domain of HSP70 through its J-domain. Jakobsson et al. (PMID:23921388) provide context for this interaction in the study of METTL21A methylation effects on HSP70 function. ATPase binding is consistent with DNAJB1&#39;s mechanism of action.
+                            <strong>Summary:</strong> DNAJB1 binds to the ATPase domain of HSP70 through its J-domain. Jakobsson et al. ATPase binding is consistent with DNAJB1&#39;s mechanism of action, but PMID:23921388 provides METTL21A/HSP70 methylation context rather than direct DNAJB1 ATPase-domain binding evidence.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> ATPase binding accurately describes DNAJB1&#39;s interaction with the ATPase domain of HSP70 via its J-domain. This is central to DNAJB1&#39;s mechanism of stimulating HSP70 ATPase activity.
+                            <strong>Reason:</strong> ATPase binding accurately describes DNAJB1&#39;s interaction with the ATPase domain of HSP70 via its J-domain. The action is undecided for this source-specific IPI because the cached PMID:23921388 evidence does not establish the interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5690250
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4074,57 +4085,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Reactome R-HSA-5690250 describes phosphorylation of DNAJB1 by MAPKAPK5 in the cytosol. Cytosolic localization of DNAJB1 is well-established and this Reactome annotation is consistent.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol is the primary localization of DNAJB1. The Reactome pathway for MAPKAPK5 phosphorylation of DNAJB1 correctly places this event in the cytosol.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23921388
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of a novel human methylt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4136,57 +4147,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> PMID:23921388 studies METTL21A methyltransferase and its effects on HSP70. The protein binding annotation is uninformative when more specific terms (Hsp70 protein binding, ATPase binding) are already present.
+                            <strong>Summary:</strong> PMID:23921388 studies METTL21A methyltransferase and its effects on HSP70. The protein binding annotation is uninformative, and the cached source does not provide DNAJB1-specific interaction evidence.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Protein binding is uninformative. The specific interactions described are already captured by Hsp70 protein binding and ATPase binding annotations from the same publication.
+                            <strong>Reason:</strong> Protein binding is too generic for curation. PMID:23921388 is a METTL21A/HSP70 methylation paper rather than a source establishing a specific DNAJB1 interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4198,75 +4209,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Hageman et al. (PMID:21231916) noted that most HSP70/HSPA and HSP40/DNAJ proteins are localized in the cytosol. This directly supports cytosolic localization of DNAJB1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosolic localization is directly stated in PMID:21231916. This is consistent with other evidence for DNAJB1 as a primarily cytosolic co-chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -4278,99 +4289,99 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962). This IDA annotation from Hageman et al. (PMID:21231916) demonstrated that DNAJB1 interacts with unfolded/denatured substrates in the context of the HSP70 chaperone machinery. The study assessed effects of overexpression of HSP70/HSPA and HSP40/DNAJ family members on refolding of heat-denatured luciferase and suppression of polyQ aggregation. DNAJB1 promoted efficient luciferase refolding when paired with HSP70, classifying it as a foldase-type co-chaperone. Unlike DNAJB6 and DNAJB8, which have independent holdase/anti-aggregation activity, DNAJB1 primarily functions by delivering substrates to HSP70 and stimulating HSP70 ATPase activity for the protein folding cycle. UniProt confirms that DNAJB1 stimulates ATP hydrolysis and the folding of unfolded proteins mediated by HSPA1A/B in vitro (PMID:24318877). The appropriate replacement is GO:0044183 (protein folding chaperone), which accurately captures DNAJB1&#39;s role in binding proteins to assist folding as part of the HSP70 machine.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is scheduled for obsoletion (go-ontology#30962), with the recommended replacement being GO:0044183 (protein folding chaperone) for foldase-type chaperones or holdase chaperone activity for holdases. Hageman et al. (PMID:21231916) is the key reference for this IDA annotation. The paper showed that DNAJB1 belongs to the foldase class of J-domain co-chaperones: it promotes luciferase refolding when combined with HSP70 but is a poor suppressor of polyQ aggregation. This functional classification is consistent with DNAJB1&#39;s known mechanism as a class II J-domain protein that stimulates HSP70 ATPase activity and delivers substrates to the HSP70 folding machinery. Additionally, DNAJB1 is a component of the Hsp70 disaggregation machinery, working with Hsp70 and HSPA4 to disassemble protein aggregates in an ATP-dependent process. The correct replacement term is GO:0044183 (protein folding chaperone), defined as binding to a protein or protein-containing complex to assist the protein folding process.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol. To test for possible functional differences and/or substrate specificity, we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090084" target="_blank" class="term-link">
                                     GO:0090084
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of inclusion body assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4382,75 +4393,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Hageman et al. (PMID:21231916) showed that DNAJB1 overexpression suppresses polyQ aggregation (inclusion body assembly), though it was a poor suppressor compared to holdase-type chaperones like DNAJB6 and DNAJB8. The paper states that chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation, and DNAJB1 falls into the foldase category.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> DNAJB1 can negatively regulate inclusion body assembly but is not primarily an anti-aggregation chaperone. Hageman et al. (PMID:21231916) showed that foldase-type chaperones like DNAJB1 are poor suppressors of polyQ aggregation compared to holdases like DNAJB6/DNAJB8. The annotation is valid but represents a minor aspect of DNAJB1 function. Keep as non-core.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21630459
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomic characterization of the human sperm nucleus.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4462,46 +4473,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:21630459 is a proteomic characterization of the human sperm nucleus. DNAJB1 was identified in the sperm nuclear proteome by mass spectrometry. This is consistent with known nuclear localization of DNAJB1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear localization of DNAJB1 is well-established from UniProt (stress-induced translocation) and HPA immunofluorescence. Detection in the sperm nucleus proteome by mass spectrometry provides additional supporting evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371467
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4513,46 +4524,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Reactome R-HSA-3371467 models SIRT1 deacetylation of HSF1. DNAJB1 is included in this pathway as part of the HSF1 regulatory complex in the nucleoplasm.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization is consistent with DNAJB1&#39;s role in HSF1 regulation in the nucleus during heat shock attenuation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371518
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4564,46 +4575,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Reactome R-HSA-3371518 models SIRT1 binding to HSF1. DNAJB1 participates in the nucleoplasmic HSF1 regulatory complex.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization during heat shock response regulation is consistent with DNAJB1&#39;s known stress-induced nuclear translocation and HSF1 binding activity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371554
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4615,46 +4626,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Reactome R-HSA-3371554 models HSF1 acetylation at Lys80. DNAJB1 participates in this HSF1 regulatory pathway in the nucleoplasm.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> DNAJB1 is part of the HSF1 regulatory complex in the nucleoplasm during heat shock attenuation. Consistent with known biology.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5082356
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4666,46 +4677,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Reactome R-HSA-5082356 models HSF1-mediated gene expression. DNAJB1 is placed in the nucleoplasm as part of the HSF1 attenuation mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> DNAJB1 localizes to the nucleoplasm during the heat shock response to participate in HSF1 regulation. Consistent with UniProt and PMID:9499401.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5082369
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4717,46 +4728,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Reactome R-HSA-5082369 models acetylated HSF1 dissociation from DNA. DNAJB1 is part of the HSF1 attenuation complex in the nucleoplasm.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> DNAJB1 nucleoplasm localization is consistent with its role in HSF1 regulation during heat shock attenuation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5082384
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4768,46 +4779,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Reactome R-HSA-5082384 specifically models HSP70:DNAJB1 binding HSF1 in the nucleoplasm. Shi et al. (PMID:9499401) showed that Hsp70 and Hdj1 interact with the HSF1 activation domain and repress transcription.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This Reactome entry directly models the DNAJB1-HSP70-HSF1 interaction in the nucleoplasm, which is a well-characterized mechanism of heat shock attenuation (PMID:9499401).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5251955
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4819,57 +4830,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Reactome R-HSA-5251955 models HSP40s activating HSP70 ATPase activity in the nucleoplasm. DNAJB1 is explicitly listed as one of the HSP40s that stimulates HSP70 ATPase activity in this compartment.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization is consistent with DNAJB1&#39;s nuclear translocation under heat shock and its ATPase activator function in the nucleoplasm.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
                                     GO:0070062
                                 </a>
                             </span>
                             <span class="term-label">extracellular exosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19056867
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Large-scale proteomics and phosphoproteomics of urinary exos...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4881,46 +4892,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:19056867 is a large-scale proteomics study of urinary exosomes. Detection of DNAJB1 in exosomes by mass spectrometry may represent passive inclusion rather than specific exosomal targeting.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Detection in extracellular exosomes by proteomics (PMID:19056867) is valid but represents a non-specific finding. Many cytosolic proteins are found in exosomes without specific functional significance. Keep as non-core.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5251959
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4932,46 +4943,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Reactome R-HSA-5251959 models HSP40s activating HSP70 ATPase activity in the cytosol. DNAJB1 is one of the HSP40s that activates HSP70 ATPase in the cytosol.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol is the primary location of DNAJB1. The Reactome pathway correctly places DNAJB1 ATPase activator function in the cytosol.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5690245
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4983,137 +4994,137 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Reactome R-HSA-5690245 models the binding of phosphorylated MAPKAPK5 to DNAJB1 in the cytosol. Cytosolic localization is consistent with known DNAJB1 biology.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization is consistent with DNAJB1 primary localization. The Reactome pathway for MAPKAPK5 binding to DNAJB1 correctly places this interaction in the cytosol.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18620420" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18620420
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Role of the cochaperone Tpr2 in Hsp90 chaperoning.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="P25685" data-a="GO:0006457" data-r="PMID:18620420" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P25685" data-a="GO:0006457" data-r="PMID:18620420" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Moffatt et al. (PMID:18620420) studied the role of the cochaperone Tpr2 in Hsp90 chaperoning. The paper mentions that Tpr2 replaced type I and II J proteins (including DNAJB1-type) in Hsp90-dependent chaperoning. DNAJB1 participation in protein folding through the Hsp90 chaperone cycle is consistent with its co-chaperone function.
+                            <strong>Summary:</strong> Moffatt et al. (PMID:18620420) studied the role of the cochaperone Tpr2 in Hsp90 chaperoning. The paper mentions that Tpr2 replaced type I and II J proteins (including DNAJB1-type) in Hsp90-dependent chaperoning. The source is Tpr2-centered and does not provide direct DNAJB1 protein-folding evidence in the cached text.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Protein folding is a core function of DNAJB1. PMID:18620420 provides evidence that J proteins including type II (DNAJB1 class) participate in Hsp90-dependent protein folding. While the paper focuses on Tpr2, it demonstrates DNAJB1-class J protein involvement in the chaperone folding cycle.
+                            <strong>Reason:</strong> Protein folding is a core function of DNAJB1. PMID:18620420 provides evidence that J-protein-like functions participate in chaperone cycles, but this paper focuses on Tpr2 and does not establish a DNAJB1-specific IDA annotation. Keep this source-specific annotation undecided.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/18620420" target="_blank" class="term-link">
                                         PMID:18620420
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Tpr2 replaced type I and II J proteins in the Hsp90-dependent chaperoning of the PR and the protein kinase, Chk1.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006986" target="_blank" class="term-link">
                                     GO:0006986
                                 </a>
                             </span>
                             <span class="term-label">response to unfolded protein</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/8975727" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:8975727
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Genomic cloning of a human heat shock protein 40 (Hsp40) gen...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5125,50 +5136,50 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Hata et al. (PMID:8975727) cloned the genomic DNA for human Hsp40 (DNAJB1) and characterized its gene structure. The 5-prime region contains typical heat shock elements, indicating stress-responsive expression consistent with response to unfolded protein.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> DNAJB1 (Hsp40) is a heat shock protein with heat shock elements in its promoter (PMID:8975727), indicating stress-responsive induction. As a co-chaperone for HSP70 that assists in folding unfolded proteins, response to unfolded protein is an appropriate biological process annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8975727" target="_blank" class="term-link">
                                         PMID:8975727
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The 5&#39; region of the gene is highly GC rich, and there are multiple basal elements for transcription factors including typical heat shock elements.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>DNAJB1 is a class B J-domain co-chaperone (foldase-type) that binds unfolded/misfolded protein substrates via its C-terminal beta-sandwich domains (CTD-I and CTD-II) and delivers them to HSP70 for productive ATP-dependent refolding. DNAJB1 stimulates the ATPase activity of HSP70 via its J-domain HPD motif and promotes substrate release and refolding. A distinctive feature of DNAJB1 is G/F-mediated autoinhibition of its J-domain, which is relieved by a secondary contact between Hsp70&#39;s EEVD motif and a positively charged groove in CTD-I, enabling productive Hsp70 engagement (DOI:10.1016/j.tcb.2022.05.004). DNAJB1 also participates in disaggregation by remaining associated with protein aggregates and scaffolding multiple Hsp70 molecules through JDP hetero-oligomerization. Classified as a foldase rather than holdase based on its ability to support luciferase refolding and poor suppression of polyQ aggregation (PMID:21231916).</h3>
                 <span class="vote-buttons" data-g="P25685" data-a="FUNCTION: DNAJB1 is a class B J-domain co-chaperone (foldase..." data-r="" data-act="CORE_FUNCTION">
@@ -5176,10 +5187,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -5188,117 +5199,111 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                 protein folding
                             </a>
                         </span>
-                        
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1903334" target="_blank" class="term-link">
-                                positive regulation of protein folding
-                            </a>
-                        </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006986" target="_blank" class="term-link">
                                 response to unfolded protein
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034605" target="_blank" class="term-link">
                                 cellular response to heat
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1900034" target="_blank" class="term-link">
                                 regulation of cellular response to heat
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                 nucleoplasm
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005730" target="_blank" class="term-link">
                                 nucleolus
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                 PMID:21231916
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24318877" target="_blank" class="term-link">
                                 PMID:24318877
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">we combined the Hsp70-NEF pairs with cochaperones of the J protein family (DnaJA1, DnaJA2, DnaJB1, and DnaJB4) to generate 16 permutations. The activity of the combinations in ATPase and luciferase refolding assays were dependent on the identity and stoichiometry of both the J protein and NEF</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>DNAJB1 stimulates the intrinsic ATPase activity of HSP70 family members (HSPA1A/B) through its J-domain HPD motif, which docks on ATP-bound Hsp70 at the interdomain linker and positions the HPD motif to activate Hsp70&#39;s catalytic center (DOI:10.1016/j.tcb.2022.05.004). This stimulation shifts Hsp70 to a high-affinity client-binding state (&#34;ultra-affinity&#34;), driving the HSP70 chaperone cycle for substrate binding, folding, and release. Nucleotide exchange factors then promote ADP release to reset the cycle. Directly demonstrated in vitro using purified components with varying Hsp70-NEF combinations (PMID:24318877). The J-domain activity is subject to G/F-mediated autoinhibition in class B JDPs, requiring Hsp70 EEVD-mediated relief for full activation.</h3>
                 <span class="vote-buttons" data-g="P25685" data-a="FUNCTION: DNAJB1 stimulates the intrinsic ATPase activity of..." data-r="" data-act="CORE_FUNCTION">
@@ -5306,10 +5311,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -5318,781 +5323,782 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                 protein folding
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                 nucleoplasm
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24318877" target="_blank" class="term-link">
                                 PMID:24318877
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">we combined the Hsp70-NEF pairs with cochaperones of the J protein family (DnaJA1, DnaJA2, DnaJB1, and DnaJB4) to generate 16 permutations. The activity of the combinations in ATPase and luciferase refolding assays were dependent on the identity and stoichiometry of both the J protein and NEF</div>
-                        
+
                     </li>
-                    
-                    <li class="finding-item">
-                        <span class="reference-id">
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link">
-                                PMID:23921388
-                            </a>
-                            
-                        </span>
-                        
-                        <div class="finding-text">Hsp70 proteins constitute an evolutionarily conserved protein family of ATP-dependent molecular chaperones involved in a wide range of biological processes.</div>
-                        
-                    </li>
-                    
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/DNAJB1/DNAJB1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for DNAJB1</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
                             GO_REF:0000052
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
                             GO_REF:0000107
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17024176" target="_blank" class="term-link">
                             PMID:17024176
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A novel HSF1-mediated death pathway that is suppressed by heat shock proteins.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18620420" target="_blank" class="term-link">
                             PMID:18620420
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Role of the cochaperone Tpr2 in Hsp90 chaperoning.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link">
                             PMID:19056867
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Large-scale proteomics and phosphoproteomics of urinary exosomes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20060297" target="_blank" class="term-link">
                             PMID:20060297
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Chaperone-assisted selective autophagy is essential for muscle maintenance.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21044950" target="_blank" class="term-link">
                             PMID:21044950
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Genome-wide YFP fluorescence complementation screen identifies new regulators for telomere signaling in human cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21163940" target="_blank" class="term-link">
                             PMID:21163940
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interactome mapping suggests new mechanistic details underlying Alzheimer&#39;s disease.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                             PMID:21231916
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The diverse members of the mammalian HSP70 machine show distinct chaperone-like activities.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link">
                             PMID:21630459
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteomic characterization of the human sperm nucleus.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link">
                             PMID:23921388
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Identification and characterization of a novel human methyltransferase modulating Hsp70 protein function through lysine methylation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24318877" target="_blank" class="term-link">
                             PMID:24318877
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Binding of human nucleotide exchange factors to heat shock protein 70 (Hsp70) generates functionally distinct complexes in vitro.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link">
                             PMID:25036637
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A quantitative chaperone interaction network reveals the architecture of cellular protein homeostasis pathways.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25468996" target="_blank" class="term-link">
                             PMID:25468996
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">E-cadherin interactome complexity and robustness resolved by quantitative proteomics.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27120771" target="_blank" class="term-link">
                             PMID:27120771
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Polyhydramnios, Transient Antenatal Bartter&#39;s Syndrome, and MAGED2 Mutations.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27173435" target="_blank" class="term-link">
                             PMID:27173435
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An organelle-specific protein landscape identifies novel diseases and molecular mechanisms.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
                             PMID:28514442
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                             PMID:32296183
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A reference map of the human binary protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
                             PMID:32814053
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link">
                             PMID:35271311
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">OpenCell: Endogenous tagging for the cartography of human cellular organization.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/36931259" target="_blank" class="term-link">
                             PMID:36931259
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A central chaperone-like role for 14-3-3 proteins in human cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/8975727" target="_blank" class="term-link">
                             PMID:8975727
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Genomic cloning of a human heat shock protein 40 (Hsp40) gene (HSPF1) and its chromosomal localization to 19p13.2.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9499401" target="_blank" class="term-link">
                             PMID:9499401
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Molecular chaperones as HSF1-specific transcriptional repressors.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371453
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Regulation of HSF1-mediated heat shock response</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371467
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">SIRT1 deacetylates HSF1</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371518
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">SIRT1 binds to HSF1</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371554
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSF1 acetylation at Lys80</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5082356
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSF1-mediated gene expression</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5082369
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Acetylated HSF1 dissociates from DNA</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5082384
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP70:DNAJB1 binds HSF1</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5251955
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP40s activate intrinsic ATPase activity of HSP70s in the nucleoplasm</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5251959
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP40s activate intrinsic ATPase activity of HSP70s in the cytosol</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5690245
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">p-T182 MAPKAPK5 binds DNAJB1</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5690250
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">p-T182-MAPKAPK5 phoshphorylates DNAJB1</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1016/j.tcb.2022.05.004
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">J-domain protein chaperone circuits in proteostasis and disease.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Class B JDPs (including DNAJB1) have G/F-mediated autoinhibition of the J-domain; interaction between Hsp70&#39;s EEVD motif and DNAJB1 CTD-I relieves this autoinhibition for productive Hsp70 engagement.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">JDP scaffolding and hetero-oligomerization, including DNAJB1 participation, creates potent Hsp70-based disaggregases; DNAJB1 remains associated with aggregates to recruit multiple Hsp70 molecules.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.3390/ijms222413527
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Regulation of p53 and cancer signaling by heat shock protein 40/J-domain protein family members.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">DNAJB1/HDJ1 binds and stabilizes MDM2 and destabilizes PDCD5, modulating p53-mediated apoptosis; can also support mutant p53 gain-of-function phenotypes in context-dependent manner.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -6386,9 +6392,9 @@ this with annotations you find in gene/protein databases, but these can be outda
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -6400,7 +6406,7 @@ this with annotations you find in gene/protein databases, but these can be outda
                 <pre><code>id: P25685
 gene_symbol: DNAJB1
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -6465,6 +6471,11 @@ existing_annotations:
       supporting_text: &gt;-
         chaperones that supported luciferase refolding were poor suppressors of polyQ
         aggregation.
+    - reference_id: file:human/DNAJB1/DNAJB1-deep-research-falcon.md
+      supporting_text: &gt;-
+        DNAJB1 stimulates the ATPase activity of HSP70 and delivers substrates
+        to the HSP70 chaperone machinery, promoting protein folding (foldase-type
+        activity).
 - term:
     id: GO:0005829
     label: cytosol
@@ -7059,15 +7070,15 @@ existing_annotations:
     summary: &gt;-
       Jakobsson et al. (PMID:23921388) characterized METTL21A methyltransferase and its
       effects on HSP70. The paper mentions that J-proteins stimulate intrinsic ATPase
-      activity of HSP70s, consistent with DNAJB1 function. However, this paper primarily
-      studies METTL21A, not DNAJB1 directly.
-    action: ACCEPT
+      activity of HSP70s, but this paper primarily studies METTL21A rather than DNAJB1
+      directly.
+    action: UNDECIDED
     reason: &gt;-
       ATPase activator activity is a core molecular function of DNAJB1. As a J-domain
       co-chaperone, DNAJB1 stimulates the intrinsic ATPase activity of HSP70 family members.
-      While PMID:23921388 focuses on METTL21A, DNAJB1 ATPase activation is extensively
-      documented (PMID:24318877, Reactome:R-HSA-5251959). Multiple independent lines of
-      evidence support this annotation.
+      However, PMID:23921388 is a METTL21A/HSP70 methylation paper and the cached text
+      does not provide DNAJB1-specific direct evidence for this annotation. Direct support
+      is captured separately from PMID:24318877 and Reactome.
     supported_by:
     - reference_id: PMID:23921388
       supporting_text: &gt;-
@@ -7082,13 +7093,13 @@ existing_annotations:
   review:
     summary: &gt;-
       Jakobsson et al. (PMID:23921388) studied methylation effects on HSP70 chaperone
-      function. DNAJB1 positively regulates protein folding by stimulating HSP70 ATPase
-      activity and promoting the HSP70 folding cycle. This is consistent with DNAJB1&#39;s
-      well-established foldase co-chaperone role.
-    action: ACCEPT
+      function. DNAJB1 positively regulates protein folding through its HSP70 co-chaperone
+      role, but this source does not directly establish that activity for DNAJB1.
+    action: UNDECIDED
     reason: &gt;-
-      Positive regulation of protein folding accurately describes DNAJB1&#39;s role as a
-      co-chaperone that stimulates HSP70-mediated folding. This is a core function.
+      Positive regulation of protein folding is a sound DNAJB1 function, but PMID:23921388
+      is not usable as direct DNAJB1-specific evidence from the cached source. Keep the
+      source-specific annotation undecided.
 - term:
     id: GO:0000122
     label: negative regulation of transcription by RNA polymerase II
@@ -7327,12 +7338,12 @@ existing_annotations:
       degradation of damaged Z disk components. DNAJB1 ATPase activator activity may be
       referenced in the context of the HSP70 chaperone cycle but this paper primarily studies
       the BAG3/CASA pathway.
-    action: ACCEPT
+    action: UNDECIDED
     reason: &gt;-
       ATPase activator activity is a core function of DNAJB1. While PMID:20060297 focuses
-      on CASA, DNAJB1&#39;s role in activating HSP70 ATPase is well-established across multiple
-      independent studies (PMID:24318877, PMID:23921388, Reactome). The annotation is
-      valid regardless of the specific reference context.
+      on CASA, the cached text does not provide DNAJB1-specific ATPase activation evidence.
+      Direct support is already represented by PMID:24318877 and Reactome, so this particular
+      IDA annotation should not be accepted on the basis of a mismatched source.
     supported_by:
     - reference_id: PMID:20060297
       supporting_text: &gt;-
@@ -7347,14 +7358,14 @@ existing_annotations:
   review:
     summary: &gt;-
       Jakobsson et al. (PMID:23921388) studied METTL21A methyltransferase effects on HSP70.
-      The study demonstrates DNAJB1 interaction with HSP70 family members in the context
-      of methylation modulation of chaperone function. HSP70 binding is a core interaction
-      for DNAJB1.
-    action: ACCEPT
+      HSP70 binding is a core interaction for DNAJB1, but this source focuses on METTL21A
+      and does not provide accessible DNAJB1-specific interaction evidence in the cached text.
+    action: UNDECIDED
     reason: &gt;-
       Hsp70 protein binding is a core molecular function of DNAJB1 as a J-domain
       co-chaperone. The J-domain of DNAJB1 directly binds HSP70 to stimulate ATPase
-      activity. This annotation is well-supported by multiple studies.
+      activity, but PMID:23921388 is not the supporting source to establish that specific
+      DNAJB1 interaction.
     supported_by:
     - reference_id: PMID:23921388
       supporting_text: &gt;-
@@ -7369,14 +7380,14 @@ existing_annotations:
   review:
     summary: &gt;-
       DNAJB1 binds to the ATPase domain of HSP70 through its J-domain. Jakobsson et al.
-      (PMID:23921388) provide context for this interaction in the study of METTL21A
-      methylation effects on HSP70 function. ATPase binding is consistent with DNAJB1&#39;s
-      mechanism of action.
-    action: ACCEPT
+      ATPase binding is consistent with DNAJB1&#39;s mechanism of action, but PMID:23921388
+      provides METTL21A/HSP70 methylation context rather than direct DNAJB1 ATPase-domain
+      binding evidence.
+    action: UNDECIDED
     reason: &gt;-
       ATPase binding accurately describes DNAJB1&#39;s interaction with the ATPase domain
-      of HSP70 via its J-domain. This is central to DNAJB1&#39;s mechanism of stimulating
-      HSP70 ATPase activity.
+      of HSP70 via its J-domain. The action is undecided for this source-specific IPI
+      because the cached PMID:23921388 evidence does not establish the interaction.
 # ===== Additional Reactome and localization annotations =====
 - term:
     id: GO:0005829
@@ -7400,13 +7411,12 @@ existing_annotations:
   review:
     summary: &gt;-
       PMID:23921388 studies METTL21A methyltransferase and its effects on HSP70. The
-      protein binding annotation is uninformative when more specific terms (Hsp70 protein
-      binding, ATPase binding) are already present.
+      protein binding annotation is uninformative, and the cached source does not provide
+      DNAJB1-specific interaction evidence.
     action: REMOVE
     reason: &gt;-
-      Protein binding is uninformative. The specific interactions described are already
-      captured by Hsp70 protein binding and ATPase binding annotations from the same
-      publication.
+      Protein binding is too generic for curation. PMID:23921388 is a METTL21A/HSP70
+      methylation paper rather than a source establishing a specific DNAJB1 interaction.
 - term:
     id: GO:0005829
     label: cytosol
@@ -7668,14 +7678,14 @@ existing_annotations:
     summary: &gt;-
       Moffatt et al. (PMID:18620420) studied the role of the cochaperone Tpr2 in Hsp90
       chaperoning. The paper mentions that Tpr2 replaced type I and II J proteins (including
-      DNAJB1-type) in Hsp90-dependent chaperoning. DNAJB1 participation in protein folding
-      through the Hsp90 chaperone cycle is consistent with its co-chaperone function.
-    action: ACCEPT
+      DNAJB1-type) in Hsp90-dependent chaperoning. The source is Tpr2-centered and does
+      not provide direct DNAJB1 protein-folding evidence in the cached text.
+    action: UNDECIDED
     reason: &gt;-
       Protein folding is a core function of DNAJB1. PMID:18620420 provides evidence that
-      J proteins including type II (DNAJB1 class) participate in Hsp90-dependent protein
-      folding. While the paper focuses on Tpr2, it demonstrates DNAJB1-class J protein
-      involvement in the chaperone folding cycle.
+      J-protein-like functions participate in chaperone cycles, but this paper focuses on
+      Tpr2 and does not establish a DNAJB1-specific IDA annotation. Keep this source-specific
+      annotation undecided.
     supported_by:
     - reference_id: PMID:18620420
       supporting_text: &gt;-
@@ -7735,8 +7745,6 @@ core_functions:
     directly_involved_in:
       - id: GO:0006457
         label: protein folding
-      - id: GO:1903334
-        label: positive regulation of protein folding
       - id: GO:0006986
         label: response to unfolded protein
       - id: GO:0034605
@@ -7771,11 +7779,6 @@ core_functions:
           DnaJA2, DnaJB1, and DnaJB4) to generate 16 permutations. The activity of the
           combinations in ATPase and luciferase refolding assays were dependent on the
           identity and stoichiometry of both the J protein and NEF
-      - reference_id: PMID:23921388
-        supporting_text: &gt;-
-          Hsp70 proteins constitute an evolutionarily conserved protein family of
-          ATP-dependent molecular chaperones involved in a wide range of biological
-          processes.
     directly_involved_in:
       - id: GO:0006457
         label: protein folding
@@ -7785,6 +7788,9 @@ core_functions:
       - id: GO:0005654
         label: nucleoplasm
 references:
+- id: file:human/DNAJB1/DNAJB1-deep-research-falcon.md
+  title: Falcon deep research report for DNAJB1
+  findings: []
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
     terms
@@ -7946,7 +7952,7 @@ references:
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/DNAJB1/DNAJB1-ai-review.yaml
+++ b/genes/human/DNAJB1/DNAJB1-ai-review.yaml
@@ -1,7 +1,7 @@
 id: P25685
 gene_symbol: DNAJB1
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -66,6 +66,11 @@ existing_annotations:
       supporting_text: >-
         chaperones that supported luciferase refolding were poor suppressors of polyQ
         aggregation.
+    - reference_id: file:human/DNAJB1/DNAJB1-deep-research-falcon.md
+      supporting_text: >-
+        DNAJB1 stimulates the ATPase activity of HSP70 and delivers substrates
+        to the HSP70 chaperone machinery, promoting protein folding (foldase-type
+        activity).
 - term:
     id: GO:0005829
     label: cytosol
@@ -660,15 +665,15 @@ existing_annotations:
     summary: >-
       Jakobsson et al. (PMID:23921388) characterized METTL21A methyltransferase and its
       effects on HSP70. The paper mentions that J-proteins stimulate intrinsic ATPase
-      activity of HSP70s, consistent with DNAJB1 function. However, this paper primarily
-      studies METTL21A, not DNAJB1 directly.
-    action: ACCEPT
+      activity of HSP70s, but this paper primarily studies METTL21A rather than DNAJB1
+      directly.
+    action: UNDECIDED
     reason: >-
       ATPase activator activity is a core molecular function of DNAJB1. As a J-domain
       co-chaperone, DNAJB1 stimulates the intrinsic ATPase activity of HSP70 family members.
-      While PMID:23921388 focuses on METTL21A, DNAJB1 ATPase activation is extensively
-      documented (PMID:24318877, Reactome:R-HSA-5251959). Multiple independent lines of
-      evidence support this annotation.
+      However, PMID:23921388 is a METTL21A/HSP70 methylation paper and the cached text
+      does not provide DNAJB1-specific direct evidence for this annotation. Direct support
+      is captured separately from PMID:24318877 and Reactome.
     supported_by:
     - reference_id: PMID:23921388
       supporting_text: >-
@@ -683,13 +688,13 @@ existing_annotations:
   review:
     summary: >-
       Jakobsson et al. (PMID:23921388) studied methylation effects on HSP70 chaperone
-      function. DNAJB1 positively regulates protein folding by stimulating HSP70 ATPase
-      activity and promoting the HSP70 folding cycle. This is consistent with DNAJB1's
-      well-established foldase co-chaperone role.
-    action: ACCEPT
+      function. DNAJB1 positively regulates protein folding through its HSP70 co-chaperone
+      role, but this source does not directly establish that activity for DNAJB1.
+    action: UNDECIDED
     reason: >-
-      Positive regulation of protein folding accurately describes DNAJB1's role as a
-      co-chaperone that stimulates HSP70-mediated folding. This is a core function.
+      Positive regulation of protein folding is a sound DNAJB1 function, but PMID:23921388
+      is not usable as direct DNAJB1-specific evidence from the cached source. Keep the
+      source-specific annotation undecided.
 - term:
     id: GO:0000122
     label: negative regulation of transcription by RNA polymerase II
@@ -928,12 +933,12 @@ existing_annotations:
       degradation of damaged Z disk components. DNAJB1 ATPase activator activity may be
       referenced in the context of the HSP70 chaperone cycle but this paper primarily studies
       the BAG3/CASA pathway.
-    action: ACCEPT
+    action: UNDECIDED
     reason: >-
       ATPase activator activity is a core function of DNAJB1. While PMID:20060297 focuses
-      on CASA, DNAJB1's role in activating HSP70 ATPase is well-established across multiple
-      independent studies (PMID:24318877, PMID:23921388, Reactome). The annotation is
-      valid regardless of the specific reference context.
+      on CASA, the cached text does not provide DNAJB1-specific ATPase activation evidence.
+      Direct support is already represented by PMID:24318877 and Reactome, so this particular
+      IDA annotation should not be accepted on the basis of a mismatched source.
     supported_by:
     - reference_id: PMID:20060297
       supporting_text: >-
@@ -948,14 +953,14 @@ existing_annotations:
   review:
     summary: >-
       Jakobsson et al. (PMID:23921388) studied METTL21A methyltransferase effects on HSP70.
-      The study demonstrates DNAJB1 interaction with HSP70 family members in the context
-      of methylation modulation of chaperone function. HSP70 binding is a core interaction
-      for DNAJB1.
-    action: ACCEPT
+      HSP70 binding is a core interaction for DNAJB1, but this source focuses on METTL21A
+      and does not provide accessible DNAJB1-specific interaction evidence in the cached text.
+    action: UNDECIDED
     reason: >-
       Hsp70 protein binding is a core molecular function of DNAJB1 as a J-domain
       co-chaperone. The J-domain of DNAJB1 directly binds HSP70 to stimulate ATPase
-      activity. This annotation is well-supported by multiple studies.
+      activity, but PMID:23921388 is not the supporting source to establish that specific
+      DNAJB1 interaction.
     supported_by:
     - reference_id: PMID:23921388
       supporting_text: >-
@@ -970,14 +975,14 @@ existing_annotations:
   review:
     summary: >-
       DNAJB1 binds to the ATPase domain of HSP70 through its J-domain. Jakobsson et al.
-      (PMID:23921388) provide context for this interaction in the study of METTL21A
-      methylation effects on HSP70 function. ATPase binding is consistent with DNAJB1's
-      mechanism of action.
-    action: ACCEPT
+      ATPase binding is consistent with DNAJB1's mechanism of action, but PMID:23921388
+      provides METTL21A/HSP70 methylation context rather than direct DNAJB1 ATPase-domain
+      binding evidence.
+    action: UNDECIDED
     reason: >-
       ATPase binding accurately describes DNAJB1's interaction with the ATPase domain
-      of HSP70 via its J-domain. This is central to DNAJB1's mechanism of stimulating
-      HSP70 ATPase activity.
+      of HSP70 via its J-domain. The action is undecided for this source-specific IPI
+      because the cached PMID:23921388 evidence does not establish the interaction.
 # ===== Additional Reactome and localization annotations =====
 - term:
     id: GO:0005829
@@ -1001,13 +1006,12 @@ existing_annotations:
   review:
     summary: >-
       PMID:23921388 studies METTL21A methyltransferase and its effects on HSP70. The
-      protein binding annotation is uninformative when more specific terms (Hsp70 protein
-      binding, ATPase binding) are already present.
+      protein binding annotation is uninformative, and the cached source does not provide
+      DNAJB1-specific interaction evidence.
     action: REMOVE
     reason: >-
-      Protein binding is uninformative. The specific interactions described are already
-      captured by Hsp70 protein binding and ATPase binding annotations from the same
-      publication.
+      Protein binding is too generic for curation. PMID:23921388 is a METTL21A/HSP70
+      methylation paper rather than a source establishing a specific DNAJB1 interaction.
 - term:
     id: GO:0005829
     label: cytosol
@@ -1269,14 +1273,14 @@ existing_annotations:
     summary: >-
       Moffatt et al. (PMID:18620420) studied the role of the cochaperone Tpr2 in Hsp90
       chaperoning. The paper mentions that Tpr2 replaced type I and II J proteins (including
-      DNAJB1-type) in Hsp90-dependent chaperoning. DNAJB1 participation in protein folding
-      through the Hsp90 chaperone cycle is consistent with its co-chaperone function.
-    action: ACCEPT
+      DNAJB1-type) in Hsp90-dependent chaperoning. The source is Tpr2-centered and does
+      not provide direct DNAJB1 protein-folding evidence in the cached text.
+    action: UNDECIDED
     reason: >-
       Protein folding is a core function of DNAJB1. PMID:18620420 provides evidence that
-      J proteins including type II (DNAJB1 class) participate in Hsp90-dependent protein
-      folding. While the paper focuses on Tpr2, it demonstrates DNAJB1-class J protein
-      involvement in the chaperone folding cycle.
+      J-protein-like functions participate in chaperone cycles, but this paper focuses on
+      Tpr2 and does not establish a DNAJB1-specific IDA annotation. Keep this source-specific
+      annotation undecided.
     supported_by:
     - reference_id: PMID:18620420
       supporting_text: >-
@@ -1336,8 +1340,6 @@ core_functions:
     directly_involved_in:
       - id: GO:0006457
         label: protein folding
-      - id: GO:1903334
-        label: positive regulation of protein folding
       - id: GO:0006986
         label: response to unfolded protein
       - id: GO:0034605
@@ -1372,11 +1374,6 @@ core_functions:
           DnaJA2, DnaJB1, and DnaJB4) to generate 16 permutations. The activity of the
           combinations in ATPase and luciferase refolding assays were dependent on the
           identity and stoichiometry of both the J protein and NEF
-      - reference_id: PMID:23921388
-        supporting_text: >-
-          Hsp70 proteins constitute an evolutionarily conserved protein family of
-          ATP-dependent molecular chaperones involved in a wide range of biological
-          processes.
     directly_involved_in:
       - id: GO:0006457
         label: protein folding
@@ -1386,6 +1383,9 @@ core_functions:
       - id: GO:0005654
         label: nucleoplasm
 references:
+- id: file:human/DNAJB1/DNAJB1-deep-research-falcon.md
+  title: Falcon deep research report for DNAJB1
+  findings: []
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
     terms

--- a/genes/human/DNAJB2/DNAJB2-ai-review.html
+++ b/genes/human/DNAJB2/DNAJB2-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>DNAJB2</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P25686" target="_blank" class="term-link">
                         P25686
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>DNAJB2 (also known as HSJ1) is a neuronally enriched class B J-domain protein (HSP40 co-chaperone) that functions as a &#34;triage&#34; co-chaperone for HSP70/Hsc70, coupling chaperone recognition of misfolded proteins to ubiquitin-dependent proteasomal degradation. Its domain architecture comprises an N-terminal J domain (with conserved HPD motif) that stimulates HSP70 ATPase activity, a G/F-rich region, and two C-terminal ubiquitin-interacting motifs (UIMs) that bind polyubiquitin chains and facilitate client delivery to the proteasome. DNAJB2 cooperates with the E3 ubiquitin ligase CHIP/STUB1 and protects polyubiquitin chains from deubiquitylation, supporting a &#34;shuttle&#34; function for ubiquitinated clients destined for proteasomal degradation (DOI:10.3390/ijms21041409). CK2 phosphorylation of UIM2 (Ser250) modulates ubiquitin-binding capacity, providing a kinase-dependent regulatory mechanism (PMID:28031292). DNAJB2 exists as two alternatively spliced isoforms: the ER-membrane-anchored HSJ1b (isoform 1, ~324 aa, geranylgeranylated) and the cytoplasmic/nuclear HSJ1a (isoform 2, ~277 aa). DNAJB2 suppresses aggregation of diverse neurodegeneration-associated proteins including polyQ-expanded huntingtin, SOD1, TDP-43, and parkin variants (DOI:10.3389/fncel.2014.00191). Mutations in DNAJB2 cause autosomal recessive distal hereditary motor neuropathy (dHMN/CMT2), and a first dominant mutation was reported in 2023: a stop-loss extension (p.*278Glyext*83) that creates a transmembrane helix driving ER mislocalization and proteasomal degradation of the mutant protein (DOI:10.1093/hmg/ddad058). The disease spectrum has expanded to include both recessive and dominant neuromyopathy and distal myopathy (DOI:10.1097/WCO.0000000000001299). Cystamine (150 uM) has been shown to increase DNAJB2 levels in patient fibroblasts, suggesting a potential pharmacologic approach (DOI:10.3390/neurolint17050073).</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
                                     GO:0001671
                                 </a>
                             </span>
                             <span class="term-label">ATPase activator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,77 +795,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> DNAJB2 (HSJ1) stimulates the ATPase activity of HSP70/Hsc70 via its conserved J domain. Cheetham et al. (1994) showed that both HSJ1a and HSJ1b enhance the weak intrinsic ATPase activity of constitutive Hsc70 more than fivefold (PMID:7957263). Gao et al. (2012) confirmed that the J domain of HSJ1a mediates interaction with and ATPase activation of HSP70 (PMID:22219199). The IBA annotation is phylogenetically sound for J-domain proteins, and the term accurately captures a core molecular function of DNAJB2.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATPase activator activity is a well-established core function of DNAJB2 as a J-domain co-chaperone. Multiple experimental studies confirm this function (PMID:7957263, PMID:22219199). The IBA annotation is consistent with the conserved role of the J domain across the DnaJ family.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7957263" target="_blank" class="term-link">
                                         PMID:7957263
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The weak intrinsic ATPase activity of the constitutive 70-kDa heat-shock protein is enhanced more than fivefold by stoichiometric amounts of both HSJ1a and HSJ1b.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22219199" target="_blank" class="term-link">
                                         PMID:22219199
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The J domain of HSJ1a shares a conserved structure with other J domains from both eukaryotic and prokaryotic species, and it mediates the interaction with and the ATPase cycle of HSP70.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/DNAJB2/DNAJB2-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">DNAJB2 &#34;traffics unfolded proteins&#34; to Hsp70 and stimulates Hsp70 ATPase activity via its J-domain, a canonical JDP activity.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -877,64 +888,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> DNAJB2 isoform 2 (HSJ1a) is cytoplasmic/cytosolic (PMID:12754272). UniProt confirms that isoform 2 localizes to cytoplasm. Hageman et al. (2011) showed cytosolic localization by immunofluorescence (PMID:21231916). The IBA annotation to cytosol is appropriate as HSJ1a is the primary cytosolic isoform. Note that isoform 1 (HSJ1b) is ER-membrane anchored.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol is a well-supported localization for DNAJB2 isoform HSJ1a. Multiple experimental studies (PMID:12754272, PMID:21231916) confirm cytoplasmic/cytosolic localization. The IBA annotation is phylogenetically reasonable for J-domain proteins.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030544" target="_blank" class="term-link">
                                     GO:0030544
                                 </a>
                             </span>
                             <span class="term-label">Hsp70 protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -946,77 +957,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> DNAJB2 physically interacts with HSP70 family members through its J domain. Cheetham et al. (1994) demonstrated in vitro interaction between HSJ1a/HSJ1b and constitutive Hsc70 (PMID:7957263). Gao et al. (2012) confirmed the J domain of HSJ1a binds HSP70 and determined the structural basis for this interaction (PMID:22219199). UniProt records interactions with HSPA1A, HSPA1B, and HSPA8 (Hsc70). The IBA annotation is well-supported for all J-domain proteins and represents a core function of DNAJB2.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Hsp70 protein binding is a fundamental and experimentally validated function of DNAJB2. Multiple studies confirm the J-domain-mediated physical interaction with HSP70/Hsc70 (PMID:7957263, PMID:22219199, PMID:21625540). This is a core molecular function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22219199" target="_blank" class="term-link">
                                         PMID:22219199
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The J-domain co-chaperones work together with the heat shock protein 70 (HSP70) chaperone to regulate many cellular events, but the mechanism underlying the J-domain-mediated HSP70 function remains elusive.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7957263" target="_blank" class="term-link">
                                         PMID:7957263
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The weak intrinsic ATPase activity of the constitutive 70-kDa heat-shock protein is enhanced more than fivefold by stoichiometric amounts of both HSJ1a and HSJ1b.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1028,64 +1039,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> DNAJB2 participates in protein refolding as part of the HSP70 chaperone machine. Hageman et al. (2011) systematically assessed HSP40/DNAJ family members for refolding of heat-denatured luciferase and suppression of polyQ aggregation (PMID:21231916). DNAJB2 showed chaperone-like activities in these assays. The IBA annotation to protein refolding is phylogenetically reasonable for J-domain proteins that assist HSP70 in protein refolding.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein refolding is a well-characterized function of DNAJB2 as an HSP70 co-chaperone. Experimental data from Hageman et al. (2011) support this annotation (PMID:21231916), and the IBA phylogenetic inference is sound for J-domain co-chaperones.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol. To test for possible functional differences and/or substrate specificity, we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1097,75 +1108,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962). DNAJB2 is a J-domain containing HSP40 co-chaperone that functions by binding to misfolded/unfolded proteins in the context of the HSP70 chaperone machine, not as an independent unfolded protein binder. The IBA annotation via PANTHER is phylogenetically reasonable for J-domain proteins in general, but the term itself is being replaced. The correct replacement is GO:0044183 (protein folding chaperone), which accurately captures DNAJB2&#39;s role in assisting protein folding as an HSP70 co-chaperone. UniProt describes it as functioning as a co-chaperone that regulates substrate binding and activates ATPase activity of HSP70 family chaperones (PMID:22219199, PMID:7957263). Hageman et al. (2011) showed DNAJB2 has chaperone-like activities including protein refolding and suppression of aggregation (PMID:21231916).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. DNAJB2 functions as a protein folding chaperone (HSP70 co-chaperone) via its J domain, not as a standalone unfolded protein binder. GO:0044183 (protein folding chaperone) is the appropriate replacement term, as it captures the functional role of binding to proteins to assist the folding process.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol. To test for possible functional differences and/or substrate specificity, we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1177,46 +1188,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation derives from UniProtKB subcellular location vocabulary mapping. UniProt records that isoform 2 (HSJ1a) localizes to the nucleus (PMID:12754272). Chapple and Cheetham (2003) showed nuclear localization for HSJ1a, and Hageman et al. (2011) confirmed nucleus localization by IDA (PMID:21231916). The IEA mapping is consistent with experimental data. HSJ1a is found in both cytoplasm and nucleus.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear localization of DNAJB2 isoform HSJ1a is experimentally supported by IDA evidence (PMID:21231916, PMID:12754272). The IEA annotation correctly reflects the UniProt subcellular location entry. This is a broader IEA that is acceptable alongside the more specific IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1228,46 +1239,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation from combined automated methods maps DNAJB2 to cytoplasm. UniProt records isoform 2 (HSJ1a) in the cytoplasm (PMID:12754272, PMID:21625540). This is a broader localization term compared to cytosol (GO:0005829), and is correct for HSJ1a. The IEA annotation is consistent with experimental data.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasm localization is experimentally confirmed for DNAJB2 isoform HSJ1a (PMID:12754272, PMID:21625540). Although cytosol (GO:0005829) is more specific and also annotated, this broader IEA annotation is acceptable.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
                                     GO:0005789
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1279,46 +1290,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation maps from UniProt subcellular location vocabulary. UniProt records that isoform 1 (HSJ1b) localizes to the endoplasmic reticulum membrane via C-terminal geranylgeranylation at Cys-321, on the cytoplasmic side (PMID:12754272). Chapple and Cheetham (2003) showed that HSJ1b is anchored to the ER membrane and that mutation of C321S causes relocalization. This annotation is isoform-specific to HSJ1b but is appropriately captured for the gene product.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ER membrane localization is experimentally confirmed for DNAJB2 isoform HSJ1b via geranylgeranylation (PMID:12754272). The IEA annotation correctly reflects the UniProt subcellular location. While isoform-specific, this is a valid annotation for the gene product.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030544" target="_blank" class="term-link">
                                     GO:0030544
                                 </a>
                             </span>
                             <span class="term-label">Hsp70 protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1330,46 +1341,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation derives from InterPro domain mapping (IPR043183, DNJB2/6-like domain). HSP70 protein binding is a core function of DNAJB2 mediated by the J domain. This is well supported by multiple experimental studies (PMID:7957263, PMID:22219199, PMID:21625540). The InterPro mapping is correct.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The InterPro-derived IEA annotation to Hsp70 protein binding is accurate for DNAJB2 as a J-domain protein. This is experimentally validated (PMID:7957263, PMID:22219199) and represents a core molecular function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1381,75 +1392,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962). This IEA annotation is based on InterPro mapping (IPR043183, the DNJB2/6-like domain). DNAJB2 is classified as a J-domain protein / HSP40 co-chaperone whose function is to assist HSP70 in protein folding, not to independently bind unfolded proteins. The InterPro-derived mapping should be updated to reflect the replacement term GO:0044183 (protein folding chaperone), which accurately describes the chaperone function of J-domain proteins.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. The IEA annotation from InterPro (IPR043183) correctly identifies DNAJB2 as having a DNJB2/6-like domain associated with chaperone function, but the target term should be updated to GO:0044183 (protein folding chaperone), which better captures the co-chaperone role of J-domain proteins in assisting protein folding.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24023695" target="_blank" class="term-link">
                                         PMID:24023695
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The molecular chaperone HSJ1 (DNAJB2) is a member of the Hsp40 (or DnaJ) family of heat shock proteins that contain a J domain, which is crucial in substrate recognition by Hsp70 [21], [22], [23]. Thus, Hsp40/DnaJ protein function is essential for Hsp70 function, including protein folding and directing misfolded proteins towards the proteasome [23].</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1461,46 +1472,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation from ARBA machine learning (GO_REF:0000117) maps DNAJB2 to protein-folding chaperone binding. DNAJB2 binds HSP70 family chaperones (HSPA1A, HSPA1B, HSPA8) via its J domain (PMID:7957263, PMID:22219199, PMID:21625540). HSP70 proteins are protein-folding chaperones, so this annotation is accurate. There is also IPI evidence for this same term (PMID:21231916).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The IEA annotation is consistent with DNAJB2&#39;s well-characterized binding to HSP70 chaperones. Experimentally confirmed by multiple studies and also annotated with IPI evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090084" target="_blank" class="term-link">
                                     GO:0090084
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of inclusion body assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1512,57 +1523,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation from ARBA machine learning captures DNAJB2&#39;s role in suppressing protein aggregation and inclusion body formation. Multiple studies show that HSJ1a suppresses inclusion formation by polyglutamine-expanded proteins (PMID:21231916) and mutant SOD1 (PMID:24023695). There is also IDA evidence for the same term (PMID:21231916). The automated annotation is consistent with experimentally demonstrated function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Negative regulation of inclusion body assembly is well supported by experimental evidence (PMID:21231916, PMID:24023695). DNAJB2 reduces inclusion formation through its J domain and UIM domain activities. The IEA annotation is consistent with IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25036637
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A quantitative chaperone interaction network reveals the arc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1574,57 +1585,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IPI annotation from Taipale et al. (2014) derives from a large-scale chaperone interaction network study. The with/from column indicates interaction with MLF1 (P58340). While the interaction may be real, GO:0005515 (protein binding) is uninformative and does not specify the nature of the interaction. DNAJB2 has more specific binding annotations (Hsp70 protein binding, ubiquitin binding, protein-folding chaperone binding) that are more informative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding (GO:0005515) is uninformative for DNAJB2. More specific molecular function binding terms are already annotated (GO:0030544 Hsp70 protein binding, GO:0043130 ubiquitin binding, GO:0051087 protein-folding chaperone binding). Per curation guidelines, this vague term should be replaced by more informative annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1636,46 +1647,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IPI annotation from Huttlin et al. (2021) BioPlex proteome-scale interactome study (with/from MLF1, P58340). As with the other protein binding annotation, GO:0005515 is uninformative. More specific binding terms already capture DNAJB2&#39;s binding functions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding (GO:0005515) is uninformative. More specific molecular function binding terms are already annotated for DNAJB2. This vague annotation does not add functional information.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031965" target="_blank" class="term-link">
                                     GO:0031965
                                 </a>
                             </span>
                             <span class="term-label">nuclear membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-undecided">
@@ -1687,57 +1698,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IDA annotation from HPA (Human Protein Atlas) immunofluorescence data places DNAJB2 at the nuclear membrane. UniProt records that isoform 2 (HSJ1a) localizes to cytoplasm and nucleus (PMID:12754272). Nuclear membrane localization is plausible but not specifically described in the primary literature for DNAJB2. The HPA immunofluorescence may be detecting perinuclear ER-associated HSJ1b or nuclear-peripheral HSJ1a. This is not a well-characterized localization for DNAJB2 in the literature.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear membrane localization comes from HPA immunofluorescence data (GO_REF:0000052), not from primary DNAJB2 literature. While DNAJB2 is found in nucleus and ER membrane, nuclear membrane specifically is not discussed in the primary literature. Without access to the HPA images or detailed characterization, this cannot be fully evaluated.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0120283" target="_blank" class="term-link">
                                     GO:0120283
                                 </a>
                             </span>
                             <span class="term-label">protein serine/threonine kinase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28031292" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28031292
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Protein kinase CK2 modulates HSJ1 function through phosphory...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1749,155 +1760,155 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Ottaviani et al. (2017) showed that CK2 (protein kinase CK2, comprising CSNK2A1/P68400 and CSNK2A2/P19784 catalytic subunits) phosphorylates DNAJB2 at Ser250 and Ser247 within its UIM2 domain (PMID:28031292). The GOA with/from column lists P19784 (CSNK2A2) and P68400 (CSNK2A1). CK2 is a serine/threonine kinase, so the annotation to protein serine/threonine kinase binding accurately captures the demonstrated physical interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> DNAJB2 is a confirmed substrate of CK2. Ottaviani et al. (2017) demonstrated direct phosphorylation and physical interaction between CK2 and HSJ1 in vitro and in cells (PMID:28031292). The term accurately describes the interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/28031292" target="_blank" class="term-link">
                                         PMID:28031292
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Here we show that CK2, a ubiquitous and constitutively active protein kinase, phosphorylates HSJ1 within its second UIM, at the dominant site Ser250 and the hierarchical site Ser247.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140318" target="_blank" class="term-link">
                                     GO:0140318
                                 </a>
                             </span>
                             <span class="term-label">protein transporter activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28031292" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28031292
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Protein kinase CK2 modulates HSJ1 function through phosphory...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P25686" data-a="GO:0140318" data-r="PMID:28031292" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="P25686" data-a="GO:0140318" data-r="PMID:28031292" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This TAS annotation from ARUK-UCL references PMID:28031292 (Ottaviani et al. 2017). The paper describes DNAJB2 as a &#34;shuttling factor to sort chaperone clients to the proteasome&#34; (citing Westhoff et al. 2005, PMID:15936278). DNAJB2 facilitates delivery of ubiquitylated misfolded proteins to the proteasome. However, &#34;protein transporter activity&#34; (GO:0140318) implies a transporter function, which is a stretch for a co-chaperone that helps target substrates for proteasomal degradation. This is more accurately described as regulation of proteasomal targeting rather than transport per se.
+                            <strong>Summary:</strong> This TAS annotation from ARUK-UCL references PMID:28031292 (Ottaviani et al. 2017). The paper describes DNAJB2 as a &#34;shuttling factor to sort chaperone clients to the proteasome&#34; (citing Westhoff et al. 2005, PMID:15936278). DNAJB2 facilitates delivery of ubiquitylated misfolded proteins to the proteasome. GO:0140318 covers direct binding to a protein cargo and delivery of that cargo to a cellular destination, so it is appropriate for DNAJB2&#39;s shuttling-factor role in delivering ubiquitylated clients to the proteasome.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> DNAJB2 acts as a co-chaperone that sorts misfolded clients to the proteasome, but this is more accurately described as chaperoning/targeting rather than transport activity. The term protein transporter activity implies a direct transport mechanism that is not well-supported for DNAJB2. The proteasomal targeting function is better captured by annotations like GO:0032436 (positive regulation of proteasomal ubiquitin-dependent protein catabolic process).
+                            <strong>Reason:</strong> DNAJB2/HSJ1 binds ubiquitylated client proteins through its UIMs and facilitates their delivery to the proteasome. This satisfies protein transporter activity in the protein- cargo delivery sense and does not require transmembrane transport.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/28031292" target="_blank" class="term-link">
                                         PMID:28031292
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSJ1 (also known as DNAJB2) is a key component in neuronal protein quality control. It is a molecular chaperone that is preferentially expressed in neurons that can act as a shuttling factor to sort chaperone clients to the proteasome (1).</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032436" target="_blank" class="term-link">
                                     GO:0032436
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of proteasomal ubiquitin-dependent protein catabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28031292" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28031292
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Protein kinase CK2 modulates HSJ1 function through phosphory...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1909,88 +1920,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This TAS annotation captures DNAJB2&#39;s role in promoting proteasomal degradation of ubiquitylated client proteins. Ottaviani et al. (2017) describe HSJ1 as binding ubiquitylated proteins through its UIMs and facilitating their delivery to the proteasome (PMID:28031292). Westhoff et al. (2005) showed HSJ1 acts as a shuttling factor for sorting chaperone clients to the proteasome (PMID:15936278). Gao et al. (2011) demonstrated HSJ1a promotes HSP70-mediated proteasomal degradation of ataxin-3 (PMID:21625540). This is a core function of DNAJB2.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Positive regulation of proteasomal ubiquitin-dependent protein catabolism is a well-characterized core function of DNAJB2, mediated through its UIM domains that bind ubiquitylated substrates and its J domain that engages HSP70. Multiple studies confirm this (PMID:28031292, PMID:15936278, PMID:21625540, PMID:24023695).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/28031292" target="_blank" class="term-link">
                                         PMID:28031292
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">It binds ubiquitylated proteins through its Ubiquitin Interacting Motifs (UIMs) and facilitates their delivery to the proteasome for degradation.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21625540" target="_blank" class="term-link">
                                         PMID:21625540
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The J-domain down-regulates the protein level of Atx3 through HSP70 mediated proteasomal degradation, while the UIM domain may alleviate this process via maintaining the ubiquitinated Atx3.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043130" target="_blank" class="term-link">
                                     GO:0043130
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28031292" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28031292
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Protein kinase CK2 modulates HSJ1 function through phosphory...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2002,75 +2013,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> DNAJB2 contains two ubiquitin-interacting motifs (UIMs) that bind ubiquitin chains. Ottaviani et al. (2017) directly demonstrated ubiquitin binding through co-immunoprecipitation of HSJ1a-associated ubiquitylated proteins, and showed that CK2 phosphorylation of the UIM2 domain reduces this binding (PMID:28031292). Gao et al. (2011) showed UIM domains bind K48- and K63-linked diubiquitin chains, with UIM2 being more important (PMID:21625540). Westhoff et al. (2005) showed UIM mutation abolishes polyubiquitin chain binding (PMID:15936278). However, the more specific term GO:0031593 (polyubiquitin modification-dependent protein binding) or GO:0140036 (ubiquitin-modified protein reader activity) may be more appropriate, as DNAJB2 specifically reads ubiquitin modifications on client proteins.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Ubiquitin binding via UIM domains is a core function of DNAJB2 directly demonstrated by IDA evidence (PMID:28031292). While more specific terms exist, this annotation is accurate and supported by multiple studies.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/28031292" target="_blank" class="term-link">
                                         PMID:28031292
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Near the C-terminus HSJ1 has two Ubiquitin Interacting Motifs (UIMs), that function to bind ubiquitin chains and help prevent client protein aggregation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070050" target="_blank" class="term-link">
                                     GO:0070050
                                 </a>
                             </span>
                             <span class="term-label">neuron cellular homeostasis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28031292" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28031292
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Protein kinase CK2 modulates HSJ1 function through phosphory...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2082,75 +2093,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This TAS annotation from ARUK-UCL references PMID:28031292. Ottaviani et al. (2017) describe HSJ1 as &#34;a key component in neuronal protein quality control&#34; and note that DNAJB2 mutations cause hereditary neuropathies (PMID:28031292). DNAJB2 is preferentially expressed in neurons and maintains proteostasis there. However, &#34;neuron cellular homeostasis&#34; (GO:0070050) is a very broad biological process term. DNAJB2&#39;s role is specifically in protein quality control and proteostasis in neurons, not in all aspects of neuronal homeostasis.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While DNAJB2 is clearly important for neuronal protein homeostasis (mutations cause neuropathy), the term &#34;neuron cellular homeostasis&#34; is broad. DNAJB2&#39;s contribution is specifically through protein quality control. This is a downstream consequence of its core chaperone/ubiquitin-binding functions rather than a direct molecular activity.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/28031292" target="_blank" class="term-link">
                                         PMID:28031292
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSJ1 (also known as DNAJB2) is a key component in neuronal protein quality control. It is a molecular chaperone that is preferentially expressed in neurons that can act as a shuttling factor to sort chaperone clients to the proteasome (1).</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140036" target="_blank" class="term-link">
                                     GO:0140036
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin-modified protein reader activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28031292" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28031292
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Protein kinase CK2 modulates HSJ1 function through phosphory...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2162,75 +2173,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> DNAJB2 reads ubiquitin modifications on client proteins via its two UIM domains and sorts them for proteasomal degradation. Ottaviani et al. (2017) showed by co-immunoprecipitation that HSJ1a binds ubiquitylated clients, and this binding is reduced by CK2 phosphorylation of UIM2 or by UIM-disrupting mutations (PMID:28031292). This term captures the specific activity of recognizing ubiquitin modifications to direct protein fate, which is more precise than simple ubiquitin binding.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Ubiquitin-modified protein reader activity precisely describes DNAJB2&#39;s UIM-mediated recognition of ubiquitylated substrates for proteasomal targeting. This is experimentally confirmed by IDA evidence (PMID:28031292) and represents a core molecular function that distinguishes DNAJB2 from other J-domain proteins.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/28031292" target="_blank" class="term-link">
                                         PMID:28031292
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">It binds ubiquitylated proteins through its Ubiquitin Interacting Motifs (UIMs) and facilitates their delivery to the proteasome for degradation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21625540" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21625540
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Co-chaperone HSJ1a dually regulates the proteasomal degradat...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -2242,57 +2253,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IPI annotation from Gao et al. (2011) records DNAJB2 self-interaction (with/from P25686-2, HSJ1a isoform). The paper shows HSJ1a interaction with HSP70 and ataxin-3, and the with/from suggesting self-interaction may reflect co-immunoprecipitation artifacts. Regardless, GO:0005515 (protein binding) is uninformative. DNAJB2&#39;s interactions are better captured by specific binding terms already annotated.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding (GO:0005515) is uninformative. DNAJB2&#39;s specific binding interactions are already captured by GO:0030544 (Hsp70 protein binding), GO:0043130 (ubiquitin binding), GO:0051087 (protein-folding chaperone binding), and GO:0140036 (ubiquitin-modified protein reader activity).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008285" target="_blank" class="term-link">
                                     GO:0008285
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of cell population proliferation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9553041" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9553041
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Inhibition of cellular proliferation by the Wilms tumor supp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -2304,75 +2315,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IGI annotation from Maheswaran et al. (1998) derives from a study of the Wilms tumor suppressor WT1, not DNAJB2 specifically. The paper showed that WT1-mediated growth inhibition requires association with Hsp70, and that substitution of a heterologous Hsp70-binding domain derived from &#34;human DNAJ&#34; could restore WT1 function (PMID:9553041). This is a chimeric construct experiment; the J domain of an unspecified human DnaJ protein was fused to WT1 to test whether Hsp70 binding mediates growth suppression. DNAJB2 is not the gene under study, and the observation is about WT1 function, not DNAJB2 function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PMID:9553041 studies WT1 tumor suppressor function, not DNAJB2. The paper used a generic &#34;human DNAJ&#34; domain as a tool to provide Hsp70-binding capability to WT1. Negative regulation of cell proliferation is not a function of DNAJB2; it is a function of WT1. The IGI annotation incorrectly attributes a WT1 phenotype to DNAJB2.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9553041" target="_blank" class="term-link">
                                         PMID:9553041
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Substitution of a heterologous Hsp70-binding domain derived from human DNAJ is sufficient to restore the functional properties of a WT1 protein with an amino-terminal deletion, an effect that is abrogated by a point mutation in DNAJ that reduces binding to Hsp70.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030308" target="_blank" class="term-link">
                                     GO:0030308
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of cell growth</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9553041" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9553041
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Inhibition of cellular proliferation by the Wilms tumor supp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -2384,75 +2395,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Same as the GO:0008285 annotation above - this IGI annotation from Maheswaran et al. (1998) derives from a WT1 study where a human DNAJ J domain was used as a chimeric tool. The growth inhibition is a property of WT1, not DNAJB2. DNAJB2&#39;s J domain was used merely to provide Hsp70-binding capability to test WT1 function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PMID:9553041 is about WT1 function, not DNAJB2. The DNAJ J domain was used as a heterologous tool in a chimeric construct. Negative regulation of cell growth is a WT1 function, not a DNAJB2 function. This annotation incorrectly attributes a WT1 phenotype to DNAJB2.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9553041" target="_blank" class="term-link">
                                         PMID:9553041
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Substitution of a heterologous Hsp70-binding domain derived from human DNAJ is sufficient to restore the functional properties of a WT1 protein with an amino-terminal deletion, an effect that is abrogated by a point mutation in DNAJ that reduces binding to Hsp70.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2464,75 +2475,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IPI annotation from Hageman et al. (2011) is based on the demonstrated interaction between DNAJB2 and HSP70 family members (with/from P0DMV8/HSPA1A, P0DMV9/HSPA1B, P17066/HSPA6). The study systematically characterized interactions between HSP40/DNAJ and HSP70/HSPA family members and demonstrated that DNAJB2 interacts with HSP70 proteins that are protein-folding chaperones (PMID:21231916). This is a core molecular function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein-folding chaperone binding is experimentally validated by co-expression studies showing DNAJB2 interaction with HSP70 chaperones HSPA1A, HSPA1B, and HSPA6 (PMID:21231916). This is a core function of DNAJB2 as a J-domain co-chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol. To test for possible functional differences and/or substrate specificity, we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24023695" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24023695
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular chaperone mediated late-stage neuroprotection in t...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2544,75 +2555,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IMP annotation from Novoselov et al. (2013) is based on data showing that HSJ1a overexpression reduces SOD1(G93A) aggregation and improves motor neuron survival in vivo (PMID:24023695). The J domain mutant H31Q lost the ability to suppress aggregation while the UIM mutant was partially functional. The paper describes HSJ1a as acting through &#34;chaperone, co-chaperone and pro-ubiquitylation activity.&#34; Protein folding is an appropriate biological process for DNAJB2&#39;s role in maintaining protein homeostasis.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein folding is a core biological process for DNAJB2 as an HSP70 co-chaperone. The IMP evidence from mutant phenotype studies (J domain and UIM mutants affecting SOD1 aggregation) supports DNAJB2&#39;s role in protein folding/quality control (PMID:24023695).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24023695" target="_blank" class="term-link">
                                         PMID:24023695
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSJ1a preferentially bound to mutant SOD1, enhanced SOD1 ubiquitylation and reduced SOD1 aggregation in a J-domain and ubiquitin interaction motif (UIM) dependent manner. Collectively, the data suggest that HSJ1a acts on mutant SOD1 through a combination of chaperone, co-chaperone and pro-ubiquitylation activity.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031396" target="_blank" class="term-link">
                                     GO:0031396
                                 </a>
                             </span>
                             <span class="term-label">regulation of protein ubiquitination</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24023695" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24023695
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular chaperone mediated late-stage neuroprotection in t...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2624,88 +2635,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IMP annotation from Novoselov et al. (2013) is based on data showing that HSJ1a enhances SOD1 ubiquitylation in a UIM-dependent manner (PMID:24023695). The UIM mutant did not enhance SOD1 ubiquitylation, while wild-type HSJ1a strongly increased ubiquitin immunoreactivity on SOD1 upon proteasome inhibition. Gao et al. (2011) also showed HSJ1a regulates ubiquitination of ataxin-3 (PMID:21625540). This is a core function linked to DNAJB2&#39;s UIM domains.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Regulation of protein ubiquitination is a well-characterized function of DNAJB2 mediated by its UIM domains. IMP evidence from mutant studies confirms this (PMID:24023695, PMID:21625540). This is a core biological process for DNAJB2.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24023695" target="_blank" class="term-link">
                                         PMID:24023695
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSJ1a preferentially bound to mutant SOD1, enhanced SOD1 ubiquitylation and reduced SOD1 aggregation in a J-domain and ubiquitin interaction motif (UIM) dependent manner.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21625540" target="_blank" class="term-link">
                                         PMID:21625540
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The J-domain down-regulates the protein level of Atx3 through HSP70 mediated proteasomal degradation, while the UIM domain may alleviate this process via maintaining the ubiquitinated Atx3.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24023695" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24023695
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular chaperone mediated late-stage neuroprotection in t...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -2717,99 +2728,99 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962). This IDA annotation from Novoselov et al. (2013) is based on data showing that HSJ1a preferentially bound to mutant SOD1(G93A) and reduced SOD1 aggregation in a J-domain and UIM-dependent manner. The paper describes HSJ1a as acting through a combination of chaperone, co-chaperone, and pro-ubiquitylation activity (PMID:24023695). The data demonstrate that DNAJB2 functions as a protein folding chaperone that cooperates with HSP70 to actively prevent protein aggregation, rather than passively binding unfolded proteins. The replacement term GO:0044183 (protein folding chaperone) accurately captures this activity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. The experimental evidence in Novoselov et al. (2013) shows that HSJ1a acts as a chaperone/co-chaperone that cooperates with HSP70 to reduce SOD1 aggregation via its J domain. The J domain mutant H31Q could still bind mutant SOD1 but non-productively, confirming this is active chaperone function rather than passive binding. GO:0044183 (protein folding chaperone) is the appropriate replacement.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24023695" target="_blank" class="term-link">
                                         PMID:24023695
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSJ1a preferentially bound to mutant SOD1, enhanced SOD1 ubiquitylation and reduced SOD1 aggregation in a J-domain and ubiquitin interaction motif (UIM) dependent manner. Collectively, the data suggest that HSJ1a acts on mutant SOD1 through a combination of chaperone, co-chaperone and pro-ubiquitylation activity.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24023695" target="_blank" class="term-link">
                                         PMID:24023695
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The J domain mutant could still bind to mutant SOD1 but the binding appears to be non-productive and suggests that HSJ1a co-operates with Hsp70 to actively prevent mutant SOD1 aggregation, rather than by a passive chaperone action.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
                                     GO:0001671
                                 </a>
                             </span>
                             <span class="term-label">ATPase activator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/7957263" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:7957263
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Regulation of 70-kDa heat-shock-protein ATPase activity and ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2821,75 +2832,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cheetham et al. (1994) directly demonstrated that HSJ1a and HSJ1b enhance the intrinsic ATPase activity of constitutive Hsc70 more than fivefold in vitro (PMID:7957263). This enhancement is mediated by an increase in the rate of bound ATP hydrolysis. This is a core molecular function of DNAJB2 as a J-domain co-chaperone.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATPase activator activity is directly demonstrated by in vitro assay showing more than fivefold stimulation of Hsc70 ATPase by HSJ1a and HSJ1b (PMID:7957263). This is the defining molecular function of J-domain co-chaperones.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7957263" target="_blank" class="term-link">
                                         PMID:7957263
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The weak intrinsic ATPase activity of the constitutive 70-kDa heat-shock protein is enhanced more than fivefold by stoichiometric amounts of both HSJ1a and HSJ1b. This enhancement is mediated by an increase in the rate of bound ATP hydrolysis, whereas the rate of ADP release is unaffected.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032091" target="_blank" class="term-link">
                                     GO:0032091
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/7957263" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:7957263
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Regulation of 70-kDa heat-shock-protein ATPase activity and ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2901,75 +2912,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cheetham et al. (1994) showed that in the presence of ATP, HSJ1 proteins reduce Hsc70/ carboxymethylated alpha-lactalbumin complex formation, i.e., they reduce binding of Hsc70 to its substrate (PMID:7957263). The authors interpreted this as HSJ1 inducing a conformational change in Hsc70 that modulates substrate release. This is a mechanistic consequence of the J-domain-mediated ATPase cycle regulation, where HSJ1 drives HSP70 substrate turnover. While the observation is valid, GO:0032091 (negative regulation of protein binding) is a very generic biological process term that does not adequately capture the specific mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The observation is valid but the term is very general. DNAJB2 modulates Hsc70 substrate binding as part of the ATPase cycle, driving substrate release. This is better understood as part of the co-chaperone mechanism (regulation of protein folding, ATPase activation) rather than as a standalone process. It is a mechanistic detail of the co-chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7957263" target="_blank" class="term-link">
                                         PMID:7957263
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">In the presence of ATP, HSJ1 proteins reduce 70-kDa constitutive heat-shock protein/carboxymethylated alpha-lactalbumin complex formation both in the presence and absence of K+.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032781" target="_blank" class="term-link">
                                     GO:0032781
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of ATP-dependent activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/7957263" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:7957263
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Regulation of 70-kDa heat-shock-protein ATPase activity and ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2981,75 +2992,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cheetham et al. (1994) showed that HSJ1a and HSJ1b stimulate the ATP-dependent activity of Hsc70, enhancing its ATPase activity more than fivefold (PMID:7957263). Positive regulation of ATP-dependent activity is an appropriate biological process term that captures the downstream effect of the J-domain-mediated ATPase activation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This accurately describes the biological process resulting from DNAJB2&#39;s ATPase activator activity. HSJ1 proteins stimulate HSP70 ATP hydrolysis, thereby positively regulating ATP-dependent chaperone function (PMID:7957263).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7957263" target="_blank" class="term-link">
                                         PMID:7957263
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The weak intrinsic ATPase activity of the constitutive 70-kDa heat-shock protein is enhanced more than fivefold by stoichiometric amounts of both HSJ1a and HSJ1b.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1903332" target="_blank" class="term-link">
                                     GO:1903332
                                 </a>
                             </span>
                             <span class="term-label">regulation of protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/7957263" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:7957263
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Regulation of 70-kDa heat-shock-protein ATPase activity and ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3061,75 +3072,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cheetham et al. (1994) demonstrated that HSJ1 proteins regulate Hsc70 ATPase activity and substrate binding, which are the key determinants of chaperone-mediated protein folding (PMID:7957263). By modulating the ATPase cycle and substrate release, HSJ1 proteins regulate the protein folding activity of Hsc70. This is an appropriate biological process annotation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Regulation of protein folding accurately captures the biological outcome of DNAJB2&#39;s co-chaperone activity. By stimulating Hsc70 ATPase and modulating substrate binding, DNAJB2 regulates the protein folding cycle (PMID:7957263). This is a core biological function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7957263" target="_blank" class="term-link">
                                         PMID:7957263
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSJ1 proteins appear to regulate the affinity of the 70-kDa constitutive heat-shock protein for the permanently unfolded substrate, carboxymethylated alpha-lactalbumin.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
                                     GO:0001671
                                 </a>
                             </span>
                             <span class="term-label">ATPase activator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22219199" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22219199
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The C-terminal helices of heat shock protein 70 are essentia...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3141,75 +3152,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Gao et al. (2012) confirmed that the J domain of HSJ1a mediates ATPase activation of HSP70, using NMR structural studies and in vitro assays (PMID:22219199). They showed the C-terminal helical subdomain of HSP70 is crucial for J-domain binding and ATPase stimulation, providing the structural basis for this core function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Independent confirmation of ATPase activator activity using structural and biochemical approaches (PMID:22219199). Corroborates the earlier findings of Cheetham et al. (1994).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22219199" target="_blank" class="term-link">
                                         PMID:22219199
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The C-terminal helical alpha-subdomain of HSP70, which was considered to function as a lid of the substrate-binding domain, is crucial for binding with the J domain of HSJ1a and stimulating the ATPase activity of HSP70.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030544" target="_blank" class="term-link">
                                     GO:0030544
                                 </a>
                             </span>
                             <span class="term-label">Hsp70 protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22219199" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22219199
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The C-terminal helices of heat shock protein 70 are essentia...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3221,75 +3232,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Gao et al. (2012) demonstrated the physical interaction between the J domain of HSJ1a and HSP70 using NMR titration and biochemical assays (PMID:22219199). The with/from column indicates P0DMV8 (HSPA1A). The paper characterized the structural determinants of this interaction, showing the C-terminal helices of HSP70 are essential for J-domain binding.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct physical interaction between DNAJB2 J domain and HSP70 is demonstrated by NMR and biochemical studies (PMID:22219199). This is a core molecular function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22219199" target="_blank" class="term-link">
                                         PMID:22219199
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We studied the interaction between human-inducible HSP70 and Homo sapiens J-domain protein (HSJ1a), a J domain and UIM motif-containing co-chaperone.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032781" target="_blank" class="term-link">
                                     GO:0032781
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of ATP-dependent activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22219199" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22219199
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The C-terminal helices of heat shock protein 70 are essentia...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3301,75 +3312,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Gao et al. (2012) confirmed that the J domain of HSJ1a stimulates the ATPase activity of HSP70, providing the structural basis for this activation (PMID:22219199). This independent confirmation corroborates the earlier functional data from Cheetham et al. (1994).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Independent confirmation of positive regulation of ATP-dependent activity by structural and biochemical studies (PMID:22219199).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22219199" target="_blank" class="term-link">
                                         PMID:22219199
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The C-terminal helical alpha-subdomain of HSP70, which was considered to function as a lid of the substrate-binding domain, is crucial for binding with the J domain of HSJ1a and stimulating the ATPase activity of HSP70.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3381,75 +3392,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Hageman et al. (2011) observed DNAJB2 in the nucleus by immunofluorescence as part of their systematic characterization of HSP70 machine components (PMID:21231916). UniProt confirms nuclear localization for isoform 2 (HSJ1a) based on PMID:12754272. The Ottaviani et al. (2017) paper also confirmed nuclear and cytosolic localization of HSJ1a in SK-N-SH neuronal cells (PMID:28031292).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear localization is experimentally confirmed by IDA evidence (PMID:21231916) and corroborated by multiple studies (PMID:12754272, PMID:28031292). HSJ1a localizes to both cytoplasm and nucleus.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/28031292" target="_blank" class="term-link">
                                         PMID:28031292
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">In all cases the HSJ1a signal was predominantly in the cytosol and nucleus, as previously reported (7).</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3461,75 +3472,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Hageman et al. (2011) observed cytosolic localization of DNAJB2 by immunofluorescence as part of their systematic HSP70 machine characterization (PMID:21231916). Multiple studies confirm that HSJ1a is predominantly cytosolic (PMID:12754272, PMID:28031292).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization is experimentally confirmed by IDA evidence (PMID:21231916) and corroborated by multiple studies. HSJ1a is the cytosolic isoform of DNAJB2.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/28031292" target="_blank" class="term-link">
                                         PMID:28031292
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">In all cases the HSJ1a signal was predominantly in the cytosol and nucleus, as previously reported (7).</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3541,75 +3552,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Hageman et al. (2011) directly assessed protein refolding activity by measuring refolding of heat-denatured luciferase upon overexpression of HSP40/DNAJ family members including DNAJB2 (PMID:21231916). DNAJB2 showed distinct chaperone-like activities in this systematic study. Protein refolding is a core function of the HSP70/HSP40 chaperone machine.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein refolding is directly demonstrated by IDA evidence from luciferase refolding assays (PMID:21231916). This is a core biological process for DNAJB2 as an HSP70 co-chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol. To test for possible functional differences and/or substrate specificity, we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -3621,99 +3632,99 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962). This IDA annotation from Hageman et al. (2011) is based on systematic characterization of HSP70 machine components. The paper assessed the effect of overexpression of HSP70 and HSP40/DNAJ family members on refolding of heat-denatured luciferase and suppression of polyQ aggregation, demonstrating that these are protein folding chaperones with distinct chaperone-like activities (PMID:21231916). DNAJB2 is part of the HSP70 chaperone machine, functioning as a J-protein co-chaperone that assists HSP70 in protein folding. The replacement term GO:0044183 (protein folding chaperone) accurately captures this function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. Hageman et al. (2011) characterized DNAJB2 as part of the HSP70 machine with distinct chaperone-like activities including protein refolding and aggregation suppression. This is protein folding chaperone activity (GO:0044183), not standalone unfolded protein binding. The term GO:0044183 (protein folding chaperone) is the appropriate replacement.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol. To test for possible functional differences and/or substrate specificity, we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24023695" target="_blank" class="term-link">
                                         PMID:24023695
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The molecular chaperone HSJ1 (DNAJB2) is a member of the Hsp40 (or DnaJ) family of heat shock proteins that contain a J domain, which is crucial in substrate recognition by Hsp70 [21], [22], [23]. Thus, Hsp40/DnaJ protein function is essential for Hsp70 function, including protein folding and directing misfolded proteins towards the proteasome [23].</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090084" target="_blank" class="term-link">
                                     GO:0090084
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of inclusion body assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3725,130 +3736,130 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Hageman et al. (2011) demonstrated that DNAJB2 (and other HSP40/DNAJ family members) suppress aggregation of polyQ-expanded Huntingtin fragment, which forms inclusion bodies (PMID:21231916). Novoselov et al. (2013) showed HSJ1a reduced SOD1 inclusion formation in SK-N-SH cells in a J-domain and UIM-dependent manner (PMID:24023695). Negative regulation of inclusion body assembly is a well-characterized function of DNAJB2.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Negative regulation of inclusion body assembly is directly demonstrated by IDA evidence showing suppression of polyQ aggregation (PMID:21231916) and SOD1 inclusion formation (PMID:24023695). This represents a key biological outcome of DNAJB2&#39;s combined chaperone and ubiquitin-binding activities.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24023695" target="_blank" class="term-link">
                                         PMID:24023695
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The expression of HSJ1a led to a significant reduction in SOD1-G93A inclusions and redistribution to an even cytoplasmic and nuclear staining pattern similar to the SOD1-WT.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006986" target="_blank" class="term-link">
                                     GO:0006986
                                 </a>
                             </span>
                             <span class="term-label">response to unfolded protein</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/1599432" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:1599432
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human homologues of the bacterial heat-shock protein DnaJ ar...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P25686" data-a="GO:0006986" data-r="PMID:1599432" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P25686" data-a="GO:0006986" data-r="PMID:1599432" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This TAS annotation from PINC references Cheetham et al. (1992), the original cloning paper for HSJ1/DNAJB2 (PMID:1599432). The paper identified HSJ1 as a human DnaJ homologue expressed preferentially in neurons, and noted the DnaJ-DnaK interaction is involved in protein folding and complex dissociation. The annotation to &#34;response to unfolded protein&#34; is appropriate as DNAJB2 is part of the chaperone response to misfolded/unfolded proteins. However, DNAJB2 is constitutively expressed and functions as a co-chaperone rather than being specifically induced as a stress response. The term is somewhat imprecise for DNAJB2&#39;s constitutive role.
+                            <strong>Summary:</strong> This TAS annotation from PINC references Cheetham et al. (1992), the original cloning paper for HSJ1/DNAJB2 (PMID:1599432). The paper identified HSJ1 as a human DnaJ homologue expressed preferentially in neurons, and noted the DnaJ-DnaK interaction is involved in protein folding and complex dissociation. The annotation to &#34;response to unfolded protein&#34; is appropriate as DNAJB2 is part of the chaperone response to misfolded/unfolded proteins. However, DNAJB2 is constitutively expressed and functions as a co-chaperone rather than being specifically induced as a stress response. The term is imprecise for DNAJB2&#39;s constitutive neuronal proteostasis role.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> While DNAJB2 is related to DnaJ stress response proteins and functions in protein quality control, &#34;response to unfolded protein&#34; implies a stress-responsive process. DNAJB2 is constitutively expressed in neurons (PMID:1599432) and functions in basal proteostasis. Its core functions are better captured by protein folding, protein refolding, and regulation of proteasomal degradation terms. This is not incorrect but is not the most precise description.
+                            <strong>Reason:</strong> While DNAJB2 is related to DnaJ stress response proteins and functions in protein quality control, &#34;response to unfolded protein&#34; implies a stress-responsive process. DNAJB2 is constitutively expressed in neurons (PMID:1599432) and functions in basal proteostasis. Its core functions are better captured by protein folding, protein refolding, and regulation of proteasomal degradation terms. The annotation overstates the stress-response aspect of the original cloning and homology evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/1599432" target="_blank" class="term-link">
                                         PMID:1599432
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The bacterial heat-shock protein DnaJ has been implicated in protein folding and protein complex dissociation. The DnaJ protein interacts with the prokaryotic analogue of Hsp70, DnaK, and accelerates the rate of ATP hydrolysis by DnaK.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>DNAJB2 (HSJ1) is a neuronally enriched class B J-domain co-chaperone that functions as a &#34;triage&#34; factor in the HSP70-dependent protein quality control pathway. It binds misfolded protein substrates and delivers them to HSP70/Hsc70 for refolding or, critically, for ubiquitin-dependent proteasomal degradation. The J-domain stimulates HSP70 ATPase activity (&gt;5-fold enhancement at stoichiometric amounts, PMID:7957263), while two C-terminal UIMs bind polyubiquitin chains and facilitate client delivery to the proteasome. DNAJB2 cooperates with CHIP/STUB1 E3 ubiquitin ligase and protects polyubiquitin chains from deubiquitylation, supporting a shuttle function for ubiquitinated substrates (DOI:10.3390/ijms21041409). CK2 phosphorylation of UIM2 (Ser250) modulates ubiquitin-binding capacity (PMID:28031292). DNAJB2 suppresses aggregation of diverse neurodegeneration-associated substrates (polyQ- expanded huntingtin, SOD1, TDP-43, parkin; DOI:10.3389/fncel.2014.00191). Mutations cause neuromuscular disease spanning dHMN/CMT2 to neuromyopathy, with both recessive and dominant (stop-loss extension) inheritance patterns now recognized (DOI:10.1093/hmg/ddad058, DOI:10.1097/WCO.0000000000001299).</h3>
                 <span class="vote-buttons" data-g="P25686" data-a="FUNCTION: DNAJB2 (HSJ1) is a neuronally enriched class B J-d..." data-r="" data-act="CORE_FUNCTION">
@@ -3856,10 +3867,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -3868,111 +3879,111 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                 protein folding
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                 protein refolding
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090084" target="_blank" class="term-link">
                                 negative regulation of inclusion body assembly
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1903332" target="_blank" class="term-link">
                                 regulation of protein folding
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032781" target="_blank" class="term-link">
                                 positive regulation of ATP-dependent activity
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                 nucleus
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24023695" target="_blank" class="term-link">
                                 PMID:24023695
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">The molecular chaperone HSJ1 (DNAJB2) is a member of the Hsp40 (or DnaJ) family of heat shock proteins that contain a J domain, which is crucial in substrate recognition by Hsp70 [21], [22], [23]. Thus, Hsp40/DnaJ protein function is essential for Hsp70 function, including protein folding and directing misfolded proteins towards the proteasome [23].</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                 PMID:21231916
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>DNAJB2 stimulates the intrinsic ATPase activity of HSP70/Hsc70 more than fivefold via its J-domain. Both HSJ1a and HSJ1b isoforms enhance ATP hydrolysis by Hsc70, driving the chaperone cycle for substrate binding and release.</h3>
                 <span class="vote-buttons" data-g="P25686" data-a="FUNCTION: DNAJB2 stimulates the intrinsic ATPase activity of..." data-r="" data-act="CORE_FUNCTION">
@@ -3980,10 +3991,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -3992,81 +4003,81 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032781" target="_blank" class="term-link">
                                 positive regulation of ATP-dependent activity
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/7957263" target="_blank" class="term-link">
                                 PMID:7957263
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">The weak intrinsic ATPase activity of the constitutive 70-kDa heat-shock protein is enhanced more than fivefold by stoichiometric amounts of both HSJ1a and HSJ1b. This enhancement is mediated by an increase in the rate of bound ATP hydrolysis, whereas the rate of ADP release is unaffected.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22219199" target="_blank" class="term-link">
                                 PMID:22219199
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">The C-terminal helical alpha-subdomain of HSP70, which was considered to function as a lid of the substrate-binding domain, is crucial for binding with the J domain of HSJ1a and stimulating the ATPase activity of HSP70.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>DNAJB2 reads ubiquitin modifications on misfolded client proteins via two C-terminal ubiquitin-interacting motifs (UIMs) and facilitates their delivery to the proteasome for degradation. It cooperates with the E3 ubiquitin ligase CHIP/STUB1 and protects polyubiquitin chains from deubiquitylation, acting as a &#34;neuronal shuttling factor&#34; that couples chaperone recognition to proteasomal clearance (DOI:10.3390/ijms21041409). CK2 phosphorylation of UIM2 (Ser250) reduces ubiquitin-binding capacity, providing a signaling-dependent regulatory switch (PMID:28031292). This function distinguishes DNAJB2 from other J-domain proteins and is especially critical in long-lived neurons where proteasomal protein degradation is essential for proteostasis. The two isoforms (HSJ1a cytosolic/ nuclear, HSJ1b ER-anchored) operate in distinct compartments to manage both cytosolic and ER-associated degradation substrates.</h3>
                 <span class="vote-buttons" data-g="P25686" data-a="FUNCTION: DNAJB2 reads ubiquitin modifications on misfolded ..." data-r="" data-act="CORE_FUNCTION">
@@ -4074,10 +4085,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -4086,505 +4097,519 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032436" target="_blank" class="term-link">
                                 positive regulation of proteasomal ubiquitin-dependent protein catabolic process
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031396" target="_blank" class="term-link">
                                 regulation of protein ubiquitination
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090084" target="_blank" class="term-link">
                                 negative regulation of inclusion body assembly
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                 nucleus
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28031292" target="_blank" class="term-link">
                                 PMID:28031292
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">It binds ubiquitylated proteins through its Ubiquitin Interacting Motifs (UIMs) and facilitates their delivery to the proteasome for degradation.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21625540" target="_blank" class="term-link">
                                 PMID:21625540
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">The J-domain down-regulates the protein level of Atx3 through HSP70 mediated proteasomal degradation, while the UIM domain may alleviate this process via maintaining the ubiquitinated Atx3.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/DNAJB2/DNAJB2-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for DNAJB2</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
                             GO_REF:0000052
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/1599432" target="_blank" class="term-link">
                             PMID:1599432
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Human homologues of the bacterial heat-shock protein DnaJ are preferentially expressed in neurons.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                             PMID:21231916
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The diverse members of the mammalian HSP70 machine show distinct chaperone-like activities.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21625540" target="_blank" class="term-link">
                             PMID:21625540
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Co-chaperone HSJ1a dually regulates the proteasomal degradation of ataxin-3.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22219199" target="_blank" class="term-link">
                             PMID:22219199
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The C-terminal helices of heat shock protein 70 are essential for J-domain binding and ATPase activation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24023695" target="_blank" class="term-link">
                             PMID:24023695
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Molecular chaperone mediated late-stage neuroprotection in the SOD1(G93A) mouse model of amyotrophic lateral sclerosis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link">
                             PMID:25036637
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A quantitative chaperone interaction network reveals the architecture of cellular protein homeostasis pathways.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28031292" target="_blank" class="term-link">
                             PMID:28031292
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Protein kinase CK2 modulates HSJ1 function through phosphorylation of the UIM2 domain.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/7957263" target="_blank" class="term-link">
                             PMID:7957263
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Regulation of 70-kDa heat-shock-protein ATPase activity and substrate binding by human DnaJ-like proteins, HSJ1a and HSJ1b.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9553041" target="_blank" class="term-link">
                             PMID:9553041
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Inhibition of cellular proliferation by the Wilms tumor suppressor WT1 requires association with the inducible chaperone Hsp70.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.3390/ijms21041409
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Neuromuscular diseases due to chaperone mutations - a review and some new results.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">DNAJB2 cooperates with CHIP/STUB1-mediated ubiquitylation and protects polyubiquitin chains from deubiquitylation, supporting a shuttle/stabilization role for ubiquitinated clients destined for proteasomal degradation.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">CK2 phosphorylation of UIM2 reduces HSJ1&#39;s ability to bind ubiquitylated clients, providing a kinase-dependent regulatory mechanism for DNAJB2 proteostasis functions.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1093/hmg/ddad058
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Extension of the DNAJB2a isoform in a dominant neuromyopathy family.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">First dominantly acting DNAJB2 mutation reported: stop-loss variant (p.*278Glyext*83) creates a transmembrane helix driving ER mislocalization and proteasomal degradation of mutant DNAJB2a with dominant-negative effects on wild-type protein.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Approximately 50% reduction of both DNAJB2 isoforms in patient muscle tissue, with rapid cycloheximide-chase turnover of the extension mutant rescued by MG132 proteasome inhibition.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1097/WCO.0000000000001299
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Current advance on distal myopathy genetics.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">DNAJB2 recognized among newly identified genes for late-onset distal myopathy and neuromyopathy, including both recessive and dominant inheritance patterns.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.3389/fncel.2014.00191
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">J protein mutations and resulting proteostasis collapse.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">DNAJB2 is an anti-aggregation cochaperone suppressing aggregation of diverse neurodegeneration-associated proteins including polyQ-expanded huntingtin, parkin, SOD1, and TDP-43.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.3390/neurolint17050073
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Impaired DNAJB2 response to heat shock in fibroblasts from a neuropathy patient with DNAJB2/HSJ1 mutation - cystamine as a potential therapeutic intervention.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">48-hour pretreatment with cystamine (150 uM) increased DNAJB2 levels in both control and patient fibroblasts, supporting a pharmacologic DNAJB2 boosting strategy.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -4870,9 +4895,9 @@ this with annotations you find in gene/protein databases, but these can be outda
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -4884,7 +4909,7 @@ this with annotations you find in gene/protein databases, but these can be outda
                 <pre><code>id: P25686
 gene_symbol: DNAJB2
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -4945,6 +4970,10 @@ existing_annotations:
           The J domain of HSJ1a shares a conserved structure with other J domains from both
           eukaryotic and prokaryotic species, and it mediates the interaction with and the
           ATPase cycle of HSP70.
+      - reference_id: file:human/DNAJB2/DNAJB2-deep-research-falcon.md
+        supporting_text: &gt;-
+          DNAJB2 &#34;traffics unfolded proteins&#34; to Hsp70 and stimulates Hsp70
+          ATPase activity via its J-domain, a canonical JDP activity.
 - term:
     id: GO:0005829
     label: cytosol
@@ -5272,17 +5301,14 @@ existing_annotations:
       This TAS annotation from ARUK-UCL references PMID:28031292 (Ottaviani et al. 2017). The paper
       describes DNAJB2 as a &#34;shuttling factor to sort chaperone clients to the proteasome&#34; (citing
       Westhoff et al. 2005, PMID:15936278). DNAJB2 facilitates delivery of ubiquitylated misfolded
-      proteins to the proteasome. However, &#34;protein transporter activity&#34; (GO:0140318) implies a
-      transporter function, which is a stretch for a co-chaperone that helps target substrates for
-      proteasomal degradation. This is more accurately described as regulation of proteasomal
-      targeting rather than transport per se.
-    action: MARK_AS_OVER_ANNOTATED
+      proteins to the proteasome. GO:0140318 covers direct binding to a protein cargo and
+      delivery of that cargo to a cellular destination, so it is appropriate for DNAJB2&#39;s
+      shuttling-factor role in delivering ubiquitylated clients to the proteasome.
+    action: ACCEPT
     reason: &gt;-
-      DNAJB2 acts as a co-chaperone that sorts misfolded clients to the proteasome, but this is
-      more accurately described as chaperoning/targeting rather than transport activity. The term
-      protein transporter activity implies a direct transport mechanism that is not well-supported
-      for DNAJB2. The proteasomal targeting function is better captured by annotations like
-      GO:0032436 (positive regulation of proteasomal ubiquitin-dependent protein catabolic process).
+      DNAJB2/HSJ1 binds ubiquitylated client proteins through its UIMs and facilitates their
+      delivery to the proteasome. This satisfies protein transporter activity in the protein-
+      cargo delivery sense and does not require transmembrane transport.
     supported_by:
       - reference_id: PMID:28031292
         supporting_text: &gt;-
@@ -5879,15 +5905,16 @@ existing_annotations:
       protein folding and complex dissociation. The annotation to &#34;response to unfolded protein&#34;
       is appropriate as DNAJB2 is part of the chaperone response to misfolded/unfolded proteins.
       However, DNAJB2 is constitutively expressed and functions as a co-chaperone rather than being
-      specifically induced as a stress response. The term is somewhat imprecise for DNAJB2&#39;s
-      constitutive role.
-    action: KEEP_AS_NON_CORE
+      specifically induced as a stress response. The term is imprecise for DNAJB2&#39;s
+      constitutive neuronal proteostasis role.
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       While DNAJB2 is related to DnaJ stress response proteins and functions in protein quality
       control, &#34;response to unfolded protein&#34; implies a stress-responsive process. DNAJB2 is
       constitutively expressed in neurons (PMID:1599432) and functions in basal proteostasis. Its
       core functions are better captured by protein folding, protein refolding, and regulation of
-      proteasomal degradation terms. This is not incorrect but is not the most precise description.
+      proteasomal degradation terms. The annotation overstates the stress-response aspect of
+      the original cloning and homology evidence.
     supported_by:
       - reference_id: PMID:1599432
         supporting_text: &gt;-
@@ -6006,6 +6033,9 @@ core_functions:
       - id: GO:0005634
         label: nucleus
 references:
+- id: file:human/DNAJB2/DNAJB2-deep-research-falcon.md
+  title: Falcon deep research report for DNAJB2
+  findings: []
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
     terms
@@ -6119,7 +6149,7 @@ references:
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/DNAJB2/DNAJB2-ai-review.yaml
+++ b/genes/human/DNAJB2/DNAJB2-ai-review.yaml
@@ -1,7 +1,7 @@
 id: P25686
 gene_symbol: DNAJB2
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -62,6 +62,10 @@ existing_annotations:
           The J domain of HSJ1a shares a conserved structure with other J domains from both
           eukaryotic and prokaryotic species, and it mediates the interaction with and the
           ATPase cycle of HSP70.
+      - reference_id: file:human/DNAJB2/DNAJB2-deep-research-falcon.md
+        supporting_text: >-
+          DNAJB2 "traffics unfolded proteins" to Hsp70 and stimulates Hsp70
+          ATPase activity via its J-domain, a canonical JDP activity.
 - term:
     id: GO:0005829
     label: cytosol
@@ -389,17 +393,14 @@ existing_annotations:
       This TAS annotation from ARUK-UCL references PMID:28031292 (Ottaviani et al. 2017). The paper
       describes DNAJB2 as a "shuttling factor to sort chaperone clients to the proteasome" (citing
       Westhoff et al. 2005, PMID:15936278). DNAJB2 facilitates delivery of ubiquitylated misfolded
-      proteins to the proteasome. However, "protein transporter activity" (GO:0140318) implies a
-      transporter function, which is a stretch for a co-chaperone that helps target substrates for
-      proteasomal degradation. This is more accurately described as regulation of proteasomal
-      targeting rather than transport per se.
-    action: MARK_AS_OVER_ANNOTATED
+      proteins to the proteasome. GO:0140318 covers direct binding to a protein cargo and
+      delivery of that cargo to a cellular destination, so it is appropriate for DNAJB2's
+      shuttling-factor role in delivering ubiquitylated clients to the proteasome.
+    action: ACCEPT
     reason: >-
-      DNAJB2 acts as a co-chaperone that sorts misfolded clients to the proteasome, but this is
-      more accurately described as chaperoning/targeting rather than transport activity. The term
-      protein transporter activity implies a direct transport mechanism that is not well-supported
-      for DNAJB2. The proteasomal targeting function is better captured by annotations like
-      GO:0032436 (positive regulation of proteasomal ubiquitin-dependent protein catabolic process).
+      DNAJB2/HSJ1 binds ubiquitylated client proteins through its UIMs and facilitates their
+      delivery to the proteasome. This satisfies protein transporter activity in the protein-
+      cargo delivery sense and does not require transmembrane transport.
     supported_by:
       - reference_id: PMID:28031292
         supporting_text: >-
@@ -996,15 +997,16 @@ existing_annotations:
       protein folding and complex dissociation. The annotation to "response to unfolded protein"
       is appropriate as DNAJB2 is part of the chaperone response to misfolded/unfolded proteins.
       However, DNAJB2 is constitutively expressed and functions as a co-chaperone rather than being
-      specifically induced as a stress response. The term is somewhat imprecise for DNAJB2's
-      constitutive role.
-    action: KEEP_AS_NON_CORE
+      specifically induced as a stress response. The term is imprecise for DNAJB2's
+      constitutive neuronal proteostasis role.
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
       While DNAJB2 is related to DnaJ stress response proteins and functions in protein quality
       control, "response to unfolded protein" implies a stress-responsive process. DNAJB2 is
       constitutively expressed in neurons (PMID:1599432) and functions in basal proteostasis. Its
       core functions are better captured by protein folding, protein refolding, and regulation of
-      proteasomal degradation terms. This is not incorrect but is not the most precise description.
+      proteasomal degradation terms. The annotation overstates the stress-response aspect of
+      the original cloning and homology evidence.
     supported_by:
       - reference_id: PMID:1599432
         supporting_text: >-
@@ -1123,6 +1125,9 @@ core_functions:
       - id: GO:0005634
         label: nucleus
 references:
+- id: file:human/DNAJB2/DNAJB2-deep-research-falcon.md
+  title: Falcon deep research report for DNAJB2
+  findings: []
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
     terms

--- a/genes/human/DNAJB6/DNAJB6-ai-review.html
+++ b/genes/human/DNAJB6/DNAJB6-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>DNAJB6</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/O75190" target="_blank" class="term-link">
                         O75190
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -737,15 +737,15 @@
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>DNAJB6 (also known as MRJ/HSJ-2) is a class B Hsp40/J-domain protein (JDP) co-chaperone that stimulates the ATPase activity of Hsp70 family members and acts as a potent suppressor of amyloid-type protein aggregation. Unlike canonical foldase chaperones, DNAJB6 does not refold denatured proteins but instead exhibits holdase-like activity, preventing aggregation of polyglutamine-expanded proteins, tau, and other aggregation-prone substrates. It functions within the Hsp70 chaperone network, requiring its J-domain for anti-aggregation activity. DNAJB6 also plays roles in keratin filament organization and nuclear pore complex assembly quality control. Mutations in DNAJB6 cause limb-girdle muscular dystrophy type D1 (LGMDD1). Two major isoforms exist: DNAJB6a (long, predominantly nuclear) and DNAJB6b (short, largely cytosolic), with isoform B being particularly important for suppression of protein aggregation.</p>
+        <p>DNAJB6 (also known as MRJ/HSJ-2) is a class B Hsp40/J-domain protein (JDP) co-chaperone that stimulates the ATPase activity of Hsp70 family members and acts as a potent suppressor of amyloid-type protein aggregation. Unlike canonical foldase chaperones, DNAJB6 does not refold denatured proteins but instead exhibits holdase-like activity, preventing aggregation of polyglutamine-expanded proteins, tau, and other aggregation-prone substrates. It functions within the Hsp70 chaperone network, requiring its J-domain for anti-aggregation activity. DNAJB6 also plays roles in keratin filament organization; emerging preprint work suggests an additional nuclear-pore condensate surveillance context. Mutations in DNAJB6 cause limb-girdle muscular dystrophy type D1 (LGMDD1). Two major isoforms exist: DNAJB6a (long, predominantly nuclear) and DNAJB6b (short, largely cytosolic), with isoform B being particularly important for suppression of protein aggregation.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,77 +795,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> DNAJB6 localizes to the cytoplasm, particularly the DNAJB6b isoform which is predominantly cytosolic. This is well supported by multiple lines of evidence including immunostaining in PMID:10954706, subcellular fractionation in PMID:21231916, and the observation in PMID:22366786 that LGMD1D mutations exert their pathogenic effect specifically through the cytoplasmic isoform DNAJB6b. The IBA annotation is appropriately broad and well supported by phylogenetic conservation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization is a well-established core feature of DNAJB6, especially the DNAJB6b isoform. PMID:10954706 showed colocalization with K8/18 filaments in HeLa cells. PMID:21231916 demonstrated cytosolic localization by IDA. PMID:22366786 showed LGMD1D mutations exert effects through the cytoplasmic isoform specifically. The IBA annotation is correct and represents a core localization.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10954706" target="_blank" class="term-link">
                                         PMID:10954706
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Immunostaining with anti-Mrj antibody showed that Mrj colocalized with K8/18 filaments in HeLa cells.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22366786" target="_blank" class="term-link">
                                         PMID:22366786
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Strikingly, these phenotypes were generated exclusively upon injection of mutant DNAJB6b; neither mutation, when engineered into DNAJB6a, had any impact (Fig. 2).</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -877,77 +877,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> DNAJB6 is a DnaJ co-chaperone that participates in the Hsp70 chaperone network, which broadly functions in protein folding and quality control. However, DNAJB6 specifically acts as a holdase rather than a foldase -- it suppresses aggregation but cannot stimulate refolding of denatured substrates (PMID:21231916). The IBA annotation to GO:0006457 (protein folding) captures the general chaperone pathway context but is somewhat misleading for DNAJB6 specifically, since the protein prevents aggregation rather than promoting productive folding. However, protein folding as a GO BP term encompasses the broader process including aggregation prevention, so the term is acceptable if understood in this context.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While DNAJB6 is specifically a holdase rather than foldase (PMID:21231916), GO:0006457 (protein folding) as a biological process broadly encompasses protein quality control activities including aggregation prevention. DNAJB6 participates in the Hsp70-dependent protein folding/quality control pathway via its J-domain, and as an IBA annotation this represents a reasonable phylogenetically inferred function for the DnaJ family. The term is not wrong, though it should be understood that DNAJB6 contributes specifically to the anti-aggregation arm of protein quality control.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11896048" target="_blank" class="term-link">
                                         PMID:11896048
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">overexpressed MRJ effectively suppressed polyglutamine-dependent protein aggregation, caspase activity, and cellular toxicity</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/DNAJB6/DNAJB6-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In neuronal cells, the DNAJB6b isoform is required and sufficient to reduce tau aggregation; its J-domain is necessary, consistent with Hsp70-dependent anti-aggregation.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -959,64 +970,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> DNAJB6 localizes to the nucleus, particularly the DNAJB6a isoform which is predominantly nuclear (PMID:10954706, PMID:22366786). PMID:10954706 showed nuclear localization by immunostaining. The deep research review also confirms nuclear localization for isoform A. The IBA annotation is well supported and phylogenetically appropriate for the DnaJ family.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear localization is well established for DNAJB6, particularly isoform A. PMID:10954706 demonstrated nuclear staining. This is a core localization for the protein, consistent with phylogenetic inference.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10954706" target="_blank" class="term-link">
                                         PMID:10954706
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Immunostaining with anti-Mrj antibody showed that Mrj colocalized with K8/18 filaments in HeLa cells. Mrj was immunoprecipitated not only with K18, but also with the stress-induced and constitutively expressed heat shock protein Hsp/c70.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1028,64 +1039,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> DNAJB6 binds Hsp70/HSPA family chaperones through its J-domain. PMID:10954706 demonstrated that Mrj (DNAJB6) immunoprecipitated with Hsp/c70 and that the N-terminal J-domain region mediates Hsp70 interaction. PMID:22366786 confirmed interaction with HSPA8 (Hsc70). The IBA annotation correctly reflects this core co-chaperone binding activity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Binding to Hsp70 chaperones is the defining molecular function of J-domain proteins. DNAJB6 interacts with Hsp/c70 via its J-domain (PMID:10954706), and this interaction is essential for the protein&#39;s co-chaperone function. The IBA annotation is a core function well supported by phylogenetic conservation across the DnaJ family.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10954706" target="_blank" class="term-link">
                                         PMID:10954706
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Mrj was immunoprecipitated not only with K18, but also with the stress-induced and constitutively expressed heat shock protein Hsp/c70. Mrj bound to K18 through its C terminus and interacted with Hsp/c70 via its N terminus, which contains the J domain.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     GO:0044183
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1097,64 +1108,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0044183 (protein folding chaperone) is an MF term describing proteins that bind other proteins to assist the protein folding process. DNAJB6 acts as a co-chaperone within the Hsp70 network, functioning specifically as a holdase that prevents aggregation rather than assisting productive folding. The IBA annotation is phylogenetically appropriate for the DnaJ family and represents the closest available GO molecular function term for DNAJB6 chaperone activity, even though a holdase-specific term would be more precise.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0044183 is the best available MF term for DNAJB6 chaperone activity. While DNAJB6 specifically acts as a holdase rather than foldase (PMID:21231916), there is no dedicated holdase term in GO. The IBA annotation is phylogenetically sound for the DnaJ family. This is already being used as the replacement term for the obsoleting GO:0051082, making it a core annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/DNAJB6/DNAJB6-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">DNAJB6 is a human class B Hsp40/JDP co-chaperone that deploys an autoinhibited, J-domain-controlled mechanism to engage Hsp70 and prevent pathological protein aggregation.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1166,75 +1188,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962). DNAJB6 does bind unfolded/misfolded proteins as a co-chaperone, but crucially it does NOT refold them. PMID:21231916 demonstrated that DNAJB6 suppresses polyQ aggregation but cannot stimulate luciferase refolding, indicating holdase-like rather than foldase activity. The IBA annotation propagated from phylogenetic inference is broadly correct in that DNAJB6 engages unfolded clients, but the term itself is being obsoleted. GO:0044183 (protein folding chaperone) is the closest available replacement, though its definition (&#34;Binding to a protein or a protein-containing complex to assist the protein folding process&#34;) is not ideal for a holdase. A dedicated holdase activity term would be more appropriate for DNAJB6 but does not currently exist in GO.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted per go-ontology#30962. DNAJB6 does interact with unfolded/aggregation-prone proteins, but its mechanism is holdase-like (preventing aggregation) rather than foldase-like (promoting refolding). PMID:21231916 showed that DNAJB6 overexpression suppressed polyQ aggregation but did not stimulate luciferase refolding. GO:0044183 (protein folding chaperone) is proposed as an interim replacement since it is the parent term already assigned by IBA, but a more specific holdase-type term would better capture DNAJB6 function if one existed in GO.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1246,64 +1268,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation from Ensembl Compara ortholog transfer is consistent with the well-established nuclear localization of DNAJB6, particularly isoform A. Multiple experimental studies confirm nuclear localization (PMID:10954706, PMID:21231916, PMID:21630459). The IEA is broader than the IBA and IDA annotations but is not incorrect.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear localization is well supported experimentally. The IEA annotation is redundant with stronger IBA and IDA evidence but is not wrong. Accepted as a valid additional annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10954706" target="_blank" class="term-link">
                                         PMID:10954706
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Immunostaining with anti-Mrj antibody showed that Mrj colocalized with K8/18 filaments in HeLa cells.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030018" target="_blank" class="term-link">
                                     GO:0030018
                                 </a>
                             </span>
                             <span class="term-label">Z disc</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1315,64 +1337,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation from UniProtKB subcellular location mapping is supported by direct experimental evidence in PMID:22366786, which demonstrated by immunofluorescence that DNAJB6 localizes primarily to Z-disks in skeletal muscle. This localization is functionally relevant as LGMDD1 mutations cause Z-disk myofibrillar disintegration.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Z disc localization is directly demonstrated by IDA in PMID:22366786. The IEA annotation is consistent with this experimental evidence and correctly maps the UniProt subcellular location annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22366786" target="_blank" class="term-link">
                                         PMID:22366786
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Immunofluorescence (IF) microscopy showed DNAJB6 primarily in Z-disks in both control (not shown) and LGMD1D muscle samples (Fig. 1a).</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030544" target="_blank" class="term-link">
                                     GO:0030544
                                 </a>
                             </span>
                             <span class="term-label">Hsp70 protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1384,64 +1406,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation from InterPro domain mapping correctly identifies DNAJB6 as an Hsp70-binding protein. DNAJB6 interacts with Hsp70/Hsc70 through its J-domain, as demonstrated experimentally in PMID:10954706 (co-immunoprecipitation with Hsp/c70) and confirmed by the Reactome pathway annotations (R-HSA-5251955, R-HSA-5251959). This is a core molecular function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Hsp70 binding is the fundamental co-chaperone activity of all J-domain proteins. DNAJB6 binds Hsp/c70 via its N-terminal J-domain (PMID:10954706). The InterPro mapping is accurate. While GO:0051087 (protein-folding chaperone binding) is a parent term also annotated, GO:0030544 is more specific to the Hsp70 interaction and is a valid annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10954706" target="_blank" class="term-link">
                                         PMID:10954706
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Mrj was immunoprecipitated not only with K18, but also with the stress-induced and constitutively expressed heat shock protein Hsp/c70. Mrj bound to K18 through its C terminus and interacted with Hsp/c70 via its N terminus, which contains the J domain.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048471" target="_blank" class="term-link">
                                     GO:0048471
                                 </a>
                             </span>
                             <span class="term-label">perinuclear region of cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1453,64 +1475,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation from UniProtKB subcellular location mapping is consistent with the experimentally determined perinuclear localization of DNAJB6. PMID:10954706 demonstrated perinuclear staining by IDA, and the UniProt entry explicitly states perinuclear region localization (ECO:0000269|PubMed:10954706).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Perinuclear localization is experimentally supported by PMID:10954706 with IDA evidence. The IEA mapping from UniProt subcellular location vocabulary is correct and consistent with the direct experimental observation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10954706" target="_blank" class="term-link">
                                         PMID:10954706
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Immunostaining with anti-Mrj antibody showed that Mrj colocalized with K8/18 filaments in HeLa cells.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1522,86 +1544,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation was inferred from InterPro domain mapping (IPR043183, DNJB2/6-like). GO:0051082 is being obsoleted (go-ontology#30962). While the InterPro domain is correctly identified, the mapped term does not accurately capture DNAJB6 function. DNAJB6 has holdase-like activity (suppressing aggregation) rather than foldase activity (refolding proteins), as demonstrated in PMID:21231916. GO:0044183 (protein folding chaperone) is the closest available replacement term, though a holdase-specific term would be more appropriate.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted per go-ontology#30962. The IEA mapping from InterPro IPR043183 correctly identifies DNAJB6 as a J-domain protein that interacts with unfolded clients, but the term itself is being retired. DNAJB6 functions as a holdase rather than a foldase (PMID:21231916), so GO:0044183 (protein folding chaperone) is proposed as an interim replacement, acknowledging that a holdase-specific term would better represent the actual molecular activity.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10954706" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10954706
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification of Mrj, a DnaJ/Hsp40 family protein, as a ker...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1613,92 +1635,92 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> PMID:10954706 demonstrated that DNAJB6 (Mrj) binds to K18 (keratin 18) and Hsp/c70 by yeast two-hybrid and co-immunoprecipitation. These are specific, functionally relevant interactions. However, GO:0005515 (protein binding) is an uninformative term that does not capture the nature of the interaction. More specific terms like GO:0030544 (Hsp70 protein binding) and GO:0045098 (type II intermediate filament binding) would better describe the interactions demonstrated.
+                            <strong>Summary:</strong> PMID:10954706 demonstrated that DNAJB6 (Mrj) binds to K18 (keratin 18) and Hsp/c70 by yeast two-hybrid and co-immunoprecipitation. These are specific, functionally relevant interactions. However, GO:0005515 (protein binding) is an uninformative term that does not capture the nature of the interaction. More specific terms like GO:0030544 (Hsp70 protein binding) and GO:0019215 (intermediate filament binding) would better describe the interactions demonstrated.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> GO:0005515 (protein binding) is too vague and uninformative. The interactions demonstrated in PMID:10954706 -- with K18 and Hsp/c70 -- are specific and functionally relevant. These are better captured by GO:0030544 (Hsp70 protein binding) for the Hsp70 interaction and GO:0045098 (type II intermediate filament binding) for the K18 interaction.
+                            <strong>Reason:</strong> GO:0005515 (protein binding) is too vague and uninformative. The interactions demonstrated in PMID:10954706 -- with K18 and Hsp/c70 -- are specific and functionally relevant. These are better captured by GO:0030544 (Hsp70 protein binding) for the Hsp70 interaction and GO:0019215 (intermediate filament binding) for the K18 interaction.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030544" target="_blank" class="term-link">
                                     Hsp70 protein binding
                                 </a>
                             </span>
-                            
+
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045098" target="_blank" class="term-link">
-                                    type II intermediate filament binding
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019215" target="_blank" class="term-link">
+                                    intermediate filament binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10954706" target="_blank" class="term-link">
                                         PMID:10954706
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Mrj was immunoprecipitated not only with K18, but also with the stress-induced and constitutively expressed heat shock protein Hsp/c70. Mrj bound to K18 through its C terminus and interacted with Hsp/c70 via its N terminus, which contains the J domain.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16919237" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16919237
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Breast cancer metastasis suppressor 1 (BRMS1) is stabilized ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1710,57 +1732,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:16919237 concerns the stabilization of BRMS1 by the Hsp90 chaperone system. DNAJB6 is listed as a binding partner from co-immunoprecipitation. The UniProt interaction data confirms BRMS1 (Q9HCU9) interacts with DNAJB6 (NbExp=2). This is likely a client or co-chaperone network interaction. GO:0005515 (protein binding) is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While the interaction with BRMS1 may be genuine from co-immunoprecipitation data, GO:0005515 (protein binding) is an uninformative term. The interaction with BRMS1 is likely part of DNAJB6&#39;s general chaperone client handling rather than a specific functional interaction. This does not add meaningful information beyond what is already captured by more specific chaperone-related MF terms.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23414517" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23414517
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A human skeletal muscle interactome centered on proteins inv...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1772,57 +1794,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:23414517 describes a human skeletal muscle interactome centered on proteins involved in muscular dystrophies. This is a large-scale interaction study. GO:0005515 (protein binding) from a high-throughput interactome study is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) from a large-scale interactome mapping study adds no specific functional information. The interactions detected in PMID:23414517 may be biologically relevant but the GO term itself is too general to be useful.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25036637
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A quantitative chaperone interaction network reveals the arc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1834,57 +1856,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:25036637 describes a quantitative chaperone interaction network. This is a systematic chaperone interactome study. GO:0005515 (protein binding) from this study is uninformative, though the underlying data about chaperone network interactions is valuable.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) from a systematic chaperone network study is too general. The chaperone-specific interactions are better captured by terms like GO:0051087 (protein-folding chaperone binding) and GO:0030544 (Hsp70 protein binding), which are already annotated.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32814053
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interactome Mapping Provides a Network of Neurodegenerative ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1896,57 +1918,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:32814053 describes interactome mapping of neurodegenerative disease proteins. This is a high-throughput study. GO:0005515 (protein binding) is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) from a large-scale neurodegenerative disease interactome mapping study is too general to be informative. The chaperone-client interactions are better represented by more specific functional terms.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1958,57 +1980,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:33961781 describes dual proteome-scale networks revealing cell-specific remodeling of the human interactome. This is a high-throughput study. GO:0005515 (protein binding) is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) from a large-scale proteomics interactome study is too general to be informative for understanding DNAJB6 function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:40205054
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Multimodal cell maps as a foundation for structural and func...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2020,46 +2042,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:40205054 describes multimodal cell maps as a foundation for structural and functional genomics. This is a high-throughput study. GO:0005515 (protein binding) is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) from a large-scale cell map study is too general to be informative for DNAJB6 functional annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003677" target="_blank" class="term-link">
                                     GO:0003677
                                 </a>
                             </span>
                             <span class="term-label">DNA binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -2071,46 +2093,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation from Ensembl Compara ortholog transfer suggests DNA binding activity. There is no direct experimental evidence for DNAJB6 binding DNA. DNAJB6 is a DnaJ co-chaperone with well-characterized protein-binding activities (Hsp70, keratin, aggregation-prone substrates) but no known nucleic acid binding activity. The J-domain and G/F-rich regions are protein interaction domains. While DNAJB6a localizes to the nucleus, this reflects its role in nuclear proteostasis rather than DNA binding. This annotation likely results from incorrect ortholog transfer.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> There is no experimental evidence for DNAJB6 DNA binding activity. DNAJB6 is a protein chaperone that interacts with Hsp70, keratins, and aggregation-prone substrates. Its nuclear localization (isoform A) relates to proteostasis functions, not DNA binding. This IEA annotation likely results from erroneous ortholog transfer and is not supported by any published literature or UniProt functional annotation. The UniProt entry describes only protein-protein interactions and chaperone activity, with no mention of DNA binding.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2122,46 +2144,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation from Ensembl Compara ortholog transfer is consistent with the well-established cytoplasmic localization of DNAJB6, particularly isoform B. Redundant with the IBA annotation but not incorrect.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization is well established for DNAJB6, especially isoform B. The IEA from ortholog transfer is consistent with direct experimental evidence and IBA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2173,46 +2195,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IDA annotation from immunofluorescence curation (HPA) indicates nucleoplasm localization. DNAJB6a is predominantly nuclear. The Human Protein Atlas immunofluorescence data provides direct observation of nucleoplasmic localization, consistent with isoform A distribution and the Reactome pathway annotation R-HSA-5251955 (HSP40s activate HSP70 ATPase in nucleoplasm).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization is consistent with the known nuclear distribution of DNAJB6a. HPA immunofluorescence data provides direct visualization. This is supported by the Reactome pathway R-HSA-5251955 which places DNAJB6 in the nucleoplasm for HSP70 ATPase activation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2224,46 +2246,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IDA annotation from immunofluorescence curation (HPA) indicates cytosol localization. DNAJB6b is predominantly cytosolic. The Human Protein Atlas data is consistent with multiple studies showing cytosolic localization of DNAJB6b (PMID:21231916, PMID:22366786).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization is well established for DNAJB6b. HPA immunofluorescence provides direct evidence. Consistent with PMID:21231916 and PMID:22366786 which demonstrate cytosolic DNAJB6b function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1900034" target="_blank" class="term-link">
                                     GO:1900034
                                 </a>
                             </span>
                             <span class="term-label">regulation of cellular response to heat</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371453
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2275,57 +2297,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This TAS annotation from Reactome (R-HSA-3371453, Regulation of HSF1-mediated heat shock response) places DNAJB6 in the heat shock response pathway. As a DnaJ/Hsp40 co-chaperone, DNAJB6 participates in the Hsp70 chaperone network that is central to the cellular heat shock response. The Reactome pathway describes how chaperones regulate HSF1 activity. This is a legitimate biological process for DNAJB6 but represents a broader pathway context rather than a core specific function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> DNAJB6 participates in the Hsp70 chaperone network that regulates the heat shock response, but this represents a general pathway context rather than the specific anti-aggregation holdase activity that is DNAJB6&#39;s primary function. The Reactome pathway annotation is valid but non-core.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050877" target="_blank" class="term-link">
                                     GO:0050877
                                 </a>
                             </span>
                             <span class="term-label">nervous system process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11896048" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11896048
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Characterization of a brain-enriched chaperone, MRJ, that in...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2337,64 +2359,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:11896048 (Chuang et al. 2002) characterized DNAJB6/MRJ as a brain-enriched chaperone that inhibits Huntingtin aggregation. The paper showed that MRJ is highly enriched in the central nervous system and suppressed polyglutamine-dependent aggregation and toxicity in neuronal cell models. However, the annotation to GO:0050877 (nervous system process) is overly broad and not directly demonstrated. The paper shows DNAJB6 has chaperone activity that is relevant in neurons, but it does not demonstrate involvement in a specific nervous system process. The enrichment in brain and activity in neuronal cells does not constitute evidence for involvement in nervous system processes per se -- the chaperone activity is a general proteostasis function that happens to be important in neurons.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PMID:11896048 demonstrates that DNAJB6 is brain-enriched and suppresses polyglutamine aggregation in neuronal cells, but this does not constitute direct evidence for involvement in nervous system processes. The chaperone/anti-aggregation activity is a general proteostasis function, not a nervous system-specific process. Being enriched in brain tissue does not make a protein&#39;s function a &#34;nervous system process.&#34; The anti-aggregation activity is better captured by GO:0090084 (negative regulation of inclusion body assembly) and GO:0006457 (protein folding).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11896048" target="_blank" class="term-link">
                                         PMID:11896048
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Tissue distribution studies showed that MRJ is highly enriched in the central nervous system. In an in vitro cell model of HD, overexpressed MRJ effectively suppressed polyglutamine-dependent protein aggregation, caspase activity, and cellular toxicity.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
                                     GO:0001671
                                 </a>
                             </span>
                             <span class="term-label">ATPase activator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5251955
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2406,64 +2428,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This TAS annotation from Reactome (R-HSA-5251955, HSP40s activate intrinsic ATPase activity of HSP70s in the nucleoplasm) correctly identifies DNAJB6 as an activator of HSP70 ATPase activity. The Reactome pathway summary explicitly lists DNAJB6 (as DNAJB6) among the HSP40s that stimulate HSP70 ATPase activity, citing Izawa et al. 2000 (PMID:10954706) and Hanai &amp; Mashima 2003. This is a core molecular function of all J-domain proteins.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATPase activator activity toward Hsp70 is the defining molecular function of J-domain proteins including DNAJB6. The Reactome pathway correctly identifies DNAJB6 as stimulating HSP70 ATPase activity in the nucleoplasm. PMID:10954706 and UniProt both confirm this function. This is a core annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10954706" target="_blank" class="term-link">
                                         PMID:10954706
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Mrj was immunoprecipitated not only with K18, but also with the stress-induced and constitutively expressed heat shock protein Hsp/c70.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
                                     GO:0001671
                                 </a>
                             </span>
                             <span class="term-label">ATPase activator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5251959
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2475,75 +2497,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This TAS annotation from Reactome (R-HSA-5251959, HSP40s activate intrinsic ATPase activity of HSP70s in the cytosol) correctly identifies DNAJB6 as an activator of HSP70 ATPase activity in the cytosol. The Reactome pathway explicitly mentions DNAJB6 (as DNAJB6) among the HSP40s that dramatically increase HSP70 ATPase activity, citing Izawa et al. 2000 (PMID:10954706). Duplicate of the nucleoplasm-specific annotation above but refers to the cytosolic context (isoform B).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Same core function as the nucleoplasm annotation above, but in the cytosolic compartment context. Both are valid as DNAJB6 isoforms function in both compartments. This is a core molecular function. The Reactome entry explicitly names DNAJB6 as an Hsp70 ATPase stimulator.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10954706" target="_blank" class="term-link">
                                         PMID:10954706
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Mrj was immunoprecipitated not only with K18, but also with the stress-induced and constitutively expressed heat shock protein Hsp/c70.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2555,75 +2577,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:21231916 (Hageman et al. 2011) systematically assessed Hsp70 and Hsp40 family members for chaperone activities and demonstrated functional interactions between DNAJB6 and HSP70s. The study showed that J-proteins including DNAJB6 stimulate Hsp70 ATPase activity, confirming the co-chaperone binding interaction. The IPI evidence from this study directly supports DNAJB6 binding to protein-folding chaperones (Hsp70s).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PMID:21231916 provides direct experimental evidence for DNAJB6 interacting with Hsp70 family chaperones in functional assays. This is a core molecular function of J-domain proteins and is well supported by the experimental data in this publication.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation. This was not related to client specificity itself, as the polyQ aggregation inhibitors often also suppressed heat-induced aggregation of luciferase.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032880" target="_blank" class="term-link">
                                     GO:0032880
                                 </a>
                             </span>
                             <span class="term-label">regulation of protein localization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20889486" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20889486
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular chaperone-mediated rescue of mitophagy by a Parkin...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2635,75 +2657,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:20889486 (Rose et al. 2011) demonstrated that DNAJB6 can rescue the relocation of misfolded Parkin (C289G mutant) to depolarized mitochondria, thereby restoring mitophagy. DNAJB6 co-expression rescued Parkin(C289G) redistribution to mitochondria in 16% of cells (comparable to HSJ1a ΔUIM mutant). This represents regulation of protein localization through chaperone-mediated refolding/stabilization of a misfolded client. However, this is a non-core function -- it reflects DNAJB6&#39;s general anti-aggregation chaperone activity applied to a specific client (misfolded Parkin) rather than a primary regulatory role in protein localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The ability of DNAJB6 to rescue localization of misfolded Parkin to mitochondria (PMID:20889486) is a secondary consequence of its chaperone/anti-aggregation activity, not a primary role in regulating protein localization. DNAJB6 helps misfolded Parkin achieve its correct conformation, allowing it to relocate to mitochondria -- this is chaperone activity applied to a specific client rather than a core protein localization regulatory function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20889486" target="_blank" class="term-link">
                                         PMID:20889486
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSJ1a and DNAJB6 also restored mitophagy by promoting the relocation of Parkin(C289G) and the autophagy marker LC3 to depolarized mitochondria.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090084" target="_blank" class="term-link">
                                     GO:0090084
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of inclusion body assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20889486" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20889486
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular chaperone-mediated rescue of mitophagy by a Parkin...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2715,75 +2737,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:20889486 (Rose et al. 2011) demonstrated that DNAJB6 suppresses Parkin(C289G) inclusion formation. HSJ1a and DNAJB6 both reduced aggregation of the misfolded Parkin RING1 domain mutant. This is consistent with DNAJB6&#39;s well-characterized anti-aggregation/holdase activity. The term GO:0090084 (negative regulation of inclusion body assembly) accurately captures this activity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Suppression of inclusion body formation is a core function of DNAJB6. PMID:20889486 demonstrated this specifically for misfolded Parkin, consistent with the broader anti-aggregation activity shown for polyglutamine proteins (PMID:11896048, PMID:20159555, PMID:21231916, PMID:22366786). This is a well-supported core annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20889486" target="_blank" class="term-link">
                                         PMID:20889486
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Parkin(C289G) aggregation and inclusion formation were suppressed by the neuronal DnaJ/Hsp40 chaperone HSJ1a(DNAJB2a). Importantly, HSJ1a and DNAJB6 also restored mitophagy by promoting the relocation of Parkin(C289G) and the autophagy marker LC3 to depolarized mitochondria.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
                                     GO:0016020
                                 </a>
                             </span>
                             <span class="term-label">membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19946888
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Defining the membrane proteome of NK cells.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -2795,75 +2817,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:19946888 is a membrane proteome study of NK cells that identified 1843 proteins from isolated membrane fractions. DNAJB6 was detected in this high-throughput proteomic analysis. However, DNAJB6 has no transmembrane domains and is not known to be a membrane protein. The detection likely reflects association with membrane-proximal complexes or contamination of membrane fractions with cytoplasmic proteins. The study itself notes that approximately 60% of identified proteins were not predicted membrane proteins but were &#34;largely involved in cellular processes and molecular functions that could be predicted to be transiently associated with membranes.&#34;
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> DNAJB6 is a soluble cytoplasmic/nuclear protein with no transmembrane domains. Detection in a membrane proteome study (PMID:19946888) likely reflects cytoplasmic contamination of membrane fractions or transient association. The study itself acknowledges that ~60% of identified proteins are not integral membrane proteins. No other evidence supports membrane localization for DNAJB6. UniProt lists cytoplasm and nucleus as subcellular locations, not membrane.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
                                         PMID:19946888
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">approximately 40% of the identified proteins were predicted as plausible membrane proteins. The remaining species were largely involved in cellular processes and molecular functions that could be predicted to be transiently associated with membranes.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2875,57 +2897,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:21231916 (Hageman et al. 2011) demonstrated nuclear localization of DNAJB6 by direct assay (IDA). This is consistent with the well-established nuclear distribution of the DNAJB6a isoform and supported by multiple other studies.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear localization is well established for DNAJB6, particularly isoform A. The IDA evidence from PMID:21231916 adds direct experimental support to the IBA and other IDA annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2937,57 +2959,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:21231916 (Hageman et al. 2011) demonstrated cytosol localization of DNAJB6 by direct assay (IDA). This is consistent with the well-established cytosolic distribution of the DNAJB6b isoform.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization is well established for DNAJB6b. The IDA evidence from PMID:21231916 provides direct experimental support.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -2999,99 +3021,99 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IDA annotation from PMID:21231916 (Hageman et al., 2011) attributed unfolded protein binding to DNAJB6 based on its ability to suppress aggregation of polyQ-expanded huntingtin and heat-denatured luciferase. However, the same study critically demonstrated that DNAJB6 could NOT stimulate refolding of heat-denatured luciferase, despite being a potent suppressor of aggregation. This dissociation between aggregation suppression and refolding indicates holdase-like rather than foldase activity. GO:0051082 is being obsoleted (go-ontology#30962). GO:0044183 (protein folding chaperone) is proposed as an interim replacement, but its definition (&#34;Binding to a protein or a protein-containing complex to assist the protein folding process&#34;) is imprecise for DNAJB6 since the protein prevents aggregation rather than assists folding per se. A holdase activity term would be the ideal annotation but does not yet exist in GO.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted per go-ontology#30962. The IDA evidence from PMID:21231916 actually demonstrates that DNAJB6 is a holdase rather than a foldase: it suppresses polyQ aggregation and heat-induced luciferase aggregation, but cannot stimulate luciferase refolding. This is a key functional distinction. GO:0044183 (protein folding chaperone) is proposed as the closest interim replacement, with the caveat that DNAJB6 prevents aggregation (holdase activity) rather than assisting in productive folding. The polyQ aggregation inhibitors in this study &#34;often also suppressed heat-induced aggregation of luciferase&#34; confirming that DNAJB6 binds and stabilizes unfolded substrates, but channels them toward aggregation prevention rather than refolding.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation. This was not related to client specificity itself, as the polyQ aggregation inhibitors often also suppressed heat-induced aggregation of luciferase.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11896048" target="_blank" class="term-link">
                                         PMID:11896048
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">overexpressed MRJ effectively suppressed polyglutamine-dependent protein aggregation, caspase activity, and cellular toxicity</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090084" target="_blank" class="term-link">
                                     GO:0090084
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of inclusion body assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3103,75 +3125,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:21231916 (Hageman et al. 2011) demonstrated that DNAJB6 is among the most potent suppressors of polyQ aggregation and inclusion body formation in the HSP70/HSP40 chaperone network. The study systematically tested all mammalian HSP70 and HSP40 members and found DNAJB6b to be a superior suppressor of polyQ inclusion body assembly. This is a core function of DNAJB6.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Suppression of inclusion body assembly is one of the most well-characterized functions of DNAJB6. PMID:21231916 provides direct experimental evidence (IDA) that DNAJB6 is a potent suppressor of polyQ aggregation. This is further supported by PMID:11896048, PMID:20159555, and PMID:22366786.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21630459
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomic characterization of the human sperm nucleus.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3183,46 +3205,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:21630459 is a proteomic characterization of the human sperm nucleus that identified 403 proteins. DNAJB6 was detected in isolated sperm nuclei by mass spectrometry. This HDA (high-throughput direct assay) provides additional evidence for nuclear localization, though in a specialized cell type (sperm). Nuclear localization of DNAJB6a is well established from other studies.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Detection of DNAJB6 in sperm nuclei by mass spectrometry (PMID:21630459) provides additional proteomic evidence for nuclear localization, consistent with the well-established nuclear distribution of DNAJB6a from multiple other studies.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5251955
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3234,46 +3256,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This TAS annotation from Reactome (R-HSA-5251955, HSP40s activate intrinsic ATPase activity of HSP70s in the nucleoplasm) places DNAJB6 in the nucleoplasm as the site where it stimulates HSP70 ATPase activity. This is consistent with the nuclear localization of DNAJB6a and the HPA immunofluorescence data showing nucleoplasm localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization is supported by the Reactome pathway placing DNAJB6 as an HSP70 ATPase activator in the nucleoplasm, consistent with IDA evidence from HPA and the known nuclear distribution of DNAJB6a.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5251959
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3285,57 +3307,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This TAS annotation from Reactome (R-HSA-5251959, HSP40s activate intrinsic ATPase activity of HSP70s in the cytosol) places DNAJB6 in the cytosol where it stimulates HSP70 ATPase activity. The Reactome entry explicitly names DNAJB6 among the HSP40s with this function. Consistent with the well-established cytosolic localization of DNAJB6b.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization is well supported by the Reactome pathway placing DNAJB6 as an HSP70 ATPase activator in the cytosol, consistent with IDA evidence and the known cytosolic distribution of DNAJB6b.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22366786" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22366786
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Mutations affecting the cytoplasmic functions of the co-chap...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -3347,86 +3369,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:22366786 (Sarparanta et al. 2012) demonstrated specific interactions of DNAJB6 with BAG3, HSPB8, and STUB1 (CHIP) -- members of the CASA (chaperone-assisted selective autophagy) complex -- by co-immunoprecipitation. These are functionally significant interactions linking DNAJB6 to Z-disk maintenance in muscle. However, GO:0005515 (protein binding) is uninformative. The interactions with CASA complex members are better described by GO:0051087 (protein-folding chaperone binding) for the chaperone interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PMID:22366786 demonstrates specific, functionally important interactions with BAG3, HSPB8, and STUB1 by co-immunoprecipitation. GO:0005515 (protein binding) is too general. The interactions with these CASA complex chaperone components are better captured by GO:0051087 (protein-folding chaperone binding), which is already annotated.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     protein-folding chaperone binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22366786" target="_blank" class="term-link">
                                         PMID:22366786
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we show that DNAJB6 interacts with members of the CASA complex, including the myofibrillar myopathy-causing protein BAG3</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030018" target="_blank" class="term-link">
                                     GO:0030018
                                 </a>
                             </span>
                             <span class="term-label">Z disc</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22366786" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22366786
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Mutations affecting the cytoplasmic functions of the co-chap...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3438,75 +3460,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:22366786 (Sarparanta et al. 2012) demonstrated by immunofluorescence microscopy that DNAJB6 localizes primarily to Z-disks in skeletal muscle. Electron microscopy of LGMD1D patient muscle revealed Z-disk myofibrillar disintegration, and DNAJB6 was found in protein accumulations at these sites. This localization is functionally relevant for the CASA complex-mediated Z-disk maintenance function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Z disc localization is directly demonstrated by immunofluorescence in PMID:22366786 and is functionally significant for DNAJB6&#39;s role in muscle sarcomere maintenance via the CASA complex. LGMD1D mutations cause Z-disk disintegration, underscoring the importance of this localization. This is a core localization in skeletal muscle.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22366786" target="_blank" class="term-link">
                                         PMID:22366786
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Immunofluorescence (IF) microscopy showed DNAJB6 primarily in Z-disks in both control (not shown) and LGMD1D muscle samples (Fig. 1a). Electron microscopy (EM) of LGMD1D patient muscle revealed Z-disk myofibrillar disintegration (Fig. 1b).</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
                                     GO:0031072
                                 </a>
                             </span>
                             <span class="term-label">heat shock protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10954706" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10954706
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification of Mrj, a DnaJ/Hsp40 family protein, as a ker...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3518,64 +3540,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:10954706 (Izawa et al. 2000) demonstrated by co-immunoprecipitation that DNAJB6 (Mrj) binds to Hsp/c70 (heat shock protein 70). The N-terminal J-domain region mediates this interaction. This is a core molecular function of all J-domain proteins. GO:0031072 (heat shock protein binding) is appropriate as it encompasses the Hsp70 binding activity and is consistent with the more specific GO:0030544 (Hsp70 protein binding).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Heat shock protein binding (specifically Hsp70) is the defining interaction for J-domain proteins. PMID:10954706 provides direct co-immunoprecipitation evidence. This is a core molecular function annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10954706" target="_blank" class="term-link">
                                         PMID:10954706
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Mrj was immunoprecipitated not only with K18, but also with the stress-induced and constitutively expressed heat shock protein Hsp/c70. Mrj bound to K18 through its C terminus and interacted with Hsp/c70 via its N terminus, which contains the J domain.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000054
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3587,137 +3609,137 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IDA annotation from curation of intracellular localizations of expressed fusion proteins in living cells confirms nuclear localization. Consistent with multiple other studies showing DNAJB6a nuclear localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear localization is thoroughly supported for DNAJB6a by multiple independent methods. This IDA from fusion protein localization adds further direct evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
                                     GO:0001671
                                 </a>
                             </span>
                             <span class="term-label">ATPase activator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11896048" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11896048
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Characterization of a brain-enriched chaperone, MRJ, that in...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="O75190" data-a="GO:0001671" data-r="PMID:11896048" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="O75190" data-a="GO:0001671" data-r="PMID:11896048" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> PMID:11896048 (Chuang et al. 2002) characterized DNAJB6 (MRJ) chaperone activity and showed it functions as a co-chaperone. The UniProt entry states &#34;Has a stimulatory effect on the ATPase activity of HSP70 in a dose-dependent and time-dependent manner&#34; citing PMID:10954706 and PMID:28233300. While PMID:11896048 focuses on the anti-aggregation activity rather than directly measuring ATPase stimulation, the co-chaperone function is integral to J-domain protein activity. The IDA from PMID:10954706 would be a more direct source for this annotation, but the co-chaperone function described in PMID:11896048 is consistent.
+                            <strong>Summary:</strong> PMID:11896048 (Chuang et al. 2002) characterized DNAJB6 (MRJ) chaperone activity and showed it functions as a co-chaperone. The UniProt entry states &#34;Has a stimulatory effect on the ATPase activity of HSP70 in a dose-dependent and time-dependent manner&#34; citing PMID:10954706 and PMID:28233300. While PMID:11896048 focuses on the anti-aggregation activity rather than directly measuring ATPase stimulation. The co-chaperone function is consistent with J-domain biology, but the PMID:11896048 cached evidence does not directly support ATPase activation.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> ATPase activator activity toward Hsp70 is a core molecular function of DNAJB6 as a J-domain co-chaperone. UniProt confirms dose-dependent and time-dependent stimulation of HSP70 ATPase activity. This is a core annotation.
+                            <strong>Reason:</strong> ATPase activator activity toward Hsp70 is a core molecular function of DNAJB6 as a J-domain co-chaperone. UniProt confirms dose-dependent and time-dependent stimulation of HSP70 ATPase activity, but this particular PMID:11896048 IDA annotation cannot be accepted because the cited source supports anti-aggregation/chaperone activity rather than direct ATPase activation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11896048" target="_blank" class="term-link">
                                         PMID:11896048
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we describe the isolation of a DnaJ-like protein MRJ and the characterization of its chaperone activity</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10954706" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10954706
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification of Mrj, a DnaJ/Hsp40 family protein, as a ker...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3729,75 +3751,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:10954706 (Izawa et al. 2000) showed nuclear localization of DNAJB6 (Mrj) by immunostaining. The UniProt subcellular location annotation cites this study as evidence for nuclear localization. This is consistent with the predominantly nuclear distribution of DNAJB6a.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear localization is directly demonstrated by immunostaining in PMID:10954706 and confirmed by UniProt annotation. This is a core localization for DNAJB6a.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10954706" target="_blank" class="term-link">
                                         PMID:10954706
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Immunostaining with anti-Mrj antibody showed that Mrj colocalized with K8/18 filaments in HeLa cells.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11896048" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11896048
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Characterization of a brain-enriched chaperone, MRJ, that in...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3809,75 +3831,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:11896048 (Chuang et al. 2002) demonstrated DNAJB6 chaperone activity in suppressing polyglutamine aggregation. As discussed above for the IBA annotation of this same term, DNAJB6 specifically acts as a holdase (preventing aggregation) rather than a foldase (refolding denatured proteins). GO:0006457 (protein folding) as a biological process encompasses the broader protein quality control pathway. The IDA evidence from PMID:11896048 demonstrates chaperone activity that contributes to the protein folding/quality control pathway, even though the specific mechanism is anti-aggregation rather than productive refolding.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0006457 (protein folding) as a BP is broadly appropriate for DNAJB6&#39;s participation in the Hsp70-dependent protein quality control pathway. PMID:11896048 provides direct evidence of chaperone activity. While DNAJB6 specifically prevents aggregation rather than promoting refolding, the protein folding BP encompass quality control.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11896048" target="_blank" class="term-link">
                                         PMID:11896048
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">overexpressed MRJ effectively suppressed polyglutamine-dependent protein aggregation, caspase activity, and cellular toxicity</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045109" target="_blank" class="term-link">
                                     GO:0045109
                                 </a>
                             </span>
                             <span class="term-label">intermediate filament organization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10954706" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10954706
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification of Mrj, a DnaJ/Hsp40 family protein, as a ker...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3889,75 +3911,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:10954706 (Izawa et al. 2000) demonstrated that DNAJB6 (Mrj) plays an essential role in K8/18 intermediate filament organization. Microinjection of anti-Mrj antibody resulted in disorganization of K8/18 filaments without affecting actin filaments or microtubules. DNAJB6 bound to K18 through its C-terminus and functioned as a K18-specific co-chaperone with Hsp/c70. This is a well-supported core function directly demonstrated by loss-of-function (antibody microinjection) experiments.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Intermediate filament organization is a directly demonstrated function of DNAJB6, supported by both gain-of-function (co-immunoprecipitation with K18, colocalization with K8/18 filaments) and loss-of-function (anti-Mrj antibody microinjection causing filament disorganization) experiments in PMID:10954706. This is a core biological process function. The UniProt entry also states DNAJB6 &#34;Plays an indispensable role in the organization of KRT8/KRT18 filaments.&#34;
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10954706" target="_blank" class="term-link">
                                         PMID:10954706
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Microinjection of anti-Mrj antibody resulted in the disorganization of K8/18 filaments, without effects on the organization of actin filaments and microtubules. Taken together, these results suggest that Mrj may play an important role in the regulation of K8/18 filament organization as a K18-specific co-chaperone working together with Hsp/c70.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048471" target="_blank" class="term-link">
                                     GO:0048471
                                 </a>
                             </span>
                             <span class="term-label">perinuclear region of cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10954706" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10954706
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification of Mrj, a DnaJ/Hsp40 family protein, as a ker...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3969,75 +3991,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:10954706 (Izawa et al. 2000) demonstrated perinuclear localization of DNAJB6 (Mrj) by immunostaining. The UniProt subcellular location explicitly states &#34;Cytoplasm, perinuclear region&#34; with ECO:0000269|PubMed:10954706 evidence. This is a well-supported localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Perinuclear localization is directly demonstrated by immunostaining in PMID:10954706 and annotated in UniProt subcellular location. This is a core localization.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10954706" target="_blank" class="term-link">
                                         PMID:10954706
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Immunostaining with anti-Mrj antibody showed that Mrj colocalized with K8/18 filaments in HeLa cells.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11896048" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11896048
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Characterization of a brain-enriched chaperone, MRJ, that in...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4049,50 +4071,50 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:11896048 (Chuang et al. 2002) characterized DNAJB6 (MRJ) as a co-chaperone that interacts with the Hsp70 chaperone network. As a J-domain protein, DNAJB6 binds and stimulates Hsp70 family chaperones. The IDA evidence supports the protein-folding chaperone binding annotation, consistent with the established co-chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein-folding chaperone binding (Hsp70 interaction) is a core molecular function of DNAJB6 as a J-domain co-chaperone. PMID:11896048 provides evidence for this co-chaperone function, and it is consistent with the more detailed binding data from PMID:10954706.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11896048" target="_blank" class="term-link">
                                         PMID:11896048
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we describe the isolation of a DnaJ-like protein MRJ and the characterization of its chaperone activity</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>DNAJB6 is a class B J-domain co-chaperone that functions as a potent holdase rather than a foldase. It prevents aggregation of polyglutamine-expanded proteins, tau, and other aggregation-prone substrates, but cannot stimulate refolding of denatured proteins. DNAJB6 functions within the HSP70 chaperone network, requiring its J-domain for anti-aggregation activity. The DNAJB6b (short, cytosolic) isoform is particularly important for suppression of protein aggregation, while DNAJB6a (long) is predominantly nuclear. Mutations in DNAJB6 cause limb-girdle muscular dystrophy type D1 (LGMDD1).</h3>
                 <span class="vote-buttons" data-g="O75190" data-a="FUNCTION: DNAJB6 is a class B J-domain co-chaperone that fun..." data-r="" data-act="CORE_FUNCTION">
@@ -4100,10 +4122,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -4112,116 +4134,127 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090084" target="_blank" class="term-link">
                                 negative regulation of inclusion body assembly
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                 protein folding
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                 nucleoplasm
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030018" target="_blank" class="term-link">
                                 Z disc
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048471" target="_blank" class="term-link">
                                 perinuclear region of cytoplasm
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                 PMID:21231916
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11896048" target="_blank" class="term-link">
                                 PMID:11896048
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">overexpressed MRJ effectively suppressed polyglutamine-dependent protein aggregation, caspase activity, and cellular toxicity</div>
-                        
+
                     </li>
-                    
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/DNAJB6/DNAJB6-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">In neuronal cells, the DNAJB6b isoform is required and sufficient to reduce tau aggregation; its J-domain is necessary, consistent with Hsp70-dependent anti-aggregation.</div>
+
+                    </li>
+
                 </ul>
             </div>
-            
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>DNAJB6 stimulates the intrinsic ATPase activity of HSP70/Hsc70 via its J-domain in both the cytosol and nucleoplasm. This is the defining co-chaperone function of J-domain proteins, confirmed by co-immunoprecipitation with Hsp/c70 and Reactome pathway annotations.</h3>
-                <span class="vote-buttons" data-g="O75190" data-a="FUNCTION: DNAJB6 stimulates the intrinsic ATPase activity of..." data-r="" data-act="CORE_FUNCTION">
+                <h3>DNAJB6 is inferred to stimulate the intrinsic ATPase activity of HSP70/Hsc70 via its J-domain in both the cytosol and nucleoplasm. This is the defining co-chaperone function of J-domain proteins and is represented by Reactome pathway annotations; PMID:10954706 directly supports Hsp/c70 interaction but does not by itself measure ATPase activation.</h3>
+                <span class="vote-buttons" data-g="O75190" data-a="FUNCTION: DNAJB6 is inferred to stimulate the intrinsic ATPa..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -4230,87 +4263,87 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                 protein folding
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                 nucleoplasm
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10954706" target="_blank" class="term-link">
                                 PMID:10954706
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">Mrj was immunoprecipitated not only with K18, but also with the stress-induced and constitutively expressed heat shock protein Hsp/c70.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11896048" target="_blank" class="term-link">
                                 PMID:11896048
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">we describe the isolation of a DnaJ-like protein MRJ and the characterization of its chaperone activity</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>DNAJB6 binds to keratin 18 (K18) via its C-terminus and to Hsp70/Hsc70 via its N-terminal J-domain, functioning as a K18-specific co-chaperone that regulates intermediate filament organization. Anti-Mrj antibody microinjection causes K8/18 filament disorganization, establishing DNAJB6 as essential for keratin filament maintenance.</h3>
                 <span class="vote-buttons" data-g="O75190" data-a="FUNCTION: DNAJB6 binds to keratin 18 (K18) via its C-terminu..." data-r="" data-act="CORE_FUNCTION">
@@ -4318,10 +4351,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -4330,477 +4363,491 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045109" target="_blank" class="term-link">
                                 intermediate filament organization
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                 cytoplasm
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048471" target="_blank" class="term-link">
                                 perinuclear region of cytoplasm
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10954706" target="_blank" class="term-link">
                                 PMID:10954706
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">Microinjection of anti-Mrj antibody resulted in the disorganization of K8/18 filaments, without effects on the organization of actin filaments and microtubules. Taken together, these results suggest that Mrj may play an important role in the regulation of K8/18 filament organization as a K18-specific co-chaperone working together with Hsp/c70.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/DNAJB6/DNAJB6-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for DNAJB6</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
                             GO_REF:0000052
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000054.md" target="_blank" class="term-link">
                             GO_REF:0000054
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on curation of intracellular localizations of expressed fusion proteins in living cells</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
                             GO_REF:0000107
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10954706" target="_blank" class="term-link">
                             PMID:10954706
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Identification of Mrj, a DnaJ/Hsp40 family protein, as a keratin 8/18 filament regulatory protein.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11896048" target="_blank" class="term-link">
                             PMID:11896048
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Characterization of a brain-enriched chaperone, MRJ, that inhibits Huntingtin aggregation and toxicity independently.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16919237" target="_blank" class="term-link">
                             PMID:16919237
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Breast cancer metastasis suppressor 1 (BRMS1) is stabilized by the Hsp90 chaperone.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
                             PMID:19946888
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Defining the membrane proteome of NK cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20159555" target="_blank" class="term-link">
                             PMID:20159555
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A DNAJB chaperone subfamily with HDAC-dependent activities suppresses toxic protein aggregation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20889486" target="_blank" class="term-link">
                             PMID:20889486
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Molecular chaperone-mediated rescue of mitophagy by a Parkin RING1 domain mutant.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                             PMID:21231916
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The diverse members of the mammalian HSP70 machine show distinct chaperone-like activities.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link">
                             PMID:21630459
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteomic characterization of the human sperm nucleus.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22366786" target="_blank" class="term-link">
                             PMID:22366786
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Mutations affecting the cytoplasmic functions of the co-chaperone DNAJB6 cause limb-girdle muscular dystrophy.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23414517" target="_blank" class="term-link">
                             PMID:23414517
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A human skeletal muscle interactome centered on proteins involved in muscular dystrophies: LGMD interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link">
                             PMID:25036637
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A quantitative chaperone interaction network reveals the architecture of cellular protein homeostasis pathways.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
                             PMID:32814053
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
                             PMID:40205054
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371453
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Regulation of HSF1-mediated heat shock response</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5251955
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP40s activate intrinsic ATPase activity of HSP70s in the nucleoplasm</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5251959
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP40s activate intrinsic ATPase activity of HSP70s in the cytosol</div>
-                
-                
+
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -5008,9 +5055,9 @@ DNAJB6 is a human class B Hsp40/JDP co-chaperone that deploys an autoinhibited, 
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -5022,7 +5069,7 @@ DNAJB6 is a human class B Hsp40/JDP co-chaperone that deploys an autoinhibited, 
                 <pre><code>id: O75190
 gene_symbol: DNAJB6
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -5031,8 +5078,8 @@ description: &gt;-
   of Hsp70 family members and acts as a potent suppressor of amyloid-type protein aggregation. Unlike canonical foldase
   chaperones, DNAJB6 does not refold denatured proteins but instead exhibits holdase-like activity, preventing aggregation
   of polyglutamine-expanded proteins, tau, and other aggregation-prone substrates. It functions within the Hsp70 chaperone
-  network, requiring its J-domain for anti-aggregation activity. DNAJB6 also plays roles in keratin filament organization
-  and nuclear pore complex assembly quality control. Mutations in DNAJB6 cause limb-girdle muscular dystrophy type D1
+  network, requiring its J-domain for anti-aggregation activity. DNAJB6 also plays roles in keratin filament organization;
+  emerging preprint work suggests an additional nuclear-pore condensate surveillance context. Mutations in DNAJB6 cause limb-girdle muscular dystrophy type D1
   (LGMDD1). Two major isoforms exist: DNAJB6a (long, predominantly nuclear) and DNAJB6b (short, largely cytosolic),
   with isoform B being particularly important for suppression of protein aggregation.
 alternative_products:
@@ -5105,6 +5152,11 @@ existing_annotations:
         supporting_text: &gt;-
           overexpressed MRJ effectively suppressed polyglutamine-dependent protein aggregation, caspase
           activity, and cellular toxicity
+      - reference_id: file:human/DNAJB6/DNAJB6-deep-research-falcon.md
+        supporting_text: &gt;-
+          In neuronal cells, the DNAJB6b isoform is required and sufficient to reduce tau
+          aggregation; its J-domain is necessary, consistent with Hsp70-dependent
+          anti-aggregation.
 - term:
     id: GO:0005634
     label: nucleus
@@ -5174,6 +5226,11 @@ existing_annotations:
           Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate
           luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors
           of polyQ aggregation.
+      - reference_id: file:human/DNAJB6/DNAJB6-deep-research-falcon.md
+        supporting_text: &gt;-
+          DNAJB6 is a human class B Hsp40/JDP co-chaperone that deploys an
+          autoinhibited, J-domain-controlled mechanism to engage Hsp70 and
+          prevent pathological protein aggregation.
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -5333,19 +5390,19 @@ existing_annotations:
       yeast two-hybrid and co-immunoprecipitation. These are specific, functionally relevant
       interactions. However, GO:0005515 (protein binding) is an uninformative term that does not
       capture the nature of the interaction. More specific terms like GO:0030544 (Hsp70 protein
-      binding) and GO:0045098 (type II intermediate filament binding) would better describe
+      binding) and GO:0019215 (intermediate filament binding) would better describe
       the interactions demonstrated.
     action: MODIFY
     reason: &gt;-
       GO:0005515 (protein binding) is too vague and uninformative. The interactions demonstrated in
       PMID:10954706 -- with K18 and Hsp/c70 -- are specific and functionally relevant. These are
       better captured by GO:0030544 (Hsp70 protein binding) for the Hsp70 interaction and
-      GO:0045098 (type II intermediate filament binding) for the K18 interaction.
+      GO:0019215 (intermediate filament binding) for the K18 interaction.
     proposed_replacement_terms:
       - id: GO:0030544
         label: Hsp70 protein binding
-      - id: GO:0045098
-        label: type II intermediate filament binding
+      - id: GO:0019215
+        label: intermediate filament binding
     supported_by:
       - reference_id: PMID:10954706
         supporting_text: &gt;-
@@ -5954,15 +6011,16 @@ existing_annotations:
       showed it functions as a co-chaperone. The UniProt entry states &#34;Has a stimulatory effect
       on the ATPase activity of HSP70 in a dose-dependent and time-dependent manner&#34; citing
       PMID:10954706 and PMID:28233300. While PMID:11896048 focuses on the anti-aggregation
-      activity rather than directly measuring ATPase stimulation, the co-chaperone function
-      is integral to J-domain protein activity. The IDA from PMID:10954706 would be a more
-      direct source for this annotation, but the co-chaperone function described in PMID:11896048
-      is consistent.
-    action: ACCEPT
+      activity rather than directly measuring ATPase stimulation. The co-chaperone function
+      is consistent with J-domain biology, but the PMID:11896048 cached evidence does not
+      directly support ATPase activation.
+    action: UNDECIDED
     reason: &gt;-
       ATPase activator activity toward Hsp70 is a core molecular function of DNAJB6 as a
       J-domain co-chaperone. UniProt confirms dose-dependent and time-dependent stimulation
-      of HSP70 ATPase activity. This is a core annotation.
+      of HSP70 ATPase activity, but this particular PMID:11896048 IDA annotation cannot be
+      accepted because the cited source supports anti-aggregation/chaperone activity rather
+      than direct ATPase activation.
     supported_by:
       - reference_id: PMID:11896048
         supporting_text: &gt;-
@@ -6102,6 +6160,11 @@ core_functions:
         supporting_text: &gt;-
           overexpressed MRJ effectively suppressed polyglutamine-dependent protein aggregation, caspase
           activity, and cellular toxicity
+      - reference_id: file:human/DNAJB6/DNAJB6-deep-research-falcon.md
+        supporting_text: &gt;-
+          In neuronal cells, the DNAJB6b isoform is required and sufficient to reduce tau
+          aggregation; its J-domain is necessary, consistent with Hsp70-dependent
+          anti-aggregation.
     directly_involved_in:
       - id: GO:0090084
         label: negative regulation of inclusion body assembly
@@ -6120,10 +6183,11 @@ core_functions:
       id: GO:0001671
       label: ATPase activator activity
     description: &gt;-
-      DNAJB6 stimulates the intrinsic ATPase activity of HSP70/Hsc70 via its J-domain
-      in both the cytosol and nucleoplasm. This is the defining co-chaperone function of
-      J-domain proteins, confirmed by co-immunoprecipitation with Hsp/c70 and Reactome
-      pathway annotations.
+      DNAJB6 is inferred to stimulate the intrinsic ATPase activity of HSP70/Hsc70 via its
+      J-domain in both the cytosol and nucleoplasm. This is the defining co-chaperone
+      function of J-domain proteins and is represented by Reactome pathway annotations;
+      PMID:10954706 directly supports Hsp/c70 interaction but does not by itself measure
+      ATPase activation.
     supported_by:
       - reference_id: PMID:10954706
         supporting_text: &gt;-
@@ -6166,6 +6230,9 @@ core_functions:
       - id: GO:0048471
         label: perinuclear region of cytoplasm
 references:
+- id: file:human/DNAJB6/DNAJB6-deep-research-falcon.md
+  title: Falcon deep research report for DNAJB6
+  findings: []
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
     terms
@@ -6260,7 +6327,7 @@ references:
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/DNAJB6/DNAJB6-ai-review.html
+++ b/genes/human/DNAJB6/DNAJB6-ai-review.html
@@ -4345,7 +4345,7 @@
         <div class="core-function-card">
 
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>DNAJB6 binds to keratin 18 (K18) via its C-terminus and to Hsp70/Hsc70 via its N-terminal J-domain, functioning as a K18-specific co-chaperone that regulates intermediate filament organization. Anti-Mrj antibody microinjection causes K8/18 filament disorganization, establishing DNAJB6 as essential for keratin filament maintenance.</h3>
+                <h3>DNAJB6 binds to keratin 18 (K18) via its C-terminus and functions as a K18-specific co-chaperone with Hsp70/Hsc70 to regulate intermediate filament organization. Anti-Mrj antibody microinjection causes K8/18 filament disorganization, establishing DNAJB6 as essential for keratin filament maintenance.</h3>
                 <span class="vote-buttons" data-g="O75190" data-a="FUNCTION: DNAJB6 binds to keratin 18 (K18) via its C-terminu..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
@@ -4358,8 +4358,8 @@
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030544" target="_blank" class="term-link">
-                            Hsp70 protein binding
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019215" target="_blank" class="term-link">
+                            intermediate filament binding
                         </a>
                     </span>
                 </div>
@@ -6206,13 +6206,13 @@ core_functions:
       - id: GO:0005654
         label: nucleoplasm
   - molecular_function:
-      id: GO:0030544
-      label: Hsp70 protein binding
+      id: GO:0019215
+      label: intermediate filament binding
     description: &gt;-
-      DNAJB6 binds to keratin 18 (K18) via its C-terminus and to Hsp70/Hsc70 via its
-      N-terminal J-domain, functioning as a K18-specific co-chaperone that regulates
-      intermediate filament organization. Anti-Mrj antibody microinjection causes K8/18
-      filament disorganization, establishing DNAJB6 as essential for keratin filament
+      DNAJB6 binds to keratin 18 (K18) via its C-terminus and functions as a
+      K18-specific co-chaperone with Hsp70/Hsc70 to regulate intermediate filament
+      organization. Anti-Mrj antibody microinjection causes K8/18 filament
+      disorganization, establishing DNAJB6 as essential for keratin filament
       maintenance.
     supported_by:
       - reference_id: PMID:10954706

--- a/genes/human/DNAJB6/DNAJB6-ai-review.yaml
+++ b/genes/human/DNAJB6/DNAJB6-ai-review.yaml
@@ -1138,13 +1138,13 @@ core_functions:
       - id: GO:0005654
         label: nucleoplasm
   - molecular_function:
-      id: GO:0030544
-      label: Hsp70 protein binding
+      id: GO:0019215
+      label: intermediate filament binding
     description: >-
-      DNAJB6 binds to keratin 18 (K18) via its C-terminus and to Hsp70/Hsc70 via its
-      N-terminal J-domain, functioning as a K18-specific co-chaperone that regulates
-      intermediate filament organization. Anti-Mrj antibody microinjection causes K8/18
-      filament disorganization, establishing DNAJB6 as essential for keratin filament
+      DNAJB6 binds to keratin 18 (K18) via its C-terminus and functions as a
+      K18-specific co-chaperone with Hsp70/Hsc70 to regulate intermediate filament
+      organization. Anti-Mrj antibody microinjection causes K8/18 filament
+      disorganization, establishing DNAJB6 as essential for keratin filament
       maintenance.
     supported_by:
       - reference_id: PMID:10954706

--- a/genes/human/DNAJB6/DNAJB6-ai-review.yaml
+++ b/genes/human/DNAJB6/DNAJB6-ai-review.yaml
@@ -1,7 +1,7 @@
 id: O75190
 gene_symbol: DNAJB6
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -10,8 +10,8 @@ description: >-
   of Hsp70 family members and acts as a potent suppressor of amyloid-type protein aggregation. Unlike canonical foldase
   chaperones, DNAJB6 does not refold denatured proteins but instead exhibits holdase-like activity, preventing aggregation
   of polyglutamine-expanded proteins, tau, and other aggregation-prone substrates. It functions within the Hsp70 chaperone
-  network, requiring its J-domain for anti-aggregation activity. DNAJB6 also plays roles in keratin filament organization
-  and nuclear pore complex assembly quality control. Mutations in DNAJB6 cause limb-girdle muscular dystrophy type D1
+  network, requiring its J-domain for anti-aggregation activity. DNAJB6 also plays roles in keratin filament organization;
+  emerging preprint work suggests an additional nuclear-pore condensate surveillance context. Mutations in DNAJB6 cause limb-girdle muscular dystrophy type D1
   (LGMDD1). Two major isoforms exist: DNAJB6a (long, predominantly nuclear) and DNAJB6b (short, largely cytosolic),
   with isoform B being particularly important for suppression of protein aggregation.
 alternative_products:
@@ -84,6 +84,11 @@ existing_annotations:
         supporting_text: >-
           overexpressed MRJ effectively suppressed polyglutamine-dependent protein aggregation, caspase
           activity, and cellular toxicity
+      - reference_id: file:human/DNAJB6/DNAJB6-deep-research-falcon.md
+        supporting_text: >-
+          In neuronal cells, the DNAJB6b isoform is required and sufficient to reduce tau
+          aggregation; its J-domain is necessary, consistent with Hsp70-dependent
+          anti-aggregation.
 - term:
     id: GO:0005634
     label: nucleus
@@ -153,6 +158,11 @@ existing_annotations:
           Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate
           luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors
           of polyQ aggregation.
+      - reference_id: file:human/DNAJB6/DNAJB6-deep-research-falcon.md
+        supporting_text: >-
+          DNAJB6 is a human class B Hsp40/JDP co-chaperone that deploys an
+          autoinhibited, J-domain-controlled mechanism to engage Hsp70 and
+          prevent pathological protein aggregation.
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -312,19 +322,19 @@ existing_annotations:
       yeast two-hybrid and co-immunoprecipitation. These are specific, functionally relevant
       interactions. However, GO:0005515 (protein binding) is an uninformative term that does not
       capture the nature of the interaction. More specific terms like GO:0030544 (Hsp70 protein
-      binding) and GO:0045098 (type II intermediate filament binding) would better describe
+      binding) and GO:0019215 (intermediate filament binding) would better describe
       the interactions demonstrated.
     action: MODIFY
     reason: >-
       GO:0005515 (protein binding) is too vague and uninformative. The interactions demonstrated in
       PMID:10954706 -- with K18 and Hsp/c70 -- are specific and functionally relevant. These are
       better captured by GO:0030544 (Hsp70 protein binding) for the Hsp70 interaction and
-      GO:0045098 (type II intermediate filament binding) for the K18 interaction.
+      GO:0019215 (intermediate filament binding) for the K18 interaction.
     proposed_replacement_terms:
       - id: GO:0030544
         label: Hsp70 protein binding
-      - id: GO:0045098
-        label: type II intermediate filament binding
+      - id: GO:0019215
+        label: intermediate filament binding
     supported_by:
       - reference_id: PMID:10954706
         supporting_text: >-
@@ -933,15 +943,16 @@ existing_annotations:
       showed it functions as a co-chaperone. The UniProt entry states "Has a stimulatory effect
       on the ATPase activity of HSP70 in a dose-dependent and time-dependent manner" citing
       PMID:10954706 and PMID:28233300. While PMID:11896048 focuses on the anti-aggregation
-      activity rather than directly measuring ATPase stimulation, the co-chaperone function
-      is integral to J-domain protein activity. The IDA from PMID:10954706 would be a more
-      direct source for this annotation, but the co-chaperone function described in PMID:11896048
-      is consistent.
-    action: ACCEPT
+      activity rather than directly measuring ATPase stimulation. The co-chaperone function
+      is consistent with J-domain biology, but the PMID:11896048 cached evidence does not
+      directly support ATPase activation.
+    action: UNDECIDED
     reason: >-
       ATPase activator activity toward Hsp70 is a core molecular function of DNAJB6 as a
       J-domain co-chaperone. UniProt confirms dose-dependent and time-dependent stimulation
-      of HSP70 ATPase activity. This is a core annotation.
+      of HSP70 ATPase activity, but this particular PMID:11896048 IDA annotation cannot be
+      accepted because the cited source supports anti-aggregation/chaperone activity rather
+      than direct ATPase activation.
     supported_by:
       - reference_id: PMID:11896048
         supporting_text: >-
@@ -1081,6 +1092,11 @@ core_functions:
         supporting_text: >-
           overexpressed MRJ effectively suppressed polyglutamine-dependent protein aggregation, caspase
           activity, and cellular toxicity
+      - reference_id: file:human/DNAJB6/DNAJB6-deep-research-falcon.md
+        supporting_text: >-
+          In neuronal cells, the DNAJB6b isoform is required and sufficient to reduce tau
+          aggregation; its J-domain is necessary, consistent with Hsp70-dependent
+          anti-aggregation.
     directly_involved_in:
       - id: GO:0090084
         label: negative regulation of inclusion body assembly
@@ -1099,10 +1115,11 @@ core_functions:
       id: GO:0001671
       label: ATPase activator activity
     description: >-
-      DNAJB6 stimulates the intrinsic ATPase activity of HSP70/Hsc70 via its J-domain
-      in both the cytosol and nucleoplasm. This is the defining co-chaperone function of
-      J-domain proteins, confirmed by co-immunoprecipitation with Hsp/c70 and Reactome
-      pathway annotations.
+      DNAJB6 is inferred to stimulate the intrinsic ATPase activity of HSP70/Hsc70 via its
+      J-domain in both the cytosol and nucleoplasm. This is the defining co-chaperone
+      function of J-domain proteins and is represented by Reactome pathway annotations;
+      PMID:10954706 directly supports Hsp/c70 interaction but does not by itself measure
+      ATPase activation.
     supported_by:
       - reference_id: PMID:10954706
         supporting_text: >-
@@ -1145,6 +1162,9 @@ core_functions:
       - id: GO:0048471
         label: perinuclear region of cytoplasm
 references:
+- id: file:human/DNAJB6/DNAJB6-deep-research-falcon.md
+  title: Falcon deep research report for DNAJB6
+  findings: []
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
     terms


### PR DESCRIPTION
## Summary

- Complete Falcon-integrated reviews for five human DNAJ/HSP40 chaperone genes: DNAJA2, DNAJA4, DNAJB1, DNAJB2, and DNAJB6.
- Update existing annotation decisions, core-function summaries, and evidence support based on reviewer feedback.
- Regenerate the corresponding review HTML pages.

## Review Follow-up

Each gene was reviewed by a subagent before PR creation. Initial review findings were addressed, then each gene was re-reviewed and approved:

- DNAJA2: approved after broad parent binding actions and core-function framing were corrected.
- DNAJA4: approved after unsupported PMID:21231916 source-specific rows were marked `UNDECIDED` and PSMD2/MYH9 was treated as cancer-context rather than conserved core function.
- DNAJB1: approved after mismatched PMID:23921388, PMID:20060297, and PMID:18620420 rows were marked `UNDECIDED` and unsupported core support was removed.
- DNAJB2: approved after protein transporter activity and unfolded-protein response decisions were corrected.
- DNAJB6: approved after intermediate-filament replacement, ATPase evidence support, tau support, and nuclear-pore preprint qualification were corrected.

## Validation

- `just validate human DNAJA2`
- `just validate human DNAJA4`
- `just validate human DNAJB1`
- `just validate human DNAJB2`
- `just validate human DNAJB6`
- `for gene in DNAJA2 DNAJA4 DNAJB1 DNAJB2 DNAJB6; do just render human "$gene"; done`
- `just pytest` -> 255 passed, 40 deselected, 6 warnings
- `just mypy` -> Success: no issues found in 68 source files
- `git diff --check`

Some validation warnings remain for source-specific `UNDECIDED` rows where stronger annotations to the same GO terms remain accepted. These are intentional: the direct-evidence source could not be verified from cached text, while other evidence supports the term elsewhere.