### PR TITLE
[codex] Review human HSPA chaperone batch

### DIFF
--- a/genes/human/HSPA1A/HSPA1A-ai-review.html
+++ b/genes/human/HSPA1A/HSPA1A-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>HSPA1A</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P0DMV8" target="_blank" class="term-link">
                         P0DMV8
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -737,15 +737,15 @@
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>Heat shock 70 kDa protein 1A (HSPA1A/HSP72/HSP70-1) is a major stress-inducible member of the HSP70 molecular chaperone family. It functions as an ATP-dependent protein folding chaperone implicated in a wide variety of cellular processes including protection of the proteome from stress, folding and transport of newly synthesized polypeptides, refolding of misfolded proteins, activation of proteolysis of misfolded proteins, and the formation and dissociation of protein complexes. HSPA1A has genuine foldase activity, demonstrated by luciferase refolding assays, and also suppresses protein aggregation. Its acetylation/deacetylation state determines whether it functions in protein refolding (via HOPX co-chaperone) or protein degradation (via STUB1/CHIP ubiquitin ligase). Additionally, HSPA1A has roles in regulating apoptosis, centrosome integrity during mitosis, TGF-beta signaling, and can function as an extracellular signaling molecule (receptor ligand activity). It also possesses ATP-dependent protein disaggregase activity.</p>
+        <p>Heat shock 70 kDa protein 1A (HSPA1A/HSP72/HSP70-1) is a major stress-inducible member of the HSP70 molecular chaperone family. It functions as an ATP-dependent protein folding chaperone implicated in a wide variety of cellular processes including protection of the proteome from stress, folding and transport of newly synthesized polypeptides, refolding of misfolded proteins, activation of proteolysis of misfolded proteins, and the formation and dissociation of protein complexes. HSPA1A has genuine foldase activity, demonstrated by luciferase refolding assays, and also suppresses protein aggregation. Its acetylation/deacetylation state determines whether it functions in protein refolding (via HOPX co-chaperone) or protein degradation (via STUB1/CHIP ubiquitin ligase). Additionally, HSPA1A has roles in regulating apoptosis, centrosome integrity during mitosis, TGF-beta signaling, and can function as an extracellular signaling molecule (receptor ligand activity).</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,77 +795,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A nuclear localization is well-supported. During heat shock, Hsp70 translocates to the nucleus via Hikeshi (PMID:22024166), interacts with HSF1 transactivation domain to repress transcription (PMID:9499401), and localizes to nuclear speck-like structures (PMID:9553041). During erythropoiesis, Hsp70 accumulates in the nucleus where it protects GATA-1 from caspase-3 cleavage (PMID:17167422). Hsp70 also sequesters AUF1 in the perinucleus/nucleus during heat shock (PMID:10205060). IBA annotation is phylogenetically sound and experimentally confirmed by multiple IDA studies.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear localization is well-established for HSPA1A under multiple conditions including heat stress (nuclear import via Hikeshi), transcriptional regulation (HSF1 repression), and erythropoiesis (GATA-1 protection). Supported by IDA evidence from PMID:17167422, PMID:10205060, PMID:9553041.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17167422" target="_blank" class="term-link">
                                         PMID:17167422
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">At the onset of caspase activation, Hsp70 co-localizes and interacts with GATA-1 in the nucleus of erythroid precursors undergoing terminal differentiation.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9499401" target="_blank" class="term-link">
                                         PMID:9499401
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the molecular chaperone Hsp70 and the cochaperone Hdj1 interact directly with the transactivation domain of HSF1 and repress heat shock gene transcription.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -877,46 +877,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A is predominantly cytoplasmic under basal conditions. This is well-established by multiple IDA studies (PMID:24061851, PMID:10859165, PMID:11785981, PMID:24790089, PMID:9553041) and consistent with its role as a cytoplasmic chaperone. IBA annotation is phylogenetically sound and strongly supported.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization is the primary location of HSPA1A, confirmed by numerous independent studies and consistent with its core chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -928,64 +928,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> HSPA1A plasma membrane association is supported by its role as a virus receptor (rotavirus A entry, UniProt annotation) and by evidence showing it functions as an extracellular receptor ligand via Tag7/PGLYRP1-Hsp70 complexes that interact with TNFR1 on cell surfaces (PMID:26183779). Also consistent with its role in extracellular signaling (PMID:17568691). IBA annotation is phylogenetically reasonable for the HSP70 family.
+                            <strong>Summary:</strong> HSPA1A plasma membrane association is supported by evidence showing it can function as an extracellular receptor ligand via Tag7/PGLYRP1-Hsp70 complexes that interact with TNFR1 on cell surfaces (PMID:26183779), and is consistent with extracellular HSP70 signaling (PMID:17568691). The rotavirus receptor citation is not used here because the available local evidence points to Hsc70 rather than HSPA1A.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Plasma membrane association is supported by HSPA1A&#39;s roles as a virus receptor and extracellular signaling molecule. Phylogenetically consistent for HSP70 family members.
+                            <strong>Reason:</strong> Plasma membrane association is supported by extracellular HSP70 signaling evidence and phylogenetically consistent for HSP70 family members, without relying on the mismatched rotavirus receptor citation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/26183779" target="_blank" class="term-link">
                                         PMID:26183779
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Tag7 (PGLYRP1) in Complex with Hsp70 Induces Alternative Cytotoxic Processes in Tumor Cells via TNFR1 Receptor</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -997,64 +997,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ATP hydrolysis activity is a core molecular function of HSPA1A. The N-terminal nucleotide binding domain (NBD) possesses intrinsic ATPase activity that is stimulated by J-domain co-chaperones (PMID:21231916). The ATPase cycle drives conformational changes between open (ATP-bound) and closed (ADP-bound) states of the substrate binding domain, which is essential for chaperone function. Directly demonstrated by IDA evidence (PMID:21231916, PMID:23921388). IBA annotation is phylogenetically sound and represents a core function of all HSP70 family members.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATP hydrolysis is the fundamental enzymatic activity driving the HSPA1A chaperone cycle. Confirmed by direct assay (PMID:21231916). This is a core conserved function of the entire HSP70 family.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
                                     GO:0031072
                                 </a>
                             </span>
                             <span class="term-label">heat shock protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1066,77 +1066,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A interacts with numerous heat shock proteins as part of its chaperone function. It binds HSP40/DNAJ co-chaperones (PMID:22219199, PMID:21231916), HSP90 via the HOP/STIP1 adapter (Reactome:R-HSA-3371503), HSP110 nucleotide exchange factors (PMID:24318877), and small HSPs. These interactions are central to its chaperone cycle. IBA annotation is well-supported and phylogenetically sound.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Heat shock protein binding is a core property of HSPA1A, essential for its chaperone cycle. Binding to J-domain co-chaperones (HSP40s), HSP110/NEFs, and HSP90 are all well-documented.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22219199" target="_blank" class="term-link">
                                         PMID:22219199
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The C-terminal helices of heat shock protein 70 are essential for J-domain binding and ATPase activation</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link">
                                         PMID:23921388
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we identified the methyltransferase METTL21A as the enzyme responsible for trimethylation of a conserved lysine residue found in several human Hsp70 (HSPA) proteins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     GO:0044183
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1148,64 +1148,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein folding chaperone is the core molecular function of HSPA1A. Hageman et al. (2011) directly demonstrated that HSPA1A has foldase activity in luciferase refolding assays, and also suppresses polyQ aggregation and protects cells from heat-induced death (PMID:21231916). Kalia et al. (2004) also showed chaperone activity via refolding assays inhibited by BAG5 (PMID:15603737). IBA annotation is phylogenetically sound and confirmed by multiple IDA studies.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is the primary molecular function of HSPA1A. Directly demonstrated by multiple independent studies (PMID:21231916, PMID:15603737). Conserved across the HSP70 family.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/HSPA1A/HSPA1A-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">HSPA1A is the stress-inducible cytosolic Hsp70-1A chaperone whose ATPase cycle drives client binding, folding/refolding, and proteostasis triage.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1217,46 +1228,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol is the primary subcellular location where HSPA1A functions as a chaperone. Confirmed by IDA (PMID:21231916) and multiple Reactome pathway annotations that place HSPA1A in the cytosol for chaperone cycle reactions. IBA annotation is phylogenetically sound.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosolic localization is the primary site of HSPA1A chaperone function. Confirmed by direct assay and consistent with all known chaperone cycle components.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1268,77 +1279,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein refolding is a core biological process for HSPA1A. Hageman et al. (2011) directly demonstrated luciferase refolding activity for HSPA1A (PMID:21231916). Kalia et al. (2004) showed BAG5 inhibits Hsp70-mediated refolding of denatured proteins (PMID:15603737). The refolding function is ATP-dependent and requires J-domain co-chaperones. IBA annotation is phylogenetically sound and confirmed by IDA evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein refolding is a core process carried out by HSPA1A. Directly demonstrated by luciferase refolding assays (PMID:21231916, PMID:15603737). Conserved function across HSP70 family.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/15603737" target="_blank" class="term-link">
                                         PMID:15603737
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Within this complex, BAG5 inhibits both parkin E3 ubiquitin ligase activity and Hsp70-mediated refolding of misfolded proteins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032436" target="_blank" class="term-link">
                                     GO:0032436
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of proteasomal ubiquitin-dependent protein catabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1350,115 +1361,115 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A promotes proteasomal degradation of substrates via its interaction with the CHIP/STUB1 ubiquitin ligase. Hsp70 delivers misfolded substrates to CHIP for ubiquitination and proteasomal degradation. Shang et al. (2014) showed Hsp70 enhances CHIP-induced ubiquitination and degradation of Smad3 (PMID:24613385). Imai et al. (2002) showed CHIP-Hsp70-Parkin complex promotes ubiquitination of Pael-R (PMID:12150907). The acetylation state of HSPA1A (by NAA10/ARD1) determines whether substrates are directed toward refolding or degradation (PMID:27708256). IBA annotation is well-supported.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPA1A promotes proteasomal degradation of substrates through CHIP/STUB1, a well-established arm of the chaperone triage decision. Confirmed by IDA (PMID:24613385) and multiple studies showing CHIP-Hsp70 mediated ubiquitination.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24613385" target="_blank" class="term-link">
                                         PMID:24613385
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">over-expressed Hsp70 or inhibition of Hsp90 by geldanamycin (GA) leads to facilitated CHIP-induced ubiquitination and degradation of Smad3</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046718" target="_blank" class="term-link">
                                     GO:0046718
                                 </a>
                             </span>
                             <span class="term-label">symbiont entry into host cell</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000108
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="P0DMV8" data-a="GO:0046718" data-r="GO_REF:0000108" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P0DMV8" data-a="GO:0046718" data-r="GO_REF:0000108" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> HSPA1A serves as a post-attachment receptor for rotavirus A, facilitating virus entry into the cell (PMID:16537599). UniProt confirms this function. The IEA annotation via logical inference from the virus receptor activity annotation is reasonable.
+                            <strong>Summary:</strong> The source evidence for this rotavirus-entry inference is PMID:16537599, but the local UniProt citation describes recombinant hsc70 rather than HSPA1A/Hsp72. This is therefore a paralog/evidence mismatch for HSPA1A.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> HSPA1A functions as a virus receptor for rotavirus A (PMID:16537599), which involves viral entry. This is a secondary/non-core function distinct from its primary chaperone role.
+                            <strong>Reason:</strong> The cited rotavirus receptor evidence does not establish HSPA1A-specific symbiont entry activity; it should not be retained for HSPA1A without HSPA1A-specific support.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000166" target="_blank" class="term-link">
                                     GO:0000166
                                 </a>
                             </span>
                             <span class="term-label">nucleotide binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1470,97 +1481,97 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A binds ATP and ADP as part of its core chaperone cycle. The N-terminal nucleotide-binding domain (NBD) binds and hydrolyzes ATP, which drives the conformational changes essential for chaperone function (PMID:21231916, PMID:23921388). Nucleotide binding is a correct but very broad parent term; the more specific GO:0005524 ATP binding is already annotated.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleotide binding is accurate for HSPA1A. While broader than GO:0005524 (ATP binding), it is acceptable as an IEA annotation that captures the fundamental nucleotide-binding property of the NBD.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001618" target="_blank" class="term-link">
                                     GO:0001618
                                 </a>
                             </span>
                             <span class="term-label">virus receptor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="P0DMV8" data-a="GO:0001618" data-r="GO_REF:0000043" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P0DMV8" data-a="GO:0001618" data-r="GO_REF:0000043" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> UniProt directly annotates HSPA1A as a receptor for rotavirus A based on PMID:16537599. The peptide-binding and ATPase domains of Hsp70 are required for rotavirus interaction and infectivity reduction.
+                            <strong>Summary:</strong> The rotavirus receptor evidence cited for this annotation is PMID:16537599, but the local UniProt citation identifies the tested protein as recombinant hsc70 rather than HSPA1A/Hsp72. The annotation therefore appears to transfer an HSPA8/Hsc70-related observation onto HSPA1A.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Virus receptor activity is experimentally supported for rotavirus A entry (PMID:16537599) but is a non-core function unrelated to HSPA1A&#39;s primary chaperone role.
+                            <strong>Reason:</strong> Virus receptor activity is not supported by HSPA1A-specific evidence in the available local citation and should not be retained for HSPA1A.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001664" target="_blank" class="term-link">
                                     GO:0001664
                                 </a>
                             </span>
                             <span class="term-label">G protein-coupled receptor binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1572,64 +1583,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation likely derives from the Hsp70-Pael-R interaction described in PMID:12150907. Pael-R (GPR37) is a GPCR, and Hsp70 forms a complex with CHIP, Parkin, and unfolded Pael-R. However, Hsp70 binds the unfolded Pael-R as a chaperone substrate, not as a GPCR ligand engaging in canonical receptor binding. The term &#34;G protein-coupled receptor binding&#34; is misleading here.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Hsp70 binds unfolded Pael-R (a GPCR) in the context of chaperone-mediated quality control and CHIP/Parkin-directed ubiquitination (PMID:12150907), not as a functional GPCR binding partner. This is chaperone-substrate interaction, not receptor binding in the signaling sense.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12150907" target="_blank" class="term-link">
                                         PMID:12150907
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">CHIP, Hsp70, Parkin, and Pael-R formed a complex in vitro and in vivo. The amount of CHIP in the complex was increased during ER stress.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
                                     GO:0005524
                                 </a>
                             </span>
                             <span class="term-label">ATP binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1641,46 +1652,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ATP binding is a core molecular function of HSPA1A. The N-terminal NBD binds ATP, and crystal structures of HSPA1A in complex with ATP analogs have been solved (PDB:2E88, 2E8A). Directly confirmed by IDA (PMID:23921388).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATP binding is fundamental to the HSPA1A chaperone cycle and is confirmed by structural and biochemical evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
                                     GO:0005576
                                 </a>
                             </span>
                             <span class="term-label">extracellular region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1692,46 +1703,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A is released extracellularly and detected in exosomes, blood microparticles, and as free protein in necrotic cell supernatants (PMID:17568691, PMID:26183779). UniProt annotates HSPA1A as secreted. Confirmed by IDA evidence from PMID:17568691 and PMID:26183779.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Extracellular localization is supported by multiple independent studies showing HSPA1A release from cells and its presence in extracellular fluids and exosomes.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1743,46 +1754,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Duplicate of the IBA-reviewed nuclear localization annotation. HSPA1A nuclear localization is well-established by multiple IDA studies (PMID:17167422, PMID:10205060, PMID:9553041) and the IBA annotation is already accepted.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> IEA annotation consistent with the already-accepted IBA annotation and multiple IDA confirmations. Nuclear localization is well-established for HSPA1A.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1794,46 +1805,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Duplicate of the IBA-reviewed cytoplasm annotation. Cytoplasm is the primary location of HSPA1A under basal conditions. Confirmed by numerous IDA studies.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> IEA annotation consistent with the already-accepted IBA annotation and multiple IDA confirmations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005813" target="_blank" class="term-link">
                                     GO:0005813
                                 </a>
                             </span>
                             <span class="term-label">centrosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1845,64 +1856,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A accumulates at mitotic centrosomes during prometaphase to metaphase and is required for bipolar spindle assembly (PMID:27137183). UniProt confirms centrosome localization. Also confirmed by IDA (PMID:27137183).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Centrosome localization is experimentally confirmed by Fang et al. 2016 (PMID:27137183) who demonstrated HSP70 accumulation at mitotic centrosomes and its role in centrosome integrity.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/27137183" target="_blank" class="term-link">
                                         PMID:27137183
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">heat shock protein (HSP) 70 considerably accumulates at the mitotic centrosome during prometaphase to metaphase and is required for bipolar spindle assembly.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005814" target="_blank" class="term-link">
                                     GO:0005814
                                 </a>
                             </span>
                             <span class="term-label">centriole</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1914,64 +1925,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A localizes to centrioles upon thermal stress in human neuronal cells (PMID:24061851). Specifically targets the proximal end of centrioles identified by gamma-tubulin marker. Confirmed by IDA (PMID:24061851) and GO_REF:0000052 (immunofluorescence-based).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Centriole localization is experimentally confirmed by Khalouei et al. 2014 (PMID:24061851) using YFP-tagged HSPA1A in neuronal cells.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24061851" target="_blank" class="term-link">
                                         PMID:24061851
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Following a brief period of thermal stress, YFP-tagged HSPA6 and HSPA1A rapidly appeared at centrioles in the cytoplasm of human neuronal cells</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006402" target="_blank" class="term-link">
                                     GO:0006402
                                 </a>
                             </span>
                             <span class="term-label">mRNA catabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1983,64 +1994,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Hsp70 participates in AU-rich element-mediated mRNA decay. Heat shock induces Hsp70 sequestration of AUF1 into the perinucleus/nucleus, blocking decay of AU-rich mRNAs (PMID:10205060). However, Hsp70 blocks mRNA decay rather than promoting it. The role is indirect and regulatory rather than direct participation in mRNA catabolism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPA1A modulates mRNA decay through the AUF1-ubiquitin-proteasome pathway (PMID:10205060), but this is an indirect regulatory role secondary to its primary chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10205060" target="_blank" class="term-link">
                                         PMID:10205060
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Induction of hsp70 by heat shock, down-regulation of the ubiquitin-proteasome network, or inactivation of ubiquitinating enzyme E1 all result in hsp70 sequestration of AUF1 in the perinucleus-nucleus, and all three processes block decay of AU-rich mRNAs and AUF1 protein.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008285" target="_blank" class="term-link">
                                     GO:0008285
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of cell population proliferation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2052,64 +2063,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This derives from the WT1-Hsp70 interaction study (PMID:9553041) where Hsp70 is required for WT1-mediated growth suppression. However, the antiproliferative effect is mediated by WT1, not by Hsp70 itself; Hsp70 acts as a cofactor/chaperone for WT1. This is not a direct function of HSPA1A.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The negative regulation of cell proliferation requires WT1, with Hsp70 serving as a cofactor (PMID:9553041). This represents a chaperone client effect, not a direct HSPA1A function in proliferation control.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9553041" target="_blank" class="term-link">
                                         PMID:9553041
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Inhibition of cellular proliferation by the Wilms tumor suppressor WT1 requires association with the inducible chaperone Hsp70.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016235" target="_blank" class="term-link">
                                     GO:0016235
                                 </a>
                             </span>
                             <span class="term-label">aggresome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2121,46 +2132,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A localizes to aggresomes. PMID:15885686 shows TRIM37 forms ubiquitin- and chaperone-positive aggresomes. Confirmed by IDA (PMID:15885686).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Aggresome localization is confirmed by IDA evidence (PMID:15885686) and is consistent with HSPA1A&#39;s role in protein quality control and handling of misfolded proteins.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016607" target="_blank" class="term-link">
                                     GO:0016607
                                 </a>
                             </span>
                             <span class="term-label">nuclear speck</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2172,64 +2183,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A localizes to nuclear speck-like structures upon association with WT1 (PMID:9553041). Maheswaran et al. showed Hsp70 is recruited to characteristic subnuclear clusters containing WT1. Confirmed by IDA (PMID:9553041).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear speck localization is confirmed by IDA (PMID:9553041) showing colocalization of Hsp70 with WT1 in subnuclear clusters.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9553041" target="_blank" class="term-link">
                                         PMID:9553041
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Hsp70 is recruited to the characteristic subnuclear clusters that contain WT1.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2241,46 +2252,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Duplicate of the IBA-reviewed ATP hydrolysis annotation. ATP hydrolysis is a core enzymatic activity of HSPA1A confirmed by IDA (PMID:21231916).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> IEA annotation consistent with the already-accepted IBA annotation and confirmed by direct assay.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030308" target="_blank" class="term-link">
                                     GO:0030308
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of cell growth</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2292,46 +2303,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Similar to GO:0008285, this likely derives from the WT1-Hsp70 study (PMID:9553041). The growth inhibition is a property of WT1 that requires Hsp70 as a cofactor. Hsp70 does not directly regulate cell growth.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> As with negative regulation of cell proliferation, the cell growth effect is mediated by WT1 with Hsp70 as a chaperone cofactor (PMID:9553041). This is an over-annotation of HSPA1A function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
                                     GO:0031072
                                 </a>
                             </span>
                             <span class="term-label">heat shock protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2343,46 +2354,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Duplicate of the IBA-reviewed heat shock protein binding annotation. HSPA1A interacts with multiple HSPs including DNAJ/HSP40 co-chaperones, HSP90, and HSP110/HSPH1. Core property confirmed by numerous IPI studies.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> IEA annotation consistent with the already-accepted IBA annotation and extensive experimental evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031397" target="_blank" class="term-link">
                                     GO:0031397
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of protein ubiquitination</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2394,64 +2405,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A can inhibit protein ubiquitination by competing with CHIP/STUB1 for substrate binding. In the CHIP-Hsp70-Parkin complex, Hsp70 can sequester substrates and prevent their ubiquitination until CHIP promotes Hsp70 dissociation (PMID:12150907). Confirmed by IDA (PMID:12150907).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Negative regulation of ubiquitination is a genuine property of Hsp70 chaperone triage. Hsp70 binding to substrates can shield them from ubiquitin ligases until the appropriate signal triggers degradation (PMID:12150907).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12150907" target="_blank" class="term-link">
                                         PMID:12150907
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">CHIP promoted the dissociation of Hsp70 from Parkin and Pael-R, thus facilitating Parkin-mediated Pael-R ubiquitination.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031625" target="_blank" class="term-link">
                                     GO:0031625
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin protein ligase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2463,46 +2474,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A interacts directly with ubiquitin ligases including CHIP/STUB1 (via TPR repeats) and Parkin (PMID:12150907, PMID:15603737, PMID:24613385). This is a core interaction mediating chaperone-directed degradation. Confirmed by multiple IPI studies.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Ubiquitin protein ligase binding is a core property of HSPA1A, mediating the chaperone triage decision between refolding and degradation. The HSPA1A-CHIP/STUB1 interaction is well-established.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032757" target="_blank" class="term-link">
                                     GO:0032757
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of interleukin-8 production</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2514,46 +2525,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A stabilizes NOD2, which activates NF-kappaB signaling and downstream IL-8 production (PMID:24790089). This is an indirect effect mediated through NOD2 stabilization. Confirmed by IMP (PMID:24790089).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Positive regulation of IL-8 production is an indirect downstream consequence of HSPA1A&#39;s chaperone-mediated stabilization of NOD2, not a direct function of HSPA1A (PMID:24790089).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034599" target="_blank" class="term-link">
                                     GO:0034599
                                 </a>
                             </span>
                             <span class="term-label">cellular response to oxidative stress</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2565,46 +2576,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A is induced by oxidative stress and provides cytoprotection. The TAS reference PMID:24252804 (a review on oxidative stress in Parkinson&#39;s disease) discusses the role of chaperones including Hsp70 in response to oxidative damage. This is a well-established general stress response.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPA1A responds to and provides protection against oxidative stress as part of its general cytoprotective role, but this is a secondary response, not its core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2616,46 +2627,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Duplicate of the IBA-reviewed protein refolding annotation. Protein refolding is a core process carried out by HSPA1A, confirmed by IDA (PMID:21231916, PMID:15603737).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> IEA annotation consistent with the already-accepted IBA annotation and confirmed by direct assay evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042826" target="_blank" class="term-link">
                                     GO:0042826
                                 </a>
                             </span>
                             <span class="term-label">histone deacetylase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2667,77 +2678,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A interacts with HDAC4, which deacetylates Hsp70 at Lys-77 during the later stages of the stress response. This deacetylation switches Hsp70 from protein refolding to protein degradation mode (PMID:27708256). Also, HDAC8-phosphorylated form recruits Hsp70 to a complex (PMID:16809764). Confirmed by IPI (PMID:16809764).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Histone deacetylase binding is confirmed by experimental evidence. HDAC4 deacetylates Hsp70 at K77 to switch its co-chaperone preference (PMID:27708256), and HDAC8 recruits Hsp70 to the hEST1B complex (PMID:16809764).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/27708256" target="_blank" class="term-link">
                                         PMID:27708256
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Here, we demonstrate that Hsp70 preferentially facilitates protein refolding after stress, gradually switching to protein degradation via a mechanism dependent on ARD1-mediated Hsp70 acetylation</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16809764" target="_blank" class="term-link">
                                         PMID:16809764
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Phosphorylated HDAC8 preferentially recruits Hsp70 to a complex that inhibits the CHIP (C-terminal heat shock protein interacting protein) E3 ligase-mediated degradation of hEST1B.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     GO:0044183
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2749,46 +2760,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Duplicate of the IBA-reviewed protein folding chaperone annotation. This is the core molecular function of HSPA1A. Confirmed by IDA (PMID:21231916, PMID:15603737).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> IEA annotation consistent with the already-accepted IBA annotation and confirmed by direct assay evidence. Core molecular function of HSPA1A.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045648" target="_blank" class="term-link">
                                     GO:0045648
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of erythrocyte differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2800,115 +2811,115 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A protects GATA-1 from caspase-3 cleavage during erythroid terminal differentiation, enabling proper erythropoiesis (PMID:17167422). Confirmed by IMP (PMID:17167422).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Positive regulation of erythrocyte differentiation is experimentally supported (PMID:17167422) but represents a tissue-specific non-core function of HSPA1A, where its chaperone activity protects GATA-1 during erythropoiesis.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17167422" target="_blank" class="term-link">
                                         PMID:17167422
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">during differentiation, but not during apoptosis, the chaperone protein Hsp70 protects GATA-1 from caspase-mediated proteolysis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046034" target="_blank" class="term-link">
                                     GO:0046034
                                 </a>
                             </span>
                             <span class="term-label">ATP metabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P0DMV8" data-a="GO:0046034" data-r="GO_REF:0000117" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P0DMV8" data-a="GO:0046034" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> HSPA1A hydrolyzes ATP as part of its chaperone cycle. The ATP metabolic process annotation broadly captures the ATPase activity. Confirmed by IDA (PMID:23921388, PMID:21231916).
+                            <strong>Summary:</strong> HSPA1A hydrolyzes ATP as part of its chaperone cycle, but ATP metabolic process is a broad biological-process term. The actual molecular activity is captured by ATP hydrolysis activity and ATP-dependent chaperone terms.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> ATP metabolic process is accurate as HSPA1A has intrinsic ATPase activity. Broader than GO:0016887 (ATP hydrolysis activity) but acceptable.
+                            <strong>Reason:</strong> This broad BP term is less informative than the molecular-function terms describing HSPA1A&#39;s ATPase-driven chaperone cycle.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048471" target="_blank" class="term-link">
                                     GO:0048471
                                 </a>
                             </span>
                             <span class="term-label">perinuclear region of cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2920,64 +2931,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Hsp70 sequesters AUF1 in the perinucleus/nucleus during heat shock (PMID:10205060). Also confirmed by IDA showing BAG5-Hsp70 perinuclear localization (PMID:15603737). Confirmed by multiple IDA studies.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Perinuclear localization is confirmed by IDA (PMID:10205060, PMID:15603737) and consistent with HSPA1A&#39;s role in mRNA decay regulation and client protein handling.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10205060" target="_blank" class="term-link">
                                         PMID:10205060
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Induction of hsp70 by heat shock [...] result in hsp70 sequestration of AUF1 in the perinucleus-nucleus</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                     GO:0050821
                                 </a>
                             </span>
                             <span class="term-label">protein stabilization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2989,64 +3000,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A stabilizes client proteins, including NOD2 (PMID:24790089) and intrinsically disordered proteins (PMID:21909508). Hsp70 binding increases NOD2 half-life. Confirmed by IDA (PMID:21909508) and IMP (PMID:24790089).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein stabilization is a genuine function of HSPA1A chaperone activity, demonstrated for multiple substrates including NOD2 (PMID:24790089).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24790089" target="_blank" class="term-link">
                                         PMID:24790089
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSP70 to regulate the half-life of NOD2, as increasing the HSP70 level in cells increased the half-life of NOD2, and down-regulating HSP70 decreased the half-life of NOD2.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -3058,75 +3069,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). HSPA1A is a bona fide molecular chaperone with demonstrated foldase activity (luciferase refolding) and aggregation suppression (PMID:21231916). The term &#34;unfolded protein binding&#34; describes only the substrate-binding aspect and misses the active chaperone function. HSPA1A already has an IBA annotation to GO:0044183 &#34;protein folding chaperone&#34; which accurately captures its core molecular function. This IEA annotation from ARBA machine learning should be replaced with GO:0044183.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. HSPA1A has genuine protein folding chaperone activity, not merely unfolded protein binding. The protein actively refolds substrates in an ATP-dependent manner, as demonstrated by Hageman et al. (PMID:21231916). The IBA annotation to GO:0044183 already correctly captures this function. This IEA annotation should be modified to GO:0044183 to align with the term obsoletion and to more accurately represent the molecular function.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation. [...] overexpression of HSPA1A protected cells from heat-induced cell death</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0055131" target="_blank" class="term-link">
                                     GO:0055131
                                 </a>
                             </span>
                             <span class="term-label">C3HC4-type RING finger domain binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3138,77 +3149,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A interacts with RING finger E3 ubiquitin ligases including CHIP/STUB1, which contains a U-box domain (structurally related to RING), and TRIM37, a RING E3 ligase (PMID:15885686). The annotation captures the binding of Hsp70 to RING-type E3 ligases as part of the chaperone-ubiquitin triage system.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPA1A binding to RING-type E3 ubiquitin ligases is a well-established aspect of chaperone-mediated protein quality control. Supported by interactions with CHIP/STUB1 and TRIM37 (PMID:15885686, PMID:12150907).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/15885686" target="_blank" class="term-link">
                                         PMID:15885686
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">TRIM37 defective in mulibrey nanism is a novel RING finger ubiquitin E3 ligase.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12150907" target="_blank" class="term-link">
                                         PMID:12150907
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">CHIP, Hsp70, Parkin, and Pael-R formed a complex in vitro and in vivo.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070370" target="_blank" class="term-link">
                                     GO:0070370
                                 </a>
                             </span>
                             <span class="term-label">cellular heat acclimation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3220,64 +3231,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A is a central effector of thermotolerance/heat acclimation. Hageman et al. (2011) showed that overexpression of HSPA1A protected cells from heat-induced cell death (PMID:21231916). Hsp70 is a primary effector of acquired thermotolerance.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cellular heat acclimation (thermotolerance) is a core function of HSPA1A. Directly demonstrated by PMID:21231916 showing HSPA1A overexpression protects from heat-induced cell death.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">whereas overexpression of HSPA1A protected cells from heat-induced cell death, overexpression of HSPA6 did not</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070434" target="_blank" class="term-link">
                                     GO:0070434
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of nucleotide-binding oligomerization domain containing 2 signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3289,64 +3300,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A stabilizes NOD2 and enhances its signaling capacity. Mohanan &amp; Grimes (2014) showed that HSP70 binds and stabilizes NOD2, increasing its half-life and NF-kappaB signaling in response to bacterial cell wall fragments (PMID:24790089).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Positive regulation of NOD2 signaling is experimentally supported (PMID:24790089) but is a downstream effect of HSPA1A&#39;s chaperone-mediated stabilization of NOD2, not a core function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24790089" target="_blank" class="term-link">
                                         PMID:24790089
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Induced HSP70 expression in cells increased the response of NOD2 to bacterial cell wall fragments.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071383" target="_blank" class="term-link">
                                     GO:0071383
                                 </a>
                             </span>
                             <span class="term-label">cellular response to steroid hormone stimulus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3358,46 +3369,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A participates in the HSP90 chaperone cycle for steroid hormone receptors (SHR). Hsp70 binds nascent/misfolded steroid hormone receptors and transfers them to HSP90 via HOP/STIP1 (Reactome:R-HSA-3371497). This is part of the general chaperone pathway rather than a specific response to steroid hormones.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPA1A participates in the HSP90 chaperone cycle for steroid hormone receptors as a general chaperone, not as a specific steroid hormone response gene. Supported by Reactome pathway R-HSA-3371497.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090063" target="_blank" class="term-link">
                                     GO:0090063
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of microtubule nucleation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3409,64 +3420,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Fang et al. (2016) showed HSP70 accumulates at mitotic centrosomes and is required for microtubule nucleation and bipolar spindle assembly. Loss of HSP70 reduced accumulation of NEDD1 and gamma-tubulin at mitotic centrosomes, disrupting MT nucleation (PMID:27137183).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Positive regulation of microtubule nucleation is experimentally confirmed (PMID:27137183) but represents a specific cell-cycle role rather than the core chaperone function of HSPA1A.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/27137183" target="_blank" class="term-link">
                                         PMID:27137183
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Inhibition or depletion of HSP70 impaired the function of mitotic centrosome and disrupted MT nucleation and polymerization from the spindle pole</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090084" target="_blank" class="term-link">
                                     GO:0090084
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of inclusion body assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3478,133 +3489,133 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A suppresses aggregation and inclusion body formation. Hageman et al. (2011) showed HSPA1A suppresses polyQ aggregation (PMID:21231916). Kalia et al. (2004) showed BAG5 inhibits Hsp70-mediated suppression of protein aggregation, and that BAG5 enhances parkin sequestration within protein aggregates (PMID:15603737).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Suppression of inclusion body/aggregate formation is a core chaperone function of HSPA1A, directly demonstrated by multiple studies (PMID:21231916, PMID:15603737).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140545" target="_blank" class="term-link">
                                     GO:0140545
                                 </a>
                             </span>
                             <span class="term-label">ATP-dependent protein disaggregase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P0DMV8" data-a="GO:0140545" data-r="GO_REF:0000117" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P0DMV8" data-a="GO:0140545" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> HSPA1A has ATP-dependent protein disaggregase activity. Jakobsson et al. (2013) showed METTL21A-mediated trimethylation of Hsp70 modulates its chaperone function including effects on alpha-synuclein disaggregation (PMID:23921388). Hsp70 disaggregase activity is well-established in the Hsp70/Hsp110/Hsp40 system.
+                            <strong>Summary:</strong> This ARBA inference cites PMID:23921388, but the local paper describes METTL21A methylation and altered HSPA8/Hsc70 affinity for alpha-synuclein, not direct HSPA1A ATP-dependent disaggregase activity. HSP70-family disaggregation can require HSP110/HSP40 systems, but this evidence does not establish HSPA1A-specific disaggregase activity.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> ATP-dependent protein disaggregase activity is a core molecular function of HSPA1A, operating in concert with Hsp110 and Hsp40 co-chaperones. Confirmed by IDA (PMID:23921388).
+                            <strong>Reason:</strong> The annotation overextends family-level proteostasis biology and HSPA8-focused evidence to HSPA1A. HSPA1A&#39;s accepted core role should remain ATP-dependent folding/refolding and client triage unless direct HSPA1A disaggregase evidence is available.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link">
                                         PMID:23921388
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we show that trimethylation of HSPA8 (Hsc70) has functional consequences, as it alters the affinity of the chaperone for both the monomeric and fibrillar forms of the Parkinson disease-associated protein alpha-synuclein.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1901673" target="_blank" class="term-link">
                                     GO:1901673
                                 </a>
                             </span>
                             <span class="term-label">regulation of mitotic spindle assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3616,64 +3627,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Fang et al. (2016) demonstrated HSP70 is required for bipolar mitotic spindle assembly. Inhibition or depletion of HSP70 disrupted MT nucleation from spindle poles and resulted in abnormal mitotic spindles (PMID:27137183).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Regulation of mitotic spindle assembly is experimentally supported (PMID:27137183) but represents a cell-cycle-specific role, not the core chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/27137183" target="_blank" class="term-link">
                                         PMID:27137183
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">In this study, we showed that heat shock protein (HSP) 70 considerably accumulates at the mitotic centrosome during prometaphase to metaphase and is required for bipolar spindle assembly.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1903265" target="_blank" class="term-link">
                                     GO:1903265
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of tumor necrosis factor-mediated signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3685,64 +3696,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Extracellular Hsp70 promotes TNF signaling. Tag7/PGLYRP1-Hsp70 complex induces cytotoxic processes in tumor cells via TNFR1 (PMID:26183779). Also, necrotic cell-released Hsp70 augments TNF-alpha responses (PMID:17568691).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Positive regulation of TNF signaling is supported for extracellular Hsp70 (PMID:26183779, PMID:17568691) but is a non-core extracellular signaling function distinct from the primary intracellular chaperone role.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/26183779" target="_blank" class="term-link">
                                         PMID:26183779
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Tag7 (PGLYRP1) in Complex with Hsp70 Induces Alternative Cytotoxic Processes in Tumor Cells via TNFR1 Receptor.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1904813" target="_blank" class="term-link">
                                     GO:1904813
                                 </a>
                             </span>
                             <span class="term-label">ficolin-1-rich granule lumen</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3754,46 +3765,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A is found in ficolin-1-rich granule lumen, a neutrophil granule compartment. This localization is supported by Reactome pathway R-HSA-6800434 and consistent with the detection of Hsp70 in immune cell granules.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Ficolin-1-rich granule lumen localization is supported by Reactome and consistent with known immune cell biology of extracellular Hsp70.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990904" target="_blank" class="term-link">
                                     GO:1990904
                                 </a>
                             </span>
                             <span class="term-label">ribonucleoprotein complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3805,64 +3816,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A associates with IMP1 ribonucleoprotein granules. Jonson et al. (2007) identified Hsp70 among the molecular composition of IMP1 RNP granules by mass spectrometry (PMID:17289661). This is consistent with Hsp70&#39;s known role in mRNA metabolism via AUF1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Ribonucleoprotein complex association is experimentally supported (PMID:17289661) but represents a secondary localization rather than a core function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17289661" target="_blank" class="term-link">
                                         PMID:17289661
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Molecular composition of IMP1 ribonucleoprotein granules.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:2001240" target="_blank" class="term-link">
                                     GO:2001240
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of extrinsic apoptotic signaling pathway in absence of ligand</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3874,75 +3885,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A inhibits the extrinsic apoptotic signaling pathway. During erythropoiesis, Hsp70 protects GATA-1 from caspase-3 cleavage, preventing apoptosis during differentiation. Erythropoietin starvation induces nuclear export of Hsp70, leading to GATA-1 cleavage and apoptosis (PMID:17167422).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Negative regulation of extrinsic apoptotic signaling is experimentally supported (PMID:17167422) but represents an indirect anti-apoptotic effect of the chaperone, not a core molecular function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17167422" target="_blank" class="term-link">
                                         PMID:17167422
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">during differentiation, but not during apoptosis, the chaperone protein Hsp70 protects GATA-1 from caspase-mediated proteolysis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21044950" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21044950
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Genome-wide YFP fluorescence complementation screen identifi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -3954,57 +3965,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#39;protein binding&#39; is uninformative per GO curation guidelines. HSPA1A interacts with many proteins as part of its chaperone function, but the generic &#39;protein binding&#39; term does not convey meaningful functional information. More specific MF terms (e.g., GO:0044183 protein folding chaperone, GO:0031072 heat shock protein binding, GO:0031625 ubiquitin protein ligase binding) already capture the biologically meaningful interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 &#39;protein binding&#39; is uninformative and should be replaced by more specific molecular function terms. HSPA1A already has appropriate specific MF annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24338975" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24338975
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Discovery of multiple interacting partners of gankyrin, a pr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4016,57 +4027,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#39;protein binding&#39; is uninformative per GO curation guidelines. HSPA1A interacts with many proteins as part of its chaperone function, but the generic &#39;protein binding&#39; term does not convey meaningful functional information. More specific MF terms (e.g., GO:0044183 protein folding chaperone, GO:0031072 heat shock protein binding, GO:0031625 ubiquitin protein ligase binding) already capture the biologically meaningful interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 &#39;protein binding&#39; is uninformative and should be replaced by more specific molecular function terms. HSPA1A already has appropriate specific MF annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24428437" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24428437
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Mutations in the substrate binding site of human heat-shock ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4078,57 +4089,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#39;protein binding&#39; is uninformative per GO curation guidelines. HSPA1A interacts with many proteins as part of its chaperone function, but the generic &#39;protein binding&#39; term does not convey meaningful functional information. More specific MF terms (e.g., GO:0044183 protein folding chaperone, GO:0031072 heat shock protein binding, GO:0031625 ubiquitin protein ligase binding) already capture the biologically meaningful interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 &#39;protein binding&#39; is uninformative and should be replaced by more specific molecular function terms. HSPA1A already has appropriate specific MF annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32814053
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interactome Mapping Provides a Network of Neurodegenerative ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4140,57 +4151,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#39;protein binding&#39; is uninformative per GO curation guidelines. HSPA1A interacts with many proteins as part of its chaperone function, but the generic &#39;protein binding&#39; term does not convey meaningful functional information. More specific MF terms (e.g., GO:0044183 protein folding chaperone, GO:0031072 heat shock protein binding, GO:0031625 ubiquitin protein ligase binding) already capture the biologically meaningful interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 &#39;protein binding&#39; is uninformative and should be replaced by more specific molecular function terms. HSPA1A already has appropriate specific MF annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043123" target="_blank" class="term-link">
                                     GO:0043123
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of canonical NF-kappaB signal transduction</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24790089" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24790089
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The molecular chaperone HSP70 binds to and stabilizes NOD2, ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4202,75 +4213,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Mohanan &amp; Grimes (2014) showed HSP70 stabilizes NOD2 which activates NF-kappaB. HSP70 overexpression increased NOD2-mediated NF-kappaB activation in response to bacterial cell wall fragments. HSP70 inhibitor KNK437 decreased NOD2-mediated NF-kappaB activation (PMID:24790089).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Positive regulation of NF-kappaB is an indirect downstream effect of HSPA1A stabilizing NOD2 (PMID:24790089). Not a core chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24790089" target="_blank" class="term-link">
                                         PMID:24790089
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">an HSP70 inhibitor, KNK437, was capable of decreasing NOD2-mediated NF-kappaB activation in response to bacterial cell wall stimulation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070434" target="_blank" class="term-link">
                                     GO:0070434
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of nucleotide-binding oligomerization domain containing 2 signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24790089" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24790089
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The molecular chaperone HSP70 binds to and stabilizes NOD2, ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4282,64 +4293,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Mohanan &amp; Grimes (2014) showed HSP70 binds and stabilizes NOD2, increasing its half-life and enhancing signaling capacity in response to bacterial cell wall fragments (PMID:24790089). Confirmed by IMP evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimentally confirmed (PMID:24790089) but represents a downstream effect of HSPA1A chaperone-mediated NOD2 stabilization, not a core function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24790089" target="_blank" class="term-link">
                                         PMID:24790089
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Induced HSP70 expression in cells increased the response of NOD2 to bacterial cell wall fragments.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005814" target="_blank" class="term-link">
                                     GO:0005814
                                 </a>
                             </span>
                             <span class="term-label">centriole</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4351,64 +4362,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A localizes to centrioles upon thermal stress in human neuronal cells. Khalouei et al. (2014) showed YFP-tagged HSPA1A rapidly appeared at centrioles following thermal stress, targeting the proximal end identified by gamma-tubulin marker (PMID:24061851). Confirmed by IDA (immunofluorescence-based).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Centriole localization is experimentally confirmed by immunofluorescence (PMID:24061851).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24061851" target="_blank" class="term-link">
                                         PMID:24061851
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Following a brief period of thermal stress, YFP-tagged HSPA6 and HSPA1A rapidly appeared at centrioles in the cytoplasm of human neuronal cells</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071383" target="_blank" class="term-link">
                                     GO:0071383
                                 </a>
                             </span>
                             <span class="term-label">cellular response to steroid hormone stimulus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371497
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4420,57 +4431,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A participates in the HSP90 chaperone cycle for steroid hormone receptors (SHR) in the presence of ligand (Reactome:R-HSA-3371497). Hsp70 binds nascent/misfolded steroid hormone receptors and hands them off to HSP90 via HOP/STIP1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPA1A participates in the HSP90 chaperone cycle for SHRs as a general chaperone; this is not a specific steroid hormone response. Supported by Reactome pathway.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030968" target="_blank" class="term-link">
                                     GO:0030968
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum unfolded protein response</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20625543" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20625543
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HSP72 protects cells from ER stress-induced apoptosis via en...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4482,64 +4493,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Gupta et al. (2010) showed Hsp72 (HSPA1A) enhances the IRE1alpha-XBP1 arm of the UPR. Hsp72 forms a stable complex with the cytosolic domain of IRE1alpha and enhances its RNase activity, promoting XBP1 mRNA splicing and cell survival under ER stress (PMID:20625543).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Participation in the ER UPR is experimentally confirmed (PMID:20625543) but represents a secondary cytoprotective function of HSPA1A rather than its core chaperone activity.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20625543" target="_blank" class="term-link">
                                         PMID:20625543
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">binding of Hsp72 to IRE1alpha enhances IRE1alpha/XBP1 signaling at the ER and inhibits ER stress-induced apoptosis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371422
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4551,57 +4562,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ATP hydrolysis by HSP70 is a Reactome-curated reaction (R-HSA-3371422). This is the core enzymatic activity of HSPA1A, confirmed by IDA (PMID:21231916) and IBA evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATP hydrolysis is a core enzymatic activity of HSPA1A. Consistent with already-accepted IBA and IDA annotations. Reactome pathway correctly represents this activity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17182002" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17182002
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HDJC9, a novel human type C DnaJ/HSP40 member interacts with...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4613,57 +4624,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#39;protein binding&#39; is uninformative per GO curation guidelines. HSPA1A interacts with many proteins as part of its chaperone function, but the generic &#39;protein binding&#39; term does not convey meaningful functional information. More specific MF terms (e.g., GO:0044183 protein folding chaperone, GO:0031072 heat shock protein binding, GO:0031625 ubiquitin protein ligase binding) already capture the biologically meaningful interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 &#39;protein binding&#39; is uninformative and should be replaced by more specific molecular function terms. HSPA1A already has appropriate specific MF annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4675,57 +4686,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#39;protein binding&#39; is uninformative per GO curation guidelines. HSPA1A interacts with many proteins as part of its chaperone function, but the generic &#39;protein binding&#39; term does not convey meaningful functional information. More specific MF terms (e.g., GO:0044183 protein folding chaperone, GO:0031072 heat shock protein binding, GO:0031625 ubiquitin protein ligase binding) already capture the biologically meaningful interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 &#39;protein binding&#39; is uninformative and should be replaced by more specific molecular function terms. HSPA1A already has appropriate specific MF annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000122" target="_blank" class="term-link">
                                     GO:0000122
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of transcription by RNA polymerase II</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9499401" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9499401
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular chaperones as HSF1-specific transcriptional repres...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4737,75 +4748,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Shi et al. (1998) showed Hsp70 and Hdj1 directly interact with the transactivation domain of HSF1 and repress heat shock gene transcription. Overexpression of Hsp70 represses transcriptional activity of endogenous HSF1 without affecting its DNA binding (PMID:9499401). This represents a bona fide transcriptional repression function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Negative regulation of transcription is experimentally confirmed for HSF1-dependent gene transcription (PMID:9499401). This represents the autoregulatory feedback loop of the heat shock response, a well-established but non-core regulatory function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9499401" target="_blank" class="term-link">
                                         PMID:9499401
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the molecular chaperone Hsp70 and the cochaperone Hdj1 interact directly with the transactivation domain of HSF1 and repress heat shock gene transcription.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034605" target="_blank" class="term-link">
                                     GO:0034605
                                 </a>
                             </span>
                             <span class="term-label">cellular response to heat</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9499401" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9499401
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular chaperones as HSF1-specific transcriptional repres...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4817,75 +4828,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A is a primary effector of the cellular response to heat. Shi et al. (1998) demonstrated Hsp70 represses HSF1 transcriptional activity during heat shock attenuation (PMID:9499401). HSPA1A is strongly induced by heat stress and is the canonical heat shock response gene.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cellular response to heat is a defining biological process for HSPA1A. It is both induced by and a primary effector of the heat shock response (PMID:9499401, PMID:21231916).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9499401" target="_blank" class="term-link">
                                         PMID:9499401
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the repression of heat shock gene transcription, which occurs during attenuation, is due to the association of Hsp70 with the HSF1 transactivation domain</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140416" target="_blank" class="term-link">
                                     GO:0140416
                                 </a>
                             </span>
                             <span class="term-label">transcription regulator inhibitor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9499401" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9499401
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular chaperones as HSF1-specific transcriptional repres...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4897,155 +4908,155 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Shi et al. (1998) showed Hsp70 directly interacts with the HSF1 transactivation domain and represses its transcriptional activity. This is a genuine transcription regulator inhibitor activity (PMID:9499401).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Transcription regulator inhibitor activity toward HSF1 is experimentally confirmed (PMID:9499401). This is part of the autoregulatory heat shock response loop, not a core chaperone function per se.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9499401" target="_blank" class="term-link">
                                         PMID:9499401
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpression of either chaperone represses the transcriptional activity of a transfected GAL4-HSF1 activation domain fusion protein and endogenous HSF1.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140545" target="_blank" class="term-link">
                                     GO:0140545
                                 </a>
                             </span>
                             <span class="term-label">ATP-dependent protein disaggregase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23921388
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of a novel human methylt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="P0DMV8" data-a="GO:0140545" data-r="PMID:23921388" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P0DMV8" data-a="GO:0140545" data-r="PMID:23921388" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Jakobsson et al. (2013) showed METTL21A-mediated trimethylation of Hsp70 modulates its chaperone function, altering affinity for monomeric and fibrillar alpha-synuclein (PMID:23921388). The disaggregase activity is a core function of the Hsp70/Hsp110/Hsp40 chaperone system.
+                            <strong>Summary:</strong> PMID:23921388 shows METTL21A-mediated methylation effects on HSPA8/Hsc70 binding to alpha-synuclein, not direct HSPA1A disaggregase activity. The evidence is therefore mismatched for an HSPA1A IDA annotation.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> ATP-dependent protein disaggregase activity is a core molecular function of HSPA1A. Confirmed by IDA (PMID:23921388).
+                            <strong>Reason:</strong> The cited IDA evidence does not support HSPA1A-specific ATP-dependent protein disaggregase activity and should not be accepted for this gene.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link">
                                         PMID:23921388
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">trimethylation of HSPA8 (Hsc70) has functional consequences, as it alters the affinity of the chaperone for both the monomeric and fibrillar forms of the Parkinson disease-associated protein alpha-synuclein.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5057,75 +5068,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Hageman et al. (2011) directly assayed HSPA1A ATPase activity and showed it possesses intrinsic ATPase activity stimulated by J-proteins (PMID:21231916). Core enzymatic function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATP hydrolysis activity directly demonstrated by Hageman et al. (PMID:21231916). Core enzymatic function of HSPA1A.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSPA6 has a functional substrate-binding domain and possesses intrinsic ATPase activity that is as high as that of the canonical HSPA1A when stimulated by J-proteins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005615" target="_blank" class="term-link">
                                     GO:0005615
                                 </a>
                             </span>
                             <span class="term-label">extracellular space</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17568691" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17568691
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Endogenous signals released from necrotic cells augment infl...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5137,75 +5148,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> El Mezayen et al. (2007) showed HSP70 is released from necrotic cells into the extracellular space and acts as a danger signal to activate innate immune cells (PMID:17568691).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Extracellular space localization is experimentally confirmed. HSPA1A is released from necrotic cells and detected in extracellular fluids (PMID:17568691).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17568691" target="_blank" class="term-link">
                                         PMID:17568691
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HMGB1 and HSP70 were indeed present in the necrotic cell lysate and were responsible for the significant induction of the proinflammatory cytokine expression</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048018" target="_blank" class="term-link">
                                     GO:0048018
                                 </a>
                             </span>
                             <span class="term-label">receptor ligand activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17568691" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17568691
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Endogenous signals released from necrotic cells augment infl...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -5217,75 +5228,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> El Mezayen et al. (2007) showed extracellular HSP70 acts as a danger signal that stimulates proinflammatory cytokine responses via TREM-1 and TLR4 receptors (PMID:17568691).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Receptor ligand activity is experimentally supported for extracellular Hsp70 (PMID:17568691) but is a non-core extracellular signaling function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17568691" target="_blank" class="term-link">
                                         PMID:17568691
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the newly identified triggering receptor expressed on myeloid cells-1 (TREM-1) was involved in mediating the HMGB1- and HSP70-induced cytokine production.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005615" target="_blank" class="term-link">
                                     GO:0005615
                                 </a>
                             </span>
                             <span class="term-label">extracellular space</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26183779" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26183779
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tag7 (PGLYRP1) in Complex with Hsp70 Induces Alternative Cyt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5297,75 +5308,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Yashin et al. (2015) showed the Tag7-Hsp70 complex is released into the extracellular space and induces cytotoxic processes in tumor cells via TNFR1 (PMID:26183779).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Extracellular space localization confirmed by IDA (PMID:26183779). Consistent with known extracellular signaling roles of Hsp70.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/26183779" target="_blank" class="term-link">
                                         PMID:26183779
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Tag7 (PGLYRP1) in Complex with Hsp70 Induces Alternative Cytotoxic Processes in Tumor Cells via TNFR1 Receptor.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048018" target="_blank" class="term-link">
                                     GO:0048018
                                 </a>
                             </span>
                             <span class="term-label">receptor ligand activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26183779" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26183779
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tag7 (PGLYRP1) in Complex with Hsp70 Induces Alternative Cyt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -5377,75 +5388,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Yashin et al. (2015) showed the Tag7-Hsp70 complex acts as a receptor ligand, binding TNFR1 on tumor cells to induce cytotoxicity (PMID:26183779).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Receptor ligand activity via Tag7-Hsp70 complex is experimentally confirmed (PMID:26183779) but is a non-core extracellular function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/26183779" target="_blank" class="term-link">
                                         PMID:26183779
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Tag7 (PGLYRP1) in Complex with Hsp70 Induces Alternative Cytotoxic Processes in Tumor Cells via TNFR1 Receptor.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051787" target="_blank" class="term-link">
                                     GO:0051787
                                 </a>
                             </span>
                             <span class="term-label">misfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28842558" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28842558
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HSP70-Hrd1 axis precludes the oncorepressor potential of N-t...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5457,64 +5468,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Wang et al. (2017) showed HSP70 recognizes and binds N-terminal misfolded Blimp-1 variants, targeting them for Hrd1-mediated degradation in lymphoma cells (PMID:28842558). Misfolded protein binding is a core property of the Hsp70 chaperone system.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Misfolded protein binding is a core molecular function of HSPA1A. Directly demonstrated for misfolded Blimp-1 variants (PMID:28842558) and consistent with its general chaperone role.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/28842558" target="_blank" class="term-link">
                                         PMID:28842558
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSP70-Hrd1 axis precludes the oncorepressor potential of N-terminal misfolded Blimp-1s in lymphoma cells.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007041" target="_blank" class="term-link">
                                     GO:0007041
                                 </a>
                             </span>
                             <span class="term-label">lysosomal transport</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -5526,57 +5537,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A has been annotated with lysosomal transport based on sequence similarity (ISS). This may relate to chaperone-mediated autophagy (CMA), where Hsc70/Hsp70 delivers substrates to lysosomes via LAMP2A. However, CMA is primarily attributed to the constitutive HSPA8 (Hsc70) rather than the inducible HSPA1A.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Lysosomal transport via CMA is better attributed to HSPA8 (Hsc70) than HSPA1A. ISS annotation from ortholog transfer; may not be wrong but not a core HSPA1A function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033120" target="_blank" class="term-link">
                                     GO:0033120
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of RNA splicing</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20625543" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20625543
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HSP72 protects cells from ER stress-induced apoptosis via en...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -5588,75 +5599,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Gupta et al. (2010) showed Hsp72 enhances XBP1 mRNA splicing by IRE1alpha. Hsp72 forms a stable complex with IRE1alpha and enhances its RNase activity in vitro, promoting the unconventional splicing of XBP1 mRNA (PMID:20625543).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Positive regulation of RNA splicing (specifically XBP1 mRNA splicing via IRE1alpha) is experimentally confirmed (PMID:20625543) but is a specific UPR-related function not a core chaperone role.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20625543" target="_blank" class="term-link">
                                         PMID:20625543
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Hsp72 enhances XBP1 mRNA splicing and expression of its target genes, associated with attenuated apoptosis under ER stress conditions.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034620" target="_blank" class="term-link">
                                     GO:0034620
                                 </a>
                             </span>
                             <span class="term-label">cellular response to unfolded protein</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20625543" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20625543
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HSP72 protects cells from ER stress-induced apoptosis via en...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5668,75 +5679,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Gupta et al. (2010) showed Hsp72 enhances cell survival under ER stress conditions by modulating the UPR via IRE1alpha-XBP1 signaling (PMID:20625543). HSPA1A participates in the cellular response to unfolded proteins.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cellular response to unfolded protein is a core function of HSPA1A as a major stress-inducible chaperone. Confirmed by IMP (PMID:20625543).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20625543" target="_blank" class="term-link">
                                         PMID:20625543
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Hsp72 enhances cell survival under ER stress conditions.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045296" target="_blank" class="term-link">
                                     GO:0045296
                                 </a>
                             </span>
                             <span class="term-label">cadherin binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25468996" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25468996
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     E-cadherin interactome complexity and robustness resolved by...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -5748,57 +5759,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A was identified in the E-cadherin interactome by quantitative proteomics (PMID:25468996). This may reflect chaperone-mediated interactions with cadherin complexes rather than functional cadherin binding.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HDA-level evidence from proteomics screen (PMID:25468996). Likely reflects chaperone-substrate interactions with cadherin complexes rather than specific cadherin binding activity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12853476" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12853476
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Cofactor Tpr2 combines two TPR domains and a J domain to reg...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -5810,57 +5821,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#39;protein binding&#39; is uninformative per GO curation guidelines. HSPA1A interacts with many proteins as part of its chaperone function, but the generic &#39;protein binding&#39; term does not convey meaningful functional information. More specific MF terms (e.g., GO:0044183 protein folding chaperone, GO:0031072 heat shock protein binding, GO:0031625 ubiquitin protein ligase binding) already capture the biologically meaningful interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 &#39;protein binding&#39; is uninformative and should be replaced by more specific molecular function terms. HSPA1A already has appropriate specific MF annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008180" target="_blank" class="term-link">
                                     GO:0008180
                                 </a>
                             </span>
                             <span class="term-label">COP9 signalosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18850735" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18850735
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Characterization of the human COP9 signalosome complex using...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -5872,57 +5883,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A was identified as associated with the COP9 signalosome by affinity purification and mass spectrometry (PMID:18850735). This may represent a chaperone-client interaction rather than bona fide COP9 signalosome membership.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> COP9 signalosome association likely represents chaperone-client interaction detected by mass spectrometry (PMID:18850735) rather than stable complex membership.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17167422" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17167422
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Hsp70 regulates erythropoiesis by preventing caspase-3-media...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5934,75 +5945,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Ribeil et al. (2007) showed Hsp70 co-localizes and interacts with GATA-1 in the nucleus of erythroid precursors undergoing terminal differentiation (PMID:17167422).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear localization confirmed by IDA in erythroid precursors (PMID:17167422). Consistent with already-accepted IBA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17167422" target="_blank" class="term-link">
                                         PMID:17167422
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Hsp70 co-localizes and interacts with GATA-1 in the nucleus of erythroid precursors undergoing terminal differentiation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043066" target="_blank" class="term-link">
                                     GO:0043066
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of apoptotic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17167422" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17167422
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Hsp70 regulates erythropoiesis by preventing caspase-3-media...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -6014,75 +6025,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Ribeil et al. (2007) showed Hsp70 protects GATA-1 from caspase-3-mediated cleavage during erythroid differentiation, preventing apoptosis (PMID:17167422). This demonstrates an anti-apoptotic function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Negative regulation of apoptosis is experimentally confirmed (PMID:17167422) and also demonstrated via multiple other mechanisms (Apaf-1 binding, Bax translocation inhibition). However, this is a downstream effect of chaperone activity rather than a core function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17167422" target="_blank" class="term-link">
                                         PMID:17167422
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">during differentiation, but not during apoptosis, the chaperone protein Hsp70 protects GATA-1 from caspase-mediated proteolysis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045648" target="_blank" class="term-link">
                                     GO:0045648
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of erythrocyte differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17167422" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17167422
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Hsp70 regulates erythropoiesis by preventing caspase-3-media...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -6094,75 +6105,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Ribeil et al. (2007) showed Hsp70 enables erythroid terminal differentiation by protecting GATA-1 from caspase-3 cleavage. Depletion of Hsp70 leads to GATA-1 cleavage and apoptosis (PMID:17167422).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Positive regulation of erythrocyte differentiation is experimentally confirmed (PMID:17167422) but represents a tissue-specific developmental function, not a core chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17167422" target="_blank" class="term-link">
                                         PMID:17167422
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">during differentiation, but not during apoptosis, the chaperone protein Hsp70 protects GATA-1 from caspase-mediated proteolysis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27133716" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27133716
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A novel nuclear DnaJ protein, DNAJC8, can suppress the forma...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -6174,57 +6185,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#39;protein binding&#39; is uninformative per GO curation guidelines. HSPA1A interacts with many proteins as part of its chaperone function, but the generic &#39;protein binding&#39; term does not convey meaningful functional information. More specific MF terms (e.g., GO:0044183 protein folding chaperone, GO:0031072 heat shock protein binding, GO:0031625 ubiquitin protein ligase binding) already capture the biologically meaningful interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 &#39;protein binding&#39; is uninformative and should be replaced by more specific molecular function terms. HSPA1A already has appropriate specific MF annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23349634" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23349634
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A newly uncovered group of distantly related lysine methyltr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -6236,57 +6247,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#39;protein binding&#39; is uninformative per GO curation guidelines. HSPA1A interacts with many proteins as part of its chaperone function, but the generic &#39;protein binding&#39; term does not convey meaningful functional information. More specific MF terms (e.g., GO:0044183 protein folding chaperone, GO:0031072 heat shock protein binding, GO:0031625 ubiquitin protein ligase binding) already capture the biologically meaningful interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 &#39;protein binding&#39; is uninformative and should be replaced by more specific molecular function terms. HSPA1A already has appropriate specific MF annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
                                     GO:0032991
                                 </a>
                             </span>
                             <span class="term-label">protein-containing complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23349634" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23349634
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A newly uncovered group of distantly related lysine methyltr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -6298,57 +6309,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cloutier et al. (2013) identified HSPA1A in complexes with lysine methyltransferases that regulate chaperone activity (PMID:23349634).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0032991 &#39;protein-containing complex&#39; is very generic. HSPA1A forms many complexes as part of its chaperone function. This annotation is too broad to be informative.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003723" target="_blank" class="term-link">
                                     GO:0003723
                                 </a>
                             </span>
                             <span class="term-label">RNA binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22658674" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22658674
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Insights into RNA biology from an atlas of mammalian mRNA-bi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -6360,57 +6371,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Castello et al. (2012) identified HSPA1A in a global mRNA-binding protein atlas (PMID:22658674). HSPA1A associates with mRNA, consistent with its role in mRNA metabolism via AUF1 (PMID:10205060) and IMP1 RNP granules (PMID:17289661).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> RNA binding is supported by HDA proteomics (PMID:22658674) and consistent with known roles in mRNA metabolism. However, this is a secondary function not a core MF.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003723" target="_blank" class="term-link">
                                     GO:0003723
                                 </a>
                             </span>
                             <span class="term-label">RNA binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22681889" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22681889
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The mRNA-bound proteome and its global occupancy profile on ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -6422,57 +6433,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Baltz et al. (2012) identified HSPA1A among mRNA-bound proteins by global UV crosslinking and mass spectrometry (PMID:22681889). Consistent with its association with RNP complexes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> RNA binding confirmed independently by second HDA study (PMID:22681889). Secondary function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15671022" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15671022
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Heat shock protein 70 inhibits alpha-synuclein fibril format...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -6484,57 +6495,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#39;protein binding&#39; is uninformative per GO curation guidelines. HSPA1A interacts with many proteins as part of its chaperone function, but the generic &#39;protein binding&#39; term does not convey meaningful functional information. More specific MF terms (e.g., GO:0044183 protein folding chaperone, GO:0031072 heat shock protein binding, GO:0031625 ubiquitin protein ligase binding) already capture the biologically meaningful interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 &#39;protein binding&#39; is uninformative and should be replaced by more specific molecular function terms. HSPA1A already has appropriate specific MF annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18975920" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18975920
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interactions between Hsp70 and the hydrophobic core of alpha...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -6546,57 +6557,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#39;protein binding&#39; is uninformative per GO curation guidelines. HSPA1A interacts with many proteins as part of its chaperone function, but the generic &#39;protein binding&#39; term does not convey meaningful functional information. More specific MF terms (e.g., GO:0044183 protein folding chaperone, GO:0031072 heat shock protein binding, GO:0031625 ubiquitin protein ligase binding) already capture the biologically meaningful interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 &#39;protein binding&#39; is uninformative and should be replaced by more specific molecular function terms. HSPA1A already has appropriate specific MF annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21081504" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21081504
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     ChChd3, an inner mitochondrial membrane protein, is essentia...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -6608,57 +6619,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#39;protein binding&#39; is uninformative per GO curation guidelines. HSPA1A interacts with many proteins as part of its chaperone function, but the generic &#39;protein binding&#39; term does not convey meaningful functional information. More specific MF terms (e.g., GO:0044183 protein folding chaperone, GO:0031072 heat shock protein binding, GO:0031625 ubiquitin protein ligase binding) already capture the biologically meaningful interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 &#39;protein binding&#39; is uninformative and should be replaced by more specific molecular function terms. HSPA1A already has appropriate specific MF annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9553041" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9553041
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Inhibition of cellular proliferation by the Wilms tumor supp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -6670,57 +6681,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#39;protein binding&#39; is uninformative per GO curation guidelines. HSPA1A interacts with many proteins as part of its chaperone function, but the generic &#39;protein binding&#39; term does not convey meaningful functional information. More specific MF terms (e.g., GO:0044183 protein folding chaperone, GO:0031072 heat shock protein binding, GO:0031625 ubiquitin protein ligase binding) already capture the biologically meaningful interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 &#39;protein binding&#39; is uninformative and should be replaced by more specific molecular function terms. HSPA1A already has appropriate specific MF annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10205060" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10205060
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Control of mRNA decay by heat shock-ubiquitin-proteasome pat...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6732,75 +6743,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Laroia et al. (1999) showed Hsp70 sequesters AUF1 in the perinucleus-nucleus during heat shock (PMID:10205060). This confirms nuclear localization of HSPA1A.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear localization confirmed by IDA (PMID:10205060). Consistent with already-accepted annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10205060" target="_blank" class="term-link">
                                         PMID:10205060
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">hsp70 sequestration of AUF1 in the perinucleus-nucleus</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10859165" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10859165
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Chaperone hsp27 inhibits translation during heat shock by bi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6812,57 +6823,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cuesta et al. (2000) showed Hsp27 inhibits translation during heat shock by interacting with eIF4G, and Hsp70 was detected in the cytoplasm (PMID:10859165).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization confirmed by IDA (PMID:10859165). Consistent with already-accepted IBA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16130169" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16130169
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomics of human umbilical vein endothelial cells applied...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6874,57 +6885,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Bruneel et al. (2005) identified HSPA1A among 162 proteins in a proteomics study of human endothelial cells (PMID:16130169). Cytoplasmic localization is well-established.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization is well-established for HSPA1A. Consistent with all other evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24061851" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24061851
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Stress-induced localization of HSPA6 (HSP70B&#39;) and HSPA1A (H...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6936,57 +6947,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Khalouei et al. (2014) showed YFP-tagged HSPA1A in the cytoplasm of human neuronal cells, with stress-induced localization to centrioles in the cytoplasm (PMID:24061851).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization confirmed by IDA (PMID:24061851). Consistent with already-accepted annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9553041" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9553041
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Inhibition of cellular proliferation by the Wilms tumor supp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6998,57 +7009,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Maheswaran et al. (1998) showed Hsp70 in the cytoplasm and nucleus of cells expressing WT1 (PMID:9553041).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization confirmed by IDA (PMID:9553041). Consistent with already-accepted IBA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16130169" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16130169
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomics of human umbilical vein endothelial cells applied...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -7060,57 +7071,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Mitochondrial localization of HSPA1A is annotated via TAS from Bruneel et al. (2005) (PMID:16130169). HSPA1A can associate with mitochondria, particularly in the context of preventing Bax translocation and cytochrome c release during stress (PMID:20625543).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Mitochondrial association is supported but is not the primary localization of HSPA1A. It occurs in the context of anti-apoptotic function rather than constitutive localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
                                     GO:0005783
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16130169" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16130169
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomics of human umbilical vein endothelial cells applied...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -7122,57 +7133,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ER localization is annotated via TAS from Bruneel et al. (2005) (PMID:16130169). HSPA1A can associate with the ER in the context of its interaction with IRE1alpha cytosolic domain during ER stress (PMID:20625543).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ER association is supported in the context of UPR signaling (PMID:20625543) but is not the primary localization of HSPA1A.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006402" target="_blank" class="term-link">
                                     GO:0006402
                                 </a>
                             </span>
                             <span class="term-label">mRNA catabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10205060" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10205060
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Control of mRNA decay by heat shock-ubiquitin-proteasome pat...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -7184,75 +7195,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Laroia et al. (1999) showed Hsp70 modulates AU-rich element-mediated mRNA decay through AUF1 sequestration. Heat shock-induced Hsp70 sequesters AUF1, blocking decay of AU-rich mRNAs (PMID:10205060).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> mRNA catabolic process involvement is confirmed (PMID:10205060) but is a secondary regulatory role of HSPA1A, not a core function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10205060" target="_blank" class="term-link">
                                         PMID:10205060
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">hsp70 sequestration of AUF1 in the perinucleus-nucleus, and all three processes block decay of AU-rich mRNAs and AUF1 protein.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006986" target="_blank" class="term-link">
                                     GO:0006986
                                 </a>
                             </span>
                             <span class="term-label">response to unfolded protein</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10859165" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10859165
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Chaperone hsp27 inhibits translation during heat shock by bi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7264,57 +7275,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A is induced by unfolded proteins and serves as a primary effector of the response to unfolded protein. PMID:10859165 provides IDA evidence. Core process.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Response to unfolded protein is a core biological process for HSPA1A. Confirmed by IDA.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008285" target="_blank" class="term-link">
                                     GO:0008285
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of cell population proliferation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9553041" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9553041
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Inhibition of cellular proliferation by the Wilms tumor supp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -7326,75 +7337,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Maheswaran et al. (1998) showed Hsp70 is required for WT1-mediated growth suppression (PMID:9553041). The antiproliferative effect is mediated by WT1, not Hsp70 directly.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Negative regulation of cell proliferation requires WT1 as the effector. Hsp70 acts as a cofactor/chaperone. This is a chaperone client effect, not a direct HSPA1A function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9553041" target="_blank" class="term-link">
                                         PMID:9553041
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Inhibition of cellular proliferation by the Wilms tumor suppressor WT1 requires association with the inducible chaperone Hsp70.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016235" target="_blank" class="term-link">
                                     GO:0016235
                                 </a>
                             </span>
                             <span class="term-label">aggresome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15885686" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15885686
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TRIM37 defective in mulibrey nanism is a novel RING finger u...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7406,57 +7417,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A localizes to aggresomes, confirmed by IDA (PMID:15885686). Consistent with its role in protein quality control.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Aggresome localization confirmed by IDA (PMID:15885686). Consistent with already-accepted IEA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016607" target="_blank" class="term-link">
                                     GO:0016607
                                 </a>
                             </span>
                             <span class="term-label">nuclear speck</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9553041" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9553041
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Inhibition of cellular proliferation by the Wilms tumor supp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7468,57 +7479,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Maheswaran et al. (1998) showed Hsp70 is recruited to subnuclear clusters containing WT1 (PMID:9553041).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear speck localization confirmed by IDA (PMID:9553041). Consistent with already-accepted IEA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030308" target="_blank" class="term-link">
                                     GO:0030308
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of cell growth</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9553041" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9553041
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Inhibition of cellular proliferation by the Wilms tumor supp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -7530,75 +7541,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Similar to GO:0008285, the cell growth inhibition requires WT1 with Hsp70 as a cofactor (PMID:9553041).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cell growth effect mediated by WT1, not directly by Hsp70. Chaperone client effect.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9553041" target="_blank" class="term-link">
                                         PMID:9553041
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Inhibition of cellular proliferation by the Wilms tumor suppressor WT1 requires association with the inducible chaperone Hsp70.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031982" target="_blank" class="term-link">
                                     GO:0031982
                                 </a>
                             </span>
                             <span class="term-label">vesicle</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19190083" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19190083
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Characterization of exosome-like vesicles released from huma...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7610,57 +7621,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A detected in exosome-like vesicles from human tracheobronchial epithelium (PMID:19190083). Consistent with known exosomal/vesicular localization of Hsp70.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Vesicle localization confirmed by HDA proteomics (PMID:19190083). Consistent with known extracellular vesicle biology of Hsp70.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043066" target="_blank" class="term-link">
                                     GO:0043066
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of apoptotic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16130169" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16130169
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomics of human umbilical vein endothelial cells applied...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -7672,57 +7683,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Anti-apoptotic function of HSPA1A is well-established by multiple mechanisms including Apaf-1 binding, Bax translocation inhibition, JNK suppression, and AIF sequestration (PMID:20625543). TAS annotation from PMID:16130169.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Anti-apoptotic function is well-supported but represents a downstream pleiotropic effect of HSPA1A chaperone activity, not a core molecular function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048471" target="_blank" class="term-link">
                                     GO:0048471
                                 </a>
                             </span>
                             <span class="term-label">perinuclear region of cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10205060" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10205060
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Control of mRNA decay by heat shock-ubiquitin-proteasome pat...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7734,75 +7745,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Laroia et al. (1999) showed Hsp70 sequesters AUF1 in the perinucleus-nucleus (PMID:10205060). Confirmed by IDA.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Perinuclear localization confirmed by IDA (PMID:10205060). Consistent with already-accepted IEA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10205060" target="_blank" class="term-link">
                                         PMID:10205060
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">hsp70 sequestration of AUF1 in the perinucleus-nucleus</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16130169" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16130169
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomics of human umbilical vein endothelial cells applied...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -7814,99 +7825,99 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). The TAS reference (PMID:16130169) is a proteomics study of endothelial cells that identified HSPA1A among 162 proteins and mentions &#34;protein folding&#34; among characterized functional categories, but does not specifically assay unfolded protein binding or chaperone activity of HSPA1A. Regardless, the broader literature clearly demonstrates HSPA1A has active protein folding chaperone activity (PMID:21231916), so the annotation should be modified to GO:0044183.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. The TAS reference (PMID:16130169, Bruneel et al. 2005) is a proteomics study that identified HSPA1A among endothelial cell proteins related to &#34;protein folding&#34; but did not specifically characterize HSPA1A chaperone activity. Nevertheless, HSPA1A is well-established as a protein folding chaperone with genuine foldase activity (PMID:21231916), so the annotation should be replaced with GO:0044183 &#34;protein folding chaperone&#34; which is already supported by IBA and IDA evidence on this gene.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16130169" target="_blank" class="term-link">
                                         PMID:16130169
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The overall functional characterization of the 162 identified proteins from primary cultures of HUVECs confirms the metabolic capabilities of endothelium and illustrates various cellular functions more related to cell motility and angiogenesis, protein folding, anti-oxidant defenses, signal transduction, proteasome pathway and resistance to apoptosis.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation. [...] overexpression of HSPA1A protected cells from heat-induced cell death</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
                                     GO:0070062
                                 </a>
                             </span>
                             <span class="term-label">extracellular exosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19199708" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19199708
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomic analysis of human parotid gland exosomes by multid...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7918,57 +7929,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A detected in exosomes from human parotid gland by MudPIT proteomics (PMID:19199708). Hsp70 is a well-established exosomal marker.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Extracellular exosome localization confirmed by proteomics (PMID:19199708). Hsp70 is a well-known exosomal protein.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
                                     GO:0070062
                                 </a>
                             </span>
                             <span class="term-label">extracellular exosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20458337" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20458337
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     MHC class II-associated proteins in B-cell exosomes and pote...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7980,57 +7991,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A detected in B-cell exosomes by proteomics (PMID:20458337). Independent confirmation of exosomal localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Extracellular exosome localization confirmed by independent proteomics study (PMID:20458337).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
                                     GO:0070062
                                 </a>
                             </span>
                             <span class="term-label">extracellular exosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23533145
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     In-depth proteomic analyses of exosomes isolated from expres...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -8042,57 +8053,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A detected in exosomes from expressed prostatic secretions (PMID:23533145). Third independent confirmation of exosomal localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Extracellular exosome localization confirmed by third independent proteomics study (PMID:23533145).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990904" target="_blank" class="term-link">
                                     GO:1990904
                                 </a>
                             </span>
                             <span class="term-label">ribonucleoprotein complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17289661" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17289661
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular composition of IMP1 ribonucleoprotein granules.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -8104,57 +8115,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Jonson et al. (2007) identified HSPA1A as a component of IMP1 ribonucleoprotein granules by mass spectrometry (PMID:17289661).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> RNP complex association confirmed by IDA (PMID:17289661) but is a secondary localization related to HSPA1A&#39;s role in mRNA metabolism.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24318877" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24318877
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Binding of human nucleotide exchange factors to heat shock p...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -8166,57 +8177,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#39;protein binding&#39; is uninformative per GO curation guidelines. HSPA1A interacts with many proteins as part of its chaperone function, but the generic &#39;protein binding&#39; term does not convey meaningful functional information. More specific MF terms (e.g., GO:0044183 protein folding chaperone, GO:0031072 heat shock protein binding, GO:0031625 ubiquitin protein ligase binding) already capture the biologically meaningful interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 &#39;protein binding&#39; is uninformative and should be replaced by more specific molecular function terms. HSPA1A already has appropriate specific MF annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27137183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27137183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HSP70 regulates the function of mitotic centrosomes.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -8228,57 +8239,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#39;protein binding&#39; is uninformative per GO curation guidelines. HSPA1A interacts with many proteins as part of its chaperone function, but the generic &#39;protein binding&#39; term does not convey meaningful functional information. More specific MF terms (e.g., GO:0044183 protein folding chaperone, GO:0031072 heat shock protein binding, GO:0031625 ubiquitin protein ligase binding) already capture the biologically meaningful interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 &#39;protein binding&#39; is uninformative and should be replaced by more specific molecular function terms. HSPA1A already has appropriate specific MF annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27708256" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27708256
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     ARD1-mediated Hsp70 acetylation balances stress-induced prot...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -8290,57 +8301,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#39;protein binding&#39; is uninformative per GO curation guidelines. HSPA1A interacts with many proteins as part of its chaperone function, but the generic &#39;protein binding&#39; term does not convey meaningful functional information. More specific MF terms (e.g., GO:0044183 protein folding chaperone, GO:0031072 heat shock protein binding, GO:0031625 ubiquitin protein ligase binding) already capture the biologically meaningful interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 &#39;protein binding&#39; is uninformative and should be replaced by more specific molecular function terms. HSPA1A already has appropriate specific MF annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005813" target="_blank" class="term-link">
                                     GO:0005813
                                 </a>
                             </span>
                             <span class="term-label">centrosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27137183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27137183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HSP70 regulates the function of mitotic centrosomes.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -8352,75 +8363,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Fang et al. (2016) showed HSP70 accumulates at mitotic centrosomes during prometaphase to metaphase (PMID:27137183).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Centrosome localization confirmed by IDA (PMID:27137183). Consistent with already-accepted IEA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/27137183" target="_blank" class="term-link">
                                         PMID:27137183
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">heat shock protein (HSP) 70 considerably accumulates at the mitotic centrosome during prometaphase to metaphase</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27708256" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27708256
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     ARD1-mediated Hsp70 acetylation balances stress-induced prot...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -8432,75 +8443,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Seo et al. (2016) showed Hsp70 acetylation by ARD1/NAA10 determines whether it functions in protein refolding (via HOPX co-chaperone) or protein degradation (via CHIP ubiquitin ligase) (PMID:27708256).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein refolding confirmed by IMP (PMID:27708256). Core function of HSPA1A. Consistent with already-accepted IBA and IDA annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/27708256" target="_blank" class="term-link">
                                         PMID:27708256
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Hsp70 preferentially facilitates protein refolding after stress, gradually switching to protein degradation via a mechanism dependent on ARD1-mediated Hsp70 acetylation</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090063" target="_blank" class="term-link">
                                     GO:0090063
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of microtubule nucleation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27137183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27137183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HSP70 regulates the function of mitotic centrosomes.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -8512,75 +8523,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Fang et al. (2016) showed HSP70 is required for microtubule nucleation from the mitotic centrosome. Inhibition or depletion of HSP70 impaired MT nucleation and polymerization (PMID:27137183).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Positive regulation of microtubule nucleation experimentally confirmed (PMID:27137183) but is a cell-cycle-specific function, not core chaperone activity.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/27137183" target="_blank" class="term-link">
                                         PMID:27137183
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Inhibition or depletion of HSP70 impaired the function of mitotic centrosome and disrupted MT nucleation and polymerization from the spindle pole</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1901673" target="_blank" class="term-link">
                                     GO:1901673
                                 </a>
                             </span>
                             <span class="term-label">regulation of mitotic spindle assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27137183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27137183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HSP70 regulates the function of mitotic centrosomes.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -8592,75 +8603,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Fang et al. (2016) showed HSP70 is required for bipolar spindle assembly and maintenance of a functional mitotic centrosome (PMID:27137183).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Regulation of mitotic spindle assembly experimentally confirmed (PMID:27137183) but is a cell-cycle-specific function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/27137183" target="_blank" class="term-link">
                                         PMID:27137183
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSP70 is required for the maintenance of a functional mitotic centrosome that supports the assembly of a bipolar mitotic spindle.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051131" target="_blank" class="term-link">
                                     GO:0051131
                                 </a>
                             </span>
                             <span class="term-label">chaperone-mediated protein complex assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10811660" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10811660
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Crystal structure and activity of human p23, a heat shock pr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -8672,57 +8683,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Weaver et al. (2000) studied p23 and the HSP90 co-chaperone system for steroid receptor assembly. HSPA1A participates in chaperone-mediated assembly of steroid hormone receptor complexes by handing off substrates to HSP90 (PMID:10811660).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Chaperone-mediated protein complex assembly is a genuine function of HSPA1A, particularly in the HSP70-HOP-HSP90 pathway for steroid receptor maturation. Confirmed by IDA (PMID:10811660).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003714" target="_blank" class="term-link">
                                     GO:0003714
                                 </a>
                             </span>
                             <span class="term-label">transcription corepressor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9499401" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9499401
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular chaperones as HSF1-specific transcriptional repres...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -8734,75 +8745,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Shi et al. (1998) showed Hsp70 represses HSF1 transcriptional activity by directly interacting with its transactivation domain (PMID:9499401). This constitutes transcription corepressor activity specifically toward HSF1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Transcription corepressor activity toward HSF1 is experimentally confirmed (PMID:9499401). Part of the autoregulatory heat shock response, not a core chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9499401" target="_blank" class="term-link">
                                         PMID:9499401
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the molecular chaperone Hsp70 and the cochaperone Hdj1 interact directly with the transactivation domain of HSF1 and repress heat shock gene transcription.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9499401" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9499401
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular chaperones as HSF1-specific transcriptional repres...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -8814,57 +8825,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#39;protein binding&#39; is uninformative per GO curation guidelines. HSPA1A interacts with many proteins as part of its chaperone function, but the generic &#39;protein binding&#39; term does not convey meaningful functional information. More specific MF terms (e.g., GO:0044183 protein folding chaperone, GO:0031072 heat shock protein binding, GO:0031625 ubiquitin protein ligase binding) already capture the biologically meaningful interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 &#39;protein binding&#39; is uninformative and should be replaced by more specific molecular function terms. HSPA1A already has appropriate specific MF annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9222587" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9222587
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Evidence for a role of Hsp70 in the regulation of the heat s...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -8876,57 +8887,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#39;protein binding&#39; is uninformative per GO curation guidelines. HSPA1A interacts with many proteins as part of its chaperone function, but the generic &#39;protein binding&#39; term does not convey meaningful functional information. More specific MF terms (e.g., GO:0044183 protein folding chaperone, GO:0031072 heat shock protein binding, GO:0031625 ubiquitin protein ligase binding) already capture the biologically meaningful interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 &#39;protein binding&#39; is uninformative and should be replaced by more specific molecular function terms. HSPA1A already has appropriate specific MF annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22219199" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22219199
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The C-terminal helices of heat shock protein 70 are essentia...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -8938,57 +8949,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#39;protein binding&#39; is uninformative per GO curation guidelines. HSPA1A interacts with many proteins as part of its chaperone function, but the generic &#39;protein binding&#39; term does not convey meaningful functional information. More specific MF terms (e.g., GO:0044183 protein folding chaperone, GO:0031072 heat shock protein binding, GO:0031625 ubiquitin protein ligase binding) already capture the biologically meaningful interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 &#39;protein binding&#39; is uninformative and should be replaced by more specific molecular function terms. HSPA1A already has appropriate specific MF annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24613385" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24613385
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Hsp70 and Hsp90 oppositely regulate TGF-β signaling through ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -9000,57 +9011,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#39;protein binding&#39; is uninformative per GO curation guidelines. HSPA1A interacts with many proteins as part of its chaperone function, but the generic &#39;protein binding&#39; term does not convey meaningful functional information. More specific MF terms (e.g., GO:0044183 protein folding chaperone, GO:0031072 heat shock protein binding, GO:0031625 ubiquitin protein ligase binding) already capture the biologically meaningful interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 &#39;protein binding&#39; is uninformative and should be replaced by more specific molecular function terms. HSPA1A already has appropriate specific MF annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030512" target="_blank" class="term-link">
                                     GO:0030512
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of transforming growth factor beta receptor signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24613385" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24613385
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Hsp70 and Hsp90 oppositely regulate TGF-β signaling through ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -9062,75 +9073,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Shang et al. (2014) showed Hsp70 promotes CHIP-mediated Smad3 ubiquitination and degradation, thereby negatively regulating TGF-beta signaling (PMID:24613385).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Negative regulation of TGF-beta signaling is experimentally confirmed (PMID:24613385) but is a downstream effect of HSPA1A-CHIP chaperone-ubiquitin triage, not a core function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24613385" target="_blank" class="term-link">
                                         PMID:24613385
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">over-expressed Hsp70 or inhibition of Hsp90 by geldanamycin (GA) leads to facilitated CHIP-induced ubiquitination and degradation of Smad3</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032436" target="_blank" class="term-link">
                                     GO:0032436
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of proteasomal ubiquitin-dependent protein catabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24613385" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24613385
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Hsp70 and Hsp90 oppositely regulate TGF-β signaling through ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -9142,75 +9153,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Shang et al. (2014) showed Hsp70 facilitates CHIP-induced ubiquitination and degradation of Smad3 (PMID:24613385). Core triage function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Positive regulation of proteasomal degradation is a core chaperone triage function of HSPA1A. Confirmed by IDA (PMID:24613385). Consistent with already-accepted IBA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24613385" target="_blank" class="term-link">
                                         PMID:24613385
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">over-expressed Hsp70 or inhibition of Hsp90 by geldanamycin (GA) leads to facilitated CHIP-induced ubiquitination and degradation of Smad3</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11785981" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11785981
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HSP90, HSP70, and GAPDH directly interact with the cytoplasm...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -9222,57 +9233,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Nakamura et al. (2002) showed HSP90, HSP70, and GAPDH directly interact with the cytoplasmic domain of macrophage scavenger receptors in the cytoplasm (PMID:11785981).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization confirmed by IDA (PMID:11785981). Consistent with already-accepted annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097718" target="_blank" class="term-link">
                                     GO:0097718
                                 </a>
                             </span>
                             <span class="term-label">disordered domain specific binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11785981" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11785981
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HSP90, HSP70, and GAPDH directly interact with the cytoplasm...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -9284,57 +9295,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Nakamura et al. (2002) showed HSP70 binds the cytoplasmic domain of macrophage scavenger receptors, which may contain disordered regions (PMID:11785981). This is consistent with HSPA1A&#39;s preference for hydrophobic peptide segments.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Disordered domain binding is consistent with HSPA1A&#39;s substrate recognition of exposed hydrophobic segments in unfolded/disordered regions. Confirmed by IPI (PMID:11785981).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031249" target="_blank" class="term-link">
                                     GO:0031249
                                 </a>
                             </span>
                             <span class="term-label">denatured protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21909508" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21909508
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Intrinsically disordered proteins as molecular shields.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -9346,68 +9357,68 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0031249 is under the same obsoletion discussion as GO:0051082 (go-ontology#30962). The PMID:21909508 data support HSPA1A recognition of non-native/disordered protein states, but the mechanistically informative molecular function for HSPA1A is ATP-dependent protein folding chaperone activity rather than a generic denatured-protein binding label.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> For HSPA1A, denatured-protein recognition is part of the broader Hsp70 chaperone cycle. The annotation is better represented by GO:0044183 (protein folding chaperone), which captures active substrate handling and folding support rather than passive binding alone.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                     GO:0050821
                                 </a>
                             </span>
                             <span class="term-label">protein stabilization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21909508" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21909508
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Intrinsically disordered proteins as molecular shields.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -9419,46 +9430,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Arhar et al. (2011) showed Hsp70 stabilizes intrinsically disordered proteins, acting as a molecular shield (PMID:21909508).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein stabilization confirmed by IDA (PMID:21909508). Consistent with already-accepted IEA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
                                     GO:0005576
                                 </a>
                             </span>
                             <span class="term-label">extracellular region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6800434
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -9470,46 +9481,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Reactome annotates HSPA1A in the extracellular region via pathway R-HSA-6800434 (neutrophil degranulation). Consistent with known extracellular Hsp70.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Extracellular region localization consistent with known biology. Supported by Reactome pathway.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1904813" target="_blank" class="term-link">
                                     GO:1904813
                                 </a>
                             </span>
                             <span class="term-label">ficolin-1-rich granule lumen</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6800434
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -9521,57 +9532,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Reactome pathway R-HSA-6800434 places HSPA1A in ficolin-1-rich granule lumen as part of neutrophil degranulation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Ficolin-1-rich granule lumen localization supported by Reactome. Consistent with already-accepted IEA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032757" target="_blank" class="term-link">
                                     GO:0032757
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of interleukin-8 production</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24790089" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24790089
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The molecular chaperone HSP70 binds to and stabilizes NOD2, ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -9583,57 +9594,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Mohanan &amp; Grimes (2014) showed HSP70 stabilizes NOD2, which activates NF-kappaB signaling and downstream IL-8 production (PMID:24790089).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> IL-8 production regulation is an indirect downstream effect of HSPA1A-mediated NOD2 stabilization (PMID:24790089). Consistent with already-accepted IEA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031396" target="_blank" class="term-link">
                                     GO:0031396
                                 </a>
                             </span>
                             <span class="term-label">regulation of protein ubiquitination</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16809764" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16809764
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Histone deacetylase 8 safeguards the human ever-shorter telo...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -9645,75 +9656,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Lee et al. (2006) showed phosphorylated HDAC8 recruits Hsp70 to a complex that inhibits CHIP E3 ligase-mediated degradation of hEST1B (PMID:16809764). Hsp70 participates in regulating protein ubiquitination.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Regulation of protein ubiquitination is a genuine function of HSPA1A through its interactions with CHIP and other E3 ligases. Confirmed by IDA (PMID:16809764).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16809764" target="_blank" class="term-link">
                                         PMID:16809764
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Phosphorylated HDAC8 preferentially recruits Hsp70 to a complex that inhibits the CHIP (C-terminal heat shock protein interacting protein) E3 ligase-mediated degradation of hEST1B.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042826" target="_blank" class="term-link">
                                     GO:0042826
                                 </a>
                             </span>
                             <span class="term-label">histone deacetylase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16809764" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16809764
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Histone deacetylase 8 safeguards the human ever-shorter telo...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -9725,57 +9736,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Lee et al. (2006) showed HDAC8 recruits Hsp70 to a protein complex (PMID:16809764). Confirmed by IPI evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Histone deacetylase binding confirmed by IPI (PMID:16809764). Consistent with already-accepted IEA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902236" target="_blank" class="term-link">
                                     GO:1902236
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of endoplasmic reticulum stress-induced intrinsic apoptotic signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12150907" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12150907
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     CHIP is associated with Parkin, a gene responsible for famil...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -9787,64 +9798,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Imai et al. (2002) showed the CHIP-Hsp70-Parkin complex promotes ubiquitination of Pael-R, preventing ER stress-induced neurodegeneration (PMID:12150907). Hsp70 is part of the protective mechanism against ER stress-induced apoptosis.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Anti-apoptotic role in ER stress is experimentally supported (PMID:12150907) but is a downstream effect of chaperone-ubiquitin quality control.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12150907" target="_blank" class="term-link">
                                         PMID:12150907
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">CHIP enhanced the ability of Parkin to inhibit cell death induced by Pael-R.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371467
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -9856,46 +9867,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Nucleoplasm localization from Reactome pathway (Reactome:R-HSA-3371467). HSPA1A is known to translocate to the nucleus during heat stress and participates in nuclear HSF1 regulation and HSP90 chaperone cycles.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization consistent with known nuclear translocation of HSPA1A during stress. Supported by Reactome pathway annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371518
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -9907,46 +9918,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Nucleoplasm localization from Reactome pathway (Reactome:R-HSA-3371518). HSPA1A is known to translocate to the nucleus during heat stress and participates in nuclear HSF1 regulation and HSP90 chaperone cycles.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization consistent with known nuclear translocation of HSPA1A during stress. Supported by Reactome pathway annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371554
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -9958,46 +9969,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Nucleoplasm localization from Reactome pathway (Reactome:R-HSA-3371554). HSPA1A is known to translocate to the nucleus during heat stress and participates in nuclear HSF1 regulation and HSP90 chaperone cycles.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization consistent with known nuclear translocation of HSPA1A during stress. Supported by Reactome pathway annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5082356
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10009,46 +10020,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Nucleoplasm localization from Reactome pathway (Reactome:R-HSA-5082356). HSPA1A is known to translocate to the nucleus during heat stress and participates in nuclear HSF1 regulation and HSP90 chaperone cycles.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization consistent with known nuclear translocation of HSPA1A during stress. Supported by Reactome pathway annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5082369
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10060,46 +10071,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Nucleoplasm localization from Reactome pathway (Reactome:R-HSA-5082369). HSPA1A is known to translocate to the nucleus during heat stress and participates in nuclear HSF1 regulation and HSP90 chaperone cycles.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization consistent with known nuclear translocation of HSPA1A during stress. Supported by Reactome pathway annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5082384
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10111,46 +10122,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Nucleoplasm localization from Reactome pathway (Reactome:R-HSA-5082384). HSPA1A is known to translocate to the nucleus during heat stress and participates in nuclear HSF1 regulation and HSP90 chaperone cycles.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization consistent with known nuclear translocation of HSPA1A during stress. Supported by Reactome pathway annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5251955
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10162,46 +10173,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Nucleoplasm localization from Reactome pathway (Reactome:R-HSA-5251955). HSPA1A is known to translocate to the nucleus during heat stress and participates in nuclear HSF1 regulation and HSP90 chaperone cycles.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization consistent with known nuclear translocation of HSPA1A during stress. Supported by Reactome pathway annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5252041
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10213,46 +10224,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Nucleoplasm localization from Reactome pathway (Reactome:R-HSA-5252041). HSPA1A is known to translocate to the nucleus during heat stress and participates in nuclear HSF1 regulation and HSP90 chaperone cycles.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization consistent with known nuclear translocation of HSPA1A during stress. Supported by Reactome pathway annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371422
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10264,46 +10275,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization from Reactome pathway (Reactome:R-HSA-3371422). Cytosol is the primary site of HSPA1A chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization consistent with primary HSPA1A function. Supported by Reactome pathway and confirmed by IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371503
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10315,46 +10326,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization from Reactome pathway (Reactome:R-HSA-3371503). Cytosol is the primary site of HSPA1A chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization consistent with primary HSPA1A function. Supported by Reactome pathway and confirmed by IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371590
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10366,46 +10377,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization from Reactome pathway (Reactome:R-HSA-3371590). Cytosol is the primary site of HSPA1A chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization consistent with primary HSPA1A function. Supported by Reactome pathway and confirmed by IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-450551
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10417,46 +10428,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization from Reactome pathway (Reactome:R-HSA-450551). Cytosol is the primary site of HSPA1A chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization consistent with primary HSPA1A function. Supported by Reactome pathway and confirmed by IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-450580
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10468,46 +10479,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization from Reactome pathway (Reactome:R-HSA-450580). Cytosol is the primary site of HSPA1A chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization consistent with primary HSPA1A function. Supported by Reactome pathway and confirmed by IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5251942
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10519,46 +10530,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization from Reactome pathway (Reactome:R-HSA-5251942). Cytosol is the primary site of HSPA1A chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization consistent with primary HSPA1A function. Supported by Reactome pathway and confirmed by IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5251959
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10570,46 +10581,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization from Reactome pathway (Reactome:R-HSA-5251959). Cytosol is the primary site of HSPA1A chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization consistent with primary HSPA1A function. Supported by Reactome pathway and confirmed by IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5252041
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10621,46 +10632,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization from Reactome pathway (Reactome:R-HSA-5252041). Cytosol is the primary site of HSPA1A chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization consistent with primary HSPA1A function. Supported by Reactome pathway and confirmed by IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5252079
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10672,46 +10683,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization from Reactome pathway (Reactome:R-HSA-5252079). Cytosol is the primary site of HSPA1A chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization consistent with primary HSPA1A function. Supported by Reactome pathway and confirmed by IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5618085
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10723,46 +10734,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization from Reactome pathway (Reactome:R-HSA-5618085). Cytosol is the primary site of HSPA1A chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization consistent with primary HSPA1A function. Supported by Reactome pathway and confirmed by IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5618098
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10774,46 +10785,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization from Reactome pathway (Reactome:R-HSA-5618098). Cytosol is the primary site of HSPA1A chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization consistent with primary HSPA1A function. Supported by Reactome pathway and confirmed by IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5618105
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10825,46 +10836,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization from Reactome pathway (Reactome:R-HSA-5618105). Cytosol is the primary site of HSPA1A chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization consistent with primary HSPA1A function. Supported by Reactome pathway and confirmed by IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5618107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10876,46 +10887,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization from Reactome pathway (Reactome:R-HSA-5618107). Cytosol is the primary site of HSPA1A chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization consistent with primary HSPA1A function. Supported by Reactome pathway and confirmed by IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5618110
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10927,46 +10938,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization from Reactome pathway (Reactome:R-HSA-5618110). Cytosol is the primary site of HSPA1A chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization consistent with primary HSPA1A function. Supported by Reactome pathway and confirmed by IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9835411
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10978,46 +10989,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization from Reactome pathway (Reactome:R-HSA-9835411). Cytosol is the primary site of HSPA1A chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization consistent with primary HSPA1A function. Supported by Reactome pathway and confirmed by IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9857076
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -11029,57 +11040,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization from Reactome pathway (Reactome:R-HSA-9857076). Cytosol is the primary site of HSPA1A chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization consistent with primary HSPA1A function. Supported by Reactome pathway and confirmed by IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22528486" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22528486
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Nucleophosmin (NPM1/B23) interacts with activating transcrip...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -11091,57 +11102,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#39;protein binding&#39; is uninformative per GO curation guidelines. HSPA1A interacts with many proteins as part of its chaperone function, but the generic &#39;protein binding&#39; term does not convey meaningful functional information. More specific MF terms (e.g., GO:0044183 protein folding chaperone, GO:0031072 heat shock protein binding, GO:0031625 ubiquitin protein ligase binding) already capture the biologically meaningful interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 &#39;protein binding&#39; is uninformative and should be replaced by more specific molecular function terms. HSPA1A already has appropriate specific MF annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0055131" target="_blank" class="term-link">
                                     GO:0055131
                                 </a>
                             </span>
                             <span class="term-label">C3HC4-type RING finger domain binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25281747" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25281747
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     RING finger protein RNF207, a novel regulator of cardiac exc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -11153,57 +11164,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Roder et al. (2014) showed RNF207 interacts with Hsp70 (PMID:25281747). RNF207 is a C3HC4-type RING finger protein involved in cardiac excitation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> RING finger domain binding confirmed by IPI (PMID:25281747). Consistent with HSPA1A interactions with RING E3 ligases in the chaperone-ubiquitin triage system.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001664" target="_blank" class="term-link">
                                     GO:0001664
                                 </a>
                             </span>
                             <span class="term-label">G protein-coupled receptor binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12150907" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12150907
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     CHIP is associated with Parkin, a gene responsible for famil...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -11215,75 +11226,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Imai et al. (2002) showed Hsp70 binds unfolded Pael-R (GPR37), a GPCR. However, this binding is in the context of chaperone-mediated quality control of a misfolded GPCR substrate, not functional GPCR binding in a signaling context (PMID:12150907).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Hsp70 binds unfolded Pael-R as a chaperone substrate, not as a GPCR binding partner in the signaling sense. Consistent with already-reviewed IEA annotation. Over-annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12150907" target="_blank" class="term-link">
                                         PMID:12150907
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">CHIP, Hsp70, Parkin, and Pael-R formed a complex in vitro and in vivo.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17616579" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17616579
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Cellular cofactors affecting hepatitis C virus infection and...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -11295,57 +11306,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#39;protein binding&#39; is uninformative per GO curation guidelines. HSPA1A interacts with many proteins as part of its chaperone function, but the generic &#39;protein binding&#39; term does not convey meaningful functional information. More specific MF terms (e.g., GO:0044183 protein folding chaperone, GO:0031072 heat shock protein binding, GO:0031625 ubiquitin protein ligase binding) already capture the biologically meaningful interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 &#39;protein binding&#39; is uninformative and should be replaced by more specific molecular function terms. HSPA1A already has appropriate specific MF annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20625543" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20625543
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HSP72 protects cells from ER stress-induced apoptosis via en...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -11357,57 +11368,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#39;protein binding&#39; is uninformative per GO curation guidelines. HSPA1A interacts with many proteins as part of its chaperone function, but the generic &#39;protein binding&#39; term does not convey meaningful functional information. More specific MF terms (e.g., GO:0044183 protein folding chaperone, GO:0031072 heat shock protein binding, GO:0031625 ubiquitin protein ligase binding) already capture the biologically meaningful interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 &#39;protein binding&#39; is uninformative and should be replaced by more specific molecular function terms. HSPA1A already has appropriate specific MF annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031397" target="_blank" class="term-link">
                                     GO:0031397
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of protein ubiquitination</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12150907" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12150907
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     CHIP is associated with Parkin, a gene responsible for famil...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -11419,75 +11430,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Imai et al. (2002) showed Hsp70 binding to Pael-R prevents its ubiquitination. CHIP promotes the dissociation of Hsp70 to facilitate ubiquitination (PMID:12150907).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Negative regulation of ubiquitination confirmed by IDA (PMID:12150907). Core chaperone triage function. Consistent with already-accepted IEA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12150907" target="_blank" class="term-link">
                                         PMID:12150907
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">CHIP promoted the dissociation of Hsp70 from Parkin and Pael-R, thus facilitating Parkin-mediated Pael-R ubiquitination.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031625" target="_blank" class="term-link">
                                     GO:0031625
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin protein ligase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12150907" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12150907
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     CHIP is associated with Parkin, a gene responsible for famil...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -11499,57 +11510,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Imai et al. (2002) showed Hsp70 forms complexes with CHIP (E3 ligase) and Parkin (E3 ligase) (PMID:12150907).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Ubiquitin protein ligase binding confirmed by IPI (PMID:12150907). Consistent with already-accepted IEA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034599" target="_blank" class="term-link">
                                     GO:0034599
                                 </a>
                             </span>
                             <span class="term-label">cellular response to oxidative stress</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24252804" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24252804
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The role of oxidative stress in Parkinson&#39;s disease.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -11561,57 +11572,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:24252804 is a review on oxidative stress in Parkinson&#39;s disease that discusses the role of chaperones including Hsp70 in response to oxidative damage.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cellular response to oxidative stress is a secondary cytoprotective role. Consistent with already-accepted IEA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                     GO:0050821
                                 </a>
                             </span>
                             <span class="term-label">protein stabilization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24252804" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24252804
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The role of oxidative stress in Parkinson&#39;s disease.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -11623,57 +11634,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:24252804 discusses Hsp70&#39;s role in stabilizing proteins in the context of Parkinson&#39;s disease. Protein stabilization is a well-established chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein stabilization is a core chaperone function. Consistent with already-accepted IEA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12150907" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12150907
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     CHIP is associated with Parkin, a gene responsible for famil...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -11685,99 +11696,99 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). The NAS reference (PMID:12150907, Imai et al. 2002) describes CHIP-Hsp70-Parkin complex formation with unfolded Pael receptor as substrate, showing Hsp70 binds unfolded Pael-R in the context of ER stress and Parkin-mediated ubiquitination. While this demonstrates Hsp70 interacts with an unfolded substrate, the functional context is chaperone-mediated quality control, not merely binding. HSPA1A has well-characterized protein folding chaperone activity (PMID:21231916), so the annotation should be modified to GO:0044183.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. PMID:12150907 (Imai et al. 2002) demonstrates that Hsp70 forms a complex with CHIP, Parkin, and unfolded Pael-R, and that CHIP promotes dissociation of Hsp70 from the complex to facilitate ubiquitination. This is a chaperone triage function, not passive binding of unfolded proteins. HSPA1A is a genuine protein folding chaperone with foldase activity (PMID:21231916), so the annotation should be replaced with GO:0044183 which accurately captures its molecular function.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12150907" target="_blank" class="term-link">
                                         PMID:12150907
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">CHIP, Hsp70, Parkin, and Pael-R formed a complex in vitro and in vivo. The amount of CHIP in the complex was increased during ER stress. CHIP promoted the dissociation of Hsp70 from Parkin and Pael-R, thus facilitating Parkin-mediated Pael-R ubiquitination.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1901029" target="_blank" class="term-link">
                                     GO:1901029
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of mitochondrial outer membrane permeabilization involved in apoptotic signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20625543" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20625543
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HSP72 protects cells from ER stress-induced apoptosis via en...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -11789,75 +11800,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Gupta et al. (2010) showed Hsp72 inhibits several features of the intrinsic apoptotic pathway including inhibiting cytochrome c release from mitochondria (preventing Bax translocation) (PMID:20625543).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Inhibition of mitochondrial outer membrane permeabilization is experimentally supported (PMID:20625543) but is a downstream anti-apoptotic function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20625543" target="_blank" class="term-link">
                                         PMID:20625543
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Hsp72 functions upstream of the caspase cascade by inhibiting the release of cytochrome c from the mitochondria</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902236" target="_blank" class="term-link">
                                     GO:1902236
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of endoplasmic reticulum stress-induced intrinsic apoptotic signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20625543" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20625543
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HSP72 protects cells from ER stress-induced apoptosis via en...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -11869,75 +11880,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Gupta et al. (2010) showed Hsp72 protects cells from ER stress-induced apoptosis by enhancing IRE1alpha-XBP1 signaling (PMID:20625543).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Anti-apoptotic function in ER stress confirmed (PMID:20625543) but is a secondary cytoprotective function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20625543" target="_blank" class="term-link">
                                         PMID:20625543
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">binding of Hsp72 to IRE1alpha enhances IRE1alpha/XBP1 signaling at the ER and inhibits ER stress-induced apoptosis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005814" target="_blank" class="term-link">
                                     GO:0005814
                                 </a>
                             </span>
                             <span class="term-label">centriole</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24061851" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24061851
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Stress-induced localization of HSPA6 (HSP70B&#39;) and HSPA1A (H...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -11949,75 +11960,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Khalouei et al. (2014) showed YFP-tagged HSPA1A localizes to centrioles upon thermal stress in human neuronal cells (PMID:24061851).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Centriole localization confirmed by IDA (PMID:24061851). Consistent with already-accepted IEA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24061851" target="_blank" class="term-link">
                                         PMID:24061851
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Following a brief period of thermal stress, YFP-tagged HSPA6 and HSPA1A rapidly appeared at centrioles in the cytoplasm of human neuronal cells</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -12029,57 +12040,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Hageman et al. (2011) performed chaperone assays with cytosolic HSPA1A (PMID:21231916). Cytosol is the primary location of HSPA1A function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization confirmed by IDA (PMID:21231916). Consistent with already-accepted IBA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005925" target="_blank" class="term-link">
                                     GO:0005925
                                 </a>
                             </span>
                             <span class="term-label">focal adhesion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21423176" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21423176
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Analysis of the myosin-II-responsive focal adhesion proteome...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -12091,57 +12102,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A detected in focal adhesion proteome by mass spectrometry (PMID:21423176). This may reflect chaperone interactions with adhesion complex proteins.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Focal adhesion localization from HDA proteomics (PMID:21423176) likely reflects chaperone-client interactions rather than specific focal adhesion targeting.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034605" target="_blank" class="term-link">
                                     GO:0034605
                                 </a>
                             </span>
                             <span class="term-label">cellular response to heat</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24061851" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24061851
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Stress-induced localization of HSPA6 (HSP70B&#39;) and HSPA1A (H...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -12153,57 +12164,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Khalouei et al. (2014) showed HSPA1A rapidly localizes to centrioles following thermal stress, demonstrating a cellular response to heat (PMID:24061851).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cellular response to heat confirmed by IDA (PMID:24061851). Core biological process.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -12215,75 +12226,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Hageman et al. (2011) directly demonstrated HSPA1A refolds heat-denatured luciferase (PMID:21231916). Core function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein refolding confirmed by direct luciferase refolding assay (PMID:21231916). Core function of HSPA1A.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -12295,99 +12306,99 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). The IDA reference (PMID:21231916, Hageman et al. 2011) is the key study that directly assayed HSPA1A chaperone activities. It demonstrated that HSPA1A has genuine foldase activity via luciferase refolding assays, can suppress polyQ aggregation, and protected cells from heat-induced cell death. The study also showed HSPA1A possesses intrinsic ATPase activity stimulated by J-domain co-chaperones. These are hallmarks of protein folding chaperone activity, not merely unfolded protein binding. The annotation should be modified to GO:0044183 &#34;protein folding chaperone&#34;, which is already annotated to this gene by both IBA (GO_REF:0000033) and IDA (PMID:15603737) evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. PMID:21231916 (Hageman et al. 2011) directly demonstrates HSPA1A has active protein folding chaperone function: it refolds heat-denatured luciferase, suppresses aggregation, and protects cells from heat-induced death, all in an ATP-dependent manner with J-protein co-chaperones. This is clearly protein folding chaperone activity (GO:0044183), not passive unfolded protein binding. UniProt also describes HSPA1A as a &#34;molecular chaperone implicated in a wide variety of cellular processes, including protection of the proteome from stress, folding and transport of newly synthesized polypeptides, activation of proteolysis of misfolded proteins&#34;. The annotation should be replaced with GO:0044183.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment. Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">whereas overexpression of HSPA1A protected cells from heat-induced cell death, overexpression of HSPA6 did not</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070370" target="_blank" class="term-link">
                                     GO:0070370
                                 </a>
                             </span>
                             <span class="term-label">cellular heat acclimation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -12399,75 +12410,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Hageman et al. (2011) showed HSPA1A overexpression protects cells from heat-induced cell death (PMID:21231916). Core thermotolerance function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cellular heat acclimation confirmed by IMP (PMID:21231916). Core function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">whereas overexpression of HSPA1A protected cells from heat-induced cell death, overexpression of HSPA6 did not</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0072562" target="_blank" class="term-link">
                                     GO:0072562
                                 </a>
                             </span>
                             <span class="term-label">blood microparticle</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22516433" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22516433
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomic analysis of microvesicles from plasma of healthy d...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -12479,57 +12490,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1A detected in blood microparticles by proteomics (PMID:22516433). Consistent with known extracellular presence of Hsp70.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Blood microparticle localization confirmed by HDA proteomics (PMID:22516433). Consistent with known extracellular Hsp70 biology.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090084" target="_blank" class="term-link">
                                     GO:0090084
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of inclusion body assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -12541,75 +12552,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Hageman et al. (2011) showed HSPA1A suppresses polyQ aggregation/inclusion body formation (PMID:21231916). Core aggregation suppression function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Negative regulation of inclusion body assembly confirmed by IDA (PMID:21231916). Core chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15603737" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15603737
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     BAG5 inhibits parkin and enhances dopaminergic neuron degene...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -12621,57 +12632,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#39;protein binding&#39; is uninformative per GO curation guidelines. HSPA1A interacts with many proteins as part of its chaperone function, but the generic &#39;protein binding&#39; term does not convey meaningful functional information. More specific MF terms (e.g., GO:0044183 protein folding chaperone, GO:0031072 heat shock protein binding, GO:0031625 ubiquitin protein ligase binding) already capture the biologically meaningful interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 &#39;protein binding&#39; is uninformative and should be replaced by more specific molecular function terms. HSPA1A already has appropriate specific MF annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
                                     GO:0005524
                                 </a>
                             </span>
                             <span class="term-label">ATP binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23921388
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of a novel human methylt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -12683,57 +12694,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Jakobsson et al. (2013) showed METTL21A-mediated methylation of Hsp70 is stimulated by ATP, confirming ATP binding (PMID:23921388). Core molecular function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATP binding confirmed by IDA (PMID:23921388). Core molecular function of HSPA1A.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010628" target="_blank" class="term-link">
                                     GO:0010628
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of gene expression</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25281747" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25281747
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     RING finger protein RNF207, a novel regulator of cardiac exc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -12745,57 +12756,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Roder et al. (2014) showed RNF207 interacts with Hsp70 and this interaction regulates cardiac excitation (PMID:25281747). The gene expression regulation may be indirect.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Positive regulation of gene expression in the context of RNF207-Hsp70 interaction (PMID:25281747) is likely an indirect effect of chaperone-client relationship.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016234" target="_blank" class="term-link">
                                     GO:0016234
                                 </a>
                             </span>
                             <span class="term-label">inclusion body</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15603737" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15603737
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     BAG5 inhibits parkin and enhances dopaminergic neuron degene...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -12807,75 +12818,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Kalia et al. (2004) showed BAG5 enhances parkin sequestration within protein aggregates/inclusion bodies. Hsp70 localizes to inclusion bodies as part of quality control (PMID:15603737).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Inclusion body localization confirmed by IDA (PMID:15603737). Consistent with HSPA1A&#39;s role in protein quality control at aggregation sites.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/15603737" target="_blank" class="term-link">
                                         PMID:15603737
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">BAG5 enhances parkin sequestration within protein aggregates</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019899" target="_blank" class="term-link">
                                     GO:0019899
                                 </a>
                             </span>
                             <span class="term-label">enzyme binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23921388
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of a novel human methylt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -12887,57 +12898,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Jakobsson et al. (2013) showed HSPA1A interacts with the methyltransferase METTL21A (PMID:23921388). Enzyme binding is accurate but broad.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Enzyme binding confirmed by IPI with METTL21A methyltransferase (PMID:23921388). Accurate but broad term.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
                                     GO:0031072
                                 </a>
                             </span>
                             <span class="term-label">heat shock protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23921388
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of a novel human methylt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -12949,57 +12960,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Jakobsson et al. (2013) showed METTL21A specifically methylates Hsp70 family proteins (PMID:23921388). Heat shock protein binding is core.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Heat shock protein binding confirmed by IPI (PMID:23921388). Consistent with already-accepted IBA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031625" target="_blank" class="term-link">
                                     GO:0031625
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin protein ligase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15603737" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15603737
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     BAG5 inhibits parkin and enhances dopaminergic neuron degene...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -13011,57 +13022,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Kalia et al. (2004) showed BAG5 directly interacts with parkin and Hsp70 in a complex. Hsp70 binds parkin (E3 ubiquitin ligase) (PMID:15603737).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Ubiquitin protein ligase binding confirmed by IPI (PMID:15603737). Consistent with already-accepted IEA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15603737" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15603737
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     BAG5 inhibits parkin and enhances dopaminergic neuron degene...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -13073,75 +13084,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Kalia et al. (2004) showed BAG5 inhibits Hsp70-mediated refolding of misfolded proteins (PMID:15603737). Confirms protein refolding activity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein refolding confirmed by IDA (PMID:15603737). Core function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/15603737" target="_blank" class="term-link">
                                         PMID:15603737
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">BAG5 inhibits both parkin E3 ubiquitin ligase activity and Hsp70-mediated refolding of misfolded proteins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     GO:0044183
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15603737" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15603737
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     BAG5 inhibits parkin and enhances dopaminergic neuron degene...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -13153,119 +13164,119 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Kalia et al. (2004) demonstrated Hsp70 chaperone activity inhibited by BAG5 (PMID:15603737). Confirms protein folding chaperone as core MF.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein folding chaperone confirmed by IDA (PMID:15603737). Core molecular function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046034" target="_blank" class="term-link">
                                     GO:0046034
                                 </a>
                             </span>
                             <span class="term-label">ATP metabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23921388
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of a novel human methylt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="P0DMV8" data-a="GO:0046034" data-r="PMID:23921388" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P0DMV8" data-a="GO:0046034" data-r="PMID:23921388" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Jakobsson et al. (2013) showed METTL21A-mediated methylation is stimulated by ATP, confirming Hsp70 ATPase function (PMID:23921388).
+                            <strong>Summary:</strong> PMID:23921388 describes METTL21A methylation assays and HSPA8/Hsc70 functional effects, not HSPA1A-specific ATP metabolic process.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> ATP metabolic process confirmed by IDA (PMID:23921388). Consistent with already-accepted IEA annotation.
+                            <strong>Reason:</strong> The cited IDA evidence does not support a broad HSPA1A ATP metabolic process annotation; ATP use is better captured by ATPase/chaperone molecular-function annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048471" target="_blank" class="term-link">
                                     GO:0048471
                                 </a>
                             </span>
                             <span class="term-label">perinuclear region of cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15603737" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15603737
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     BAG5 inhibits parkin and enhances dopaminergic neuron degene...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -13277,57 +13288,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Kalia et al. (2004) showed BAG5-Hsp70 complex localizes to the perinuclear region (PMID:15603737).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Perinuclear localization confirmed by IDA (PMID:15603737). Consistent with already-accepted IEA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090084" target="_blank" class="term-link">
                                     GO:0090084
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of inclusion body assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15603737" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15603737
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     BAG5 inhibits parkin and enhances dopaminergic neuron degene...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -13339,57 +13350,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Kalia et al. (2004) showed Hsp70 suppresses protein aggregation, which is inhibited by BAG5 (PMID:15603737).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Negative regulation of inclusion body assembly confirmed by IDA (PMID:15603737). Core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:2001240" target="_blank" class="term-link">
                                     GO:2001240
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of extrinsic apoptotic signaling pathway in absence of ligand</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17167422" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17167422
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Hsp70 regulates erythropoiesis by preventing caspase-3-media...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -13401,75 +13412,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Ribeil et al. (2007) showed Hsp70 protects GATA-1 from caspase-3 cleavage, preventing apoptosis during erythroid differentiation. Erythropoietin starvation (absence of ligand) leads to Hsp70 nuclear export and GATA-1 cleavage (PMID:17167422).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Anti-apoptotic function in the absence of survival signaling is experimentally supported (PMID:17167422) but is a downstream effect.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17167422" target="_blank" class="term-link">
                                         PMID:17167422
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">erythropoietin starvation induces the nuclear export of Hsp70 and the cleavage of GATA-1.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005102" target="_blank" class="term-link">
                                     GO:0005102
                                 </a>
                             </span>
                             <span class="term-label">signaling receptor binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24790089" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24790089
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The molecular chaperone HSP70 binds to and stabilizes NOD2, ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -13481,57 +13492,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Mohanan &amp; Grimes (2014) showed HSP70 binds NOD2, an intracellular pattern recognition receptor (PMID:24790089). This is a chaperone-client interaction with a signaling receptor.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Signaling receptor binding is confirmed for NOD2 (PMID:24790089) but represents a chaperone-client interaction rather than a core signaling function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24790089" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24790089
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The molecular chaperone HSP70 binds to and stabilizes NOD2, ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -13543,57 +13554,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Mohanan &amp; Grimes (2014) showed HSP70 and NOD2 interact in the cytoplasm (PMID:24790089).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization confirmed by IDA (PMID:24790089). Consistent with already-accepted IBA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1903265" target="_blank" class="term-link">
                                     GO:1903265
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of tumor necrosis factor-mediated signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24790089" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24790089
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The molecular chaperone HSP70 binds to and stabilizes NOD2, ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -13605,32 +13616,32 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Mohanan &amp; Grimes (2014) showed HSP70-mediated NOD2 stabilization enhances downstream signaling including TNF-mediated pathways (PMID:24790089).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Positive regulation of TNF signaling is an indirect downstream effect of NOD2 stabilization by HSPA1A (PMID:24790089). Not a core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>HSPA1A is the major stress-inducible HSP70 chaperone. It functions as an ATP-dependent foldase that assists folding of newly synthesized polypeptides and refolding of stress-denatured proteins. HSPA1A binds unfolded/misfolded substrates via its C-terminal substrate-binding domain and undergoes iterative ATP hydrolysis-driven conformational cycles regulated by J-domain co-chaperones (DNAJB1, DNAJA1/2) and nucleotide exchange factors (BAG1/2/3, HSPH1). It triages substrates between refolding and proteasomal degradation via STUB1/CHIP E3 ubiquitin ligase. HSPA1A protected cells from heat-induced cell death and supported luciferase refolding in functional assays.</h3>
                 <span class="vote-buttons" data-g="P0DMV8" data-a="FUNCTION: HSPA1A is the major stress-inducible HSP70 chapero..." data-r="" data-act="CORE_FUNCTION">
@@ -13638,10 +13649,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -13650,1523 +13661,1487 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                 protein refolding
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032436" target="_blank" class="term-link">
                                 positive regulation of proteasomal ubiquitin-dependent protein catabolic process
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070370" target="_blank" class="term-link">
                                 cellular heat acclimation
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006986" target="_blank" class="term-link">
                                 response to unfolded protein
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090084" target="_blank" class="term-link">
                                 negative regulation of inclusion body assembly
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                 nucleus
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                 PMID:21231916
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">overexpression of HSPA1A protected cells from heat-induced cell death</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                 PMID:21231916
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation</div>
-                        
+
                     </li>
-                    
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/HSPA1A/HSPA1A-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">HSPA1A encodes the inducible cytosolic Hsp70-1A that, via a conserved ATPase cycle governed by J-proteins and nucleotide exchange factors, binds hydrophobic client segments to maintain proteostasis and interface with degradation and autophagy pathways.</div>
+
+                    </li>
+
                 </ul>
             </div>
-            
+
         </div>
-        
-        <div class="core-function-card">
-            
-            <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>HSPA1A works with DNAJ co-chaperones and HSPH1 nucleotide exchange factor to solubilize and disaggregate protein aggregates. This disaggregase activity uses the same ATP hydrolysis cycle as the foldase function but is directed toward pre-formed aggregates rather than nascent or stress-denatured monomers. This function is important for preventing accumulation of toxic protein aggregates and inclusion bodies under stress conditions.</h3>
-                <span class="vote-buttons" data-g="P0DMV8" data-a="FUNCTION: HSPA1A works with DNAJ co-chaperones and HSPH1 nuc..." data-r="" data-act="CORE_FUNCTION">
-                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
-                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
-                </span>
-            </div>
-            
 
-            <div class="core-function-terms">
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">Molecular Function:</div>
-                    <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140545" target="_blank" class="term-link">
-                            ATP-dependent protein disaggregase activity
-                        </a>
-                    </span>
-                </div>
-                
-
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">Directly Involved In:</div>
-                    <div class="function-annotations">
-                        
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090084" target="_blank" class="term-link">
-                                negative regulation of inclusion body assembly
-                            </a>
-                        </span>
-                        
-                    </div>
-                </div>
-                
-
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">Cellular Locations:</div>
-                    <div class="function-annotations">
-                        
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
-                                cytosol
-                            </a>
-                        </span>
-                        
-                    </div>
-                </div>
-                
-
-                
-
-                
-            </div>
-
-            
-        </div>
-        
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/HSPA1A/HSPA1A-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for HSPA1A</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
                             GO_REF:0000024
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
                             GO_REF:0000052
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000108.md" target="_blank" class="term-link">
                             GO_REF:0000108
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Automatic assignment of GO terms using logical inference, based on on inter-ontology links</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10205060" target="_blank" class="term-link">
                             PMID:10205060
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Control of mRNA decay by heat shock-ubiquitin-proteasome pathway.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10811660" target="_blank" class="term-link">
                             PMID:10811660
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Crystal structure and activity of human p23, a heat shock protein 90 co-chaperone.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10859165" target="_blank" class="term-link">
                             PMID:10859165
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Chaperone hsp27 inhibits translation during heat shock by binding eIF4G and facilitating dissociation of cap-initiation complexes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11785981" target="_blank" class="term-link">
                             PMID:11785981
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP90, HSP70, and GAPDH directly interact with the cytoplasmic domain of macrophage scavenger receptors.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12150907" target="_blank" class="term-link">
                             PMID:12150907
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">CHIP is associated with Parkin, a gene responsible for familial Parkinson&#39;s disease, and enhances its ubiquitin ligase activity.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12853476" target="_blank" class="term-link">
                             PMID:12853476
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Cofactor Tpr2 combines two TPR domains and a J domain to regulate the Hsp70/Hsp90 chaperone system.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15603737" target="_blank" class="term-link">
                             PMID:15603737
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">BAG5 inhibits parkin and enhances dopaminergic neuron degeneration.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15671022" target="_blank" class="term-link">
                             PMID:15671022
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Heat shock protein 70 inhibits alpha-synuclein fibril formation via preferential binding to prefibrillar species.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15885686" target="_blank" class="term-link">
                             PMID:15885686
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TRIM37 defective in mulibrey nanism is a novel RING finger ubiquitin E3 ligase.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16130169" target="_blank" class="term-link">
                             PMID:16130169
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteomics of human umbilical vein endothelial cells applied to etoposide-induced apoptosis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16809764" target="_blank" class="term-link">
                             PMID:16809764
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Histone deacetylase 8 safeguards the human ever-shorter telomeres 1B (hEST1B) protein from ubiquitin-mediated degradation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17167422" target="_blank" class="term-link">
                             PMID:17167422
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Hsp70 regulates erythropoiesis by preventing caspase-3-mediated cleavage of GATA-1.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17182002" target="_blank" class="term-link">
                             PMID:17182002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HDJC9, a novel human type C DnaJ/HSP40 member interacts with and cochaperones HSP70 through the J domain.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17289661" target="_blank" class="term-link">
                             PMID:17289661
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Molecular composition of IMP1 ribonucleoprotein granules.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17568691" target="_blank" class="term-link">
                             PMID:17568691
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Endogenous signals released from necrotic cells augment inflammatory responses to bacterial endotoxin.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17616579" target="_blank" class="term-link">
                             PMID:17616579
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Cellular cofactors affecting hepatitis C virus infection and replication.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18850735" target="_blank" class="term-link">
                             PMID:18850735
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Characterization of the human COP9 signalosome complex using affinity purification and mass spectrometry.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18975920" target="_blank" class="term-link">
                             PMID:18975920
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interactions between Hsp70 and the hydrophobic core of alpha-synuclein inhibit fibril assembly.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19190083" target="_blank" class="term-link">
                             PMID:19190083
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Characterization of exosome-like vesicles released from human tracheobronchial ciliated epithelium: a possible role in innate defense.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19199708" target="_blank" class="term-link">
                             PMID:19199708
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteomic analysis of human parotid gland exosomes by multidimensional protein identification technology (MudPIT).</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20458337" target="_blank" class="term-link">
                             PMID:20458337
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">MHC class II-associated proteins in B-cell exosomes and potential functional implications for exosome biogenesis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20625543" target="_blank" class="term-link">
                             PMID:20625543
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP72 protects cells from ER stress-induced apoptosis via enhancement of IRE1alpha-XBP1 signaling through a physical interaction.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21044950" target="_blank" class="term-link">
                             PMID:21044950
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Genome-wide YFP fluorescence complementation screen identifies new regulators for telomere signaling in human cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21081504" target="_blank" class="term-link">
                             PMID:21081504
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ChChd3, an inner mitochondrial membrane protein, is essential for maintaining crista integrity and mitochondrial function.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                             PMID:21231916
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The diverse members of the mammalian HSP70 machine show distinct chaperone-like activities.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21423176" target="_blank" class="term-link">
                             PMID:21423176
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Analysis of the myosin-II-responsive focal adhesion proteome reveals a role for β-Pix in negative regulation of focal adhesion maturation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21909508" target="_blank" class="term-link">
                             PMID:21909508
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Intrinsically disordered proteins as molecular shields.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22219199" target="_blank" class="term-link">
                             PMID:22219199
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The C-terminal helices of heat shock protein 70 are essential for J-domain binding and ATPase activation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22516433" target="_blank" class="term-link">
                             PMID:22516433
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteomic analysis of microvesicles from plasma of healthy donors reveals high individual variability.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22528486" target="_blank" class="term-link">
                             PMID:22528486
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Nucleophosmin (NPM1/B23) interacts with activating transcription factor 5 (ATF5) protein and promotes proteasome- and caspase-dependent ATF5 degradation in hepatocellular carcinoma cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22658674" target="_blank" class="term-link">
                             PMID:22658674
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Insights into RNA biology from an atlas of mammalian mRNA-binding proteins.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22681889" target="_blank" class="term-link">
                             PMID:22681889
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The mRNA-bound proteome and its global occupancy profile on protein-coding transcripts.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23349634" target="_blank" class="term-link">
                             PMID:23349634
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A newly uncovered group of distantly related lysine methyltransferases preferentially interact with molecular chaperones to regulate their activity.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link">
                             PMID:23533145
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">In-depth proteomic analyses of exosomes isolated from expressed prostatic secretions in urine.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link">
                             PMID:23921388
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Identification and characterization of a novel human methyltransferase modulating Hsp70 protein function through lysine methylation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24061851" target="_blank" class="term-link">
                             PMID:24061851
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Stress-induced localization of HSPA6 (HSP70B&#39;) and HSPA1A (HSP70-1) proteins to centrioles in human neuronal cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24252804" target="_blank" class="term-link">
                             PMID:24252804
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The role of oxidative stress in Parkinson&#39;s disease.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24318877" target="_blank" class="term-link">
                             PMID:24318877
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Binding of human nucleotide exchange factors to heat shock protein 70 (Hsp70) generates functionally distinct complexes in vitro.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24338975" target="_blank" class="term-link">
                             PMID:24338975
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Discovery of multiple interacting partners of gankyrin, a proteasomal chaperone and an oncoprotein--evidence for a common hot spot site at the interface and its functional relevance.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24428437" target="_blank" class="term-link">
                             PMID:24428437
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Mutations in the substrate binding site of human heat-shock protein 70 indicate specific interaction with HLA-DR outside the peptide binding groove.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24613385" target="_blank" class="term-link">
                             PMID:24613385
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Hsp70 and Hsp90 oppositely regulate TGF-β signaling through CHIP/Stub1.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24790089" target="_blank" class="term-link">
                             PMID:24790089
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The molecular chaperone HSP70 binds to and stabilizes NOD2, an important protein involved in Crohn disease.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25281747" target="_blank" class="term-link">
                             PMID:25281747
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RING finger protein RNF207, a novel regulator of cardiac excitation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25468996" target="_blank" class="term-link">
                             PMID:25468996
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">E-cadherin interactome complexity and robustness resolved by quantitative proteomics.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26183779" target="_blank" class="term-link">
                             PMID:26183779
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Tag7 (PGLYRP1) in Complex with Hsp70 Induces Alternative Cytotoxic Processes in Tumor Cells via TNFR1 Receptor.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27133716" target="_blank" class="term-link">
                             PMID:27133716
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A novel nuclear DnaJ protein, DNAJC8, can suppress the formation of spinocerebellar ataxia 3 polyglutamine aggregation in a J-domain independent manner.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27137183" target="_blank" class="term-link">
                             PMID:27137183
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP70 regulates the function of mitotic centrosomes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27708256" target="_blank" class="term-link">
                             PMID:27708256
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ARD1-mediated Hsp70 acetylation balances stress-induced protein refolding and degradation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28842558" target="_blank" class="term-link">
                             PMID:28842558
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP70-Hrd1 axis precludes the oncorepressor potential of N-terminal misfolded Blimp-1s in lymphoma cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
                             PMID:32814053
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9222587" target="_blank" class="term-link">
                             PMID:9222587
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Evidence for a role of Hsp70 in the regulation of the heat shock response in mammalian cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9499401" target="_blank" class="term-link">
                             PMID:9499401
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Molecular chaperones as HSF1-specific transcriptional repressors.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9553041" target="_blank" class="term-link">
                             PMID:9553041
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Inhibition of cellular proliferation by the Wilms tumor suppressor WT1 requires association with the inducible chaperone Hsp70.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371422
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ATP hydrolysis by HSP70</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371467
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">SIRT1 deacetylates HSF1</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371497
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP90 chaperone cycle for steroid hormone receptors (SHR) in the presence of ligand</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371503
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">STIP1(HOP) binds HSP90 and HSP70:HSP40:nascent protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371518
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">SIRT1 binds to HSF1</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371554
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSF1 acetylation at Lys80</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371590
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP70 binds to HSP40:nascent protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-450551
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">AUF1 binds translation and heat shock proteins</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-450580
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">AUF1 (hnRNP D0) is ubiquitinylated</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5082356
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSF1-mediated gene expression</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5082369
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Acetylated HSF1 dissociates from DNA</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5082384
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP70:DNAJB1 binds HSF1</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5251942
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Hikeshi binds HSP70s:ATP</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5251955
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP40s activate intrinsic ATPase activity of HSP70s in the nucleoplasm</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5251959
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP40s activate intrinsic ATPase activity of HSP70s in the cytosol</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5252041
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NPC transports Hikeshi:HSP70s:ATP from cytosol to nucleoplasm</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5252079
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP110s exchange ATP for ADP on HSP70s:ADP</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5618085
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">FKBP4 binds HSP90:ATP:STIP1:HSP70:nascent protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5618098
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">p23 (PTGES3) binds HSP90:ATP:FKBP5:nascent protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5618105
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">FKBP5 binds HSP90:ATP:STIP1:HSP70:nascent protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5618107
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ATP binding to HSP90 triggers conformation change</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5618110
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">p23 (PTGES3) binds HSP90:ATP:FKBP4:nascent protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6800434
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Exocytosis of ficolin-rich granule lumen proteins</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9835411
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">FA core complex:HSP70s binds PKR</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9857076
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Oxidized DNAJA1 binds HSPA1A,B (HSP70) displacing HSF1</div>
-                
-                
+
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -15373,9 +15348,9 @@ HSPA1A encodes the inducible cytosolic Hsp70-1A that, via a conserved ATPase cyc
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -15387,7 +15362,7 @@ HSPA1A encodes the inducible cytosolic Hsp70-1A that, via a conserved ATPase cyc
                 <pre><code>id: P0DMV8
 gene_symbol: HSPA1A
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -15400,8 +15375,7 @@ description: Heat shock 70 kDa protein 1A (HSPA1A/HSP72/HSP70-1) is a major stre
   acetylation/deacetylation state determines whether it functions in protein refolding (via HOPX co-chaperone)
   or protein degradation (via STUB1/CHIP ubiquitin ligase). Additionally, HSPA1A has roles in regulating
   apoptosis, centrosome integrity during mitosis, TGF-beta signaling, and can function as an extracellular
-  signaling molecule (receptor ligand activity). It also possesses ATP-dependent protein disaggregase
-  activity.
+  signaling molecule (receptor ligand activity).
 alternative_products:
 - name: &#39;1&#39;
   id: P0DMV8-1
@@ -15451,14 +15425,18 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: HSPA1A plasma membrane association is supported by its role as a virus receptor (rotavirus
-      A entry, UniProt annotation) and by evidence showing it functions as an extracellular receptor ligand
-      via Tag7/PGLYRP1-Hsp70 complexes that interact with TNFR1 on cell surfaces (PMID:26183779). Also
-      consistent with its role in extracellular signaling (PMID:17568691). IBA annotation is phylogenetically
-      reasonable for the HSP70 family.
+    summary: &gt;-
+      HSPA1A plasma membrane association is supported by evidence showing it can
+      function as an extracellular receptor ligand via Tag7/PGLYRP1-Hsp70
+      complexes that interact with TNFR1 on cell surfaces (PMID:26183779), and
+      is consistent with extracellular HSP70 signaling (PMID:17568691). The
+      rotavirus receptor citation is not used here because the available local
+      evidence points to Hsc70 rather than HSPA1A.
     action: ACCEPT
-    reason: Plasma membrane association is supported by HSPA1A&#39;s roles as a virus receptor and extracellular
-      signaling molecule. Phylogenetically consistent for HSP70 family members.
+    reason: &gt;-
+      Plasma membrane association is supported by extracellular HSP70 signaling
+      evidence and phylogenetically consistent for HSP70 family members, without
+      relying on the mismatched rotavirus receptor citation.
     supported_by:
     - reference_id: PMID:26183779
       supporting_text: Tag7 (PGLYRP1) in Complex with Hsp70 Induces Alternative Cytotoxic Processes in
@@ -15522,6 +15500,10 @@ existing_annotations:
       supporting_text: Overexpressed chaperones that suppressed polyQ aggregation were found not to be
         able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding
         were poor suppressors of polyQ aggregation.
+    - reference_id: file:human/HSPA1A/HSPA1A-deep-research-falcon.md
+      supporting_text: &gt;-
+        HSPA1A is the stress-inducible cytosolic Hsp70-1A chaperone whose ATPase
+        cycle drives client binding, folding/refolding, and proteostasis triage.
 - term:
     id: GO:0005829
     label: cytosol
@@ -15581,12 +15563,15 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000108
   review:
-    summary: HSPA1A serves as a post-attachment receptor for rotavirus A, facilitating virus entry into
-      the cell (PMID:16537599). UniProt confirms this function. The IEA annotation via logical inference
-      from the virus receptor activity annotation is reasonable.
-    action: KEEP_AS_NON_CORE
-    reason: HSPA1A functions as a virus receptor for rotavirus A (PMID:16537599), which involves viral
-      entry. This is a secondary/non-core function distinct from its primary chaperone role.
+    summary: &gt;-
+      The source evidence for this rotavirus-entry inference is PMID:16537599, but
+      the local UniProt citation describes recombinant hsc70 rather than HSPA1A/Hsp72.
+      This is therefore a paralog/evidence mismatch for HSPA1A.
+    action: REMOVE
+    reason: &gt;-
+      The cited rotavirus receptor evidence does not establish HSPA1A-specific
+      symbiont entry activity; it should not be retained for HSPA1A without
+      HSPA1A-specific support.
 - term:
     id: GO:0000166
     label: nucleotide binding
@@ -15607,12 +15592,15 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: UniProt directly annotates HSPA1A as a receptor for rotavirus A based on PMID:16537599. The
-      peptide-binding and ATPase domains of Hsp70 are required for rotavirus interaction and infectivity
-      reduction.
-    action: KEEP_AS_NON_CORE
-    reason: Virus receptor activity is experimentally supported for rotavirus A entry (PMID:16537599)
-      but is a non-core function unrelated to HSPA1A&#39;s primary chaperone role.
+    summary: &gt;-
+      The rotavirus receptor evidence cited for this annotation is PMID:16537599,
+      but the local UniProt citation identifies the tested protein as recombinant
+      hsc70 rather than HSPA1A/Hsp72. The annotation therefore appears to transfer
+      an HSPA8/Hsc70-related observation onto HSPA1A.
+    action: REMOVE
+    reason: &gt;-
+      Virus receptor activity is not supported by HSPA1A-specific evidence in the
+      available local citation and should not be retained for HSPA1A.
 - term:
     id: GO:0001664
     label: G protein-coupled receptor binding
@@ -15924,11 +15912,14 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: HSPA1A hydrolyzes ATP as part of its chaperone cycle. The ATP metabolic process annotation
-      broadly captures the ATPase activity. Confirmed by IDA (PMID:23921388, PMID:21231916).
-    action: ACCEPT
-    reason: ATP metabolic process is accurate as HSPA1A has intrinsic ATPase activity. Broader than GO:0016887
-      (ATP hydrolysis activity) but acceptable.
+    summary: &gt;-
+      HSPA1A hydrolyzes ATP as part of its chaperone cycle, but ATP metabolic
+      process is a broad biological-process term. The actual molecular activity
+      is captured by ATP hydrolysis activity and ATP-dependent chaperone terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      This broad BP term is less informative than the molecular-function terms
+      describing HSPA1A&#39;s ATPase-driven chaperone cycle.
 - term:
     id: GO:0048471
     label: perinuclear region of cytoplasm
@@ -16090,12 +16081,18 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: HSPA1A has ATP-dependent protein disaggregase activity. Jakobsson et al. (2013) showed METTL21A-mediated
-      trimethylation of Hsp70 modulates its chaperone function including effects on alpha-synuclein disaggregation
-      (PMID:23921388). Hsp70 disaggregase activity is well-established in the Hsp70/Hsp110/Hsp40 system.
-    action: ACCEPT
-    reason: ATP-dependent protein disaggregase activity is a core molecular function of HSPA1A, operating
-      in concert with Hsp110 and Hsp40 co-chaperones. Confirmed by IDA (PMID:23921388).
+    summary: &gt;-
+      This ARBA inference cites PMID:23921388, but the local paper describes
+      METTL21A methylation and altered HSPA8/Hsc70 affinity for alpha-synuclein,
+      not direct HSPA1A ATP-dependent disaggregase activity. HSP70-family
+      disaggregation can require HSP110/HSP40 systems, but this evidence does not
+      establish HSPA1A-specific disaggregase activity.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The annotation overextends family-level proteostasis biology and HSPA8-focused
+      evidence to HSPA1A. HSPA1A&#39;s accepted core role should remain ATP-dependent
+      folding/refolding and client triage unless direct HSPA1A disaggregase evidence
+      is available.
     supported_by:
     - reference_id: PMID:23921388
       supporting_text: we show that trimethylation of HSPA8 (Hsc70) has functional consequences, as it
@@ -16404,12 +16401,14 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:23921388
   review:
-    summary: Jakobsson et al. (2013) showed METTL21A-mediated trimethylation of Hsp70 modulates its chaperone
-      function, altering affinity for monomeric and fibrillar alpha-synuclein (PMID:23921388). The disaggregase
-      activity is a core function of the Hsp70/Hsp110/Hsp40 chaperone system.
-    action: ACCEPT
-    reason: ATP-dependent protein disaggregase activity is a core molecular function of HSPA1A. Confirmed
-      by IDA (PMID:23921388).
+    summary: &gt;-
+      PMID:23921388 shows METTL21A-mediated methylation effects on HSPA8/Hsc70
+      binding to alpha-synuclein, not direct HSPA1A disaggregase activity.
+      The evidence is therefore mismatched for an HSPA1A IDA annotation.
+    action: REMOVE
+    reason: &gt;-
+      The cited IDA evidence does not support HSPA1A-specific ATP-dependent protein
+      disaggregase activity and should not be accepted for this gene.
     supported_by:
     - reference_id: PMID:23921388
       supporting_text: trimethylation of HSPA8 (Hsc70) has functional consequences, as it alters the affinity
@@ -18064,11 +18063,14 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:23921388
   review:
-    summary: Jakobsson et al. (2013) showed METTL21A-mediated methylation is stimulated by ATP, confirming
-      Hsp70 ATPase function (PMID:23921388).
-    action: ACCEPT
-    reason: ATP metabolic process confirmed by IDA (PMID:23921388). Consistent with already-accepted IEA
-      annotation.
+    summary: &gt;-
+      PMID:23921388 describes METTL21A methylation assays and HSPA8/Hsc70
+      functional effects, not HSPA1A-specific ATP metabolic process.
+    action: REMOVE
+    reason: &gt;-
+      The cited IDA evidence does not support a broad HSPA1A ATP metabolic
+      process annotation; ATP use is better captured by ATPase/chaperone
+      molecular-function annotations.
 - term:
     id: GO:0048471
     label: perinuclear region of cytoplasm
@@ -18175,23 +18177,16 @@ core_functions:
     supporting_text: &gt;-
       chaperones that supported luciferase refolding were poor suppressors of polyQ
       aggregation
-- molecular_function:
-    id: GO:0140545
-    label: ATP-dependent protein disaggregase activity
-  description: &gt;-
-    HSPA1A works with DNAJ co-chaperones and HSPH1 nucleotide exchange factor to
-    solubilize and disaggregate protein aggregates. This disaggregase activity uses
-    the same ATP hydrolysis cycle as the foldase function but is directed toward
-    pre-formed aggregates rather than nascent or stress-denatured monomers. This
-    function is important for preventing accumulation of toxic protein aggregates
-    and inclusion bodies under stress conditions.
-  directly_involved_in:
-  - id: GO:0090084
-    label: negative regulation of inclusion body assembly
-  locations:
-  - id: GO:0005829
-    label: cytosol
+  - reference_id: file:human/HSPA1A/HSPA1A-deep-research-falcon.md
+    supporting_text: &gt;-
+      HSPA1A encodes the inducible cytosolic Hsp70-1A that, via a conserved ATPase
+      cycle governed by J-proteins and nucleotide exchange factors, binds hydrophobic
+      client segments to maintain proteostasis and interface with degradation and
+      autophagy pathways.
 references:
+- id: file:human/HSPA1A/HSPA1A-deep-research-falcon.md
+  title: Falcon deep research report for HSPA1A
+  findings: []
 - id: GO_REF:0000024
   title: Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator
     judgment of sequence similarity
@@ -18485,7 +18480,7 @@ references:
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/HSPA1A/HSPA1A-ai-review.yaml
+++ b/genes/human/HSPA1A/HSPA1A-ai-review.yaml
@@ -1,7 +1,7 @@
 id: P0DMV8
 gene_symbol: HSPA1A
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -14,8 +14,7 @@ description: Heat shock 70 kDa protein 1A (HSPA1A/HSP72/HSP70-1) is a major stre
   acetylation/deacetylation state determines whether it functions in protein refolding (via HOPX co-chaperone)
   or protein degradation (via STUB1/CHIP ubiquitin ligase). Additionally, HSPA1A has roles in regulating
   apoptosis, centrosome integrity during mitosis, TGF-beta signaling, and can function as an extracellular
-  signaling molecule (receptor ligand activity). It also possesses ATP-dependent protein disaggregase
-  activity.
+  signaling molecule (receptor ligand activity).
 alternative_products:
 - name: '1'
   id: P0DMV8-1
@@ -65,14 +64,18 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: HSPA1A plasma membrane association is supported by its role as a virus receptor (rotavirus
-      A entry, UniProt annotation) and by evidence showing it functions as an extracellular receptor ligand
-      via Tag7/PGLYRP1-Hsp70 complexes that interact with TNFR1 on cell surfaces (PMID:26183779). Also
-      consistent with its role in extracellular signaling (PMID:17568691). IBA annotation is phylogenetically
-      reasonable for the HSP70 family.
+    summary: >-
+      HSPA1A plasma membrane association is supported by evidence showing it can
+      function as an extracellular receptor ligand via Tag7/PGLYRP1-Hsp70
+      complexes that interact with TNFR1 on cell surfaces (PMID:26183779), and
+      is consistent with extracellular HSP70 signaling (PMID:17568691). The
+      rotavirus receptor citation is not used here because the available local
+      evidence points to Hsc70 rather than HSPA1A.
     action: ACCEPT
-    reason: Plasma membrane association is supported by HSPA1A's roles as a virus receptor and extracellular
-      signaling molecule. Phylogenetically consistent for HSP70 family members.
+    reason: >-
+      Plasma membrane association is supported by extracellular HSP70 signaling
+      evidence and phylogenetically consistent for HSP70 family members, without
+      relying on the mismatched rotavirus receptor citation.
     supported_by:
     - reference_id: PMID:26183779
       supporting_text: Tag7 (PGLYRP1) in Complex with Hsp70 Induces Alternative Cytotoxic Processes in
@@ -136,6 +139,10 @@ existing_annotations:
       supporting_text: Overexpressed chaperones that suppressed polyQ aggregation were found not to be
         able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding
         were poor suppressors of polyQ aggregation.
+    - reference_id: file:human/HSPA1A/HSPA1A-deep-research-falcon.md
+      supporting_text: >-
+        HSPA1A is the stress-inducible cytosolic Hsp70-1A chaperone whose ATPase
+        cycle drives client binding, folding/refolding, and proteostasis triage.
 - term:
     id: GO:0005829
     label: cytosol
@@ -195,12 +202,15 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000108
   review:
-    summary: HSPA1A serves as a post-attachment receptor for rotavirus A, facilitating virus entry into
-      the cell (PMID:16537599). UniProt confirms this function. The IEA annotation via logical inference
-      from the virus receptor activity annotation is reasonable.
-    action: KEEP_AS_NON_CORE
-    reason: HSPA1A functions as a virus receptor for rotavirus A (PMID:16537599), which involves viral
-      entry. This is a secondary/non-core function distinct from its primary chaperone role.
+    summary: >-
+      The source evidence for this rotavirus-entry inference is PMID:16537599, but
+      the local UniProt citation describes recombinant hsc70 rather than HSPA1A/Hsp72.
+      This is therefore a paralog/evidence mismatch for HSPA1A.
+    action: REMOVE
+    reason: >-
+      The cited rotavirus receptor evidence does not establish HSPA1A-specific
+      symbiont entry activity; it should not be retained for HSPA1A without
+      HSPA1A-specific support.
 - term:
     id: GO:0000166
     label: nucleotide binding
@@ -221,12 +231,15 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: UniProt directly annotates HSPA1A as a receptor for rotavirus A based on PMID:16537599. The
-      peptide-binding and ATPase domains of Hsp70 are required for rotavirus interaction and infectivity
-      reduction.
-    action: KEEP_AS_NON_CORE
-    reason: Virus receptor activity is experimentally supported for rotavirus A entry (PMID:16537599)
-      but is a non-core function unrelated to HSPA1A's primary chaperone role.
+    summary: >-
+      The rotavirus receptor evidence cited for this annotation is PMID:16537599,
+      but the local UniProt citation identifies the tested protein as recombinant
+      hsc70 rather than HSPA1A/Hsp72. The annotation therefore appears to transfer
+      an HSPA8/Hsc70-related observation onto HSPA1A.
+    action: REMOVE
+    reason: >-
+      Virus receptor activity is not supported by HSPA1A-specific evidence in the
+      available local citation and should not be retained for HSPA1A.
 - term:
     id: GO:0001664
     label: G protein-coupled receptor binding
@@ -538,11 +551,14 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: HSPA1A hydrolyzes ATP as part of its chaperone cycle. The ATP metabolic process annotation
-      broadly captures the ATPase activity. Confirmed by IDA (PMID:23921388, PMID:21231916).
-    action: ACCEPT
-    reason: ATP metabolic process is accurate as HSPA1A has intrinsic ATPase activity. Broader than GO:0016887
-      (ATP hydrolysis activity) but acceptable.
+    summary: >-
+      HSPA1A hydrolyzes ATP as part of its chaperone cycle, but ATP metabolic
+      process is a broad biological-process term. The actual molecular activity
+      is captured by ATP hydrolysis activity and ATP-dependent chaperone terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      This broad BP term is less informative than the molecular-function terms
+      describing HSPA1A's ATPase-driven chaperone cycle.
 - term:
     id: GO:0048471
     label: perinuclear region of cytoplasm
@@ -704,12 +720,18 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: HSPA1A has ATP-dependent protein disaggregase activity. Jakobsson et al. (2013) showed METTL21A-mediated
-      trimethylation of Hsp70 modulates its chaperone function including effects on alpha-synuclein disaggregation
-      (PMID:23921388). Hsp70 disaggregase activity is well-established in the Hsp70/Hsp110/Hsp40 system.
-    action: ACCEPT
-    reason: ATP-dependent protein disaggregase activity is a core molecular function of HSPA1A, operating
-      in concert with Hsp110 and Hsp40 co-chaperones. Confirmed by IDA (PMID:23921388).
+    summary: >-
+      This ARBA inference cites PMID:23921388, but the local paper describes
+      METTL21A methylation and altered HSPA8/Hsc70 affinity for alpha-synuclein,
+      not direct HSPA1A ATP-dependent disaggregase activity. HSP70-family
+      disaggregation can require HSP110/HSP40 systems, but this evidence does not
+      establish HSPA1A-specific disaggregase activity.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      The annotation overextends family-level proteostasis biology and HSPA8-focused
+      evidence to HSPA1A. HSPA1A's accepted core role should remain ATP-dependent
+      folding/refolding and client triage unless direct HSPA1A disaggregase evidence
+      is available.
     supported_by:
     - reference_id: PMID:23921388
       supporting_text: we show that trimethylation of HSPA8 (Hsc70) has functional consequences, as it
@@ -1018,12 +1040,14 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:23921388
   review:
-    summary: Jakobsson et al. (2013) showed METTL21A-mediated trimethylation of Hsp70 modulates its chaperone
-      function, altering affinity for monomeric and fibrillar alpha-synuclein (PMID:23921388). The disaggregase
-      activity is a core function of the Hsp70/Hsp110/Hsp40 chaperone system.
-    action: ACCEPT
-    reason: ATP-dependent protein disaggregase activity is a core molecular function of HSPA1A. Confirmed
-      by IDA (PMID:23921388).
+    summary: >-
+      PMID:23921388 shows METTL21A-mediated methylation effects on HSPA8/Hsc70
+      binding to alpha-synuclein, not direct HSPA1A disaggregase activity.
+      The evidence is therefore mismatched for an HSPA1A IDA annotation.
+    action: REMOVE
+    reason: >-
+      The cited IDA evidence does not support HSPA1A-specific ATP-dependent protein
+      disaggregase activity and should not be accepted for this gene.
     supported_by:
     - reference_id: PMID:23921388
       supporting_text: trimethylation of HSPA8 (Hsc70) has functional consequences, as it alters the affinity
@@ -2678,11 +2702,14 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:23921388
   review:
-    summary: Jakobsson et al. (2013) showed METTL21A-mediated methylation is stimulated by ATP, confirming
-      Hsp70 ATPase function (PMID:23921388).
-    action: ACCEPT
-    reason: ATP metabolic process confirmed by IDA (PMID:23921388). Consistent with already-accepted IEA
-      annotation.
+    summary: >-
+      PMID:23921388 describes METTL21A methylation assays and HSPA8/Hsc70
+      functional effects, not HSPA1A-specific ATP metabolic process.
+    action: REMOVE
+    reason: >-
+      The cited IDA evidence does not support a broad HSPA1A ATP metabolic
+      process annotation; ATP use is better captured by ATPase/chaperone
+      molecular-function annotations.
 - term:
     id: GO:0048471
     label: perinuclear region of cytoplasm
@@ -2789,23 +2816,16 @@ core_functions:
     supporting_text: >-
       chaperones that supported luciferase refolding were poor suppressors of polyQ
       aggregation
-- molecular_function:
-    id: GO:0140545
-    label: ATP-dependent protein disaggregase activity
-  description: >-
-    HSPA1A works with DNAJ co-chaperones and HSPH1 nucleotide exchange factor to
-    solubilize and disaggregate protein aggregates. This disaggregase activity uses
-    the same ATP hydrolysis cycle as the foldase function but is directed toward
-    pre-formed aggregates rather than nascent or stress-denatured monomers. This
-    function is important for preventing accumulation of toxic protein aggregates
-    and inclusion bodies under stress conditions.
-  directly_involved_in:
-  - id: GO:0090084
-    label: negative regulation of inclusion body assembly
-  locations:
-  - id: GO:0005829
-    label: cytosol
+  - reference_id: file:human/HSPA1A/HSPA1A-deep-research-falcon.md
+    supporting_text: >-
+      HSPA1A encodes the inducible cytosolic Hsp70-1A that, via a conserved ATPase
+      cycle governed by J-proteins and nucleotide exchange factors, binds hydrophobic
+      client segments to maintain proteostasis and interface with degradation and
+      autophagy pathways.
 references:
+- id: file:human/HSPA1A/HSPA1A-deep-research-falcon.md
+  title: Falcon deep research report for HSPA1A
+  findings: []
 - id: GO_REF:0000024
   title: Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator
     judgment of sequence similarity

--- a/genes/human/HSPA1B/HSPA1B-ai-review.html
+++ b/genes/human/HSPA1B/HSPA1B-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>HSPA1B</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P0DMV9" target="_blank" class="term-link">
                         P0DMV9
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>HSPA1B (Heat shock 70 kDa protein 1B, also known as HSP72/HSP70-2) encodes a stress-inducible member of the HSP70 molecular chaperone family. The protein encoded by HSPA1B is &gt;99% identical to HSPA1A (HSP70-1) and functions as an ATP-dependent foldase chaperone. It has the conserved tripartite HSP70 architecture: an N-terminal nucleotide-binding domain (NBD/ATPase, residues 2-386), a C-terminal substrate-binding domain (SBD) that engages client polypeptides via exposed hydrophobic segments, and a C-terminal tail mediating co-chaperone interactions (DOI:10.3390/biom13020272). HSPA1B plays a pivotal role in the protein quality control system, assisting in the correct folding of newly synthesized polypeptides, refolding of misfolded proteins, prevention of protein aggregation, and targeting of terminally misfolded proteins for proteasomal degradation. Its chaperone cycle is regulated by co-chaperones including J-domain proteins (HSP40s/DNAJs) that stimulate ATP hydrolysis and assist substrate recognition, nucleotide exchange factors (BAG1/2/3, HSPH1), and TPR domain co-chaperones (HOPX, STUB1/CHIP) (DOI:10.3390/biom13020272). Stress-induced expression can reach very high levels, reported up to approximately 15% of total cellular protein (DOI:10.3390/biom13020272). Beyond its intracellular roles, HSPA1B is also found on the plasma membrane and in extracellular vesicles (exosomes), where it can be actively secreted via non-classical pathways including secretory granules, ABC transporter-mediated endolysosomal translocation, and exosome/ectosome release (DOI:10.3389/fonc.2024.1388999). Membrane- associated HSPA1B binds negatively charged phospholipids (especially phosphatidylserine), oligomerizes upon membrane insertion, and exposes a defined extracellular epitope (TKD peptide, aa450-461) detectable by cmHSP70.1 antibody (DOI:10.3390/biom13040604). HSPA1B also participates in centrosome function during mitosis, regulation of apoptosis, and various signaling pathways including NF-kappaB and NOD2 signaling.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,64 +795,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSP70/HSPA1B localizes to the nucleus under stress conditions. IDA evidence from PMID:10205060 and PMID:17167422 confirms nuclear localization. UniProt notes HSPA1B translocates to the nucleus during heat shock, where it participates in mRNA decay regulation and erythropoiesis-related functions. Reactome entries describe HSP70 nuclear transport via Hikeshi (R-HSA-5252041) and nuclear roles in HSF1 regulation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Well-supported by phylogenetic inference and confirmed by multiple IDA annotations. HSPA1B is known to shuttle between cytoplasm and nucleus, particularly under stress conditions.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10205060" target="_blank" class="term-link">
                                         PMID:10205060
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Induction of hsp70 by heat shock, down-regulation of the ubiquitin-proteasome network, or inactivation of ubiquitinating enzyme E1 all result in hsp70 sequestration of AUF1 in the perinucleus-nucleus</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -864,46 +864,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1B is predominantly cytoplasmic under basal conditions. UniProt lists cytoplasm as a primary subcellular location (ECO:0000269|PubMed:17289661). Multiple IDA annotations confirm cytoplasmic localization (PMID:10859165, PMID:24061851, PMID:9553041, PMID:24790089).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization for HSPA1B, well-supported by IBA and multiple IDA annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -915,46 +915,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Phylogenetic inference places HSPA1B at the plasma membrane. HSP70 family members have been reported at the cell surface in some contexts, including as a receptor for rotavirus A entry (PMID:16537599, referenced in UniProt). This is consistent with the IBA annotation.
+                            <strong>Summary:</strong> Phylogenetic inference places HSPA1B at the plasma membrane. HSP70 family members have been reported at the cell surface in some contexts, including extracellular HSP70 signaling and membrane-associated chaperone pools. The rotavirus receptor citation is not used as HSPA1B-specific support because the local UniProt citation describes recombinant hsc70.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Plasma membrane localization is not a core feature of HSPA1B function but is phylogenetically supported and consistent with some reported activities such as virus receptor function.
+                            <strong>Reason:</strong> Plasma membrane localization is not a core feature of HSPA1B function but is phylogenetically plausible and consistent with cell-surface HSP70-family observations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -966,64 +966,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> ATP hydrolysis is the central enzymatic activity of HSP70 chaperones. HSPA1B has a well-characterized N-terminal ATPase domain (NBD, residues 2-386) with multiple ATP binding sites confirmed by X-ray crystallography. IDA evidence from PMID:21231916 directly demonstrates ATPase activity, and Reactome entry R-HSA-3371422 describes ATP hydrolysis by HSP70 in detail.
+                            <strong>Summary:</strong> ATP hydrolysis is the central enzymatic activity of HSP70 chaperones. HSPA1B has a conserved N-terminal nucleotide-binding/ATPase domain. The available HSPA1A/HSPA6-specific PMID:21231916 evidence should not be treated as direct HSPA1B evidence, but the IBA inference is consistent with conserved HSP70 family mechanism and Reactome HSP70 ATP-hydrolysis models.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core molecular function of HSPA1B. ATP hydrolysis drives the chaperone cycle and is essential for all HSP70 functions.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
-                                        PMID:21231916
-                                    </a>
-                                    
+
+                                    file:human/HSPA1B/HSPA1B-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">HSPA6 has a functional substrate-binding domain and possesses intrinsic ATPase activity that is as high as that of the canonical HSPA1A when stimulated by J-proteins.</div>
-                                
+
+                                <div class="support-text">HSPA1B is a stress-inducible HSP70 paralog with conserved ATP-dependent chaperone architecture, while isoform-specific claims require caution.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
                                     GO:0031072
                                 </a>
                             </span>
                             <span class="term-label">heat shock protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1035,46 +1033,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1B interacts with numerous heat shock proteins including HSP40/DNAJ co-chaperones (DNAJC7, DNAJC8, DNAJC9, DNAJB1), HSP90, and HSP110/HSPH1. These interactions are essential for the chaperone cycle. IPI evidence from PMID:17182002, PMID:21231916, and PMID:23921388 confirms these interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core function. HSP70 co-chaperone interactions are fundamental to the chaperone cycle and are well-supported by both phylogenetic and experimental evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     GO:0044183
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1086,64 +1084,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> HSPA1B is a bona fide ATP-dependent protein folding chaperone. This is the core molecular function annotation for this gene. IDA evidence from PMID:15603737 directly demonstrates chaperone activity. UniProt describes HSPA1B as a &#34;Molecular chaperone implicated in a wide variety of cellular processes, including protection of the proteome from stress, folding and transport of newly synthesized polypeptides.&#34;
+                            <strong>Summary:</strong> HSPA1B is a bona fide ATP-dependent protein folding chaperone. This is the core molecular function annotation for this gene, supported by HSP70-family phylogenetic inference and conserved domain architecture. UniProt describes HSPA1B as a &#34;Molecular chaperone implicated in a wide variety of cellular processes, including protection of the proteome from stress, folding and transport of newly synthesized polypeptides.&#34;
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> The defining molecular function of HSPA1B. Well-supported by both phylogenetic inference and direct experimental evidence.
+                            <strong>Reason:</strong> The defining molecular function of HSPA1B, well-supported by phylogenetic inference and conserved HSP70 chaperone architecture.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
-                                        PMID:21231916
-                                    </a>
-                                    
+
+                                    file:human/HSPA1B/HSPA1B-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">whereas overexpression of HSPA1A protected cells from heat-induced cell death, overexpression of HSPA6 did not</div>
-                                
+
+                                <div class="support-text">HSPA1B is a stress-inducible Hsp70 paralog with a core proteostasis role, while many HSP70/HSP72 studies do not distinguish it cleanly from HSPA1A.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1155,46 +1151,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol is the primary subcellular compartment where HSPA1B exerts its chaperone function. Confirmed by IDA (GO_REF:0000052, PMID:21231916) and multiple Reactome TAS annotations describing cytosolic chaperone activities.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization for HSPA1B chaperone function in the cytosol.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1206,64 +1202,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Protein refolding is a core biological process for HSPA1B. IDA evidence from PMID:21231916 and PMID:15603737 demonstrates luciferase refolding activity. PMID:27708256 shows that acetylation state determines whether HSPA1B functions in protein refolding vs degradation.
+                            <strong>Summary:</strong> Protein refolding is a core biological process inferred for HSPA1B from conserved HSP70-family chaperone architecture and IBA evidence. Local HSPA1A/HSPA6-specific assays should not be treated as direct HSPA1B evidence; HSPA1B-specific claims require caution.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core biological process. HSPA1B actively refolds heat-denatured substrates through its ATP-dependent chaperone cycle.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
-                                        PMID:21231916
-                                    </a>
-                                    
+
+                                    file:human/HSPA1B/HSPA1B-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                                
+
+                                <div class="support-text">HSPA1B is a major stress-inducible HSP70 protein with central roles in proteostasis, but many HSP70/HSP72 studies do not distinguish it cleanly from HSPA1A.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032436" target="_blank" class="term-link">
                                     GO:0032436
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of proteasomal ubiquitin-dependent protein catabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1275,97 +1269,97 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA1B participates in targeting misfolded proteins for proteasomal degradation through its interaction with STUB1/CHIP E3 ubiquitin ligase. PMID:27708256 shows that deacetylated HSP70 binds STUB1, promoting ubiquitin-mediated protein degradation. PMID:12150907 demonstrates the CHIP-Hsp70-Parkin complex facilitating ubiquitination.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core function of the HSP70 chaperone system. HSP70 triages substrates between refolding and degradation pathways, with STUB1/CHIP mediating the degradation arm.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046718" target="_blank" class="term-link">
                                     GO:0046718
                                 </a>
                             </span>
                             <span class="term-label">symbiont entry into host cell</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000108
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0046718" data-r="GO_REF:0000108" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0046718" data-r="GO_REF:0000108" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IEA annotation from logical inference. UniProt notes that HSPA1B serves as a post-attachment receptor for rotavirus A to facilitate entry into the cell (PMID:16537599). This is a specialized, non-core function.
+                            <strong>Summary:</strong> The source evidence for this rotavirus-entry inference is PMID:16537599, but the local UniProt citation describes recombinant hsc70 rather than HSPA1B. This is therefore a paralog/evidence mismatch for HSPA1B.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Supported by virus receptor activity documented in UniProt, but this is a secondary role exploited by pathogens rather than a core cellular function.
+                            <strong>Reason:</strong> The cited rotavirus receptor evidence does not establish HSPA1B-specific symbiont entry activity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000166" target="_blank" class="term-link">
                                     GO:0000166
                                 </a>
                             </span>
                             <span class="term-label">nucleotide binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1377,97 +1371,97 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from UniProt keyword mapping. HSPA1B binds ATP/ADP through its N-terminal NBD, confirmed by crystal structures and IDA evidence for ATP binding (PMID:23921388). This is a broad parent term of ATP binding.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Correct but very general. Subsumed by the more specific ATP binding annotation which is also present. Acceptable as an IEA broadening.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001618" target="_blank" class="term-link">
                                     GO:0001618
                                 </a>
                             </span>
                             <span class="term-label">virus receptor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0001618" data-r="GO_REF:0000043" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0001618" data-r="GO_REF:0000043" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IEA from UniProt keyword mapping for Host cell receptor for virus entry. UniProt documents that HSPA1B serves as a post-attachment receptor for rotavirus A (PMID:16537599).
+                            <strong>Summary:</strong> IEA from UniProt keyword mapping for host cell receptor for virus entry. The cited PMID:16537599 evidence in the local UniProt record describes recombinant hsc70 rather than HSPA1B.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Documented in UniProt but represents a non-core function exploited by viruses.
+                            <strong>Reason:</strong> Virus receptor activity is not supported by HSPA1B-specific evidence in the available local citation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001664" target="_blank" class="term-link">
                                     GO:0001664
                                 </a>
                             </span>
                             <span class="term-label">G protein-coupled receptor binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1479,46 +1473,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. IDA evidence from PMID:12150907 documents HSP70 interaction with Pael-R (an orphan GPCR). UniProt also records an interaction with F2RL1 (a GPCR). However, this binding is in the context of chaperone substrate recognition, not classical GPCR signaling.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While HSPA1B does bind GPCRs such as Pael-R, this is in the context of chaperone-substrate interaction, not GPCR-specific binding activity. The term implies a specific functional binding to GPCRs as signaling partners.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
                                     GO:0005524
                                 </a>
                             </span>
                             <span class="term-label">ATP binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1530,46 +1524,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from combined automated annotation. ATP binding is a core function of HSPA1B confirmed by crystal structures of the NBD domain with ADP/ATP and IDA evidence (PMID:23921388).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core molecular function. ATP binding drives the chaperone cycle.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1581,46 +1575,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from UniProt subcellular location mapping. Confirmed by multiple IDA annotations and IBA.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Correct and redundant with IBA and IDA annotations for this localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005813" target="_blank" class="term-link">
                                     GO:0005813
                                 </a>
                             </span>
                             <span class="term-label">centrosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1632,97 +1626,97 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from UniProt subcellular location. UniProt records centrosome localization (ECO:0000269|PubMed:27137183). IDA evidence from PMID:27137183 confirms HSP70 accumulates at the mitotic centrosome during prometaphase to metaphase.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Supported by experimental evidence. HSPA1B localizes to centrosomes during mitosis where it regulates centrosome integrity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005814" target="_blank" class="term-link">
                                     GO:0005814
                                 </a>
                             </span>
                             <span class="term-label">centriole</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0005814" data-r="GO_REF:0000117" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0005814" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IEA from ARBA models. IDA evidence from PMID:24061851 and GO_REF:0000052 confirms centriole localization of HSPA1A (functionally identical to HSPA1B) under stress conditions.
+                            <strong>Summary:</strong> IEA from ARBA models. The supporting experimental paper PMID:24061851 tested HSPA1A and HSPA6, not HSPA1B, so it does not provide direct HSPA1B-specific centriole-localization evidence.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Confirmed by IDA evidence showing stress-induced centriole localization.
+                            <strong>Reason:</strong> Centriole localization is plausible by paralog inference, but the cited experimental evidence is HSPA1A/HSPA6-specific. This should not be accepted as a supported HSPA1B localization without HSPA1B-specific data.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006402" target="_blank" class="term-link">
                                     GO:0006402
                                 </a>
                             </span>
                             <span class="term-label">mRNA catabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1734,46 +1728,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. Supported by IDA from PMID:10205060 which demonstrates that hsp70 participates in AU-rich element-mediated mRNA decay by sequestering AUF1 in the perinucleus-nucleus during heat shock.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While experimentally supported, mRNA catabolism is a secondary consequence of HSP70 chaperone activity on AUF1, not a core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008285" target="_blank" class="term-link">
                                     GO:0008285
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of cell population proliferation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1785,46 +1779,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. IMP evidence from PMID:9553041 shows that HSP70 association with WT1 is required for WT1-mediated inhibition of cell proliferation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimentally supported but represents a secondary, context-dependent function dependent on interaction with specific partners like WT1.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016235" target="_blank" class="term-link">
                                     GO:0016235
                                 </a>
                             </span>
                             <span class="term-label">aggresome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1836,46 +1830,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. IDA evidence from PMID:15885686 confirms aggresome localization. HSP70 chaperones are recruited to aggresomes as part of the protein quality control response.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Confirmed by IDA evidence. Aggresome localization is consistent with HSP70 role in protein quality control.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016607" target="_blank" class="term-link">
                                     GO:0016607
                                 </a>
                             </span>
                             <span class="term-label">nuclear speck</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1887,46 +1881,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. IDA evidence from PMID:9553041 confirms nuclear speck localization of HSP70.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimentally confirmed but represents a specific subnuclear localization that is not central to HSPA1B core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1938,46 +1932,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from combined automated annotation. Redundant with IBA and IDA annotations for the same term. Core function of HSPA1B.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Correct and consistent with IBA and IDA evidence for this core activity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030308" target="_blank" class="term-link">
                                     GO:0030308
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of cell growth</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1989,46 +1983,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. IMP evidence from PMID:9553041 shows HSP70 is required for WT1-mediated growth inhibition.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Context-dependent secondary function mediated through WT1 interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
                                     GO:0031072
                                 </a>
                             </span>
                             <span class="term-label">heat shock protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2040,46 +2034,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. Redundant with IBA and multiple IPI annotations for the same term. Well-supported by extensive co-chaperone interaction data.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Correct and consistent with IBA and IPI evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031397" target="_blank" class="term-link">
                                     GO:0031397
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of protein ubiquitination</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2091,46 +2085,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. IDA evidence from PMID:12150907 shows HSP70 participates in regulating ubiquitination of Pael-R in the CHIP-Parkin complex. HSP70 binding can shield substrates from ubiquitination.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimentally supported but represents a context-dependent regulatory outcome of chaperone activity rather than a core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031625" target="_blank" class="term-link">
                                     GO:0031625
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin protein ligase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2142,46 +2136,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. IPI evidence from PMID:12150907 and PMID:15603737 confirms binding to E3 ligases CHIP/STUB1, Parkin, and BAG5. This is a key part of the chaperone triage system.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core co-chaperone interaction. HSP70 binding to E3 ubiquitin ligases like STUB1/CHIP is integral to the protein quality control triage mechanism.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032757" target="_blank" class="term-link">
                                     GO:0032757
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of interleukin-8 production</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2193,46 +2187,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. IMP evidence from PMID:24790089 shows HSP70 involvement in NOD2-mediated NF-kappaB signaling, which leads to IL-8 production in response to bacterial cell wall fragments.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimentally supported but a downstream consequence of HSP70 stabilization of NOD2, not a core chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034599" target="_blank" class="term-link">
                                     GO:0034599
                                 </a>
                             </span>
                             <span class="term-label">cellular response to oxidative stress</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2244,46 +2238,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. TAS evidence from PMID:24252804 supports this annotation in the context of Parkinson disease pathogenesis.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSP70 is induced by and participates in oxidative stress response, but this is a general stress-responsive phenotype rather than a core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2295,46 +2289,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. Redundant with IBA and IDA annotations for the same term. Core function of HSPA1B.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Correct and consistent with IBA and multiple IDA annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042826" target="_blank" class="term-link">
                                     GO:0042826
                                 </a>
                             </span>
                             <span class="term-label">histone deacetylase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2346,46 +2340,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. IPI evidence from PMID:16809764 confirms interaction with HDAC8, and UniProt documents interaction with HDAC4 (PMID:27708256). HDAC4 deacetylates HSP70 at Lys-77 to regulate chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Confirmed by experimental evidence. HDAC binding is functionally relevant to regulation of HSP70 chaperone activity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     GO:0044183
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2397,46 +2391,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. Redundant with IBA and IDA for the same core molecular function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core molecular function, confirmed by multiple evidence types.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045648" target="_blank" class="term-link">
                                     GO:0045648
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of erythrocyte differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2448,97 +2442,97 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. IMP evidence from PMID:17167422 shows Hsp70 protects GATA-1 from caspase-3-mediated cleavage during erythropoiesis.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimentally supported but a tissue-specific downstream consequence of HSP70 anti-apoptotic activity rather than a core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046034" target="_blank" class="term-link">
                                     GO:0046034
                                 </a>
                             </span>
                             <span class="term-label">ATP metabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0046034" data-r="GO_REF:0000117" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0046034" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IEA from ARBA models. IDA evidence from PMID:23921388 supports this. HSPA1B hydrolyzes ATP as part of its chaperone cycle.
+                            <strong>Summary:</strong> HSPA1B hydrolyzes ATP as part of its chaperone cycle, but ATP metabolic process is a broad biological-process term. The actual molecular activity is captured by ATP hydrolysis activity and ATP-dependent chaperone terms.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Correct. ATP metabolic process is an inherent aspect of the ATPase-driven chaperone cycle.
+                            <strong>Reason:</strong> This broad BP term is less informative than the molecular-function terms describing HSPA1B&#39;s ATPase-driven chaperone cycle.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048471" target="_blank" class="term-link">
                                     GO:0048471
                                 </a>
                             </span>
                             <span class="term-label">perinuclear region of cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2550,46 +2544,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. IDA evidence from PMID:10205060 and PMID:15603737 confirms perinuclear localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Confirmed by IDA evidence. Perinuclear localization is observed particularly during stress conditions.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                     GO:0050821
                                 </a>
                             </span>
                             <span class="term-label">protein stabilization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2601,46 +2595,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. TAS evidence from PMID:24252804 supports this. PMID:24790089 directly demonstrates HSP70 stabilizes NOD2 by increasing its half-life. UniProt also describes HSP70 stabilization of ATF5 (PMID:22528486).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Well-supported function. HSP70 chaperone activity inherently stabilizes client proteins, preventing misfolding and degradation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -2652,75 +2646,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962). This IEA annotation from ARBA machine learning models reflects the well-known ability of HSP70 chaperones to bind unfolded/misfolded proteins as substrates, but the term conflates substrate binding with the chaperone activity itself. HSPA1B is a bona fide ATP-dependent foldase chaperone that actively assists protein folding through iterative cycles of ATP hydrolysis, substrate binding, and release (PMID:21231916, PMID:24012426). The correct molecular function annotation is GO:0044183 (protein folding chaperone), which already has both IBA and IDA support for this gene product. UniProt describes HSPA1B as a &#34;Molecular chaperone implicated in a wide variety of cellular processes, including protection of the proteome from stress, folding and transport of newly synthesized polypeptides&#34; (UniProt:P0DMV9).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. HSPA1B does not merely bind unfolded proteins passively; it is an active ATP-dependent protein folding chaperone. The replacement term GO:0044183 (protein folding chaperone) accurately captures the molecular function and is already annotated to HSPA1B via IBA (GO_REF:0000033) and IDA (PMID:15603737) evidence.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0055131" target="_blank" class="term-link">
                                     GO:0055131
                                 </a>
                             </span>
                             <span class="term-label">C3HC4-type RING finger domain binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2732,97 +2726,97 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. IPI evidence from PMID:25281747 confirms interaction with RNF207, a RING finger protein. HSP70 also interacts with CHIP/STUB1 which contains a U-box domain related to RING fingers.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Confirmed by experimental evidence for binding to RING domain proteins.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070370" target="_blank" class="term-link">
                                     GO:0070370
                                 </a>
                             </span>
                             <span class="term-label">cellular heat acclimation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0070370" data-r="GO_REF:0000117" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0070370" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IEA from ARBA models. IMP evidence from PMID:21231916 confirms that HSPA1A (functionally identical to HSPA1B) protects cells from heat-induced cell death and is involved in thermotolerance.
+                            <strong>Summary:</strong> IEA from ARBA models. HSPA1B is a stress-inducible HSP70 paralog, but PMID:21231916 directly reports HSPA1A protection from heat-induced cell death and warns that HSPA-family functional differences can be larger than expected. The evidence should not be treated as HSPA1B-specific proof of heat acclimation.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Core stress-response function. HSPA1B is heat-inducible and protects cells during heat stress.
+                            <strong>Reason:</strong> HSPA1B likely participates in heat-stress proteostasis as an inducible HSP70, but the cited direct evidence is paralog-specific to HSPA1A/HSPA6. Keep this as non-core rather than accepting it as a demonstrated HSPA1B heat-acclimation function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070434" target="_blank" class="term-link">
                                     GO:0070434
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of nucleotide-binding oligomerization domain containing 2 signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2834,46 +2828,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. IMP evidence from PMID:24790089 confirms that HSP70 binds and stabilizes NOD2, enhancing NOD2-mediated signaling in response to bacterial cell wall fragments.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimentally supported but represents a specific downstream signaling consequence of HSP70 chaperone activity on NOD2, not a core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071383" target="_blank" class="term-link">
                                     GO:0071383
                                 </a>
                             </span>
                             <span class="term-label">cellular response to steroid hormone stimulus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2885,46 +2879,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. TAS evidence from Reactome R-HSA-3371497 documents HSP70 role in the HSP90 chaperone cycle for steroid hormone receptors. HSP70 participates in the maturation of steroid hormone receptor complexes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSP70 participates in steroid hormone receptor maturation as part of the HSP70/HSP90 chaperone relay, but this is a general chaperone function rather than a specific steroid hormone response.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090063" target="_blank" class="term-link">
                                     GO:0090063
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of microtubule nucleation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2936,46 +2930,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. IMP evidence from PMID:27137183 confirms HSP70 is required for microtubule nucleation from the mitotic centrosome, interacting with NEDD1 and gamma-tubulin.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimentally supported centrosome-related function during mitosis but not a core chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090084" target="_blank" class="term-link">
                                     GO:0090084
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of inclusion body assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2987,97 +2981,97 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. IDA evidence from PMID:21231916 and PMID:15603737 confirms HSPA1B suppresses protein aggregation and inclusion body formation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core chaperone function. Preventing protein aggregation and inclusion body formation is a direct consequence of HSP70 foldase activity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140545" target="_blank" class="term-link">
                                     GO:0140545
                                 </a>
                             </span>
                             <span class="term-label">ATP-dependent protein disaggregase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0140545" data-r="GO_REF:0000117" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0140545" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IEA from ARBA models. IDA evidence from PMID:23921388 confirms disaggregase activity. HSP70 works with co-chaperones to disaggregate and refold aggregated proteins.
+                            <strong>Summary:</strong> IEA from ARBA models. PMID:23921388 describes METTL21A methylation and altered HSPA8/Hsc70 affinity for alpha-synuclein, not direct HSPA1B ATP-dependent disaggregase activity. The HSP70/HSP110/HSP40 system can participate in disaggregation, but this evidence is not HSPA1B-specific.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Core molecular function. HSP70 disaggregase activity is well-established and directly related to its protein quality control role.
+                            <strong>Reason:</strong> This overextends family-level disaggregation biology and HSPA8-focused evidence to HSPA1B. HSPA1B&#39;s core role should be represented as ATP-dependent folding/refolding unless direct HSPA1B disaggregase evidence is available.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1901673" target="_blank" class="term-link">
                                     GO:1901673
                                 </a>
                             </span>
                             <span class="term-label">regulation of mitotic spindle assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3089,46 +3083,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. IMP evidence from PMID:27137183 shows HSP70 is required for bipolar spindle assembly, and its inhibition disrupts spindle formation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimentally supported but represents a specific mitotic function rather than the core chaperone activity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1903265" target="_blank" class="term-link">
                                     GO:1903265
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of tumor necrosis factor-mediated signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3140,46 +3134,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. IMP evidence from PMID:24790089 supports HSP70 involvement in inflammatory signaling through NOD2 stabilization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimentally supported downstream effect of HSP70 chaperone activity on innate immune signaling components.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1904813" target="_blank" class="term-link">
                                     GO:1904813
                                 </a>
                             </span>
                             <span class="term-label">ficolin-1-rich granule lumen</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3191,46 +3185,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. TAS evidence from Reactome R-HSA-6800434 (exocytosis of ficolin-rich granule lumen proteins) supports this localization in neutrophils.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cell-type-specific localization in neutrophils, supported by Reactome but not a core localization for HSPA1B.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990904" target="_blank" class="term-link">
                                     GO:1990904
                                 </a>
                             </span>
                             <span class="term-label">ribonucleoprotein complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3242,46 +3236,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. IDA evidence from PMID:17289661 confirms HSPA1B is a component of IGF2BP1 (IMP1) mRNP granules containing untranslated mRNAs. UniProt notes this localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Confirmed by mass spectrometry identification in mRNP granule complex.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:2001240" target="_blank" class="term-link">
                                     GO:2001240
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of extrinsic apoptotic signaling pathway in absence of ligand</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3293,57 +3287,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA from ARBA models. IMP evidence from PMID:17167422 shows Hsp70 protects GATA-1 from caspase-3 cleavage, preventing apoptosis during erythropoiesis.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimentally supported anti-apoptotic function but represents a specific downstream effect of HSP70 chaperone activity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28298427" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28298427
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Systematic protein-protein interaction mapping for clinicall...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -3355,57 +3349,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding from systematic GPCR-protein interaction mapping. HSPA1B binds many proteins as a chaperone; protein binding is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 protein binding is uninformative for a molecular chaperone that interacts with hundreds of substrates and co-chaperones. More specific binding terms are already annotated.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043123" target="_blank" class="term-link">
                                     GO:0043123
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of canonical NF-kappaB signal transduction</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24790089" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24790089
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The molecular chaperone HSP70 binds to and stabilizes NOD2, ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3417,75 +3411,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:24790089 demonstrates that HSP70 stabilizes NOD2, and an HSP70 inhibitor (KNK437) decreases NOD2-mediated NF-kappaB activation in response to bacterial cell wall stimulation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimentally well-supported but a downstream consequence of HSP70 stabilization of NOD2 rather than a core chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24790089" target="_blank" class="term-link">
                                         PMID:24790089
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">an HSP70 inhibitor, KNK437, was capable of decreasing NOD2-mediated NF-kappaB activation in response to bacterial cell wall stimulation</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070434" target="_blank" class="term-link">
                                     GO:0070434
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of nucleotide-binding oligomerization domain containing 2 signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24790089" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24790089
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The molecular chaperone HSP70 binds to and stabilizes NOD2, ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3497,64 +3491,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:24790089 shows induced HSP70 expression increases NOD2 response to bacterial cell wall fragments by stabilizing NOD2 protein.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimentally well-supported. HSP70 enhances NOD2 signaling by increasing NOD2 stability, but this is a secondary consequence of chaperone activity.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24790089" target="_blank" class="term-link">
                                         PMID:24790089
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Induced HSP70 expression in cells increased the response of NOD2 to bacterial cell wall fragments.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005814" target="_blank" class="term-link">
                                     GO:0005814
                                 </a>
                             </span>
                             <span class="term-label">centriole</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3566,46 +3560,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA from immunofluorescence curation. HSPA1B localizes to centrioles under stress conditions, consistent with its role in centrosome integrity during mitosis (PMID:24061851, PMID:27137183).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Confirmed by immunofluorescence data and consistent with published literature on HSP70 centrosome function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3617,46 +3611,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA from immunofluorescence curation confirming cytosolic localization. Core localization for HSPA1B.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization confirmed by immunofluorescence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071383" target="_blank" class="term-link">
                                     GO:0071383
                                 </a>
                             </span>
                             <span class="term-label">cellular response to steroid hormone stimulus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371497
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3668,46 +3662,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Reactome describing HSP90 chaperone cycle for steroid hormone receptors, in which HSP70 participates by delivering client proteins to the HSP90 complex via HOP/STIP1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSP70 participates in steroid hormone receptor maturation as part of the HSP70-HSP90 relay system, but this is a general chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371422
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3719,57 +3713,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Reactome entry R-HSA-3371422 describing ATP hydrolysis by HSP70. Core molecular function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core molecular function, consistent with IBA and IDA annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33857403" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33857403
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     DNAJC9 integrates heat shock molecular chaperones into the h...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -3781,199 +3775,199 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:33857403 demonstrates DNAJC9 interacts with HSP70 to integrate heat shock chaperones into the histone chaperone network. The specific interaction is with DNAJC9 via J domain.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 protein binding is uninformative. The specific interaction with DNAJC9 is better captured by heat shock protein binding (GO:0031072).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140545" target="_blank" class="term-link">
                                     GO:0140545
                                 </a>
                             </span>
                             <span class="term-label">ATP-dependent protein disaggregase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23921388
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of a novel human methylt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0140545" data-r="PMID:23921388" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0140545" data-r="PMID:23921388" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> PMID:23921388 characterizes METTL21A methylation of HSP70 and shows that methylation alters chaperone affinity for alpha-synuclein fibrils. The disaggregase activity is a well-established function of HSP70 chaperones.
+                            <strong>Summary:</strong> PMID:23921388 characterizes METTL21A methylation and altered HSPA8/Hsc70 affinity for alpha-synuclein fibrils. It does not provide direct HSPA1B ATP-dependent protein disaggregase evidence.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Core molecular function. HSP70 disaggregase activity is integral to protein quality control.
+                            <strong>Reason:</strong> The cited IDA evidence is mismatched for HSPA1B and should not be accepted as HSPA1B-specific disaggregase activity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0016887" data-r="PMID:21231916" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0016887" data-r="PMID:21231916" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> PMID:21231916 directly demonstrates intrinsic ATPase activity of HSPA1A (functionally identical to HSPA1B) that is stimulated by J-protein co-chaperones. Core molecular function.
+                            <strong>Summary:</strong> PMID:21231916 directly demonstrates J-protein-stimulated intrinsic ATPase activity for HSPA1A and HSPA6, but it does not provide direct HSPA1B-specific ATPase evidence.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Core molecular function with direct experimental evidence.
+                            <strong>Reason:</strong> The cited IDA evidence is paralog-specific and should not be accepted as direct HSPA1B ATP hydrolysis activity.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSPA6 has a functional substrate-binding domain and possesses intrinsic ATPase activity that is as high as that of the canonical HSPA1A when stimulated by J-proteins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17167422" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17167422
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Hsp70 regulates erythropoiesis by preventing caspase-3-media...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3985,57 +3979,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:17167422 shows Hsp70 localizes to the nucleus where it protects GATA-1 from caspase-3 cleavage during erythropoiesis.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear localization confirmed by direct assay in the context of erythropoiesis studies.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043066" target="_blank" class="term-link">
                                     GO:0043066
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of apoptotic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17167422" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17167422
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Hsp70 regulates erythropoiesis by preventing caspase-3-media...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4047,57 +4041,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:17167422 demonstrates Hsp70 prevents caspase-3-mediated cleavage of GATA-1, thereby inhibiting apoptosis during erythroid differentiation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Well-established anti-apoptotic function of HSP70 but represents a downstream consequence of chaperone activity rather than core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045648" target="_blank" class="term-link">
                                     GO:0045648
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of erythrocyte differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17167422" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17167422
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Hsp70 regulates erythropoiesis by preventing caspase-3-media...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4109,57 +4103,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:17167422 shows Hsp70 regulates erythropoiesis by preventing caspase-3-mediated cleavage of GATA-1, a key erythroid transcription factor.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimentally supported tissue-specific function but not a core chaperone activity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27133716" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27133716
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A novel nuclear DnaJ protein, DNAJC8, can suppress the forma...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -4171,57 +4165,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:27133716 shows DNAJC8 interacts with HSP70. This is a specific co-chaperone interaction better captured by heat shock protein binding.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 protein binding is uninformative. The DNAJC8 interaction is better captured by GO:0031072 (heat shock protein binding).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23349634" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23349634
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A newly uncovered group of distantly related lysine methyltr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -4233,57 +4227,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:23349634 identifies lysine methyltransferases that interact with molecular chaperones including HSP70. Protein binding is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 protein binding is uninformative for a chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
                                     GO:0032991
                                 </a>
                             </span>
                             <span class="term-label">protein-containing complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23349634" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23349634
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A newly uncovered group of distantly related lysine methyltr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4295,57 +4289,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:23349634 demonstrates HSP70 exists in complexes with lysine methyltransferases. HSP70 participates in many protein complexes as part of its chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSP70 is found in multiple protein complexes as part of its chaperone and co-chaperone machinery.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003723" target="_blank" class="term-link">
                                     GO:0003723
                                 </a>
                             </span>
                             <span class="term-label">RNA binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22658674" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22658674
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Insights into RNA biology from an atlas of mammalian mRNA-bi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4357,57 +4351,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:22658674 (Castello et al. 2012) is a large-scale mRNA interactome capture study identifying mRNA-binding proteins. HSPA1B was identified as an mRNA-binding protein. This is consistent with its role in mRNP granules (PMID:17289661).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> High-throughput data supports RNA binding. HSP70 association with mRNP granules is documented but RNA binding is not a core chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003723" target="_blank" class="term-link">
                                     GO:0003723
                                 </a>
                             </span>
                             <span class="term-label">RNA binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22681889" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22681889
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The mRNA-bound proteome and its global occupancy profile on ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4419,57 +4413,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:22681889 (Baltz et al. 2012) is another large-scale mRNA-bound proteome study confirming HSPA1B as an mRNA-associated protein.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent with other high-throughput data but RNA binding is not a core function of HSPA1B.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15671022" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15671022
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Heat shock protein 70 inhibits alpha-synuclein fibril format...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -4481,57 +4475,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:15671022 shows HSP70 binds alpha-synuclein prefibrillar species, inhibiting fibril formation. This reflects chaperone substrate binding.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 protein binding is uninformative. The alpha-synuclein interaction reflects chaperone substrate binding already captured by protein folding chaperone (GO:0044183).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18975920" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18975920
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interactions between Hsp70 and the hydrophobic core of alpha...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -4543,57 +4537,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:18975920 demonstrates Hsp70 interactions with alpha-synuclein hydrophobic core inhibit fibril assembly. Chaperone substrate binding.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 protein binding is uninformative for a molecular chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21081504" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21081504
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     ChChd3, an inner mitochondrial membrane protein, is essentia...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -4605,57 +4599,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:21081504 identifies interaction between HSPA1B and ChChd3/CHCHD3, an inner mitochondrial membrane protein. UniProt confirms this interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 protein binding is uninformative for a molecular chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9553041" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9553041
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Inhibition of cellular proliferation by the Wilms tumor supp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -4667,57 +4661,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:9553041 shows HSP70 interaction with WT1 is required for WT1-mediated growth inhibition.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 protein binding is uninformative for a molecular chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10205060" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10205060
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Control of mRNA decay by heat shock-ubiquitin-proteasome pat...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4729,75 +4723,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:10205060 shows hsp70 sequesters AUF1 in the perinucleus-nucleus during heat shock, confirming nuclear localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct experimental evidence for nuclear localization during stress.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10205060" target="_blank" class="term-link">
                                         PMID:10205060
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Induction of hsp70 by heat shock, down-regulation of the ubiquitin-proteasome network, or inactivation of ubiquitinating enzyme E1 all result in hsp70 sequestration of AUF1 in the perinucleus-nucleus</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10859165" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10859165
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Chaperone hsp27 inhibits translation during heat shock by bi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4809,57 +4803,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:10859165 documents cytoplasmic localization of HSP70 in the context of translation regulation during heat shock.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization confirmed by direct assay.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16130169" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16130169
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomics of human umbilical vein endothelial cells applied...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4871,119 +4865,119 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from proteomics study PMID:16130169 identifying HSPA1B among 162 proteins in human endothelial cells.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24061851" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24061851
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Stress-induced localization of HSPA6 (HSP70B&#39;) and HSPA1A (H...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0005737" data-r="PMID:24061851" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0005737" data-r="PMID:24061851" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> PMID:24061851 documents cytoplasmic and centriolar localization of HSPA1A (functionally identical to HSPA1B) under stress conditions.
+                            <strong>Summary:</strong> PMID:24061851 documents cytoplasmic and centriolar localization of HSPA1A and HSPA6 under stress conditions, not HSPA1B.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Core localization confirmed by direct assay.
+                            <strong>Reason:</strong> The cited IDA evidence does not support HSPA1B-specific cytoplasmic localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9553041" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9553041
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Inhibition of cellular proliferation by the Wilms tumor supp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4995,57 +4989,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:9553041 shows cytoplasmic localization of HSP70 in the context of WT1 interaction studies.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization confirmed by direct assay.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16130169" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16130169
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomics of human umbilical vein endothelial cells applied...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -5057,57 +5051,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from proteomics study. HSPA1B is primarily cytosolic but has been detected in mitochondrial fractions. UniProt lists mitochondrion as a TAS localization. HSP70 participates in mitochondrial protein import.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Supported by proteomics data but mitochondrial localization is not a primary site for HSPA1B. Note that HSPA9/mortalin is the dedicated mitochondrial HSP70.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
                                     GO:0005783
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16130169" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16130169
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomics of human umbilical vein endothelial cells applied...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -5119,57 +5113,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from proteomics study. HSPA1B has been detected in ER fractions. HSP70 participates in ER stress response and ERAD. Note that HSPA5/BiP is the dedicated ER HSP70.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Detected in ER fractions but HSPA1B is primarily cytosolic. HSPA5/BiP is the dedicated ER-resident HSP70.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006402" target="_blank" class="term-link">
                                     GO:0006402
                                 </a>
                             </span>
                             <span class="term-label">mRNA catabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10205060" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10205060
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Control of mRNA decay by heat shock-ubiquitin-proteasome pat...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -5181,75 +5175,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:10205060 directly demonstrates HSP70 role in AU-rich element-mediated mRNA decay through regulation of AUF1 localization and ubiquitination.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimentally well-supported but a secondary function of HSP70 rather than its core chaperone activity.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10205060" target="_blank" class="term-link">
                                         PMID:10205060
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Rapid decay involves AU-rich binding protein AUF1, which complexes with heat shock proteins hsc70-hsp70, translation initiation factor eIF4G, and poly(A) binding protein.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008285" target="_blank" class="term-link">
                                     GO:0008285
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of cell population proliferation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9553041" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9553041
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Inhibition of cellular proliferation by the Wilms tumor supp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -5261,57 +5255,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:9553041 shows HSP70 association with WT1 is required for WT1-mediated inhibition of cellular proliferation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Context-dependent secondary function mediated through WT1 interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016235" target="_blank" class="term-link">
                                     GO:0016235
                                 </a>
                             </span>
                             <span class="term-label">aggresome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15885686" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15885686
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TRIM37 defective in mulibrey nanism is a novel RING finger u...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5323,57 +5317,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:15885686 shows TRIM37 forms aggresomes that are chaperone-positive, indicating HSP70 recruitment to aggresomes. Consistent with HSP70 role in protein quality control at aggresomes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct evidence for aggresome localization, consistent with protein quality control function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016607" target="_blank" class="term-link">
                                     GO:0016607
                                 </a>
                             </span>
                             <span class="term-label">nuclear speck</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9553041" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9553041
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Inhibition of cellular proliferation by the Wilms tumor supp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -5385,57 +5379,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:9553041 shows HSP70 localization to nuclear speckles in the context of WT1 interaction studies.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimentally confirmed but a specific subnuclear localization that is context-dependent.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030308" target="_blank" class="term-link">
                                     GO:0030308
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of cell growth</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9553041" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9553041
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Inhibition of cellular proliferation by the Wilms tumor supp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -5447,57 +5441,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:9553041 demonstrates HSP70 is required for WT1-mediated growth inhibition.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Context-dependent secondary function mediated through WT1 interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031982" target="_blank" class="term-link">
                                     GO:0031982
                                 </a>
                             </span>
                             <span class="term-label">vesicle</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19190083" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19190083
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Characterization of exosome-like vesicles released from huma...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -5509,57 +5503,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:19190083 characterizes exosome-like vesicles from human tracheobronchial ciliated epithelium, identifying HSPA1B.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> High-throughput proteomics data. Vesicle localization is a secondary feature, not core localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043066" target="_blank" class="term-link">
                                     GO:0043066
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of apoptotic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16130169" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16130169
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomics of human umbilical vein endothelial cells applied...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -5571,57 +5565,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from proteomics study describing HSPA1B in context of endothelial cell resistance to etoposide-induced apoptosis.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Anti-apoptotic function is well-established for HSP70 but represents a downstream consequence of chaperone activity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048471" target="_blank" class="term-link">
                                     GO:0048471
                                 </a>
                             </span>
                             <span class="term-label">perinuclear region of cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10205060" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10205060
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Control of mRNA decay by heat shock-ubiquitin-proteasome pat...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5633,75 +5627,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:10205060 demonstrates that hsp70 sequesters AUF1 in the perinucleus-nucleus during heat shock, confirming perinuclear localization of HSP70 by direct assay.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Confirmed by direct experimental evidence. Perinuclear localization is observed during stress conditions when HSP70 participates in mRNA decay regulation through AUF1 sequestration.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10205060" target="_blank" class="term-link">
                                         PMID:10205060
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Induction of hsp70 by heat shock, down-regulation of the ubiquitin-proteasome network, or inactivation of ubiquitinating enzyme E1 all result in hsp70 sequestration of AUF1 in the perinucleus-nucleus</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16130169" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16130169
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomics of human umbilical vein endothelial cells applied...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -5713,86 +5707,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962). This TAS annotation references PMID:16130169 (Bruneel et al. 2005), a proteomics study of human umbilical vein endothelial cells during etoposide-induced apoptosis. The study identified HSPA1B among 162 proteins and discusses functions related to &#34;protein folding&#34; in the context of endothelial cell biology. The paper does not specifically characterize HSPA1B unfolded protein binding activity but rather identifies it in the context of broader chaperone-related functions. HSPA1B is a well-established ATP-dependent foldase chaperone and the correct molecular function term is GO:0044183 (protein folding chaperone).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. The referenced paper (PMID:16130169) is a proteomics study that does not specifically demonstrate unfolded protein binding activity for HSPA1B but identifies it among proteins with chaperone-related functions. HSPA1B is an established protein folding chaperone whose primary molecular function is actively assisting protein folding through ATP-dependent cycles, not merely binding unfolded substrates. The replacement term GO:0044183 is already supported by direct experimental evidence (IDA, PMID:15603737) and phylogenetic inference (IBA, GO_REF:0000033).
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16130169" target="_blank" class="term-link">
                                         PMID:16130169
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The overall functional characterization of the 162 identified proteins from primary cultures of HUVECs confirms the metabolic capabilities of endothelium and illustrates various cellular functions more related to cell motility and angiogenesis, protein folding, anti-oxidant defenses, signal transduction, proteasome pathway and resistance to apoptosis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
                                     GO:0070062
                                 </a>
                             </span>
                             <span class="term-label">extracellular exosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19199708" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19199708
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomic analysis of human parotid gland exosomes by multid...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -5804,57 +5798,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:19199708 is a proteomic analysis of human parotid gland exosomes identifying HSPA1B among exosome proteins. HSP70 is a commonly identified exosomal protein, consistent with extracellular release as described in reviews of eHsp70 biology.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> High-throughput proteomics data. Exosomal localization of HSP70 is well-documented but represents a non-core secondary localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
                                     GO:0070062
                                 </a>
                             </span>
                             <span class="term-label">extracellular exosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20458337" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20458337
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     MHC class II-associated proteins in B-cell exosomes and pote...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -5866,57 +5860,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:20458337 identifies MHC class II-associated proteins in B-cell exosomes, including HSPA1B. Consistent with known exosomal release of HSP70 family members.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> High-throughput proteomics data. Exosomal localization is a secondary, non-core feature of HSPA1B.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
                                     GO:0070062
                                 </a>
                             </span>
                             <span class="term-label">extracellular exosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23533145
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     In-depth proteomic analyses of exosomes isolated from expres...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -5928,57 +5922,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:23533145 identifies HSPA1B in exosomes isolated from expressed prostatic secretions in urine. Consistent with known exosomal HSP70 release from various cell types.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> High-throughput proteomics data. Exosomal localization is non-core.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990904" target="_blank" class="term-link">
                                     GO:1990904
                                 </a>
                             </span>
                             <span class="term-label">ribonucleoprotein complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17289661" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17289661
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular composition of IMP1 ribonucleoprotein granules.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5990,57 +5984,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:17289661 identifies HSPA1B as a component of IGF2BP1 (IMP1) mRNP granules containing untranslated mRNAs by mass spectrometry. UniProt confirms this localization (ECO:0000269|PubMed:17289661).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Confirmed by mass spectrometry identification in mRNP granule complex. Consistent with known HSP70 association with RNA granules.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24318877" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24318877
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Binding of human nucleotide exchange factors to heat shock p...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -6052,57 +6046,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:24318877 (Rauch and Gestwicki 2014) characterizes how binding of human nucleotide exchange factors (BAG1, BAG2, BAG3, HSPH1) to Hsp70 generates functionally distinct complexes. The protein binding annotation is uninformative for a chaperone with many specific co-chaperone interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 protein binding is uninformative for a molecular chaperone. The specific interactions with NEFs are better captured by heat shock protein binding (GO:0031072) already annotated.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27137183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27137183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HSP70 regulates the function of mitotic centrosomes.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -6114,57 +6108,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:27137183 shows HSP70 interacts with NEDD1 and gamma-tubulin at the mitotic centrosome. Protein binding is uninformative for a chaperone that interacts with many client proteins.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 protein binding is uninformative for a molecular chaperone. The specific NEDD1 interaction is in the context of centrosome function already captured by more specific annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27708256" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27708256
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     ARD1-mediated Hsp70 acetylation balances stress-induced prot...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -6176,57 +6170,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:27708256 demonstrates specific interactions between Hsp70 and NAA10 (ARD1), HDAC4, HOPX, STUB1, HSP40, and HSP90 in the context of acetylation-regulated chaperone switching. Protein binding is uninformative for a chaperone with many well-characterized co-chaperone interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 protein binding is uninformative. The specific interactions with HDAC4, STUB1, HOPX etc. are better captured by more specific MF terms already annotated (e.g., histone deacetylase binding, ubiquitin protein ligase binding, heat shock protein binding).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005813" target="_blank" class="term-link">
                                     GO:0005813
                                 </a>
                             </span>
                             <span class="term-label">centrosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27137183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27137183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HSP70 regulates the function of mitotic centrosomes.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6238,75 +6232,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:27137183 directly demonstrates that HSP70 accumulates at the mitotic centrosome during prometaphase to metaphase by immunofluorescence. UniProt confirms this localization (ECO:0000269|PubMed:27137183).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Confirmed by direct assay showing centrosome accumulation during mitosis. HSP70 is required for centrosome integrity and bipolar spindle assembly.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/27137183" target="_blank" class="term-link">
                                         PMID:27137183
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">heat shock protein (HSP) 70 considerably accumulates at the mitotic centrosome during prometaphase to metaphase and is required for bipolar spindle assembly</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27708256" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27708256
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     ARD1-mediated Hsp70 acetylation balances stress-induced prot...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6318,75 +6312,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:27708256 demonstrates that acetylated Hsp70 binds HOPX to facilitate protein refolding during the early stress response. K77R mutation impairs refolding capacity. Core biological process.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein refolding is a core function of HSPA1B, confirmed by direct demonstration that the acetylation state regulates the refolding vs degradation switch.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/27708256" target="_blank" class="term-link">
                                         PMID:27708256
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">During the early stress response, Hsp70 is immediately acetylated by ARD1 at K77, and the acetylated Hsp70 binds to the co-chaperone Hop to allow protein refolding</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090063" target="_blank" class="term-link">
                                     GO:0090063
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of microtubule nucleation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27137183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27137183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HSP70 regulates the function of mitotic centrosomes.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -6398,75 +6392,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:27137183 demonstrates that inhibition or depletion of HSP70 impaired microtubule nucleation and polymerization from the spindle pole. HSP70 associates with NEDD1 and gamma-tubulin, two PCM components essential for MT nucleation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimentally well-supported centrosome-related function during mitosis but not a core chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/27137183" target="_blank" class="term-link">
                                         PMID:27137183
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Inhibition or depletion of HSP70 impaired the function of mitotic centrosome and disrupted MT nucleation and polymerization from the spindle pole</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1901673" target="_blank" class="term-link">
                                     GO:1901673
                                 </a>
                             </span>
                             <span class="term-label">regulation of mitotic spindle assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27137183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27137183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HSP70 regulates the function of mitotic centrosomes.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -6478,64 +6472,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:27137183 shows HSP70 is required for bipolar spindle assembly. Its inhibition disrupts spindle formation and may result in formation of abnormal mitotic spindles.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimentally supported but represents a specific mitotic function rather than the core chaperone activity.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/27137183" target="_blank" class="term-link">
                                         PMID:27137183
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSP70 is required for the maintenance of a functional mitotic centrosome that supports the assembly of a bipolar mitotic spindle</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
                                     GO:0005576
                                 </a>
                             </span>
                             <span class="term-label">extracellular region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6800434
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -6547,46 +6541,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Reactome R-HSA-6800434 (exocytosis of ficolin-rich granule lumen proteins) describing release of HSP70 into the extracellular space during neutrophil degranulation. HSP70 is known to be released extracellularly via exosomes and neutrophil granules.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Extracellular localization is supported by Reactome and proteomics data but is a secondary, cell-type-specific feature.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1904813" target="_blank" class="term-link">
                                     GO:1904813
                                 </a>
                             </span>
                             <span class="term-label">ficolin-1-rich granule lumen</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6800434
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -6598,57 +6592,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Reactome R-HSA-6800434 describing HSP70 in ficolin-rich granule lumen of neutrophils. Cell-type-specific localization in neutrophils.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cell-type-specific localization in neutrophils, supported by Reactome but not a core localization for HSPA1B.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032757" target="_blank" class="term-link">
                                     GO:0032757
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of interleukin-8 production</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24790089" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24790089
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The molecular chaperone HSP70 binds to and stabilizes NOD2, ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -6660,75 +6654,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:24790089 shows induced HSP70 expression increases NOD2 response to bacterial cell wall fragments, which leads to NF-kappaB-dependent IL-8 production. HSP70 stabilizes NOD2 protein, enhancing its signaling capacity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimentally supported downstream consequence of HSP70 stabilization of NOD2, not a core chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24790089" target="_blank" class="term-link">
                                         PMID:24790089
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Induced HSP70 expression in cells increased the response of NOD2 to bacterial cell wall fragments</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031396" target="_blank" class="term-link">
                                     GO:0031396
                                 </a>
                             </span>
                             <span class="term-label">regulation of protein ubiquitination</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16809764" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16809764
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Histone deacetylase 8 safeguards the human ever-shorter telo...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -6740,75 +6734,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:16809764 shows that phosphorylated HDAC8 recruits Hsp70 to a complex that inhibits CHIP E3 ligase-mediated degradation of hEST1B. HSP70 participates in regulating ubiquitination of client proteins through its interaction with CHIP/STUB1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimentally supported regulation of ubiquitination in the context of HDAC8-mediated hEST1B stabilization. This is a specific downstream consequence of HSP70 chaperone-E3 ligase interaction rather than core function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16809764" target="_blank" class="term-link">
                                         PMID:16809764
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Phosphorylated HDAC8 preferentially recruits Hsp70 to a complex that inhibits the CHIP (C-terminal heat shock protein interacting protein) E3 ligase-mediated degradation of hEST1B</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042826" target="_blank" class="term-link">
                                     GO:0042826
                                 </a>
                             </span>
                             <span class="term-label">histone deacetylase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16809764" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16809764
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Histone deacetylase 8 safeguards the human ever-shorter telo...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6820,64 +6814,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:16809764 confirms interaction between HSP70 and HDAC8. Phosphorylated HDAC8 recruits Hsp70 to a complex. UniProt also documents interaction with HDAC4 (PMID:27708256), which deacetylates Hsp70 at Lys-77 to regulate chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Confirmed by experimental evidence from multiple studies. HDAC binding is functionally relevant to regulation of HSP70 chaperone activity through acetylation/deacetylation of Lys-77.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16809764" target="_blank" class="term-link">
                                         PMID:16809764
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Phosphorylated HDAC8 preferentially recruits Hsp70 to a complex that inhibits the CHIP (C-terminal heat shock protein interacting protein) E3 ligase-mediated degradation of hEST1B</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371467
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6889,46 +6883,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Reactome R-HSA-3371467 (SIRT1 deacetylates HSF1) describing HSP70 involvement in the nucleoplasm during HSF1-mediated heat shock response regulation. HSP70 shuttles to the nucleus during stress via Hikeshi-mediated import.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization is consistent with HSP70 nuclear functions during the heat shock response, particularly in HSF1 regulation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371518
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6940,46 +6934,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Reactome R-HSA-3371518 (SIRT1 binds to HSF1) describing nucleoplasmic localization of HSP70 in the context of HSF1 regulation. Redundant with other nucleoplasm TAS annotations.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent with established HSP70 nuclear localization during stress.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371554
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6991,46 +6985,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Reactome R-HSA-3371554 (HSF1 acetylation at Lys80) describing nucleoplasmic localization of HSP70 during the heat shock response attenuation phase.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent with established HSP70 nuclear localization during stress and its role in HSF1 regulation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5082356
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7042,46 +7036,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Reactome R-HSA-5082356 (HSF1-mediated gene expression) describing nucleoplasmic localization of HSP70 during HSF1-dependent transactivation. HSP70 feeds back on HSF1 to attenuate the heat shock response.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent with nucleoplasmic localization during HSF1 regulation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5082369
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7093,46 +7087,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Reactome R-HSA-5082369 (acetylated HSF1 dissociates from DNA) describing HSP70 nucleoplasmic role in HSF1 attenuation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent with established nucleoplasmic localization of HSP70 during stress response regulation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5082384
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7144,46 +7138,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Reactome R-HSA-5082384 (HSP70:DNAJB1 binds HSF1) describing HSP70 nucleoplasmic function in the attenuation phase of the heat shock response, where HSP70 with DNAJB1 binds to HSF1 to suppress transcription.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core nuclear function of HSP70 in regulating HSF1. This is a well-established feedback mechanism.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5251955
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7195,46 +7189,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Reactome R-HSA-5251955 (HSP40s activate intrinsic ATPase activity of HSP70s in the nucleoplasm) describing nucleoplasmic HSP70 ATPase cycle driven by J-domain proteins.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent with HSP70 functioning in the nucleoplasm during stress.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5252041
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7246,46 +7240,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Reactome R-HSA-5252041 (NPC transports Hikeshi:HSP70s:ATP from cytosol to nucleoplasm) describing Hikeshi-mediated nuclear import of HSP70 during heat shock.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent with the established Hikeshi-dependent HSP70 nuclear import mechanism under stress conditions.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371422
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7297,46 +7291,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Reactome R-HSA-3371422 (ATP hydrolysis by HSP70) describing cytosolic HSP70 ATPase activity. Core localization for HSPA1B.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization. Cytosol is the primary site of HSP70 chaperone activity, consistent with IBA and IDA annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371503
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7348,46 +7342,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Reactome R-HSA-3371503 (STIP1/HOP binds HSP90 and HSP70:HSP40:nascent protein) describing cytosolic HSP70 in the HSP70-HSP90 chaperone relay.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization. Cytosolic HSP70-HSP90 relay is a well-established chaperone pathway.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371590
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7399,46 +7393,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Reactome R-HSA-3371590 (HSP70 binds to HSP40:nascent protein) describing cytosolic HSP70 initial substrate engagement.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization. HSP70 engagement with HSP40-bound nascent proteins occurs in the cytosol.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5251942
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7450,46 +7444,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Reactome R-HSA-5251942 (Hikeshi binds HSP70s:ATP) describing cytosolic HSP70:ATP binding to Hikeshi for nuclear import during heat stress.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization. HSP70 is cytosolic prior to Hikeshi-mediated nuclear transport.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5251959
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7501,46 +7495,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Reactome R-HSA-5251959 (HSP40s activate intrinsic ATPase activity of HSP70s in the cytosol) describing cytosolic HSP70 ATPase cycle activation by J-domain proteins.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization. Cytosolic chaperone cycle activation is a central function of HSP70.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5252041
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7552,46 +7546,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Reactome R-HSA-5252041 (NPC transports Hikeshi:HSP70s:ATP from cytosol to nucleoplasm) describing cytosolic origin of HSP70 prior to nuclear import.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization. HSP70 is cytosolic prior to nuclear import.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5252079
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7603,46 +7597,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Reactome R-HSA-5252079 (HSP110s exchange ATP for ADP on HSP70s:ADP) describing cytosolic nucleotide exchange on HSP70 by HSP110 nucleotide exchange factors.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization. NEF-mediated nucleotide exchange occurs in the cytosol as part of the chaperone cycle.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5618085
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7654,46 +7648,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Reactome R-HSA-5618085 (FKBP4 binds HSP90:ATP:STIP1:HSP70: nascent protein) describing cytosolic HSP70 in the HSP90 chaperone cycle for steroid hormone receptors.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization. Cytosolic HSP70 participates in HSP90 chaperone relay for client protein maturation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5618098
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7705,46 +7699,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Reactome R-HSA-5618098 (p23/PTGES3 binds HSP90:ATP:FKBP5: nascent protein) describing cytosolic localization of HSP70 during HSP90 chaperone cycle.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization in the cytosol during HSP90 chaperone cycle.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5618105
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7756,46 +7750,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Reactome R-HSA-5618105 (FKBP5 binds HSP90:ATP:STIP1:HSP70: nascent protein) describing cytosolic HSP70 in HSP90 chaperone cycle.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization in the cytosol.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5618107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7807,46 +7801,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Reactome R-HSA-5618107 (ATP binding to HSP90 triggers conformation change) describing cytosolic localization of HSP70 in the context of HSP90 chaperone machinery.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization in the cytosol.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5618110
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7858,46 +7852,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Reactome R-HSA-5618110 (p23/PTGES3 binds HSP90:ATP:FKBP4: nascent protein) describing cytosolic localization of HSP70 during HSP90 chaperone cycle maturation steps.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization in the cytosol.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9835411
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7909,46 +7903,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Reactome R-HSA-9835411 (FA core complex:HSP70s binds PKR) describing cytosolic HSP70 involvement in PKR-mediated signaling.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization in the cytosol.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9857076
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7960,57 +7954,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Reactome R-HSA-9857076 (oxidized DNAJA1 binds HSPA1A,B displacing HSF1) describing cytosolic HSP70 involved in redox-sensitive HSF1 regulation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization in the cytosol.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22528486" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22528486
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Nucleophosmin (NPM1/B23) interacts with activating transcrip...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -8022,75 +8016,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:22528486 identifies HSP70 as an ATF5-interacting protein. NPM1 displaces HSP70 from ATF5, leading to ATF5 degradation. The HSP70-ATF5 interaction reflects chaperone client stabilization. Protein binding is uninformative for a chaperone.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 protein binding is uninformative for a molecular chaperone. The ATF5 interaction is a specific client stabilization function better captured by protein stabilization (GO:0050821) already annotated.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22528486" target="_blank" class="term-link">
                                         PMID:22528486
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">NPM1 interaction with ATF5 displaces HSP70, a known ATF5-interacting protein, from ATF5 protein complexes and antagonizes its role in stabilization of ATF5 protein</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0055131" target="_blank" class="term-link">
                                     GO:0055131
                                 </a>
                             </span>
                             <span class="term-label">C3HC4-type RING finger domain binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25281747" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25281747
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     RING finger protein RNF207, a novel regulator of cardiac exc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -8102,75 +8096,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:25281747 demonstrates that coexpression of RNF207 and HSP70 increases HERG expression in a heat shock protein-dependent manner. RNF207 is a RING finger protein that interacts with HSP70 via its C-terminus.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Confirmed by experimental evidence showing HSP70 interaction with the RING finger protein RNF207 to regulate HERG trafficking.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/25281747" target="_blank" class="term-link">
                                         PMID:25281747
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">coexpression of RNF207 and HSP70 increased HERG expression compared with HSP70 alone. This effect was dependent on the C terminus of RNF207</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
                                     GO:0031072
                                 </a>
                             </span>
                             <span class="term-label">heat shock protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17182002" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17182002
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HDJC9, a novel human type C DnaJ/HSP40 member interacts with...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -8182,75 +8176,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:17182002 shows DNAJC9 (HDJC9), a novel type C DnaJ/HSP40 member, interacts with and cochaperones HSP70 through the J domain. DNAJC9 activates the ATPase activity of HSP70.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core co-chaperone interaction. J-domain protein (DNAJC9) binding to HSP70 is fundamental to the chaperone cycle.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17182002" target="_blank" class="term-link">
                                         PMID:17182002
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HDJC9 can interact with HSP70s and activate the ATPase activity of HSP70s, both of which are dependent on the J domain</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001664" target="_blank" class="term-link">
                                     GO:0001664
                                 </a>
                             </span>
                             <span class="term-label">G protein-coupled receptor binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12150907" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12150907
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     CHIP is associated with Parkin, a gene responsible for famil...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -8262,75 +8256,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:12150907 shows CHIP, Hsp70, Parkin, and unfolded Pael-R (an orphan GPCR) form a complex. Hsp70 binds Pael-R as a chaperone substrate, not as a GPCR signaling partner.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While HSPA1B does bind the GPCR Pael-R, this is in the context of chaperone-substrate interaction for an unfolded receptor, not GPCR signaling. The term implies specific binding to GPCRs as signaling partners.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12150907" target="_blank" class="term-link">
                                         PMID:12150907
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">CHIP, Hsp70, Parkin, and Pael-R formed a complex in vitro and in vivo</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031397" target="_blank" class="term-link">
                                     GO:0031397
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of protein ubiquitination</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12150907" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12150907
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     CHIP is associated with Parkin, a gene responsible for famil...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -8342,75 +8336,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:12150907 demonstrates that Hsp70 binding to Pael-R can shield the substrate from ubiquitination. CHIP promotes dissociation of Hsp70 from the complex, facilitating Parkin-mediated ubiquitination. HSP70 thus negatively regulates ubiquitination by sequestering substrates from E3 ligases.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimentally supported but represents a context-dependent regulatory outcome of chaperone activity on substrate triage.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12150907" target="_blank" class="term-link">
                                         PMID:12150907
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">CHIP promoted the dissociation of Hsp70 from Parkin and Pael-R, thus facilitating Parkin-mediated Pael-R ubiquitination</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031625" target="_blank" class="term-link">
                                     GO:0031625
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin protein ligase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12150907" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12150907
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     CHIP is associated with Parkin, a gene responsible for famil...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -8422,75 +8416,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:12150907 demonstrates that Hsp70 forms a complex with CHIP (an E3 ubiquitin ligase) and Parkin (an E3 ubiquitin ligase) in the context of Pael-R ubiquitination. HSP70 directly binds E3 ligases as part of its chaperone triage function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core co-chaperone interaction. HSP70 binding to E3 ubiquitin ligases like CHIP/STUB1 and Parkin is integral to the protein quality control triage mechanism.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12150907" target="_blank" class="term-link">
                                         PMID:12150907
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">CHIP, Hsp70, Parkin, and Pael-R formed a complex in vitro and in vivo</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034599" target="_blank" class="term-link">
                                     GO:0034599
                                 </a>
                             </span>
                             <span class="term-label">cellular response to oxidative stress</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24252804" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24252804
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The role of oxidative stress in Parkinson&#39;s disease.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -8502,57 +8496,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from PMID:24252804 (a review of the role of oxidative stress in Parkinson disease pathogenesis) supporting HSP70 involvement in oxidative stress response. HSP70 is induced by and participates in oxidative stress response.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSP70 is induced by and participates in oxidative stress response, but this is a general stress-responsive phenotype rather than a core chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                     GO:0050821
                                 </a>
                             </span>
                             <span class="term-label">protein stabilization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24252804" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24252804
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The role of oxidative stress in Parkinson&#39;s disease.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -8564,57 +8558,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from PMID:24252804 supporting HSP70 protein stabilization function in the context of Parkinson disease. HSP70 chaperone activity inherently stabilizes client proteins. PMID:24790089 directly demonstrates HSP70 stabilizes NOD2 by increasing its half-life.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Well-supported core function. HSP70 chaperone activity inherently stabilizes client proteins, preventing misfolding and degradation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12150907" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12150907
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     CHIP is associated with Parkin, a gene responsible for famil...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -8626,148 +8620,148 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962). This NAS annotation references PMID:12150907 (Imai et al. 2002), which describes how CHIP, Hsp70, Parkin, and unfolded Pael receptor (Pael-R) form a complex involved in ER stress-related ubiquitination. The paper demonstrates that Hsp70 participates in a chaperone-E3 ligase complex facilitating ubiquitination of the unfolded substrate Pael-R, consistent with Hsp70 functioning as a protein folding chaperone that triages substrates between refolding and degradation pathways. HSPA1B is an ATP-dependent foldase chaperone and the correct replacement term is GO:0044183 (protein folding chaperone).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. The referenced paper (PMID:12150907) describes Hsp70 participating in a complex with CHIP and Parkin for ubiquitination of unfolded Pael-R, which reflects Hsp70 chaperone triage function rather than simple unfolded protein binding. HSPA1B is an active ATP-dependent protein folding chaperone whose substrate binding is coupled to its ATPase cycle. GO:0044183 (protein folding chaperone) correctly captures the molecular function.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12150907" target="_blank" class="term-link">
                                         PMID:12150907
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">CHIP, Hsp70, Parkin, and Pael-R formed a complex in vitro and in vivo. The amount of CHIP in the complex was increased during ER stress. CHIP promoted the dissociation of Hsp70 from Parkin and Pael-R, thus facilitating Parkin-mediated Pael-R ubiquitination.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005814" target="_blank" class="term-link">
                                     GO:0005814
                                 </a>
                             </span>
                             <span class="term-label">centriole</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24061851" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24061851
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Stress-induced localization of HSPA6 (HSP70B&#39;) and HSPA1A (H...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0005814" data-r="PMID:24061851" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0005814" data-r="PMID:24061851" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> PMID:24061851 documents stress-induced localization of HSPA1A (functionally identical to HSPA1B) to centrioles in human neuronal cells. Consistent with HSP70 centrosome function during stress.
+                            <strong>Summary:</strong> PMID:24061851 documents stress-induced localization of HSPA1A and HSPA6 to centrioles in human neuronal cells, but it does not test HSPA1B.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Confirmed by direct assay showing stress-induced centriole localization in neuronal cells.
+                            <strong>Reason:</strong> The cited IDA evidence is not HSPA1B-specific and should not be accepted for HSPA1B centriole localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -8779,57 +8773,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:21231916 (Hageman et al. 2011) characterized HSP70 family members in the cytosol, demonstrating cytosolic chaperone activities including luciferase refolding and polyQ aggregation suppression.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization confirmed by direct assay. Cytosol is the primary site of HSP70 chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005925" target="_blank" class="term-link">
                                     GO:0005925
                                 </a>
                             </span>
                             <span class="term-label">focal adhesion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21423176" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21423176
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Analysis of the myosin-II-responsive focal adhesion proteome...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -8841,463 +8835,452 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:21423176 is a proteomic analysis of the myosin-II-responsive focal adhesion proteome that identified HSPA1B among focal adhesion proteins.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> High-throughput proteomics data. Focal adhesion localization is a secondary, context-dependent feature, not a core localization for HSP70.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
                                     GO:0031072
                                 </a>
                             </span>
                             <span class="term-label">heat shock protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0031072" data-r="PMID:21231916" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0031072" data-r="PMID:21231916" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> PMID:21231916 demonstrates functional interactions between HSP70 family members and various J-domain protein co-chaperones (HSP40s). HSPA1A ATPase activity is stimulated by J-proteins.
+                            <strong>Summary:</strong> PMID:21231916 demonstrates functional interactions between HSP70-family proteins and J-domain co-chaperones, but the local supporting excerpt specifically names HSPA6 and HSPA1A rather than HSPA1B.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Core co-chaperone interaction. HSP70-HSP40 (J-protein) interactions are fundamental to the chaperone cycle.
+                            <strong>Reason:</strong> HSP70-HSP40 interactions are fundamental to the chaperone cycle, but the available local evidence does not resolve HSPA1B-specific IPI support for this source.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSPA6 has a functional substrate-binding domain and possesses intrinsic ATPase activity that is as high as that of the canonical HSPA1A when stimulated by J-proteins</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034605" target="_blank" class="term-link">
                                     GO:0034605
                                 </a>
                             </span>
                             <span class="term-label">cellular response to heat</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24061851" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24061851
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Stress-induced localization of HSPA6 (HSP70B&#39;) and HSPA1A (H...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0034605" data-r="PMID:24061851" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0034605" data-r="PMID:24061851" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> PMID:24061851 demonstrates stress-induced localization changes of HSPA1A to centrioles in human neuronal cells, showing a direct cellular response to heat stress.
+                            <strong>Summary:</strong> PMID:24061851 demonstrates stress-induced localization changes of HSPA1A and HSPA6 to centrioles in human neuronal cells, but it does not test HSPA1B.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Core stress-response function. HSPA1B is heat-inducible and directly responds to heat stress by changing its subcellular localization and activity.
+                            <strong>Reason:</strong> The cited IDA evidence is not HSPA1B-specific and should not be accepted as direct cellular response to heat for HSPA1B.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0042026" data-r="PMID:21231916" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0042026" data-r="PMID:21231916" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> PMID:21231916 directly demonstrates that HSPA1A (functionally identical to HSPA1B) supports luciferase refolding after heat denaturation. Core biological process for HSP70.
+                            <strong>Summary:</strong> PMID:21231916 reports HSPA1A-associated luciferase refolding activity, but the available local evidence does not establish this as an HSPA1B-specific IDA result.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Core biological process confirmed by direct assay showing heat-denatured luciferase refolding activity.
+                            <strong>Reason:</strong> The cited IDA evidence should not be accepted as direct HSPA1B protein refolding evidence. HSPA1B refolding/chaperone function is represented by better-supported chaperone annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0051082" data-r="PMID:21231916" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0051082" data-r="PMID:21231916" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962). This IDA annotation references PMID:21231916 (Hageman et al. 2011), a key study that systematically compared chaperone activities of mammalian HSP70 family members. The study demonstrated that HSPA1A (&gt;99% identical to HSPA1B) possesses robust luciferase refolding activity and protects cells from heat-induced cell death. While the study does demonstrate that HSPA1A/HSPA1B can bind heat-denatured substrates, this binding is intrinsically coupled to the ATP-dependent chaperone folding cycle. The correct molecular function term is GO:0044183 (protein folding chaperone), which captures the active chaperone function rather than the passive substrate-binding aspect that GO:0051082 implies.
+                            <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962). This IDA annotation references PMID:21231916 (Hageman et al. 2011), a key study that systematically compared chaperone activities of mammalian HSP70 family members. The study demonstrated HSPA1A and HSPA6 activities but did not directly test HSPA1B for this annotation. While HSP70 proteins bind heat-denatured substrates, this binding is intrinsically coupled to the ATP-dependent chaperone folding cycle. The correct molecular function term is GO:0044183 (protein folding chaperone), which captures the active chaperone function rather than the passive substrate-binding aspect that GO:0051082 implies.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> GO:0051082 is being obsoleted. PMID:21231916 directly demonstrates that HSPA1A (functionally identical to HSPA1B) is an active ATP-dependent foldase that refolds heat-denatured luciferase and suppresses protein aggregation. The binding of unfolded substrates by HSP70 is mechanistically inseparable from its chaperone folding cycle. GO:0044183 (protein folding chaperone) is the correct replacement and is already annotated to HSPA1B via IDA (PMID:15603737) and IBA (GO_REF:0000033) evidence.
+                            <strong>Reason:</strong> GO:0051082 is being obsoleted, and the cited PMID:21231916 evidence is not HSPA1B-specific. HSPA1B&#39;s chaperone function is already represented by GO:0044183 from better-supported annotations.
                         </div>
-                        
-                        
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-                            
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
-                                </a>
-                            </span>
-                            
-                        </div>
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSPA6 has a functional substrate-binding domain and possesses intrinsic ATPase activity that is as high as that of the canonical HSPA1A when stimulated by J-proteins.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">whereas overexpression of HSPA1A protected cells from heat-induced cell death, overexpression of HSPA6 did not</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070370" target="_blank" class="term-link">
                                     GO:0070370
                                 </a>
                             </span>
                             <span class="term-label">cellular heat acclimation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0070370" data-r="PMID:21231916" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0070370" data-r="PMID:21231916" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> PMID:21231916 confirms that HSPA1A (functionally identical to HSPA1B) protects cells from heat-induced cell death. Overexpression of HSPA1A conferred thermotolerance whereas HSPA6 did not.
+                            <strong>Summary:</strong> PMID:21231916 reports HSPA1A protection from heat-induced cell death and HSPA6 lack of thermotolerance; it does not directly test HSPA1B for cellular heat acclimation.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Core stress-response function. HSPA1B is heat-inducible and protects cells during heat stress, directly contributing to cellular heat acclimation.
+                            <strong>Reason:</strong> The cited IMP evidence is HSPA1A/HSPA6-specific and should not be accepted as a direct HSPA1B heat-acclimation annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">whereas overexpression of HSPA1A protected cells from heat-induced cell death, overexpression of HSPA6 did not</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0072562" target="_blank" class="term-link">
                                     GO:0072562
                                 </a>
                             </span>
                             <span class="term-label">blood microparticle</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22516433" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22516433
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomic analysis of microvesicles from plasma of healthy d...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -9309,119 +9292,119 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:22516433 is a proteomic analysis of microvesicles from plasma of healthy donors identifying HSPA1B among blood microparticle proteins. Consistent with known extracellular release of HSP70.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> High-throughput proteomics data. Blood microparticle localization is a secondary, non-core feature consistent with extracellular HSP70 release.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090084" target="_blank" class="term-link">
                                     GO:0090084
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of inclusion body assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0090084" data-r="PMID:21231916" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0090084" data-r="PMID:21231916" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> PMID:21231916 demonstrates that HSPA1A (functionally identical to HSPA1B) suppresses polyQ aggregation and inclusion body formation. Core protein quality control function.
+                            <strong>Summary:</strong> PMID:21231916 discusses HSPA-family effects on polyQ aggregation, but the local evidence does not establish this as an HSPA1B-specific IDA result.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Core chaperone function. Preventing protein aggregation and inclusion body formation is a direct consequence of HSP70 foldase and holdase activity.
+                            <strong>Reason:</strong> The cited IDA evidence should not be accepted as HSPA1B-specific negative regulation of inclusion body assembly.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15603737" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15603737
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     BAG5 inhibits parkin and enhances dopaminergic neuron degene...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -9433,75 +9416,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:15603737 shows BAG5 directly interacts with Hsp70 and inhibits Hsp70-mediated refolding of misfolded proteins. Protein binding is uninformative for a chaperone.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 protein binding is uninformative for a molecular chaperone. The BAG5 interaction is a specific co-chaperone interaction better captured by heat shock protein binding (GO:0031072).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/15603737" target="_blank" class="term-link">
                                         PMID:15603737
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">bcl-2-associated athanogene 5 (BAG5), a BAG family member, directly interacts with parkin and the chaperone Hsp70. Within this complex, BAG5 inhibits both parkin E3 ubiquitin ligase activity and Hsp70-mediated refolding of misfolded proteins</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
                                     GO:0005524
                                 </a>
                             </span>
                             <span class="term-label">ATP binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23921388
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of a novel human methylt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -9513,155 +9496,155 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:23921388 characterizes METTL21A methylation of HSP70, with the methylation reaction stimulated by ATP, demonstrating HSP70 ATP binding. Core molecular function confirmed by crystal structures of the NBD domain with ADP/ATP.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core molecular function. ATP binding drives the chaperone cycle and is essential for all HSP70 functions.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link">
                                         PMID:23921388
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the reaction was stimulated by ATP</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010628" target="_blank" class="term-link">
                                     GO:0010628
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of gene expression</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25281747" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25281747
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     RING finger protein RNF207, a novel regulator of cardiac exc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0010628" data-r="PMID:25281747" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0010628" data-r="PMID:25281747" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> PMID:25281747 shows that coexpression of RNF207 and HSP70 increased HERG expression, suggesting HSP70 participates in positive regulation of gene expression for specific client proteins through its chaperone activity on trafficking.
+                            <strong>Summary:</strong> PMID:25281747 reports increased total and membrane HERG/KCNH2 protein and current density with RNF207 and HSP70, consistent with chaperone-mediated trafficking or stabilization rather than regulation of gene expression.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Experimentally supported but a downstream consequence of HSP70 chaperone-mediated protein trafficking/stabilization in the cardiac context, not a core gene expression regulatory function.
+                            <strong>Reason:</strong> The evidence supports effects on HERG protein trafficking/localization and current density, not positive regulation of gene expression.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/25281747" target="_blank" class="term-link">
                                         PMID:25281747
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">coexpression of RNF207 and HSP70 increased HERG expression compared with HSP70 alone</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016234" target="_blank" class="term-link">
                                     GO:0016234
                                 </a>
                             </span>
                             <span class="term-label">inclusion body</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15603737" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15603737
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     BAG5 inhibits parkin and enhances dopaminergic neuron degene...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -9673,75 +9656,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:15603737 shows BAG5 enhances parkin sequestration within protein aggregates, with HSP70 localized to inclusion bodies as part of its protein quality control response.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Confirmed by direct assay. HSP70 localizes to inclusion bodies as part of its role in protein aggregate management and quality control.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/15603737" target="_blank" class="term-link">
                                         PMID:15603737
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">BAG5 enhances parkin sequestration within protein aggregates and mitigates parkin-dependent preservation of proteasome function</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019899" target="_blank" class="term-link">
                                     GO:0019899
                                 </a>
                             </span>
                             <span class="term-label">enzyme binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23921388
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of a novel human methylt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -9753,75 +9736,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:23921388 demonstrates METTL21A (HSPA-KMT) is a highly specific methyltransferase that interacts with and methylates HSP70 family members. Enzyme binding is confirmed by the direct enzyme-substrate interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Confirmed by experimental evidence. METTL21A is a specific enzyme that binds and modifies HSP70 at Lys-561.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link">
                                         PMID:23921388
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we identified the methyltransferase METTL21A as the enzyme responsible for trimethylation of a conserved lysine residue found in several human Hsp70 (HSPA) proteins</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
                                     GO:0031072
                                 </a>
                             </span>
                             <span class="term-label">heat shock protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23921388
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of a novel human methylt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -9833,57 +9816,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:23921388 demonstrates that METTL21A trimethylation alters the affinity of Hsp70 for alpha-synuclein fibrils, reflecting functionally relevant HSP-HSP interactions. The study also shows METTL21A interacts with HSP70 family members.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core co-chaperone interaction. HSP70 binding to other heat shock proteins and modifiers is fundamental to chaperone regulation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031625" target="_blank" class="term-link">
                                     GO:0031625
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin protein ligase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15603737" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15603737
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     BAG5 inhibits parkin and enhances dopaminergic neuron degene...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -9895,75 +9878,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:15603737 demonstrates that BAG5 directly interacts with both parkin (an E3 ubiquitin ligase) and Hsp70, forming a complex. HSP70 binding to E3 ligases is a core part of the chaperone triage system.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core co-chaperone interaction. HSP70 binding to E3 ubiquitin ligases like Parkin is integral to the protein quality control triage mechanism.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/15603737" target="_blank" class="term-link">
                                         PMID:15603737
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">bcl-2-associated athanogene 5 (BAG5), a BAG family member, directly interacts with parkin and the chaperone Hsp70</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15603737" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15603737
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     BAG5 inhibits parkin and enhances dopaminergic neuron degene...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -9975,75 +9958,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:15603737 demonstrates Hsp70-mediated refolding of misfolded proteins, which is inhibited by BAG5. Core biological process for HSP70.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core biological process confirmed by direct assay. HSP70 refolds misfolded proteins through its ATP-dependent chaperone cycle.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/15603737" target="_blank" class="term-link">
                                         PMID:15603737
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">BAG5 inhibits both parkin E3 ubiquitin ligase activity and Hsp70-mediated refolding of misfolded proteins</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     GO:0044183
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15603737" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15603737
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     BAG5 inhibits parkin and enhances dopaminergic neuron degene...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10055,137 +10038,137 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:15603737 demonstrates Hsp70 chaperone activity in the context of the BAG5-Parkin-Hsp70 complex. Hsp70 actively refolds misfolded proteins. This is the core molecular function annotation for HSPA1B.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The defining molecular function of HSPA1B. HSP70 is an ATP-dependent protein folding chaperone confirmed by direct assay.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/15603737" target="_blank" class="term-link">
                                         PMID:15603737
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">BAG5 inhibits both parkin E3 ubiquitin ligase activity and Hsp70-mediated refolding of misfolded proteins</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046034" target="_blank" class="term-link">
                                     GO:0046034
                                 </a>
                             </span>
                             <span class="term-label">ATP metabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23921388
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of a novel human methylt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0046034" data-r="PMID:23921388" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P0DMV9" data-a="GO:0046034" data-r="PMID:23921388" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> PMID:23921388 confirms ATP-dependent activity of HSP70 in the context of METTL21A methylation studies. HSP70 hydrolyzes ATP as part of its chaperone cycle.
+                            <strong>Summary:</strong> PMID:23921388 describes METTL21A methylation assays and HSPA8/Hsc70 functional effects, not HSPA1B-specific ATP metabolic process.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Core function. ATP metabolic process is an inherent aspect of the ATPase-driven chaperone cycle.
+                            <strong>Reason:</strong> The cited IDA evidence does not support a broad HSPA1B ATP metabolic process annotation; ATP use is better captured by ATPase/chaperone molecular-function annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048471" target="_blank" class="term-link">
                                     GO:0048471
                                 </a>
                             </span>
                             <span class="term-label">perinuclear region of cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15603737" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15603737
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     BAG5 inhibits parkin and enhances dopaminergic neuron degene...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10197,57 +10180,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:15603737 documents perinuclear localization of HSP70 in the context of dopaminergic neuron studies with BAG5 and Parkin. Consistent with perinuclear HSP70 localization during stress.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Confirmed by direct assay. Perinuclear localization is observed particularly in the context of protein quality control near the nucleus.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090084" target="_blank" class="term-link">
                                     GO:0090084
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of inclusion body assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15603737" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15603737
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     BAG5 inhibits parkin and enhances dopaminergic neuron degene...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10259,57 +10242,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:15603737 shows HSP70 suppresses protein aggregation and inclusion body formation, which is inhibited by BAG5. Core protein quality control function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core chaperone function. Preventing protein aggregation and inclusion body formation is a direct consequence of HSP70 foldase activity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:2001240" target="_blank" class="term-link">
                                     GO:2001240
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of extrinsic apoptotic signaling pathway in absence of ligand</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17167422" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17167422
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Hsp70 regulates erythropoiesis by preventing caspase-3-media...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -10321,57 +10304,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:17167422 shows Hsp70 protects GATA-1 from caspase-3 cleavage, preventing apoptosis during erythroid differentiation. This is a specific anti-apoptotic function mediated through chaperone protection of GATA-1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimentally supported anti-apoptotic function but represents a specific downstream effect of HSP70 chaperone-mediated protection of client proteins from caspase cleavage.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005102" target="_blank" class="term-link">
                                     GO:0005102
                                 </a>
                             </span>
                             <span class="term-label">signaling receptor binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24790089" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24790089
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The molecular chaperone HSP70 binds to and stabilizes NOD2, ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -10383,75 +10366,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:24790089 demonstrates HSP70 binds NOD2, an intracellular pattern recognition receptor. This interaction stabilizes NOD2 and enhances its signaling capacity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimentally supported but reflects chaperone-client stabilization of NOD2 rather than specific signaling receptor binding activity. The interaction is in the context of HSP70 chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24790089" target="_blank" class="term-link">
                                         PMID:24790089
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We identified heat shock protein 70 (HSP70) as a protein interactor of both wild type and Crohn mutant NOD2</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24790089" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24790089
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The molecular chaperone HSP70 binds to and stabilizes NOD2, ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10463,57 +10446,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:24790089 documents cytoplasmic localization of HSP70 in the context of NOD2 interaction studies. Core localization for HSPA1B.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization confirmed by direct assay.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1903265" target="_blank" class="term-link">
                                     GO:1903265
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of tumor necrosis factor-mediated signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24790089" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24790089
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The molecular chaperone HSP70 binds to and stabilizes NOD2, ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -10525,61 +10508,61 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:24790089 shows HSP70 stabilizes NOD2, enhancing NOD2-mediated signaling which includes TNF-mediated pathway activation in response to bacterial cell wall fragments.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimentally supported downstream effect of HSP70 chaperone activity on innate immune signaling components through NOD2 stabilization.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24790089" target="_blank" class="term-link">
                                         PMID:24790089
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Induced HSP70 expression in cells increased the response of NOD2 to bacterial cell wall fragments</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>ATP-dependent foldase chaperone that assists folding of newly synthesized polypeptides and refolding of stress-denatured proteins. HSPA1B has the conserved tripartite HSP70 architecture: the N-terminal NBD binds and hydrolyzes ATP, allosterically driving an open-to-closed conformational transition of the SBD lid that regulates client binding and release (DOI:10.3390/biom13020272). HSP40/DNAJ co-chaperones stimulate ATP hydrolysis and deliver substrates, while nucleotide exchange factors (BAG1/2/3, HSPH1/HSP110) accelerate ADP-to-ATP exchange to trigger client release (DOI:10.3390/biom13020272). HSPA1B triages substrates between refolding (via HOPX/STIP1 co-chaperone) and proteasomal degradation (via STUB1/CHIP E3 ubiquitin ligase), with the acetylation state of Lys-77 governing this switch. Under stress, expression can reach approximately 15% of total cellular protein (DOI:10.3390/biom13020272). HSP70 cooperates with HSP90 in client maturation pathways and also participates in disaggregation of protein aggregates through cooperation with HSP110 as a disaggregase NEF (DOI:10.3390/biom13020272).</h3>
+                <h3>ATP-dependent foldase chaperone that assists folding of newly synthesized polypeptides and refolding of stress-denatured proteins. HSPA1B has the conserved tripartite HSP70 architecture: the N-terminal NBD binds and hydrolyzes ATP, allosterically driving an open-to-closed conformational transition of the SBD lid that regulates client binding and release (DOI:10.3390/biom13020272). HSP40/DNAJ co-chaperones stimulate ATP hydrolysis and deliver substrates, while nucleotide exchange factors (BAG1/2/3, HSPH1/HSP110) accelerate ADP-to-ATP exchange to trigger client release (DOI:10.3390/biom13020272). HSPA1B triages substrates between refolding (via HOPX/STIP1 co-chaperone) and proteasomal degradation (via STUB1/CHIP E3 ubiquitin ligase), with the acetylation state of Lys-77 governing this switch. Under stress, expression can reach approximately 15% of total cellular protein (DOI:10.3390/biom13020272). HSP70 cooperates with HSP90 in client maturation pathways; HSPA1B-specific disaggregase activity should not be inferred without direct supporting evidence.</h3>
                 <span class="vote-buttons" data-g="P0DMV9" data-a="FUNCTION: ATP-dependent foldase chaperone that assists foldi..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -10588,1237 +10571,1202 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                 protein refolding
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032436" target="_blank" class="term-link">
                                 positive regulation of proteasomal ubiquitin-dependent protein catabolic process
                             </a>
                         </span>
-                        
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070370" target="_blank" class="term-link">
-                                cellular heat acclimation
-                            </a>
-                        </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090084" target="_blank" class="term-link">
                                 negative regulation of inclusion body assembly
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                 nucleus
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
-        </div>
-        
-        <div class="core-function-card">
-            
-            <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>Works with co-chaperones (notably HSP110/HSPH1 and DNAJB1) to solubilize and disaggregate ordered protein aggregates, including alpha-synuclein fibrils. This disaggregase activity is driven by the same ATP hydrolysis cycle as the foldase function but is directed toward pre-formed aggregates rather than nascent or stress-denatured monomers. Recent reviews position HSP110-family proteins as major NEFs/co-chaperones that cooperate with HSP70 and HSP40 to disaggregate and refold denatured proteins (DOI:10.3390/biom13040604).</h3>
-                <span class="vote-buttons" data-g="P0DMV9" data-a="FUNCTION: Works with co-chaperones (notably HSP110/HSPH1 and..." data-r="" data-act="CORE_FUNCTION">
-                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
-                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
-                </span>
-            </div>
-            
 
-            <div class="core-function-terms">
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">Molecular Function:</div>
-                    <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140545" target="_blank" class="term-link">
-                            ATP-dependent protein disaggregase activity
-                        </a>
-                    </span>
-                </div>
-                
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
 
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">Directly Involved In:</div>
-                    <div class="function-annotations">
-                        
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090084" target="_blank" class="term-link">
-                                negative regulation of inclusion body assembly
-                            </a>
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/HSPA1B/HSPA1B-deep-research-falcon.md
+
                         </span>
-                        
-                    </div>
-                </div>
-                
 
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">Cellular Locations:</div>
-                    <div class="function-annotations">
-                        
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
-                                cytosol
-                            </a>
-                        </span>
-                        
-                    </div>
-                </div>
-                
+                        <div class="finding-text">HSPA1B is a major stress-inducible HSP70 protein with central roles in proteostasis, survival signaling, and immune modulation; many studies do not distinguish HSPA1B from HSPA1A, so isoform-specific claims require caution.</div>
 
-                
+                    </li>
 
-                
+                </ul>
             </div>
 
-            
         </div>
-        
+
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/HSPA1B/HSPA1B-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for HSPA1B</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
                             GO_REF:0000052
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000108.md" target="_blank" class="term-link">
                             GO_REF:0000108
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Automatic assignment of GO terms using logical inference, based on on inter-ontology links</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10205060" target="_blank" class="term-link">
                             PMID:10205060
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Control of mRNA decay by heat shock-ubiquitin-proteasome pathway.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10859165" target="_blank" class="term-link">
                             PMID:10859165
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Chaperone hsp27 inhibits translation during heat shock by binding eIF4G and facilitating dissociation of cap-initiation complexes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12150907" target="_blank" class="term-link">
                             PMID:12150907
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">CHIP is associated with Parkin, a gene responsible for familial Parkinson&#39;s disease, and enhances its ubiquitin ligase activity.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15603737" target="_blank" class="term-link">
                             PMID:15603737
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">BAG5 inhibits parkin and enhances dopaminergic neuron degeneration.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15671022" target="_blank" class="term-link">
                             PMID:15671022
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Heat shock protein 70 inhibits alpha-synuclein fibril formation via preferential binding to prefibrillar species.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15885686" target="_blank" class="term-link">
                             PMID:15885686
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TRIM37 defective in mulibrey nanism is a novel RING finger ubiquitin E3 ligase.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16130169" target="_blank" class="term-link">
                             PMID:16130169
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteomics of human umbilical vein endothelial cells applied to etoposide-induced apoptosis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16809764" target="_blank" class="term-link">
                             PMID:16809764
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Histone deacetylase 8 safeguards the human ever-shorter telomeres 1B (hEST1B) protein from ubiquitin-mediated degradation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17167422" target="_blank" class="term-link">
                             PMID:17167422
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Hsp70 regulates erythropoiesis by preventing caspase-3-mediated cleavage of GATA-1.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17182002" target="_blank" class="term-link">
                             PMID:17182002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HDJC9, a novel human type C DnaJ/HSP40 member interacts with and cochaperones HSP70 through the J domain.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17289661" target="_blank" class="term-link">
                             PMID:17289661
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Molecular composition of IMP1 ribonucleoprotein granules.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18975920" target="_blank" class="term-link">
                             PMID:18975920
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interactions between Hsp70 and the hydrophobic core of alpha-synuclein inhibit fibril assembly.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19190083" target="_blank" class="term-link">
                             PMID:19190083
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Characterization of exosome-like vesicles released from human tracheobronchial ciliated epithelium: a possible role in innate defense.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19199708" target="_blank" class="term-link">
                             PMID:19199708
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteomic analysis of human parotid gland exosomes by multidimensional protein identification technology (MudPIT).</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20458337" target="_blank" class="term-link">
                             PMID:20458337
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">MHC class II-associated proteins in B-cell exosomes and potential functional implications for exosome biogenesis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21081504" target="_blank" class="term-link">
                             PMID:21081504
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ChChd3, an inner mitochondrial membrane protein, is essential for maintaining crista integrity and mitochondrial function.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                             PMID:21231916
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The diverse members of the mammalian HSP70 machine show distinct chaperone-like activities.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21423176" target="_blank" class="term-link">
                             PMID:21423176
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Analysis of the myosin-II-responsive focal adhesion proteome reveals a role for β-Pix in negative regulation of focal adhesion maturation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22516433" target="_blank" class="term-link">
                             PMID:22516433
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteomic analysis of microvesicles from plasma of healthy donors reveals high individual variability.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22528486" target="_blank" class="term-link">
                             PMID:22528486
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Nucleophosmin (NPM1/B23) interacts with activating transcription factor 5 (ATF5) protein and promotes proteasome- and caspase-dependent ATF5 degradation in hepatocellular carcinoma cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22658674" target="_blank" class="term-link">
                             PMID:22658674
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Insights into RNA biology from an atlas of mammalian mRNA-binding proteins.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22681889" target="_blank" class="term-link">
                             PMID:22681889
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The mRNA-bound proteome and its global occupancy profile on protein-coding transcripts.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23349634" target="_blank" class="term-link">
                             PMID:23349634
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A newly uncovered group of distantly related lysine methyltransferases preferentially interact with molecular chaperones to regulate their activity.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link">
                             PMID:23533145
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">In-depth proteomic analyses of exosomes isolated from expressed prostatic secretions in urine.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link">
                             PMID:23921388
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Identification and characterization of a novel human methyltransferase modulating Hsp70 protein function through lysine methylation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24061851" target="_blank" class="term-link">
                             PMID:24061851
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Stress-induced localization of HSPA6 (HSP70B&#39;) and HSPA1A (HSP70-1) proteins to centrioles in human neuronal cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24252804" target="_blank" class="term-link">
                             PMID:24252804
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The role of oxidative stress in Parkinson&#39;s disease.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24318877" target="_blank" class="term-link">
                             PMID:24318877
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Binding of human nucleotide exchange factors to heat shock protein 70 (Hsp70) generates functionally distinct complexes in vitro.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24790089" target="_blank" class="term-link">
                             PMID:24790089
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The molecular chaperone HSP70 binds to and stabilizes NOD2, an important protein involved in Crohn disease.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25281747" target="_blank" class="term-link">
                             PMID:25281747
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RING finger protein RNF207, a novel regulator of cardiac excitation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27133716" target="_blank" class="term-link">
                             PMID:27133716
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A novel nuclear DnaJ protein, DNAJC8, can suppress the formation of spinocerebellar ataxia 3 polyglutamine aggregation in a J-domain independent manner.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27137183" target="_blank" class="term-link">
                             PMID:27137183
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP70 regulates the function of mitotic centrosomes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27708256" target="_blank" class="term-link">
                             PMID:27708256
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ARD1-mediated Hsp70 acetylation balances stress-induced protein refolding and degradation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28298427" target="_blank" class="term-link">
                             PMID:28298427
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Systematic protein-protein interaction mapping for clinically relevant human GPCRs.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33857403" target="_blank" class="term-link">
                             PMID:33857403
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">DNAJC9 integrates heat shock molecular chaperones into the histone chaperone network.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9553041" target="_blank" class="term-link">
                             PMID:9553041
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Inhibition of cellular proliferation by the Wilms tumor suppressor WT1 requires association with the inducible chaperone Hsp70.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371422
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ATP hydrolysis by HSP70</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371467
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">SIRT1 deacetylates HSF1</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371497
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP90 chaperone cycle for steroid hormone receptors (SHR) in the presence of ligand</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371503
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">STIP1(HOP) binds HSP90 and HSP70:HSP40:nascent protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371518
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">SIRT1 binds to HSF1</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371554
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSF1 acetylation at Lys80</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371590
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP70 binds to HSP40:nascent protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5082356
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSF1-mediated gene expression</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5082369
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Acetylated HSF1 dissociates from DNA</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5082384
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP70:DNAJB1 binds HSF1</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5251942
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Hikeshi binds HSP70s:ATP</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5251955
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP40s activate intrinsic ATPase activity of HSP70s in the nucleoplasm</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5251959
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP40s activate intrinsic ATPase activity of HSP70s in the cytosol</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5252041
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NPC transports Hikeshi:HSP70s:ATP from cytosol to nucleoplasm</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5252079
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP110s exchange ATP for ADP on HSP70s:ADP</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5618085
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">FKBP4 binds HSP90:ATP:STIP1:HSP70:nascent protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5618098
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">p23 (PTGES3) binds HSP90:ATP:FKBP5:nascent protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5618105
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">FKBP5 binds HSP90:ATP:STIP1:HSP70:nascent protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5618107
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ATP binding to HSP90 triggers conformation change</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5618110
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">p23 (PTGES3) binds HSP90:ATP:FKBP4:nascent protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6800434
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Exocytosis of ficolin-rich granule lumen proteins</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9835411
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">FA core complex:HSP70s binds PKR</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9857076
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Oxidized DNAJA1 binds HSPA1A,B (HSP70) displacing HSF1</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.3390/biom13020272
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP70 and Primary Arterial Hypertension</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Comprehensive review of HSP70 domain architecture (NBD, SBD, C-terminal tail), co-chaperone dependence (HSP40/DnaJ, HSP90), and role in proteostasis and stress adaptation. Notes stress-induced HSP70 expression can reach up to 15% of cellular protein.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.3389/fonc.2024.1388999
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Diversity of extracellular HSP70 in cancer - advancing from a molecular biomarker to a novel therapeutic target</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSPA1B is among HSP70 family members reported on the plasma membrane and in exosomes. Extracellular HSP70 can be actively trafficked through secretory granules, ABC transporter-mediated endolysosomal translocation, and exosome/ ectosome release. Membrane association involves phosphatidylserine binding, oligomerization, and enrichment in lipid rafts.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.3390/biom13040604
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Is It Still Possible to Think about HSP70 as a Therapeutic Target in Onco-Hematological Diseases?</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Reviews membrane-localized HSP70 exposing the TKD epitope (aa450-461) detectable by cmHSP70.1 antibody. Notes that HSP70 inhibitors have not reached the clinic despite extensive preclinical work. HSP110-family proteins cooperate with HSP70 and HSP40 in disaggregation.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -12092,9 +12040,9 @@ The 2024 review notes PTMs influence exosome loading of HSP70, but does not spec
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -12106,7 +12054,7 @@ The 2024 review notes PTMs influence exosome loading of HSP70, but does not spec
                 <pre><code>id: P0DMV9
 gene_symbol: HSPA1B
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -12187,13 +12135,14 @@ existing_annotations:
     summary: &gt;-
       Phylogenetic inference places HSPA1B at the plasma membrane. HSP70 family
       members have been reported at the cell surface in some contexts, including
-      as a receptor for rotavirus A entry (PMID:16537599, referenced in UniProt).
-      This is consistent with the IBA annotation.
+      extracellular HSP70 signaling and membrane-associated chaperone pools. The
+      rotavirus receptor citation is not used as HSPA1B-specific support because
+      the local UniProt citation describes recombinant hsc70.
     action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Plasma membrane localization is not a core feature of HSPA1B function but is
-      phylogenetically supported and consistent with some reported activities such
-      as virus receptor function.
+      Plasma membrane localization is not a core feature of HSPA1B function but
+      is phylogenetically plausible and consistent with cell-surface HSP70-family
+      observations.
 - term:
     id: GO:0016887
     label: ATP hydrolysis activity
@@ -12202,20 +12151,19 @@ existing_annotations:
   review:
     summary: &gt;-
       ATP hydrolysis is the central enzymatic activity of HSP70 chaperones. HSPA1B
-      has a well-characterized N-terminal ATPase domain (NBD, residues 2-386) with
-      multiple ATP binding sites confirmed by X-ray crystallography. IDA evidence
-      from PMID:21231916 directly demonstrates ATPase activity, and Reactome entry
-      R-HSA-3371422 describes ATP hydrolysis by HSP70 in detail.
+      has a conserved N-terminal nucleotide-binding/ATPase domain. The available
+      HSPA1A/HSPA6-specific PMID:21231916 evidence should not be treated as direct
+      HSPA1B evidence, but the IBA inference is consistent with conserved HSP70
+      family mechanism and Reactome HSP70 ATP-hydrolysis models.
     action: ACCEPT
     reason: &gt;-
       Core molecular function of HSPA1B. ATP hydrolysis drives the chaperone cycle
       and is essential for all HSP70 functions.
     supported_by:
-    - reference_id: PMID:21231916
+    - reference_id: file:human/HSPA1B/HSPA1B-deep-research-falcon.md
       supporting_text: &gt;-
-        HSPA6 has a functional substrate-binding domain and possesses intrinsic
-        ATPase activity that is as high as that of the canonical HSPA1A when
-        stimulated by J-proteins.
+        HSPA1B is a stress-inducible HSP70 paralog with conserved ATP-dependent
+        chaperone architecture, while isoform-specific claims require caution.
 - term:
     id: GO:0031072
     label: heat shock protein binding
@@ -12240,20 +12188,20 @@ existing_annotations:
   review:
     summary: &gt;-
       HSPA1B is a bona fide ATP-dependent protein folding chaperone. This is the
-      core molecular function annotation for this gene. IDA evidence from
-      PMID:15603737 directly demonstrates chaperone activity. UniProt describes
+      core molecular function annotation for this gene, supported by HSP70-family
+      phylogenetic inference and conserved domain architecture. UniProt describes
       HSPA1B as a &#34;Molecular chaperone implicated in a wide variety of cellular
       processes, including protection of the proteome from stress, folding and
       transport of newly synthesized polypeptides.&#34;
     action: ACCEPT
     reason: &gt;-
-      The defining molecular function of HSPA1B. Well-supported by both phylogenetic
-      inference and direct experimental evidence.
+      The defining molecular function of HSPA1B, well-supported by phylogenetic
+      inference and conserved HSP70 chaperone architecture.
     supported_by:
-    - reference_id: PMID:21231916
+    - reference_id: file:human/HSPA1B/HSPA1B-deep-research-falcon.md
       supporting_text: &gt;-
-        whereas overexpression of HSPA1A protected cells from heat-induced cell
-        death, overexpression of HSPA6 did not
+        HSPA1B is a stress-inducible Hsp70 paralog with a core proteostasis role,
+        while many HSP70/HSP72 studies do not distinguish it cleanly from HSPA1A.
 - term:
     id: GO:0005829
     label: cytosol
@@ -12274,20 +12222,20 @@ existing_annotations:
   original_reference_id: GO_REF:0000033
   review:
     summary: &gt;-
-      Protein refolding is a core biological process for HSPA1B. IDA evidence from
-      PMID:21231916 and PMID:15603737 demonstrates luciferase refolding activity.
-      PMID:27708256 shows that acetylation state determines whether HSPA1B functions
-      in protein refolding vs degradation.
+      Protein refolding is a core biological process inferred for HSPA1B from
+      conserved HSP70-family chaperone architecture and IBA evidence. Local
+      HSPA1A/HSPA6-specific assays should not be treated as direct HSPA1B
+      evidence; HSPA1B-specific claims require caution.
     action: ACCEPT
     reason: &gt;-
       Core biological process. HSPA1B actively refolds heat-denatured substrates
       through its ATP-dependent chaperone cycle.
     supported_by:
-    - reference_id: PMID:21231916
+    - reference_id: file:human/HSPA1B/HSPA1B-deep-research-falcon.md
       supporting_text: &gt;-
-        Overexpressed chaperones that suppressed polyQ aggregation were found not
-        to be able to stimulate luciferase refolding. Inversely, chaperones that
-        supported luciferase refolding were poor suppressors of polyQ aggregation.
+        HSPA1B is a major stress-inducible HSP70 protein with central roles in
+        proteostasis, but many HSP70/HSP72 studies do not distinguish it cleanly
+        from HSPA1A.
 - term:
     id: GO:0032436
     label: positive regulation of proteasomal ubiquitin-dependent protein catabolic
@@ -12312,13 +12260,13 @@ existing_annotations:
   original_reference_id: GO_REF:0000108
   review:
     summary: &gt;-
-      IEA annotation from logical inference. UniProt notes that HSPA1B serves as a
-      post-attachment receptor for rotavirus A to facilitate entry into the cell
-      (PMID:16537599). This is a specialized, non-core function.
-    action: KEEP_AS_NON_CORE
+      The source evidence for this rotavirus-entry inference is PMID:16537599, but
+      the local UniProt citation describes recombinant hsc70 rather than HSPA1B.
+      This is therefore a paralog/evidence mismatch for HSPA1B.
+    action: REMOVE
     reason: &gt;-
-      Supported by virus receptor activity documented in UniProt, but this is a
-      secondary role exploited by pathogens rather than a core cellular function.
+      The cited rotavirus receptor evidence does not establish HSPA1B-specific
+      symbiont entry activity.
 - term:
     id: GO:0000166
     label: nucleotide binding
@@ -12340,12 +12288,13 @@ existing_annotations:
   original_reference_id: GO_REF:0000043
   review:
     summary: &gt;-
-      IEA from UniProt keyword mapping for Host cell receptor for virus entry.
-      UniProt documents that HSPA1B serves as a post-attachment receptor for
-      rotavirus A (PMID:16537599).
-    action: KEEP_AS_NON_CORE
+      IEA from UniProt keyword mapping for host cell receptor for virus entry.
+      The cited PMID:16537599 evidence in the local UniProt record describes
+      recombinant hsc70 rather than HSPA1B.
+    action: REMOVE
     reason: &gt;-
-      Documented in UniProt but represents a non-core function exploited by viruses.
+      Virus receptor activity is not supported by HSPA1B-specific evidence in
+      the available local citation.
 - term:
     id: GO:0001664
     label: G protein-coupled receptor binding
@@ -12408,12 +12357,14 @@ existing_annotations:
   original_reference_id: GO_REF:0000117
   review:
     summary: &gt;-
-      IEA from ARBA models. IDA evidence from PMID:24061851 and GO_REF:0000052
-      confirms centriole localization of HSPA1A (functionally identical to HSPA1B)
-      under stress conditions.
-    action: ACCEPT
+      IEA from ARBA models. The supporting experimental paper PMID:24061851
+      tested HSPA1A and HSPA6, not HSPA1B, so it does not provide direct
+      HSPA1B-specific centriole-localization evidence.
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      Confirmed by IDA evidence showing stress-induced centriole localization.
+      Centriole localization is plausible by paralog inference, but the cited
+      experimental evidence is HSPA1A/HSPA6-specific. This should not be accepted
+      as a supported HSPA1B localization without HSPA1B-specific data.
 - term:
     id: GO:0006402
     label: mRNA catabolic process
@@ -12618,12 +12569,13 @@ existing_annotations:
   original_reference_id: GO_REF:0000117
   review:
     summary: &gt;-
-      IEA from ARBA models. IDA evidence from PMID:23921388 supports this.
-      HSPA1B hydrolyzes ATP as part of its chaperone cycle.
-    action: ACCEPT
+      HSPA1B hydrolyzes ATP as part of its chaperone cycle, but ATP metabolic
+      process is a broad biological-process term. The actual molecular activity
+      is captured by ATP hydrolysis activity and ATP-dependent chaperone terms.
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      Correct. ATP metabolic process is an inherent aspect of the ATPase-driven
-      chaperone cycle.
+      This broad BP term is less informative than the molecular-function terms
+      describing HSPA1B&#39;s ATPase-driven chaperone cycle.
 - term:
     id: GO:0048471
     label: perinuclear region of cytoplasm
@@ -12710,13 +12662,17 @@ existing_annotations:
   original_reference_id: GO_REF:0000117
   review:
     summary: &gt;-
-      IEA from ARBA models. IMP evidence from PMID:21231916 confirms that
-      HSPA1A (functionally identical to HSPA1B) protects cells from heat-induced
-      cell death and is involved in thermotolerance.
-    action: ACCEPT
+      IEA from ARBA models. HSPA1B is a stress-inducible HSP70 paralog, but
+      PMID:21231916 directly reports HSPA1A protection from heat-induced cell
+      death and warns that HSPA-family functional differences can be larger than
+      expected. The evidence should not be treated as HSPA1B-specific proof of
+      heat acclimation.
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Core stress-response function. HSPA1B is heat-inducible and protects cells
-      during heat stress.
+      HSPA1B likely participates in heat-stress proteostasis as an inducible
+      HSP70, but the cited direct evidence is paralog-specific to HSPA1A/HSPA6.
+      Keep this as non-core rather than accepting it as a demonstrated HSPA1B
+      heat-acclimation function.
 - term:
     id: GO:0070434
     label: positive regulation of nucleotide-binding oligomerization domain containing
@@ -12781,13 +12737,16 @@ existing_annotations:
   original_reference_id: GO_REF:0000117
   review:
     summary: &gt;-
-      IEA from ARBA models. IDA evidence from PMID:23921388 confirms
-      disaggregase activity. HSP70 works with co-chaperones to disaggregate
-      and refold aggregated proteins.
-    action: ACCEPT
+      IEA from ARBA models. PMID:23921388 describes METTL21A methylation and
+      altered HSPA8/Hsc70 affinity for alpha-synuclein, not direct HSPA1B
+      ATP-dependent disaggregase activity. The HSP70/HSP110/HSP40 system can
+      participate in disaggregation, but this evidence is not HSPA1B-specific.
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      Core molecular function. HSP70 disaggregase activity is well-established
-      and directly related to its protein quality control role.
+      This overextends family-level disaggregation biology and HSPA8-focused
+      evidence to HSPA1B. HSPA1B&#39;s core role should be represented as
+      ATP-dependent folding/refolding unless direct HSPA1B disaggregase evidence
+      is available.
 - term:
     id: GO:1901673
     label: regulation of mitotic spindle assembly
@@ -12982,13 +12941,13 @@ existing_annotations:
   original_reference_id: PMID:23921388
   review:
     summary: &gt;-
-      PMID:23921388 characterizes METTL21A methylation of HSP70 and shows that
-      methylation alters chaperone affinity for alpha-synuclein fibrils. The
-      disaggregase activity is a well-established function of HSP70 chaperones.
-    action: ACCEPT
+      PMID:23921388 characterizes METTL21A methylation and altered HSPA8/Hsc70
+      affinity for alpha-synuclein fibrils. It does not provide direct HSPA1B
+      ATP-dependent protein disaggregase evidence.
+    action: REMOVE
     reason: &gt;-
-      Core molecular function. HSP70 disaggregase activity is integral to
-      protein quality control.
+      The cited IDA evidence is mismatched for HSPA1B and should not be accepted
+      as HSPA1B-specific disaggregase activity.
 - term:
     id: GO:0016887
     label: ATP hydrolysis activity
@@ -12996,12 +12955,13 @@ existing_annotations:
   original_reference_id: PMID:21231916
   review:
     summary: &gt;-
-      PMID:21231916 directly demonstrates intrinsic ATPase activity of HSPA1A
-      (functionally identical to HSPA1B) that is stimulated by J-protein
-      co-chaperones. Core molecular function.
-    action: ACCEPT
+      PMID:21231916 directly demonstrates J-protein-stimulated intrinsic ATPase
+      activity for HSPA1A and HSPA6, but it does not provide direct HSPA1B-specific
+      ATPase evidence.
+    action: REMOVE
     reason: &gt;-
-      Core molecular function with direct experimental evidence.
+      The cited IDA evidence is paralog-specific and should not be accepted as
+      direct HSPA1B ATP hydrolysis activity.
     supported_by:
     - reference_id: PMID:21231916
       supporting_text: &gt;-
@@ -13213,11 +13173,12 @@ existing_annotations:
   original_reference_id: PMID:24061851
   review:
     summary: &gt;-
-      PMID:24061851 documents cytoplasmic and centriolar localization of
-      HSPA1A (functionally identical to HSPA1B) under stress conditions.
-    action: ACCEPT
+      PMID:24061851 documents cytoplasmic and centriolar localization of HSPA1A
+      and HSPA6 under stress conditions, not HSPA1B.
+    action: REMOVE
     reason: &gt;-
-      Core localization confirmed by direct assay.
+      The cited IDA evidence does not support HSPA1B-specific cytoplasmic
+      localization.
 - term:
     id: GO:0005737
     label: cytoplasm
@@ -14197,13 +14158,12 @@ existing_annotations:
   original_reference_id: PMID:24061851
   review:
     summary: &gt;-
-      PMID:24061851 documents stress-induced localization of HSPA1A
-      (functionally identical to HSPA1B) to centrioles in human neuronal
-      cells. Consistent with HSP70 centrosome function during stress.
-    action: ACCEPT
+      PMID:24061851 documents stress-induced localization of HSPA1A and HSPA6 to
+      centrioles in human neuronal cells, but it does not test HSPA1B.
+    action: REMOVE
     reason: &gt;-
-      Confirmed by direct assay showing stress-induced centriole
-      localization in neuronal cells.
+      The cited IDA evidence is not HSPA1B-specific and should not be accepted
+      for HSPA1B centriole localization.
 - term:
     id: GO:0005829
     label: cytosol
@@ -14240,13 +14200,14 @@ existing_annotations:
   original_reference_id: PMID:21231916
   review:
     summary: &gt;-
-      PMID:21231916 demonstrates functional interactions between HSP70
-      family members and various J-domain protein co-chaperones (HSP40s).
-      HSPA1A ATPase activity is stimulated by J-proteins.
-    action: ACCEPT
+      PMID:21231916 demonstrates functional interactions between HSP70-family
+      proteins and J-domain co-chaperones, but the local supporting excerpt
+      specifically names HSPA6 and HSPA1A rather than HSPA1B.
+    action: UNDECIDED
     reason: &gt;-
-      Core co-chaperone interaction. HSP70-HSP40 (J-protein) interactions
-      are fundamental to the chaperone cycle.
+      HSP70-HSP40 interactions are fundamental to the chaperone cycle, but the
+      available local evidence does not resolve HSPA1B-specific IPI support for
+      this source.
     supported_by:
     - reference_id: PMID:21231916
       supporting_text: &gt;-
@@ -14260,14 +14221,13 @@ existing_annotations:
   original_reference_id: PMID:24061851
   review:
     summary: &gt;-
-      PMID:24061851 demonstrates stress-induced localization changes of
-      HSPA1A to centrioles in human neuronal cells, showing a direct
-      cellular response to heat stress.
-    action: ACCEPT
+      PMID:24061851 demonstrates stress-induced localization changes of HSPA1A
+      and HSPA6 to centrioles in human neuronal cells, but it does not test
+      HSPA1B.
+    action: REMOVE
     reason: &gt;-
-      Core stress-response function. HSPA1B is heat-inducible and
-      directly responds to heat stress by changing its subcellular
-      localization and activity.
+      The cited IDA evidence is not HSPA1B-specific and should not be accepted
+      as direct cellular response to heat for HSPA1B.
 - term:
     id: GO:0042026
     label: protein refolding
@@ -14275,13 +14235,14 @@ existing_annotations:
   original_reference_id: PMID:21231916
   review:
     summary: &gt;-
-      PMID:21231916 directly demonstrates that HSPA1A (functionally
-      identical to HSPA1B) supports luciferase refolding after heat
-      denaturation. Core biological process for HSP70.
-    action: ACCEPT
+      PMID:21231916 reports HSPA1A-associated luciferase refolding activity, but
+      the available local evidence does not establish this as an HSPA1B-specific
+      IDA result.
+    action: REMOVE
     reason: &gt;-
-      Core biological process confirmed by direct assay showing
-      heat-denatured luciferase refolding activity.
+      The cited IDA evidence should not be accepted as direct HSPA1B protein
+      refolding evidence. HSPA1B refolding/chaperone function is represented by
+      better-supported chaperone annotations.
     supported_by:
     - reference_id: PMID:21231916
       supporting_text: &gt;-
@@ -14299,28 +14260,18 @@ existing_annotations:
       GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962).
       This IDA annotation references PMID:21231916 (Hageman et al. 2011), a key
       study that systematically compared chaperone activities of mammalian HSP70
-      family members. The study demonstrated that HSPA1A (&gt;99% identical to
-      HSPA1B) possesses robust luciferase refolding activity and protects cells
-      from heat-induced cell death. While the study does demonstrate that
-      HSPA1A/HSPA1B can bind heat-denatured substrates, this binding is
-      intrinsically coupled to the ATP-dependent chaperone folding cycle. The
-      correct molecular function term is GO:0044183 (protein folding chaperone),
+      family members. The study demonstrated HSPA1A and HSPA6 activities but did
+      not directly test HSPA1B for this annotation. While HSP70 proteins bind
+      heat-denatured substrates, this binding is intrinsically coupled to the
+      ATP-dependent chaperone folding cycle. The correct molecular function term
+      is GO:0044183 (protein folding chaperone),
       which captures the active chaperone function rather than the passive
       substrate-binding aspect that GO:0051082 implies.
-    action: MODIFY
+    action: REMOVE
     reason: &gt;-
-      GO:0051082 is being obsoleted. PMID:21231916 directly demonstrates that
-      HSPA1A (functionally identical to HSPA1B) is an active ATP-dependent
-      foldase that refolds heat-denatured luciferase and suppresses protein
-      aggregation. The binding of unfolded substrates by HSP70 is mechanistically
-      inseparable from its chaperone folding cycle. GO:0044183 (protein folding
-      chaperone) is the correct replacement and is already annotated to HSPA1B
-      via IDA (PMID:15603737) and IBA (GO_REF:0000033) evidence.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
-    additional_reference_ids:
-    - PMID:24012426
+      GO:0051082 is being obsoleted, and the cited PMID:21231916 evidence is not
+      HSPA1B-specific. HSPA1B&#39;s chaperone function is already represented by
+      GO:0044183 from better-supported annotations.
     supported_by:
     - reference_id: PMID:21231916
       supporting_text: &gt;-
@@ -14338,14 +14289,13 @@ existing_annotations:
   original_reference_id: PMID:21231916
   review:
     summary: &gt;-
-      PMID:21231916 confirms that HSPA1A (functionally identical to
-      HSPA1B) protects cells from heat-induced cell death. Overexpression
-      of HSPA1A conferred thermotolerance whereas HSPA6 did not.
-    action: ACCEPT
+      PMID:21231916 reports HSPA1A protection from heat-induced cell death and
+      HSPA6 lack of thermotolerance; it does not directly test HSPA1B for cellular
+      heat acclimation.
+    action: REMOVE
     reason: &gt;-
-      Core stress-response function. HSPA1B is heat-inducible and
-      protects cells during heat stress, directly contributing to
-      cellular heat acclimation.
+      The cited IMP evidence is HSPA1A/HSPA6-specific and should not be accepted
+      as a direct HSPA1B heat-acclimation annotation.
     supported_by:
     - reference_id: PMID:21231916
       supporting_text: &gt;-
@@ -14373,14 +14323,12 @@ existing_annotations:
   original_reference_id: PMID:21231916
   review:
     summary: &gt;-
-      PMID:21231916 demonstrates that HSPA1A (functionally identical to
-      HSPA1B) suppresses polyQ aggregation and inclusion body formation.
-      Core protein quality control function.
-    action: ACCEPT
+      PMID:21231916 discusses HSPA-family effects on polyQ aggregation, but the
+      local evidence does not establish this as an HSPA1B-specific IDA result.
+    action: REMOVE
     reason: &gt;-
-      Core chaperone function. Preventing protein aggregation and
-      inclusion body formation is a direct consequence of HSP70 foldase
-      and holdase activity.
+      The cited IDA evidence should not be accepted as HSPA1B-specific negative
+      regulation of inclusion body assembly.
 - term:
     id: GO:0005515
     label: protein binding
@@ -14430,15 +14378,13 @@ existing_annotations:
   original_reference_id: PMID:25281747
   review:
     summary: &gt;-
-      PMID:25281747 shows that coexpression of RNF207 and HSP70 increased
-      HERG expression, suggesting HSP70 participates in positive
-      regulation of gene expression for specific client proteins through
-      its chaperone activity on trafficking.
-    action: KEEP_AS_NON_CORE
+      PMID:25281747 reports increased total and membrane HERG/KCNH2 protein and
+      current density with RNF207 and HSP70, consistent with chaperone-mediated
+      trafficking or stabilization rather than regulation of gene expression.
+    action: REMOVE
     reason: &gt;-
-      Experimentally supported but a downstream consequence of HSP70
-      chaperone-mediated protein trafficking/stabilization in the cardiac
-      context, not a core gene expression regulatory function.
+      The evidence supports effects on HERG protein trafficking/localization and
+      current density, not positive regulation of gene expression.
     supported_by:
     - reference_id: PMID:25281747
       supporting_text: &gt;-
@@ -14565,13 +14511,13 @@ existing_annotations:
   original_reference_id: PMID:23921388
   review:
     summary: &gt;-
-      PMID:23921388 confirms ATP-dependent activity of HSP70 in the
-      context of METTL21A methylation studies. HSP70 hydrolyzes ATP as
-      part of its chaperone cycle.
-    action: ACCEPT
+      PMID:23921388 describes METTL21A methylation assays and HSPA8/Hsc70
+      functional effects, not HSPA1B-specific ATP metabolic process.
+    action: REMOVE
     reason: &gt;-
-      Core function. ATP metabolic process is an inherent aspect of the
-      ATPase-driven chaperone cycle.
+      The cited IDA evidence does not support a broad HSPA1B ATP metabolic
+      process annotation; ATP use is better captured by ATPase/chaperone
+      molecular-function annotations.
 - term:
     id: GO:0048471
     label: perinuclear region of cytoplasm
@@ -14690,17 +14636,14 @@ core_functions:
     state of Lys-77 governing this switch. Under stress, expression can
     reach approximately 15% of total cellular protein
     (DOI:10.3390/biom13020272). HSP70 cooperates with HSP90 in client
-    maturation pathways and also participates in disaggregation of protein
-    aggregates through cooperation with HSP110 as a disaggregase NEF
-    (DOI:10.3390/biom13020272).
+    maturation pathways; HSPA1B-specific disaggregase activity should not be
+    inferred without direct supporting evidence.
   directly_involved_in:
   - id: GO:0042026
     label: protein refolding
   - id: GO:0032436
     label: positive regulation of proteasomal ubiquitin-dependent protein catabolic
       process
-  - id: GO:0070370
-    label: cellular heat acclimation
   - id: GO:0090084
     label: negative regulation of inclusion body assembly
   locations:
@@ -14708,25 +14651,17 @@ core_functions:
     label: cytosol
   - id: GO:0005634
     label: nucleus
-- molecular_function:
-    id: GO:0140545
-    label: ATP-dependent protein disaggregase activity
-  description: &gt;-
-    Works with co-chaperones (notably HSP110/HSPH1 and DNAJB1) to solubilize
-    and disaggregate ordered protein aggregates, including alpha-synuclein
-    fibrils. This disaggregase activity is driven by the same ATP hydrolysis
-    cycle as the foldase function but is directed toward pre-formed aggregates
-    rather than nascent or stress-denatured monomers. Recent reviews position
-    HSP110-family proteins as major NEFs/co-chaperones that cooperate with
-    HSP70 and HSP40 to disaggregate and refold denatured proteins
-    (DOI:10.3390/biom13040604).
-  directly_involved_in:
-  - id: GO:0090084
-    label: negative regulation of inclusion body assembly
-  locations:
-  - id: GO:0005829
-    label: cytosol
+  supported_by:
+  - reference_id: file:human/HSPA1B/HSPA1B-deep-research-falcon.md
+    supporting_text: &gt;-
+      HSPA1B is a major stress-inducible HSP70 protein with central roles in
+      proteostasis, survival signaling, and immune modulation; many studies do
+      not distinguish HSPA1B from HSPA1A, so isoform-specific claims require
+      caution.
 references:
+- id: file:human/HSPA1B/HSPA1B-deep-research-falcon.md
+  title: Falcon deep research report for HSPA1B
+  findings: []
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
   findings: []
@@ -14991,7 +14926,7 @@ references:
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/HSPA1B/HSPA1B-ai-review.yaml
+++ b/genes/human/HSPA1B/HSPA1B-ai-review.yaml
@@ -1,7 +1,7 @@
 id: P0DMV9
 gene_symbol: HSPA1B
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -82,13 +82,14 @@ existing_annotations:
     summary: >-
       Phylogenetic inference places HSPA1B at the plasma membrane. HSP70 family
       members have been reported at the cell surface in some contexts, including
-      as a receptor for rotavirus A entry (PMID:16537599, referenced in UniProt).
-      This is consistent with the IBA annotation.
+      extracellular HSP70 signaling and membrane-associated chaperone pools. The
+      rotavirus receptor citation is not used as HSPA1B-specific support because
+      the local UniProt citation describes recombinant hsc70.
     action: KEEP_AS_NON_CORE
     reason: >-
-      Plasma membrane localization is not a core feature of HSPA1B function but is
-      phylogenetically supported and consistent with some reported activities such
-      as virus receptor function.
+      Plasma membrane localization is not a core feature of HSPA1B function but
+      is phylogenetically plausible and consistent with cell-surface HSP70-family
+      observations.
 - term:
     id: GO:0016887
     label: ATP hydrolysis activity
@@ -97,20 +98,19 @@ existing_annotations:
   review:
     summary: >-
       ATP hydrolysis is the central enzymatic activity of HSP70 chaperones. HSPA1B
-      has a well-characterized N-terminal ATPase domain (NBD, residues 2-386) with
-      multiple ATP binding sites confirmed by X-ray crystallography. IDA evidence
-      from PMID:21231916 directly demonstrates ATPase activity, and Reactome entry
-      R-HSA-3371422 describes ATP hydrolysis by HSP70 in detail.
+      has a conserved N-terminal nucleotide-binding/ATPase domain. The available
+      HSPA1A/HSPA6-specific PMID:21231916 evidence should not be treated as direct
+      HSPA1B evidence, but the IBA inference is consistent with conserved HSP70
+      family mechanism and Reactome HSP70 ATP-hydrolysis models.
     action: ACCEPT
     reason: >-
       Core molecular function of HSPA1B. ATP hydrolysis drives the chaperone cycle
       and is essential for all HSP70 functions.
     supported_by:
-    - reference_id: PMID:21231916
+    - reference_id: file:human/HSPA1B/HSPA1B-deep-research-falcon.md
       supporting_text: >-
-        HSPA6 has a functional substrate-binding domain and possesses intrinsic
-        ATPase activity that is as high as that of the canonical HSPA1A when
-        stimulated by J-proteins.
+        HSPA1B is a stress-inducible HSP70 paralog with conserved ATP-dependent
+        chaperone architecture, while isoform-specific claims require caution.
 - term:
     id: GO:0031072
     label: heat shock protein binding
@@ -135,20 +135,20 @@ existing_annotations:
   review:
     summary: >-
       HSPA1B is a bona fide ATP-dependent protein folding chaperone. This is the
-      core molecular function annotation for this gene. IDA evidence from
-      PMID:15603737 directly demonstrates chaperone activity. UniProt describes
+      core molecular function annotation for this gene, supported by HSP70-family
+      phylogenetic inference and conserved domain architecture. UniProt describes
       HSPA1B as a "Molecular chaperone implicated in a wide variety of cellular
       processes, including protection of the proteome from stress, folding and
       transport of newly synthesized polypeptides."
     action: ACCEPT
     reason: >-
-      The defining molecular function of HSPA1B. Well-supported by both phylogenetic
-      inference and direct experimental evidence.
+      The defining molecular function of HSPA1B, well-supported by phylogenetic
+      inference and conserved HSP70 chaperone architecture.
     supported_by:
-    - reference_id: PMID:21231916
+    - reference_id: file:human/HSPA1B/HSPA1B-deep-research-falcon.md
       supporting_text: >-
-        whereas overexpression of HSPA1A protected cells from heat-induced cell
-        death, overexpression of HSPA6 did not
+        HSPA1B is a stress-inducible Hsp70 paralog with a core proteostasis role,
+        while many HSP70/HSP72 studies do not distinguish it cleanly from HSPA1A.
 - term:
     id: GO:0005829
     label: cytosol
@@ -169,20 +169,20 @@ existing_annotations:
   original_reference_id: GO_REF:0000033
   review:
     summary: >-
-      Protein refolding is a core biological process for HSPA1B. IDA evidence from
-      PMID:21231916 and PMID:15603737 demonstrates luciferase refolding activity.
-      PMID:27708256 shows that acetylation state determines whether HSPA1B functions
-      in protein refolding vs degradation.
+      Protein refolding is a core biological process inferred for HSPA1B from
+      conserved HSP70-family chaperone architecture and IBA evidence. Local
+      HSPA1A/HSPA6-specific assays should not be treated as direct HSPA1B
+      evidence; HSPA1B-specific claims require caution.
     action: ACCEPT
     reason: >-
       Core biological process. HSPA1B actively refolds heat-denatured substrates
       through its ATP-dependent chaperone cycle.
     supported_by:
-    - reference_id: PMID:21231916
+    - reference_id: file:human/HSPA1B/HSPA1B-deep-research-falcon.md
       supporting_text: >-
-        Overexpressed chaperones that suppressed polyQ aggregation were found not
-        to be able to stimulate luciferase refolding. Inversely, chaperones that
-        supported luciferase refolding were poor suppressors of polyQ aggregation.
+        HSPA1B is a major stress-inducible HSP70 protein with central roles in
+        proteostasis, but many HSP70/HSP72 studies do not distinguish it cleanly
+        from HSPA1A.
 - term:
     id: GO:0032436
     label: positive regulation of proteasomal ubiquitin-dependent protein catabolic
@@ -207,13 +207,13 @@ existing_annotations:
   original_reference_id: GO_REF:0000108
   review:
     summary: >-
-      IEA annotation from logical inference. UniProt notes that HSPA1B serves as a
-      post-attachment receptor for rotavirus A to facilitate entry into the cell
-      (PMID:16537599). This is a specialized, non-core function.
-    action: KEEP_AS_NON_CORE
+      The source evidence for this rotavirus-entry inference is PMID:16537599, but
+      the local UniProt citation describes recombinant hsc70 rather than HSPA1B.
+      This is therefore a paralog/evidence mismatch for HSPA1B.
+    action: REMOVE
     reason: >-
-      Supported by virus receptor activity documented in UniProt, but this is a
-      secondary role exploited by pathogens rather than a core cellular function.
+      The cited rotavirus receptor evidence does not establish HSPA1B-specific
+      symbiont entry activity.
 - term:
     id: GO:0000166
     label: nucleotide binding
@@ -235,12 +235,13 @@ existing_annotations:
   original_reference_id: GO_REF:0000043
   review:
     summary: >-
-      IEA from UniProt keyword mapping for Host cell receptor for virus entry.
-      UniProt documents that HSPA1B serves as a post-attachment receptor for
-      rotavirus A (PMID:16537599).
-    action: KEEP_AS_NON_CORE
+      IEA from UniProt keyword mapping for host cell receptor for virus entry.
+      The cited PMID:16537599 evidence in the local UniProt record describes
+      recombinant hsc70 rather than HSPA1B.
+    action: REMOVE
     reason: >-
-      Documented in UniProt but represents a non-core function exploited by viruses.
+      Virus receptor activity is not supported by HSPA1B-specific evidence in
+      the available local citation.
 - term:
     id: GO:0001664
     label: G protein-coupled receptor binding
@@ -303,12 +304,14 @@ existing_annotations:
   original_reference_id: GO_REF:0000117
   review:
     summary: >-
-      IEA from ARBA models. IDA evidence from PMID:24061851 and GO_REF:0000052
-      confirms centriole localization of HSPA1A (functionally identical to HSPA1B)
-      under stress conditions.
-    action: ACCEPT
+      IEA from ARBA models. The supporting experimental paper PMID:24061851
+      tested HSPA1A and HSPA6, not HSPA1B, so it does not provide direct
+      HSPA1B-specific centriole-localization evidence.
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      Confirmed by IDA evidence showing stress-induced centriole localization.
+      Centriole localization is plausible by paralog inference, but the cited
+      experimental evidence is HSPA1A/HSPA6-specific. This should not be accepted
+      as a supported HSPA1B localization without HSPA1B-specific data.
 - term:
     id: GO:0006402
     label: mRNA catabolic process
@@ -513,12 +516,13 @@ existing_annotations:
   original_reference_id: GO_REF:0000117
   review:
     summary: >-
-      IEA from ARBA models. IDA evidence from PMID:23921388 supports this.
-      HSPA1B hydrolyzes ATP as part of its chaperone cycle.
-    action: ACCEPT
+      HSPA1B hydrolyzes ATP as part of its chaperone cycle, but ATP metabolic
+      process is a broad biological-process term. The actual molecular activity
+      is captured by ATP hydrolysis activity and ATP-dependent chaperone terms.
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      Correct. ATP metabolic process is an inherent aspect of the ATPase-driven
-      chaperone cycle.
+      This broad BP term is less informative than the molecular-function terms
+      describing HSPA1B's ATPase-driven chaperone cycle.
 - term:
     id: GO:0048471
     label: perinuclear region of cytoplasm
@@ -605,13 +609,17 @@ existing_annotations:
   original_reference_id: GO_REF:0000117
   review:
     summary: >-
-      IEA from ARBA models. IMP evidence from PMID:21231916 confirms that
-      HSPA1A (functionally identical to HSPA1B) protects cells from heat-induced
-      cell death and is involved in thermotolerance.
-    action: ACCEPT
+      IEA from ARBA models. HSPA1B is a stress-inducible HSP70 paralog, but
+      PMID:21231916 directly reports HSPA1A protection from heat-induced cell
+      death and warns that HSPA-family functional differences can be larger than
+      expected. The evidence should not be treated as HSPA1B-specific proof of
+      heat acclimation.
+    action: KEEP_AS_NON_CORE
     reason: >-
-      Core stress-response function. HSPA1B is heat-inducible and protects cells
-      during heat stress.
+      HSPA1B likely participates in heat-stress proteostasis as an inducible
+      HSP70, but the cited direct evidence is paralog-specific to HSPA1A/HSPA6.
+      Keep this as non-core rather than accepting it as a demonstrated HSPA1B
+      heat-acclimation function.
 - term:
     id: GO:0070434
     label: positive regulation of nucleotide-binding oligomerization domain containing
@@ -676,13 +684,16 @@ existing_annotations:
   original_reference_id: GO_REF:0000117
   review:
     summary: >-
-      IEA from ARBA models. IDA evidence from PMID:23921388 confirms
-      disaggregase activity. HSP70 works with co-chaperones to disaggregate
-      and refold aggregated proteins.
-    action: ACCEPT
+      IEA from ARBA models. PMID:23921388 describes METTL21A methylation and
+      altered HSPA8/Hsc70 affinity for alpha-synuclein, not direct HSPA1B
+      ATP-dependent disaggregase activity. The HSP70/HSP110/HSP40 system can
+      participate in disaggregation, but this evidence is not HSPA1B-specific.
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      Core molecular function. HSP70 disaggregase activity is well-established
-      and directly related to its protein quality control role.
+      This overextends family-level disaggregation biology and HSPA8-focused
+      evidence to HSPA1B. HSPA1B's core role should be represented as
+      ATP-dependent folding/refolding unless direct HSPA1B disaggregase evidence
+      is available.
 - term:
     id: GO:1901673
     label: regulation of mitotic spindle assembly
@@ -877,13 +888,13 @@ existing_annotations:
   original_reference_id: PMID:23921388
   review:
     summary: >-
-      PMID:23921388 characterizes METTL21A methylation of HSP70 and shows that
-      methylation alters chaperone affinity for alpha-synuclein fibrils. The
-      disaggregase activity is a well-established function of HSP70 chaperones.
-    action: ACCEPT
+      PMID:23921388 characterizes METTL21A methylation and altered HSPA8/Hsc70
+      affinity for alpha-synuclein fibrils. It does not provide direct HSPA1B
+      ATP-dependent protein disaggregase evidence.
+    action: REMOVE
     reason: >-
-      Core molecular function. HSP70 disaggregase activity is integral to
-      protein quality control.
+      The cited IDA evidence is mismatched for HSPA1B and should not be accepted
+      as HSPA1B-specific disaggregase activity.
 - term:
     id: GO:0016887
     label: ATP hydrolysis activity
@@ -891,12 +902,13 @@ existing_annotations:
   original_reference_id: PMID:21231916
   review:
     summary: >-
-      PMID:21231916 directly demonstrates intrinsic ATPase activity of HSPA1A
-      (functionally identical to HSPA1B) that is stimulated by J-protein
-      co-chaperones. Core molecular function.
-    action: ACCEPT
+      PMID:21231916 directly demonstrates J-protein-stimulated intrinsic ATPase
+      activity for HSPA1A and HSPA6, but it does not provide direct HSPA1B-specific
+      ATPase evidence.
+    action: REMOVE
     reason: >-
-      Core molecular function with direct experimental evidence.
+      The cited IDA evidence is paralog-specific and should not be accepted as
+      direct HSPA1B ATP hydrolysis activity.
     supported_by:
     - reference_id: PMID:21231916
       supporting_text: >-
@@ -1108,11 +1120,12 @@ existing_annotations:
   original_reference_id: PMID:24061851
   review:
     summary: >-
-      PMID:24061851 documents cytoplasmic and centriolar localization of
-      HSPA1A (functionally identical to HSPA1B) under stress conditions.
-    action: ACCEPT
+      PMID:24061851 documents cytoplasmic and centriolar localization of HSPA1A
+      and HSPA6 under stress conditions, not HSPA1B.
+    action: REMOVE
     reason: >-
-      Core localization confirmed by direct assay.
+      The cited IDA evidence does not support HSPA1B-specific cytoplasmic
+      localization.
 - term:
     id: GO:0005737
     label: cytoplasm
@@ -2092,13 +2105,12 @@ existing_annotations:
   original_reference_id: PMID:24061851
   review:
     summary: >-
-      PMID:24061851 documents stress-induced localization of HSPA1A
-      (functionally identical to HSPA1B) to centrioles in human neuronal
-      cells. Consistent with HSP70 centrosome function during stress.
-    action: ACCEPT
+      PMID:24061851 documents stress-induced localization of HSPA1A and HSPA6 to
+      centrioles in human neuronal cells, but it does not test HSPA1B.
+    action: REMOVE
     reason: >-
-      Confirmed by direct assay showing stress-induced centriole
-      localization in neuronal cells.
+      The cited IDA evidence is not HSPA1B-specific and should not be accepted
+      for HSPA1B centriole localization.
 - term:
     id: GO:0005829
     label: cytosol
@@ -2135,13 +2147,14 @@ existing_annotations:
   original_reference_id: PMID:21231916
   review:
     summary: >-
-      PMID:21231916 demonstrates functional interactions between HSP70
-      family members and various J-domain protein co-chaperones (HSP40s).
-      HSPA1A ATPase activity is stimulated by J-proteins.
-    action: ACCEPT
+      PMID:21231916 demonstrates functional interactions between HSP70-family
+      proteins and J-domain co-chaperones, but the local supporting excerpt
+      specifically names HSPA6 and HSPA1A rather than HSPA1B.
+    action: UNDECIDED
     reason: >-
-      Core co-chaperone interaction. HSP70-HSP40 (J-protein) interactions
-      are fundamental to the chaperone cycle.
+      HSP70-HSP40 interactions are fundamental to the chaperone cycle, but the
+      available local evidence does not resolve HSPA1B-specific IPI support for
+      this source.
     supported_by:
     - reference_id: PMID:21231916
       supporting_text: >-
@@ -2155,14 +2168,13 @@ existing_annotations:
   original_reference_id: PMID:24061851
   review:
     summary: >-
-      PMID:24061851 demonstrates stress-induced localization changes of
-      HSPA1A to centrioles in human neuronal cells, showing a direct
-      cellular response to heat stress.
-    action: ACCEPT
+      PMID:24061851 demonstrates stress-induced localization changes of HSPA1A
+      and HSPA6 to centrioles in human neuronal cells, but it does not test
+      HSPA1B.
+    action: REMOVE
     reason: >-
-      Core stress-response function. HSPA1B is heat-inducible and
-      directly responds to heat stress by changing its subcellular
-      localization and activity.
+      The cited IDA evidence is not HSPA1B-specific and should not be accepted
+      as direct cellular response to heat for HSPA1B.
 - term:
     id: GO:0042026
     label: protein refolding
@@ -2170,13 +2182,14 @@ existing_annotations:
   original_reference_id: PMID:21231916
   review:
     summary: >-
-      PMID:21231916 directly demonstrates that HSPA1A (functionally
-      identical to HSPA1B) supports luciferase refolding after heat
-      denaturation. Core biological process for HSP70.
-    action: ACCEPT
+      PMID:21231916 reports HSPA1A-associated luciferase refolding activity, but
+      the available local evidence does not establish this as an HSPA1B-specific
+      IDA result.
+    action: REMOVE
     reason: >-
-      Core biological process confirmed by direct assay showing
-      heat-denatured luciferase refolding activity.
+      The cited IDA evidence should not be accepted as direct HSPA1B protein
+      refolding evidence. HSPA1B refolding/chaperone function is represented by
+      better-supported chaperone annotations.
     supported_by:
     - reference_id: PMID:21231916
       supporting_text: >-
@@ -2194,28 +2207,18 @@ existing_annotations:
       GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962).
       This IDA annotation references PMID:21231916 (Hageman et al. 2011), a key
       study that systematically compared chaperone activities of mammalian HSP70
-      family members. The study demonstrated that HSPA1A (>99% identical to
-      HSPA1B) possesses robust luciferase refolding activity and protects cells
-      from heat-induced cell death. While the study does demonstrate that
-      HSPA1A/HSPA1B can bind heat-denatured substrates, this binding is
-      intrinsically coupled to the ATP-dependent chaperone folding cycle. The
-      correct molecular function term is GO:0044183 (protein folding chaperone),
+      family members. The study demonstrated HSPA1A and HSPA6 activities but did
+      not directly test HSPA1B for this annotation. While HSP70 proteins bind
+      heat-denatured substrates, this binding is intrinsically coupled to the
+      ATP-dependent chaperone folding cycle. The correct molecular function term
+      is GO:0044183 (protein folding chaperone),
       which captures the active chaperone function rather than the passive
       substrate-binding aspect that GO:0051082 implies.
-    action: MODIFY
+    action: REMOVE
     reason: >-
-      GO:0051082 is being obsoleted. PMID:21231916 directly demonstrates that
-      HSPA1A (functionally identical to HSPA1B) is an active ATP-dependent
-      foldase that refolds heat-denatured luciferase and suppresses protein
-      aggregation. The binding of unfolded substrates by HSP70 is mechanistically
-      inseparable from its chaperone folding cycle. GO:0044183 (protein folding
-      chaperone) is the correct replacement and is already annotated to HSPA1B
-      via IDA (PMID:15603737) and IBA (GO_REF:0000033) evidence.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
-    additional_reference_ids:
-    - PMID:24012426
+      GO:0051082 is being obsoleted, and the cited PMID:21231916 evidence is not
+      HSPA1B-specific. HSPA1B's chaperone function is already represented by
+      GO:0044183 from better-supported annotations.
     supported_by:
     - reference_id: PMID:21231916
       supporting_text: >-
@@ -2233,14 +2236,13 @@ existing_annotations:
   original_reference_id: PMID:21231916
   review:
     summary: >-
-      PMID:21231916 confirms that HSPA1A (functionally identical to
-      HSPA1B) protects cells from heat-induced cell death. Overexpression
-      of HSPA1A conferred thermotolerance whereas HSPA6 did not.
-    action: ACCEPT
+      PMID:21231916 reports HSPA1A protection from heat-induced cell death and
+      HSPA6 lack of thermotolerance; it does not directly test HSPA1B for cellular
+      heat acclimation.
+    action: REMOVE
     reason: >-
-      Core stress-response function. HSPA1B is heat-inducible and
-      protects cells during heat stress, directly contributing to
-      cellular heat acclimation.
+      The cited IMP evidence is HSPA1A/HSPA6-specific and should not be accepted
+      as a direct HSPA1B heat-acclimation annotation.
     supported_by:
     - reference_id: PMID:21231916
       supporting_text: >-
@@ -2268,14 +2270,12 @@ existing_annotations:
   original_reference_id: PMID:21231916
   review:
     summary: >-
-      PMID:21231916 demonstrates that HSPA1A (functionally identical to
-      HSPA1B) suppresses polyQ aggregation and inclusion body formation.
-      Core protein quality control function.
-    action: ACCEPT
+      PMID:21231916 discusses HSPA-family effects on polyQ aggregation, but the
+      local evidence does not establish this as an HSPA1B-specific IDA result.
+    action: REMOVE
     reason: >-
-      Core chaperone function. Preventing protein aggregation and
-      inclusion body formation is a direct consequence of HSP70 foldase
-      and holdase activity.
+      The cited IDA evidence should not be accepted as HSPA1B-specific negative
+      regulation of inclusion body assembly.
 - term:
     id: GO:0005515
     label: protein binding
@@ -2325,15 +2325,13 @@ existing_annotations:
   original_reference_id: PMID:25281747
   review:
     summary: >-
-      PMID:25281747 shows that coexpression of RNF207 and HSP70 increased
-      HERG expression, suggesting HSP70 participates in positive
-      regulation of gene expression for specific client proteins through
-      its chaperone activity on trafficking.
-    action: KEEP_AS_NON_CORE
+      PMID:25281747 reports increased total and membrane HERG/KCNH2 protein and
+      current density with RNF207 and HSP70, consistent with chaperone-mediated
+      trafficking or stabilization rather than regulation of gene expression.
+    action: REMOVE
     reason: >-
-      Experimentally supported but a downstream consequence of HSP70
-      chaperone-mediated protein trafficking/stabilization in the cardiac
-      context, not a core gene expression regulatory function.
+      The evidence supports effects on HERG protein trafficking/localization and
+      current density, not positive regulation of gene expression.
     supported_by:
     - reference_id: PMID:25281747
       supporting_text: >-
@@ -2460,13 +2458,13 @@ existing_annotations:
   original_reference_id: PMID:23921388
   review:
     summary: >-
-      PMID:23921388 confirms ATP-dependent activity of HSP70 in the
-      context of METTL21A methylation studies. HSP70 hydrolyzes ATP as
-      part of its chaperone cycle.
-    action: ACCEPT
+      PMID:23921388 describes METTL21A methylation assays and HSPA8/Hsc70
+      functional effects, not HSPA1B-specific ATP metabolic process.
+    action: REMOVE
     reason: >-
-      Core function. ATP metabolic process is an inherent aspect of the
-      ATPase-driven chaperone cycle.
+      The cited IDA evidence does not support a broad HSPA1B ATP metabolic
+      process annotation; ATP use is better captured by ATPase/chaperone
+      molecular-function annotations.
 - term:
     id: GO:0048471
     label: perinuclear region of cytoplasm
@@ -2585,17 +2583,14 @@ core_functions:
     state of Lys-77 governing this switch. Under stress, expression can
     reach approximately 15% of total cellular protein
     (DOI:10.3390/biom13020272). HSP70 cooperates with HSP90 in client
-    maturation pathways and also participates in disaggregation of protein
-    aggregates through cooperation with HSP110 as a disaggregase NEF
-    (DOI:10.3390/biom13020272).
+    maturation pathways; HSPA1B-specific disaggregase activity should not be
+    inferred without direct supporting evidence.
   directly_involved_in:
   - id: GO:0042026
     label: protein refolding
   - id: GO:0032436
     label: positive regulation of proteasomal ubiquitin-dependent protein catabolic
       process
-  - id: GO:0070370
-    label: cellular heat acclimation
   - id: GO:0090084
     label: negative regulation of inclusion body assembly
   locations:
@@ -2603,25 +2598,17 @@ core_functions:
     label: cytosol
   - id: GO:0005634
     label: nucleus
-- molecular_function:
-    id: GO:0140545
-    label: ATP-dependent protein disaggregase activity
-  description: >-
-    Works with co-chaperones (notably HSP110/HSPH1 and DNAJB1) to solubilize
-    and disaggregate ordered protein aggregates, including alpha-synuclein
-    fibrils. This disaggregase activity is driven by the same ATP hydrolysis
-    cycle as the foldase function but is directed toward pre-formed aggregates
-    rather than nascent or stress-denatured monomers. Recent reviews position
-    HSP110-family proteins as major NEFs/co-chaperones that cooperate with
-    HSP70 and HSP40 to disaggregate and refold denatured proteins
-    (DOI:10.3390/biom13040604).
-  directly_involved_in:
-  - id: GO:0090084
-    label: negative regulation of inclusion body assembly
-  locations:
-  - id: GO:0005829
-    label: cytosol
+  supported_by:
+  - reference_id: file:human/HSPA1B/HSPA1B-deep-research-falcon.md
+    supporting_text: >-
+      HSPA1B is a major stress-inducible HSP70 protein with central roles in
+      proteostasis, survival signaling, and immune modulation; many studies do
+      not distinguish HSPA1B from HSPA1A, so isoform-specific claims require
+      caution.
 references:
+- id: file:human/HSPA1B/HSPA1B-deep-research-falcon.md
+  title: Falcon deep research report for HSPA1B
+  findings: []
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
   findings: []

--- a/genes/human/HSPA1L/HSPA1L-ai-review.html
+++ b/genes/human/HSPA1L/HSPA1L-ai-review.html
@@ -864,13 +864,13 @@
                             <div class="support-item">
                                 <span class="support-ref">
 
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
-                                        PMID:21231916
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20072699" target="_blank" class="term-link">
+                                        PMID:20072699
                                     </a>
 
                                 </span>
 
-                                <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol.</div>
+                                <div class="support-text">In all ATPase domains except for that of HSPA5/BiP the products of ATP hydrolysis, including inorganic phosphate, were observed.</div>
 
                             </div>
 
@@ -4009,10 +4009,10 @@ existing_annotations:
       supported by both phylogenetic inference and direct experimental evidence
       from Hageman et al. (2011) (PMID:21231916).
     supported_by:
-      - reference_id: PMID:21231916
+      - reference_id: PMID:20072699
         supporting_text: &gt;-
-          Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding
-          genes and most of the corresponding proteins are localized in the cytosol.
+          In all ATPase domains except for that of HSPA5/BiP the products of
+          ATP hydrolysis, including inorganic phosphate, were observed.
 - term:
     id: GO:0005886
     label: plasma membrane

--- a/genes/human/HSPA1L/HSPA1L-ai-review.html
+++ b/genes/human/HSPA1L/HSPA1L-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>HSPA1L</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P34931" target="_blank" class="term-link">
                         P34931
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -737,15 +737,15 @@
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>HSPA1L (Heat shock 70 kDa protein 1-like, also known as HSP70-Hom) is a constitutively expressed member of the HSP70/HSPA family of molecular chaperones, encoded in the MHC class III region on chromosome 6 in close genomic proximity (within approximately 14 kb) to the stress-inducible paralogs HSPA1A and HSPA1B (DOI:10.62347/cwpe7813). It is approximately 90% identical in sequence to HSPA1A. Unlike HSPA1A, HSPA1L is not induced by heat shock (PMID:1700760) and is notably enriched in testis/spermatids (PMID:9685725). HSPA1L has the canonical HSP70 domain architecture: an N-terminal nucleotide-binding domain (NBD/ATPase) that binds and hydrolyzes ATP, a C-terminal substrate-binding domain (SBD) that binds exposed hydrophobic peptide segments in client proteins, and an interdomain linker coupling nucleotide state to substrate affinity -- ATP binding promotes an open SBD lid conformation, ATP hydrolysis promotes lid closure and higher client affinity, and nucleotide exchange resets the cycle (DOI:10.14712/fb2024070030152). The ATPase domain crystal structure has been solved at 1.80 angstrom resolution (PDB:3GDQ; PMID:20072699). HSPA1L has been shown to refold heat-denatured luciferase and to suppress polyglutamine aggregation (PMID:21231916). It also functions as a positive regulator of PRKN (Parkin) translocation to damaged mitochondria, requiring both its ATPase and substrate-binding domains as well as its EEVD co-chaperone interaction motif (PMID:24270810). In neuronal heat-stress models, HSPA1L protein was induced approximately 2.5-3.5-fold with gene expression peaking at approximately 1 hour post-stress and protein at approximately 5-6 hours, indicating context-dependent inducibility in some cell types (DOI:10.3390/biology12030416). Recent epitranscriptomic studies show that METTL3-mediated m6A modification regulates HSPA1L mRNA levels, and METTL3 silencing increases HSPA1L expression while reducing fibrotic markers in keratocytes stimulated with TGF-beta1 (DOI:10.1167/iovs.65.13.9). Mendelian randomization studies identify circulating HSPA1L as inversely associated with ankylosing spondylitis risk (OR=0.089, colocalization PPH4 approximately 0.74; DOI:10.3389/fimmu.2024.1394438) and lung squamous cell carcinoma risk (combined OR approximately 0.51; DOI:10.1007/s44272-024-00024-w). Additionally, the HSPA1L rs2227956 variant is associated with idiopathic male infertility in an Iranian population (DOI:10.1016/j.ejogrb.2019.06.014).</p>
+        <p>HSPA1L (Heat shock 70 kDa protein 1-like, also known as HSP70-Hom) is a constitutively expressed member of the HSP70/HSPA family of molecular chaperones, encoded in the MHC class III region on chromosome 6 in close genomic proximity (within approximately 14 kb) to the stress-inducible paralogs HSPA1A and HSPA1B (DOI:10.62347/cwpe7813). It is approximately 90% identical in sequence to HSPA1A. Unlike HSPA1A, HSPA1L is not induced by heat shock (PMID:1700760) and is notably enriched in testis/spermatids (PMID:9685725). HSPA1L has the canonical HSP70 domain architecture: an N-terminal nucleotide-binding domain (NBD/ATPase) that binds and hydrolyzes ATP, a C-terminal substrate-binding domain (SBD) that binds exposed hydrophobic peptide segments in client proteins, and an interdomain linker coupling nucleotide state to substrate affinity -- ATP binding promotes an open SBD lid conformation, ATP hydrolysis promotes lid closure and higher client affinity, and nucleotide exchange resets the cycle (DOI:10.14712/fb2024070030152). The ATPase domain crystal structure has been solved at 1.80 angstrom resolution (PDB:3GDQ; PMID:20072699). HSPA1L is an HSP70-family chaperone with inferred foldase/refolding capacity, but direct HSPA1L-specific biochemical evidence remains limited. It also functions as a positive regulator of PRKN (Parkin) translocation to damaged mitochondria, requiring both its ATPase and substrate-binding domains as well as its EEVD co-chaperone interaction motif (PMID:24270810). In neuronal heat-stress models, HSPA1L protein was induced approximately 2.5-3.5-fold with gene expression peaking at approximately 1 hour post-stress and protein at approximately 5-6 hours, indicating context-dependent inducibility in some cell types (DOI:10.3390/biology12030416). Recent epitranscriptomic studies show that METTL3-mediated m6A modification regulates HSPA1L mRNA levels, and METTL3 silencing increases HSPA1L expression while reducing fibrotic markers in keratocytes stimulated with TGF-beta1 (DOI:10.1167/iovs.65.13.9). Mendelian randomization studies identify circulating HSPA1L as inversely associated with ankylosing spondylitis risk (OR=0.089, colocalization PPH4 approximately 0.74; DOI:10.3389/fimmu.2024.1394438) and lung squamous cell carcinoma risk (combined OR approximately 0.51; DOI:10.1007/s44272-024-00024-w). Additionally, the HSPA1L rs2227956 variant is associated with idiopathic male infertility in an Iranian population (DOI:10.1016/j.ejogrb.2019.06.014).</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,46 +795,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for nuclear localization of HSPA1L based on phylogenetic inference across HSP70 family members. Cytosolic HSP70 family members are known to undergo nucleocytoplasmic shuttling. While HSPA1L is constitutively expressed rather than stress-inducible (PMID:1700760), as an HSP70 family member it retains the same domain architecture as HSPA1A enabling nuclear import. The Reactome pathway R-HSA-5082356 includes HSPA1L in a nuclear context for HSF1-mediated gene expression. The IBA is well-supported phylogenetically with evidence from multiple orthologs across species.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear localization is a well-established property of cytosolic HSP70 family members. The phylogenetic inference is sound and additionally supported by the Reactome TAS annotation to nucleoplasm (R-HSA-5082356). HSPA1L retains the same domain architecture as HSPA1A enabling nuclear import.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -846,64 +846,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for cytoplasmic localization based on phylogenetic inference. HSPA1L is a cytosolic HSP70 family member. Hageman et al. (2011) state that &#34;most of the corresponding proteins are localized in the cytosol&#34; (PMID:21231916). HSPA1L has direct experimental evidence (IDA) for cytosol localization from the same study. The cytoplasm annotation is a broader parent term that is fully consistent with the more specific cytosol annotation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization is the primary site of action for HSPA1L. This is supported by both phylogenetic inference and direct experimental evidence from Hageman et al. (2011) (PMID:21231916).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -915,46 +915,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for plasma membrane localization based on phylogenetic inference from multiple HSP70 orthologs. Some HSP70 family members have been detected at the plasma membrane, particularly in the context of immune signaling and antigen presentation. However, there is no direct experimental evidence for HSPA1L specifically at the plasma membrane. The IBA is phylogenetically derived and the localization may be more relevant to stress-inducible HSP70 members (HSPA1A/B) rather than the constitutively expressed HSPA1L.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Plasma membrane localization has been documented for some HSP70 family members, particularly in immune and stress contexts. However, HSPA1L is constitutively expressed and primarily testis-enriched (PMID:9685725), making plasma membrane localization a peripheral rather than core aspect of its function. The phylogenetic inference is valid but this is not a primary localization for HSPA1L.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -966,64 +966,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for ATP hydrolysis activity based on phylogenetic inference across HSP70 family members. HSPA1L contains a well-characterized N-terminal nucleotide-binding domain (NBD, residues 3-388) with defined ATP binding sites (UniProt P34931). The crystal structure of the HSPA1L ATPase domain has been solved in complex with ADP and phosphate at 1.80 angstrom resolution (PDB:3GDQ; PMID:20072699). UniProt describes the function as achieved &#34;through cycles of ATP binding, ATP hydrolysis and ADP release, mediated by co-chaperones&#34; (UniProt P34931). The ATPase activity of HSP70 family members is stimulated by J-domain proteins (PMID:21231916).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATP hydrolysis is a core molecular function of HSPA1L. The crystal structure of the ATPase domain confirms the structural basis (PDB:3GDQ), and the phylogenetic inference is rock-solid across HSP70 family members.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
                                     GO:0031072
                                 </a>
                             </span>
                             <span class="term-label">heat shock protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1035,77 +1035,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for heat shock protein binding based on phylogenetic inference. HSP70 family members interact with HSP40/DNAJ co-chaperones through J-domain interactions. Han et al. (2007) demonstrated that HDJC9 (a J-domain protein) &#34;can interact with HSP70s and activate the ATPase activity of HSP70s, both of which are dependent on the J domain&#34; (PMID:17182002). UniProt lists interactions with BAG4, CCDC28B, DNAJC7, and TRIM38 (UniProt P34931). Taipale et al. (2014) characterized the chaperone-cochaperone interaction network and detected HSPA1L interactions with cochaperones BAG4 and DNAJC7 (PMID:25036637).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Heat shock protein binding is a core functional property of HSPA1L reflecting its interactions with J-domain co-chaperones and other HSP family members. This is well-supported by both phylogenetic inference and direct experimental evidence (IPI from PMID:17182002 and PMID:25036637).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17182002" target="_blank" class="term-link">
                                         PMID:17182002
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HDJC9 can interact with HSP70s and activate the ATPase activity of HSP70s, both of which are dependent on the J domain.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link">
                                         PMID:25036637
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Chaperones are abundant cellular proteins that promote the folding and function of their substrate proteins (clients). In vivo, chaperones also associate with a large and diverse set of cofactors (cochaperones) that regulate their specificity and function.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     GO:0044183
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1117,64 +1117,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for protein folding chaperone activity based on phylogenetic inference across HSP70 family members. This is the core molecular function of HSPA1L. UniProt describes HSPA1L as a &#34;molecular chaperone implicated in a wide variety of cellular processes, including protection of the proteome from stress, folding and transport of newly synthesized polypeptides&#34; (UniProt P34931). Hageman et al. (2011) directly tested HSPA1L chaperone activity in luciferase refolding and polyQ aggregation suppression assays (PMID:21231916).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein folding chaperone is the primary molecular function of HSPA1L. This is supported by direct experimental evidence (PMID:21231916), UniProt functional annotation, and strong phylogenetic inference across HSP70 family members.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol. To test for possible functional differences and/or substrate specificity, we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/HSPA1L/HSPA1L-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">HSPA1L is an Hsp70-family ATP-dependent molecular chaperone, though direct HSPA1L-specific biochemical and localization evidence is more limited than for HSPA1A/HSPA1B.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1186,64 +1197,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for cytosol localization based on phylogenetic inference. This is consistent with the IDA annotation from Hageman et al. (2011) who stated that &#34;most of the corresponding proteins are localized in the cytosol&#34; (PMID:21231916). HSPA1L is a canonical cytosolic HSP70 family member.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol is the primary site of action for HSPA1L. The IBA is consistent with direct experimental evidence (IDA from PMID:21231916) and is the expected localization for a cytosolic HSP70 family member.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1255,64 +1266,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for protein refolding based on phylogenetic inference across HSP70 family members. HSPA1L has direct experimental support for refolding activity from Hageman et al. (2011), who tested its ability to refold heat-denatured luciferase (PMID:21231916). UniProt describes HSPA1L function as including &#34;re-folding of misfolded proteins&#34; (UniProt P34931).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein refolding is a core biological process for HSPA1L. The IBA is fully supported by direct experimental evidence from the luciferase refolding assay (PMID:21231916) and phylogenetic conservation across HSP70 family members.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol. To test for possible functional differences and/or substrate specificity, we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000166" target="_blank" class="term-link">
                                     GO:0000166
                                 </a>
                             </span>
                             <span class="term-label">nucleotide binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1324,46 +1335,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for nucleotide binding based on UniProtKB keyword mapping (KW-0547). HSPA1L has a well-characterized nucleotide-binding domain (NBD, residues 3-388) with defined ATP binding sites at positions 14-17, 73, 204-206, 270-277, and 341-344 (UniProt P34931). The crystal structure confirms ADP and phosphate binding (PDB:3GDQ). This is a correct but very broad annotation; the more specific GO:0005524 (ATP binding) and GO:0016887 (ATP hydrolysis activity) annotations are already present.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleotide binding is correct for HSPA1L. While broad, IEA annotations at this level are acceptable. The annotation is consistent with the more specific ATP binding and ATP hydrolysis activity annotations and is supported by crystal structure data (PDB:3GDQ).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
                                     GO:0005524
                                 </a>
                             </span>
                             <span class="term-label">ATP binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1375,46 +1386,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for ATP binding based on combined automated annotation from InterPro and UniProtKB keyword mapping. HSPA1L has extensive ATP binding site annotations in UniProt (positions 14-17, 73, 204-206, 270-277, 341-344) and the crystal structure of its ATPase domain was solved in complex with ADP and phosphate at 1.80 angstrom resolution (PDB:3GDQ; PMID:20072699). ATP binding is fundamental to the chaperone cycle.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATP binding is a core molecular function of HSPA1L, essential for its chaperone cycle. The structural evidence from PDB:3GDQ directly confirms nucleotide binding in the NBD domain.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006950" target="_blank" class="term-link">
                                     GO:0006950
                                 </a>
                             </span>
                             <span class="term-label">response to stress</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1426,46 +1437,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for response to stress based on ARBA machine learning model. While HSP70 family members are generally associated with stress response, HSPA1L is notable for being constitutively expressed and NOT induced by heat shock, unlike HSPA1A/B (PMID:1700760). The annotation is technically not wrong since HSPA1L does function in protein quality control which is a component of the cellular stress response, but it is misleading for a constitutively expressed member. The term is also very broad.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPA1L participates in protein quality control which broadly relates to stress response. However, HSPA1L is specifically NOT heat-shock inducible (PMID:1700760) and is constitutively expressed primarily in testis (PMID:9685725). The annotation is not wrong but is misleading as it suggests stress-inducibility. Keeping as non-core rather than removing because HSPA1L does contribute to proteostasis under stress conditions.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1477,46 +1488,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for ATP hydrolysis activity based on InterPro domain mapping (IPR013126, HSP70 family). This duplicates the IBA annotation for the same GO term (GO_REF:0000033). The annotation is correct; HSPA1L has a well-characterized ATPase domain whose crystal structure has been solved (PDB:3GDQ; PMID:20072699).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATP hydrolysis is a core molecular function of HSPA1L. This IEA annotation is correctly derived from InterPro domain mapping and is consistent with the IBA annotation and structural evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
                                     GO:0031072
                                 </a>
                             </span>
                             <span class="term-label">heat shock protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1528,46 +1539,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for heat shock protein binding from ARBA machine learning model. This duplicates the IBA annotation for the same GO term. HSP70 family members interact with HSP40/DNAJ co-chaperones and other heat shock proteins. The annotation is consistent with experimental evidence from PMID:17182002 (interaction with HDJC9) and PMID:25036637 (interaction with BAG4 and DNAJC7).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Heat shock protein binding is a core function of HSPA1L reflecting its co-chaperone interactions. This IEA annotation is consistent with existing IBA and IPI annotations for the same term.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031625" target="_blank" class="term-link">
                                     GO:0031625
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin protein ligase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1579,64 +1590,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for ubiquitin protein ligase binding from ARBA machine learning model. This is consistent with the IPI annotation from PMID:24270810 showing HSPA1L interaction with PRKN (Parkin), an E3 ubiquitin ligase. Hasson et al. (2013) showed that &#34;HSPA1L (HSP70 family member) and BAG4 have mutually opposing roles in the regulation of parkin translocation&#34; (PMID:24270810).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Ubiquitin protein ligase binding is supported by the experimentally validated interaction between HSPA1L and PRKN/Parkin (PMID:24270810). This IEA annotation is consistent with the IPI evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24270810" target="_blank" class="term-link">
                                         PMID:24270810
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We also discovered that HSPA1L (HSP70 family member) and BAG4 have mutually opposing roles in the regulation of parkin translocation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1648,46 +1659,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for protein refolding from ARBA machine learning model. This duplicates the IBA and IDA annotations for the same GO term. Protein refolding is directly demonstrated for HSPA1L by Hageman et al. (2011) in luciferase refolding assays (PMID:21231916).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein refolding is a core biological process for HSPA1L. This IEA annotation is consistent with existing IBA and IDA annotations and direct experimental evidence from PMID:21231916.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1699,68 +1710,68 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962). This IEA annotation was generated by the ARBA machine learning model (GO_REF:0000117). HSPA1L is a bona fide ATP-dependent protein folding chaperone of the HSP70 family. Its function is not merely passive binding to unfolded proteins, but rather active, ATP-driven chaperone-mediated protein folding. The correct replacement term is GO:0044183 (protein folding chaperone), which is already annotated via IBA (GO_REF:0000033). UniProt describes HSPA1L as a &#34;molecular chaperone implicated in a wide variety of cellular processes, including protection of the proteome from stress, folding and transport of newly synthesized polypeptides&#34; (UniProt P34931). An even more specific term, GO:0140662 (ATP-dependent protein folding chaperone), is also annotated via IEA from InterPro.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. The term conflates passive binding with the active chaperone function that HSP70 family members perform. HSPA1L is an ATP-dependent foldase that undergoes conformational cycling between ATP-bound (low substrate affinity) and ADP-bound (high substrate affinity) states to actively fold client proteins (UniProt P34931). The replacement term GO:0044183 (protein folding chaperone) accurately captures this molecular function. This IEA annotation is redundant with existing IBA and IEA annotations to GO:0044183 and GO:0140662 respectively.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25036637
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A quantitative chaperone interaction network reveals the arc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1772,86 +1783,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding based on Taipale et al. (2014), a systematic characterization of the chaperone-cochaperone interaction network using mass spectrometry and LUMIER assays. The interacting partners from IntAct are BAG4 (O95429) and DNAJC7 (Q99615). BAG4 is a nucleotide exchange factor for HSP70, and DNAJC7 is a J-domain co-chaperone. These are functionally relevant chaperone-cochaperone interactions. However, GO:0005515 (protein binding) is uninformative. The more specific GO:0031072 (heat shock protein binding) is already annotated.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The interaction data from Taipale et al. (2014) are valid and represent functionally meaningful chaperone-cochaperone interactions (HSPA1L with BAG4 and DNAJC7). However, GO:0005515 (protein binding) is uninformative per curation guidelines. The interactions are better captured by GO:0031072 (heat shock protein binding), which is already annotated via IBA and IPI.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
                                     heat shock protein binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link">
                                         PMID:25036637
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We combined mass spectrometry and quantitative high-throughput LUMIER assays to systematically characterize the chaperone-cochaperone-client interaction network in human cells.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27173435" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27173435
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An organelle-specific protein landscape identifies novel dis...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1863,57 +1874,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding based on Boldt et al. (2016), a large-scale organelle-specific protein landscape study. The interacting partner from IntAct is CCDC28B (Q9BUN5). CCDC28B is a coiled-coil domain protein associated with ciliopathies. The interaction with HSPA1L is from a high-throughput study and the functional significance of this specific interaction is unclear. GO:0005515 (protein binding) is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This annotation derives from a large-scale organelle-specific proteomics study (PMID:27173435). The interaction between HSPA1L and CCDC28B has no clear functional relevance to HSPA1L chaperone function, and may represent a transient or non-specific chaperone-client interaction captured in a high-throughput screen. GO:0005515 (protein binding) is uninformative per curation guidelines.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32296183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A reference map of the human binary protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1925,68 +1936,68 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding based on Luck et al. (2020), a reference map of the human binary protein interactome using yeast two-hybrid and other methods. The interacting partners from IntAct are TRIM38 (O00635) and BAG4 (O95429). BAG4 is a known HSP70 nucleotide exchange factor and this interaction is functionally relevant. TRIM38 is an E3 ubiquitin ligase involved in innate immunity. UniProt also lists TRIM38 as an interactor (IntAct). GO:0005515 (protein binding) is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The BAG4 interaction is well-characterized as a functional cochaperone interaction and is better described by GO:0031072 (heat shock protein binding). The TRIM38 interaction is validated in two independent studies but GO:0005515 does not inform us about function. More specific terms for E3 ligase or cochaperone binding are preferred.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
                                     heat shock protein binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:40205054
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Multimodal cell maps as a foundation for structural and func...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1998,57 +2009,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from Schaffer et al. (2025), a multimodal cell map study. The interacting partner from IntAct is DNAJC7 (Q99615), a J-domain co-chaperone that is a known functional partner of HSP70 family members. This duplicates information already captured by the PMID:25036637 annotation. GO:0005515 (protein binding) is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The DNAJC7 interaction is functionally meaningful as a J-domain co-chaperone partner but GO:0005515 is uninformative. This interaction is better captured by GO:0031072 (heat shock protein binding) which is already annotated.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
                                     heat shock protein binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0002199" target="_blank" class="term-link">
                                     GO:0002199
                                 </a>
                             </span>
                             <span class="term-label">zona pellucida receptor complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2060,64 +2071,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for zona pellucida receptor complex transferred from mouse ortholog Hspa1l (UniProtKB:P16627) via Ensembl Compara. In mouse, HSP70 family members have been implicated in sperm-zona pellucida interactions during fertilization. Given that HSPA1L is specifically expressed in spermatids (PMID:9685725) and the mouse ortholog Hsc70t shares the same spermatid-specific expression pattern, this annotation is biologically plausible for a role in fertilization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The annotation is transferred from the mouse ortholog and is biologically plausible given HSPA1L spermatid-specific expression (PMID:9685725). However, direct experimental evidence for HSPA1L in the zona pellucida receptor complex in human is lacking. This is a specialized reproductive function rather than the core chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9685725" target="_blank" class="term-link">
                                         PMID:9685725
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The Hsc70t gene is a Hsp70 homolog gene expressed constitutively in spermatids in mice.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044297" target="_blank" class="term-link">
                                     GO:0044297
                                 </a>
                             </span>
                             <span class="term-label">cell body</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2129,57 +2140,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for cell body localization transferred from mouse ortholog Hspa1l (UniProtKB:P16627) via Ensembl Compara. The term GO:0044297 (cell body) refers to the neuronal cell body (soma). While some HSP70 family members are expressed in neurons, HSPA1L is primarily testis-enriched (PMID:9685725). The transfer from mouse ortholog may reflect neuronal expression of Hsc70t in mouse but this is not well-established for human HSPA1L.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cell body (neuronal soma) localization is likely an over-annotation for HSPA1L. While transferred from the mouse ortholog, HSPA1L is primarily enriched in testis/spermatids (PMID:9685725) and there is no specific evidence for neuronal cell body localization in human. The ortholog transfer may not be appropriate for this specific localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
                                     GO:0031072
                                 </a>
                             </span>
                             <span class="term-label">heat shock protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17182002" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17182002
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HDJC9, a novel human type C DnaJ/HSP40 member interacts with...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2191,75 +2202,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for heat shock protein binding based on Han et al. (2007), who characterized HDJC9 (DNAJC9, Q8WXX5), a novel J-domain protein. The study demonstrated that &#34;HDJC9 can interact with HSP70s and activate the ATPase activity of HSP70s, both of which are dependent on the J domain&#34; (PMID:17182002). The J-domain-dependent interaction between DNAJC9 and HSP70 (including HSPA1L) is a core functional interaction in the HSP70 chaperone machine.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is a well-characterized functional interaction between HSPA1L and a J-domain co-chaperone (DNAJC9/HDJC9). The J-domain-dependent interaction is fundamental to HSP70 chaperone function, as J-domain proteins stimulate the ATPase cycle. Heat shock protein binding accurately captures this co-chaperone interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17182002" target="_blank" class="term-link">
                                         PMID:17182002
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HDJC9 can interact with HSP70s and activate the ATPase activity of HSP70s, both of which are dependent on the J domain.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031625" target="_blank" class="term-link">
                                     GO:0031625
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin protein ligase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24270810" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24270810
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     High-content genome-wide RNAi screens identify regulators of...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2271,75 +2282,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for ubiquitin protein ligase binding based on Hasson et al. (2013), who identified HSPA1L as a positive regulator of PRKN (Parkin) translocation to damaged mitochondria. The interacting partner is PRKN/Parkin (O60260), an E3 ubiquitin ligase. The abstract states &#34;HSPA1L (HSP70 family member) and BAG4 have mutually opposing roles in the regulation of parkin translocation&#34; (PMID:24270810). UniProt confirms the interaction and notes mutagenesis data: K73E (ATPase domain), L396D (substrate-binding domain), and deletion of the C-terminal EEVD motif (residues 638-641) all abolish rescue of PRKN translocation (UniProt P34931).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The interaction between HSPA1L and PRKN/Parkin is well-characterized with supporting mutagenesis data. The binding to this E3 ubiquitin ligase is functionally significant in regulating mitochondrial quality control. This annotation is accurate and represents a validated non-chaperone interaction of HSPA1L.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24270810" target="_blank" class="term-link">
                                         PMID:24270810
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We also discovered that HSPA1L (HSP70 family member) and BAG4 have mutually opposing roles in the regulation of parkin translocation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1903749" target="_blank" class="term-link">
                                     GO:1903749
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of protein localization to mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24270810" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24270810
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     High-content genome-wide RNAi screens identify regulators of...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2351,75 +2362,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IMP annotation for positive regulation of establishment of protein localization to mitochondrion based on Hasson et al. (2013). The study used genome-wide RNAi screens and found that HSPA1L promotes PRKN translocation to damaged mitochondria. The abstract states that &#34;HSPA1L (HSP70 family member) and BAG4 have mutually opposing roles in the regulation of parkin translocation&#34; (PMID:24270810). UniProt mutagenesis data confirm that the ATPase domain (K73E), substrate-binding domain (L396D), and EEVD motif (deletion of 638-641) are all required for this function (UniProt P34931). This represents a specific biological role for HSPA1L in mitochondrial quality control.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This annotation is well-supported by the genome-wide RNAi screen and subsequent validation in Hasson et al. (2013). HSPA1L positively regulates PRKN/Parkin translocation to damaged mitochondria, requiring functional ATPase, substrate-binding, and co-chaperone interaction domains. This is a validated biological role distinct from the general chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24270810" target="_blank" class="term-link">
                                         PMID:24270810
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We also discovered that HSPA1L (HSP70 family member) and BAG4 have mutually opposing roles in the regulation of parkin translocation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2431,75 +2442,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for cytosol localization based on Hageman et al. (2011), who systematically characterized HSP70 family members. The study states that &#34;most of the corresponding proteins are localized in the cytosol&#34; (PMID:21231916). This is the primary subcellular localization for HSPA1L and is consistent with its function as a cytosolic chaperone.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol is the primary localization for HSPA1L function. The IDA evidence from Hageman et al. (2011) directly supports this annotation and is consistent with the IBA annotation for the same term.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2511,75 +2522,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for protein refolding based on Hageman et al. (2011), who directly tested HSPA1L in luciferase refolding and polyQ aggregation suppression assays. The study &#34;assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment&#34; (PMID:21231916). This is direct experimental evidence for HSPA1L protein refolding activity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein refolding is directly demonstrated for HSPA1L by functional assays in Hageman et al. (2011). This is a core biological process annotation with strong direct experimental support.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol. To test for possible functional differences and/or substrate specificity, we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -2591,99 +2602,99 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962). This IDA annotation is based on Hageman et al. (2011), which systematically compared the chaperone activities of mammalian HSP70 family members. The study tested HSPA1L and other HSP70 members for their ability to refold heat-denatured luciferase and suppress polyglutamine aggregation. As stated in the abstract, the authors &#34;assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment&#34; (PMID:21231916). These assays measure active protein folding chaperone function, not merely passive binding to unfolded substrates. HSPA1L, like other cytosolic HSP70 members, functions as an ATP-dependent foldase with a substrate-binding domain (residues 396-511) that binds client proteins and a nucleotide-binding domain (residues 3-388) that drives conformational cycling. The correct replacement is GO:0044183 (protein folding chaperone).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. The original annotation was made based on data from Hageman et al. (2011), who tested HSP70 family members in functional chaperone assays including luciferase refolding and polyQ aggregation suppression. These are active chaperone assays, not passive binding assays. The abstract states that &#34;Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol&#34; and describes their role in &#34;refolding of heat-denatured luciferase&#34; (PMID:21231916). UniProt further describes HSPA1L function as achieved &#34;through cycles of ATP binding, ATP hydrolysis and ADP release, mediated by co-chaperones&#34; where &#34;the affinity for polypeptides is regulated by its nucleotide bound state&#34; (UniProt P34931). This is protein folding chaperone activity, not passive unfolded protein binding. GO:0044183 (protein folding chaperone) is the correct replacement term and already has IBA support.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol. To test for possible functional differences and/or substrate specificity, we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0072562" target="_blank" class="term-link">
                                     GO:0072562
                                 </a>
                             </span>
                             <span class="term-label">blood microparticle</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22516433" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22516433
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomic analysis of microvesicles from plasma of healthy d...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2695,64 +2706,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HDA annotation for blood microparticle localization based on Bastos-Amador et al. (2012), a proteomic analysis of microvesicles from plasma of healthy donors. The study &#34;purified microvesicles smaller than 220nm from plasma of healthy donors and performed proteomic, ultra-structural, biochemical and functional analyses&#34; and &#34;detected 161 microvesicle-associated proteins&#34; (PMID:22516433). HSPA1L was identified among these proteins. This is a high-throughput proteomic detection that likely reflects the general abundance of HSP70 proteins in extracellular vesicles.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Detection in blood microparticles is from a high-throughput proteomics study and likely reflects general HSP70 family presence in extracellular vesicles rather than a specific function of HSPA1L. The study noted &#34;remarkably high variability in the protein content of plasma from different donors&#34; (PMID:22516433), suggesting this may not be a consistent localization. Not a core localization for HSPA1L function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22516433" target="_blank" class="term-link">
                                         PMID:22516433
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">In this study, we have purified microvesicles smaller than 220nm from plasma of healthy donors and performed proteomic, ultra-structural, biochemical and functional analyses. We have detected 161 microvesicle-associated proteins</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5082356
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2764,57 +2775,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for nucleoplasm localization based on Reactome pathway R-HSA-5082356 (HSF1-mediated gene expression). The Reactome pathway describes HSF1-driven upregulation of heat shock genes and places HSP70 family members in the nucleoplasm in the context of heat shock response regulation. HSF1 is &#34;best known for rapid stress-induced upregulation of certain genes related to protein folding, such as HSPA1A/HSP70&#34; (Reactome:R-HSA-5082356). While HSPA1L is not itself heat-inducible, it is included in this Reactome pathway as an HSP70 family member. Nuclear/nucleoplasmic localization is consistent with the IBA annotation for nucleus.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization is plausible for HSP70 family members that shuttle between cytoplasm and nucleus. However, the Reactome pathway context (HSF1-mediated heat shock response) is somewhat misleading for HSPA1L since it is not heat-inducible (PMID:1700760). The nucleoplasm localization is likely a secondary site rather than the primary cytosolic localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008180" target="_blank" class="term-link">
                                     GO:0008180
                                 </a>
                             </span>
                             <span class="term-label">COP9 signalosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18850735" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18850735
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Characterization of the human COP9 signalosome complex using...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2826,141 +2837,141 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for COP9 signalosome colocalization based on Fang et al. (2008), who characterized the human CSN complex using affinity purification and mass spectrometry. HSPA1L was identified among &#34;52 putative human CSN interacting proteins&#34; (PMID:18850735). Note that the GOA qualifier is &#34;colocalizes_with&#34; rather than &#34;part_of&#34;, indicating HSPA1L was detected in proximity to the CSN but is not a core subunit. HSP70 chaperones commonly co-purify with multi-protein complexes as transient interactors assisting in complex assembly or quality control.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPA1L colocalization with the COP9 signalosome likely reflects its role as a chaperone transiently interacting with the complex during assembly or quality control, rather than being a functional component of the CSN. The study identified HSPA1L among 52 putative interactors using mass spectrometry (PMID:18850735). This is a peripheral observation rather than a core localization for HSPA1L.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/18850735" target="_blank" class="term-link">
                                         PMID:18850735
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">A total of 52 putative human CSN interacting proteins were identified, most of which are reported for the first time.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006986" target="_blank" class="term-link">
                                     GO:0006986
                                 </a>
                             </span>
                             <span class="term-label">response to unfolded protein</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9685725" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9685725
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Genomic structure of the spermatid-specific hsp70 homolog ge...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="P34931" data-a="GO:0006986" data-r="PMID:9685725" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P34931" data-a="GO:0006986" data-r="PMID:9685725" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for response to unfolded protein based on Ito et al. (1998), who characterized the genomic structure of HSPA1L and its mouse ortholog Hsc70t. The paper describes HSPA1L as a &#34;spermatid-specific hsp70 homolog gene&#34; and establishes its &#34;constitutive&#34; expression in spermatids (PMID:9685725). While HSPA1L is an HSP70 family member that functions in protein quality control, the term &#34;response to unfolded protein&#34; specifically implies a response to proteotoxic stress. HSPA1L is constitutively expressed, not stress-inducible, and the cited paper does not provide evidence for induction by unfolded protein stress.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> HSPA1L does function in protein quality control as an HSP70 chaperone, which is part of the broader unfolded protein response system. However, the annotation is somewhat misleading because HSPA1L is constitutively expressed rather than induced by proteotoxic stress (PMID:1700760, PMID:9685725). The cited reference (PMID:9685725) characterizes genomic structure and tissue specificity rather than stress response per se. Keeping as non-core because HSPA1L does participate in protein quality control but is not a stress-responsive component.
+                            <strong>Reason:</strong> PMID:9685725 supports spermatid/testis expression and genomic structure, not response to unfolded protein or proteotoxic stress. HSPA1L&#39;s chaperone role is better represented by molecular chaperone/refolding annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9685725" target="_blank" class="term-link">
                                         PMID:9685725
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The Hsc70t gene is a Hsp70 homolog gene expressed constitutively in spermatids in mice.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>Constitutively expressed ATP-dependent protein folding chaperone enriched in testis/spermatids. Functions as a foldase that refolds heat-denatured proteins and suppresses polyglutamine aggregation in the cytosol, through the canonical HSP70 ATPase-driven allosteric cycle: ATP binding promotes an open SBD lid conformation permissive for substrate binding, ATP hydrolysis promotes lid closure and higher client affinity, and nucleotide exchange (mediated by BAG-family and HSP110-type NEFs) resets the cycle (DOI:10.14712/fb2024070030152). J-domain proteins (DNAJC7, DNAJC9) stimulate ATP hydrolysis and deliver substrates. The crystal structure of the HSPA1L ATPase domain has been solved at 1.80 angstrom resolution (PDB:3GDQ; PMID:20072699). Unlike the closely related HSPA1A, HSPA1L is generally not induced by heat shock, though context-dependent induction (approximately 2.5-3.5-fold) has been observed in neuronal heat-stress models (DOI:10.3390/biology12030416). HSPA1L expression is also regulated by the METTL3-m6A epitranscriptomic axis in keratocyte fibrosis models (DOI:10.1167/iovs.65.13.9).</h3>
-                <span class="vote-buttons" data-g="P34931" data-a="FUNCTION: Constitutively expressed ATP-dependent protein fol..." data-r="" data-act="CORE_FUNCTION">
+                <h3>Constitutively expressed HSP70-family ATP-dependent protein folding chaperone enriched in testis/spermatids. By HSP70-family mechanism, HSPA1L is inferred to bind exposed hydrophobic client segments through its substrate-binding domain and use the canonical ATPase-driven allosteric cycle to promote folding/refolding or triage. Direct HSPA1L-specific biochemical and localization evidence is more limited than for HSPA1A/HSPA1B, so stress-response and polyQ-suppression claims should be treated cautiously. The crystal structure of the HSPA1L ATPase domain has been solved at 1.80 angstrom resolution (PDB:3GDQ; PMID:20072699). Unlike the closely related HSPA1A, HSPA1L is generally not induced by heat shock, though context-dependent induction has been observed in neuronal heat-stress models (DOI:10.3390/biology12030416).</h3>
+                <span class="vote-buttons" data-g="P34931" data-a="FUNCTION: Constitutively expressed HSP70-family ATP-dependen..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -2969,87 +2980,92 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                 protein refolding
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
-                                nucleus
-                            </a>
-                        </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                 PMID:21231916
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9685725" target="_blank" class="term-link">
                                 PMID:9685725
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">The Hsc70t gene is a Hsp70 homolog gene expressed constitutively in spermatids in mice.</div>
-                        
+
                     </li>
-                    
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/HSPA1L/HSPA1L-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">HSPA1L is part of the HSP70 family of ATP-dependent molecular chaperones that stabilize proteins against aggregation, promote folding of nascent polypeptides, and support refolding or triage of misfolded proteins.</div>
+
+                    </li>
+
                 </ul>
             </div>
-            
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>Positive regulator of PRKN (Parkin) translocation to damaged mitochondria, functioning as a chaperone that facilitates the mitochondrial quality control pathway. This activity requires the ATPase domain, substrate-binding domain, and the C-terminal EEVD co-chaperone interaction motif. BAG4 acts as an antagonist of this HSPA1L-mediated function. Co-expression/network analysis in neuronal proteotoxic stress models links HSPA1L with PRKN and STUB1 (an E3 ubiquitin ligase/co-chaperone), connecting HSPA1L to protein quality control pathways that interface with ubiquitination and mitophagy (DOI:10.3390/biology12030416).</h3>
                 <span class="vote-buttons" data-g="P34931" data-a="FUNCTION: Positive regulator of PRKN (Parkin) translocation ..." data-r="" data-act="CORE_FUNCTION">
@@ -3057,10 +3073,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -3069,524 +3085,549 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1903749" target="_blank" class="term-link">
                                 positive regulation of protein localization to mitochondrion
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24270810" target="_blank" class="term-link">
                                 PMID:24270810
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">We also discovered that HSPA1L (HSP70 family member) and BAG4 have mutually opposing roles in the regulation of parkin translocation.</div>
-                        
+
                     </li>
-                    
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/HSPA1L/HSPA1L-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Co-expression/network analysis in neuronal proteotoxic stress models links HSPA1L with PRKN and STUB1, connecting HSPA1L to protein quality-control pathways that interface with ubiquitination and mitophagy/autophagy.</div>
+
+                    </li>
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/HSPA1L/HSPA1L-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for HSPA1L</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
                             GO_REF:0000107
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17182002" target="_blank" class="term-link">
                             PMID:17182002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HDJC9, a novel human type C DnaJ/HSP40 member interacts with and cochaperones HSP70 through the J domain.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18850735" target="_blank" class="term-link">
                             PMID:18850735
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Characterization of the human COP9 signalosome complex using affinity purification and mass spectrometry.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                             PMID:21231916
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The diverse members of the mammalian HSP70 machine show distinct chaperone-like activities.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22516433" target="_blank" class="term-link">
                             PMID:22516433
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteomic analysis of microvesicles from plasma of healthy donors reveals high individual variability.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24270810" target="_blank" class="term-link">
                             PMID:24270810
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">High-content genome-wide RNAi screens identify regulators of parkin upstream of mitophagy.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link">
                             PMID:25036637
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A quantitative chaperone interaction network reveals the architecture of cellular protein homeostasis pathways.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27173435" target="_blank" class="term-link">
                             PMID:27173435
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An organelle-specific protein landscape identifies novel diseases and molecular mechanisms.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                             PMID:32296183
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A reference map of the human binary protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
                             PMID:40205054
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9685725" target="_blank" class="term-link">
                             PMID:9685725
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Genomic structure of the spermatid-specific hsp70 homolog gene located in the class III region of the major histocompatibility complex of mouse and man.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5082356
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSF1-mediated gene expression</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.14712/fb2024070030152
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Heat Shock Protein Network - the Mode of Action, the Role in Protein Folding and Human Pathologies</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Describes the canonical HSP70 ATPase-driven allosteric cycle in detail: ATP binding promotes open SBD lid, hydrolysis promotes closure and higher client affinity, nucleotide exchange resets cycle. J-domain proteins deliver substrates and stimulate hydrolysis; NEFs (BAG proteins, HSP110) accelerate ADP-to-ATP exchange. HSPA1L function cannot be fully interpreted from sequence alone; context-specific co-chaperone availability drives functional specialization among paralogs.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.3390/biology12030416
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Profiling the Hsp70 Chaperone Network in Heat-Induced Proteotoxic Stress Models of Human Neurons</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSPA1L protein was induced approximately 2.5-3.5-fold in SH-SY5Y and differentiated SH-SY5Y neuronal cells under heat stress, with gene expression peaking at approximately 1 hour post-stress and protein at approximately 5-6 hours. Co-expression network analysis linked HSPA1L with PRKN (Parkin) and STUB1, connecting it to protein quality control pathways.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1167/iovs.65.13.9
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Silencing METTL3 Increases HSP70 Expression and Alleviates Fibrosis in Keratocytes</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSPA1L expression decreased after alkali burn and TGF-beta1 stimulation in keratocytes. METTL3 silencing increased HSPA1L mRNA and HSP70 protein levels, with reduced fibrotic markers. Eight potential m6A sites predicted in HSPA1L RNA.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.3389/fimmu.2024.1394438
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Genetic associations in ankylosing spondylitis - circulating proteins as drug targets and biomarkers</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Proteome-wide Mendelian randomization identified circulating HSPA1L as inversely associated with ankylosing spondylitis risk (OR=0.089, P=1.76e-15) with substantial colocalization support (PPH4 approximately 0.743).</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1007/s44272-024-00024-w
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Causal associations of plasma proteins with lung squamous cell carcinoma risk</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Proteome-wide Mendelian randomization identified HSPA1L as inversely associated with LUSC risk (discovery OR=0.47, combined replication OR approximately 0.51).</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1016/j.ejogrb.2019.06.014
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSPA1L and HSPA1B gene polymorphisms and haplotypes are associated with idiopathic male infertility in Iranian population</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSPA1L rs2227956 was significantly associated with idiopathic male infertility in a case-control study (308 infertile men vs 208 controls). CT vs TT OR=2.049, CC vs TT OR=3.028.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.62347/cwpe7813
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Bioinformatics analysis and alternative polyadenylation in Heat Shock Proteins 70 (HSP70) family members</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Reports HSPA1L length 641 aa and molecular weight approximately 70.4 kDa. HSPA1L is located in the MHC class III region within approximately 14 kb of HSPA1A and HSPA1B in reverse orientation. Predicted phosphorylation sites at multiple serine and threonine positions.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -3876,9 +3917,9 @@ Within the retrieved corpus, direct biochemical measurements specific to HSPA1L 
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -3890,7 +3931,7 @@ Within the retrieved corpus, direct biochemical measurements specific to HSPA1L 
                 <pre><code>id: P34931
 gene_symbol: HSPA1L
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -3909,8 +3950,9 @@ description: &gt;-
   conformation, ATP hydrolysis promotes lid closure and higher client affinity, and
   nucleotide exchange resets the cycle (DOI:10.14712/fb2024070030152). The ATPase
   domain crystal structure has been solved at 1.80 angstrom resolution (PDB:3GDQ;
-  PMID:20072699). HSPA1L has been shown to refold heat-denatured luciferase and to
-  suppress polyglutamine aggregation (PMID:21231916). It also functions as a positive
+  PMID:20072699). HSPA1L is an HSP70-family chaperone with inferred foldase/refolding
+  capacity, but direct HSPA1L-specific biochemical evidence remains limited. It also
+  functions as a positive
   regulator of PRKN (Parkin) translocation to damaged mitochondria, requiring both its
   ATPase and substrate-binding domains as well as its EEVD co-chaperone interaction
   motif (PMID:24270810). In neuronal heat-stress models, HSPA1L protein was induced
@@ -4078,6 +4120,11 @@ existing_annotations:
           assessed the effect of overexpression of each of these HSPs on refolding of
           heat-denatured luciferase and on the suppression of aggregation of a
           non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment.
+      - reference_id: file:human/HSPA1L/HSPA1L-deep-research-falcon.md
+        supporting_text: &gt;-
+          HSPA1L is an Hsp70-family ATP-dependent molecular chaperone, though
+          direct HSPA1L-specific biochemical and localization evidence is more
+          limited than for HSPA1A/HSPA1B.
 - term:
     id: GO:0005829
     label: cytosol
@@ -4719,16 +4766,11 @@ existing_annotations:
       implies a response to proteotoxic stress. HSPA1L is constitutively expressed,
       not stress-inducible, and the cited paper does not provide evidence for
       induction by unfolded protein stress.
-    action: KEEP_AS_NON_CORE
+    action: REMOVE
     reason: &gt;-
-      HSPA1L does function in protein quality control as an HSP70 chaperone, which
-      is part of the broader unfolded protein response system. However, the
-      annotation is somewhat misleading because HSPA1L is constitutively expressed
-      rather than induced by proteotoxic stress (PMID:1700760, PMID:9685725). The
-      cited reference (PMID:9685725) characterizes genomic structure and tissue
-      specificity rather than stress response per se. Keeping as non-core because
-      HSPA1L does participate in protein quality control but is not a stress-responsive
-      component.
+      PMID:9685725 supports spermatid/testis expression and genomic structure,
+      not response to unfolded protein or proteotoxic stress. HSPA1L&#39;s chaperone
+      role is better represented by molecular chaperone/refolding annotations.
     supported_by:
       - reference_id: PMID:9685725
         supporting_text: &gt;-
@@ -4736,22 +4778,18 @@ existing_annotations:
           spermatids in mice.
 core_functions:
 - description: &gt;-
-    Constitutively expressed ATP-dependent protein folding chaperone enriched
-    in testis/spermatids. Functions as a foldase that refolds heat-denatured
-    proteins and suppresses polyglutamine aggregation in the cytosol, through
-    the canonical HSP70 ATPase-driven allosteric cycle: ATP binding promotes
-    an open SBD lid conformation permissive for substrate binding, ATP
-    hydrolysis promotes lid closure and higher client affinity, and nucleotide
-    exchange (mediated by BAG-family and HSP110-type NEFs) resets the cycle
-    (DOI:10.14712/fb2024070030152). J-domain proteins (DNAJC7, DNAJC9)
-    stimulate ATP hydrolysis and deliver substrates. The crystal structure of
-    the HSPA1L ATPase domain has been solved at 1.80 angstrom resolution
-    (PDB:3GDQ; PMID:20072699). Unlike the closely related HSPA1A, HSPA1L is
-    generally not induced by heat shock, though context-dependent induction
-    (approximately 2.5-3.5-fold) has been observed in neuronal heat-stress
-    models (DOI:10.3390/biology12030416). HSPA1L expression is also regulated
-    by the METTL3-m6A epitranscriptomic axis in keratocyte fibrosis models
-    (DOI:10.1167/iovs.65.13.9).
+    Constitutively expressed HSP70-family ATP-dependent protein folding
+    chaperone enriched in testis/spermatids. By HSP70-family mechanism, HSPA1L
+    is inferred to bind exposed hydrophobic client segments through its
+    substrate-binding domain and use the canonical ATPase-driven allosteric
+    cycle to promote folding/refolding or triage. Direct HSPA1L-specific
+    biochemical and localization evidence is more limited than for HSPA1A/HSPA1B,
+    so stress-response and polyQ-suppression claims should be treated cautiously.
+    The crystal structure of the HSPA1L ATPase domain has been solved at 1.80
+    angstrom resolution (PDB:3GDQ; PMID:20072699). Unlike the closely related
+    HSPA1A, HSPA1L is generally not induced by heat shock, though context-dependent
+    induction has been observed in neuronal heat-stress models
+    (DOI:10.3390/biology12030416).
   molecular_function:
     id: GO:0044183
     label: protein folding chaperone
@@ -4761,8 +4799,6 @@ core_functions:
   locations:
   - id: GO:0005829
     label: cytosol
-  - id: GO:0005634
-    label: nucleus
   supported_by:
   - reference_id: PMID:21231916
     supporting_text: &gt;-
@@ -4774,6 +4810,11 @@ core_functions:
     supporting_text: &gt;-
       The Hsc70t gene is a Hsp70 homolog gene expressed constitutively in
       spermatids in mice.
+  - reference_id: file:human/HSPA1L/HSPA1L-deep-research-falcon.md
+    supporting_text: &gt;-
+      HSPA1L is part of the HSP70 family of ATP-dependent molecular chaperones
+      that stabilize proteins against aggregation, promote folding of nascent
+      polypeptides, and support refolding or triage of misfolded proteins.
 - description: &gt;-
     Positive regulator of PRKN (Parkin) translocation to damaged
     mitochondria, functioning as a chaperone that facilitates the
@@ -4799,7 +4840,15 @@ core_functions:
     supporting_text: &gt;-
       We also discovered that HSPA1L (HSP70 family member) and BAG4 have
       mutually opposing roles in the regulation of parkin translocation.
+  - reference_id: file:human/HSPA1L/HSPA1L-deep-research-falcon.md
+    supporting_text: &gt;-
+      Co-expression/network analysis in neuronal proteotoxic stress models links
+      HSPA1L with PRKN and STUB1, connecting HSPA1L to protein quality-control
+      pathways that interface with ubiquitination and mitophagy/autophagy.
 references:
+- id: file:human/HSPA1L/HSPA1L-deep-research-falcon.md
+  title: Falcon deep research report for HSPA1L
+  findings: []
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
     terms
@@ -4931,7 +4980,7 @@ references:
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/HSPA1L/HSPA1L-ai-review.yaml
+++ b/genes/human/HSPA1L/HSPA1L-ai-review.yaml
@@ -1,7 +1,7 @@
 id: P34931
 gene_symbol: HSPA1L
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -20,8 +20,9 @@ description: >-
   conformation, ATP hydrolysis promotes lid closure and higher client affinity, and
   nucleotide exchange resets the cycle (DOI:10.14712/fb2024070030152). The ATPase
   domain crystal structure has been solved at 1.80 angstrom resolution (PDB:3GDQ;
-  PMID:20072699). HSPA1L has been shown to refold heat-denatured luciferase and to
-  suppress polyglutamine aggregation (PMID:21231916). It also functions as a positive
+  PMID:20072699). HSPA1L is an HSP70-family chaperone with inferred foldase/refolding
+  capacity, but direct HSPA1L-specific biochemical evidence remains limited. It also
+  functions as a positive
   regulator of PRKN (Parkin) translocation to damaged mitochondria, requiring both its
   ATPase and substrate-binding domains as well as its EEVD co-chaperone interaction
   motif (PMID:24270810). In neuronal heat-stress models, HSPA1L protein was induced
@@ -189,6 +190,11 @@ existing_annotations:
           assessed the effect of overexpression of each of these HSPs on refolding of
           heat-denatured luciferase and on the suppression of aggregation of a
           non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment.
+      - reference_id: file:human/HSPA1L/HSPA1L-deep-research-falcon.md
+        supporting_text: >-
+          HSPA1L is an Hsp70-family ATP-dependent molecular chaperone, though
+          direct HSPA1L-specific biochemical and localization evidence is more
+          limited than for HSPA1A/HSPA1B.
 - term:
     id: GO:0005829
     label: cytosol
@@ -830,16 +836,11 @@ existing_annotations:
       implies a response to proteotoxic stress. HSPA1L is constitutively expressed,
       not stress-inducible, and the cited paper does not provide evidence for
       induction by unfolded protein stress.
-    action: KEEP_AS_NON_CORE
+    action: REMOVE
     reason: >-
-      HSPA1L does function in protein quality control as an HSP70 chaperone, which
-      is part of the broader unfolded protein response system. However, the
-      annotation is somewhat misleading because HSPA1L is constitutively expressed
-      rather than induced by proteotoxic stress (PMID:1700760, PMID:9685725). The
-      cited reference (PMID:9685725) characterizes genomic structure and tissue
-      specificity rather than stress response per se. Keeping as non-core because
-      HSPA1L does participate in protein quality control but is not a stress-responsive
-      component.
+      PMID:9685725 supports spermatid/testis expression and genomic structure,
+      not response to unfolded protein or proteotoxic stress. HSPA1L's chaperone
+      role is better represented by molecular chaperone/refolding annotations.
     supported_by:
       - reference_id: PMID:9685725
         supporting_text: >-
@@ -847,22 +848,18 @@ existing_annotations:
           spermatids in mice.
 core_functions:
 - description: >-
-    Constitutively expressed ATP-dependent protein folding chaperone enriched
-    in testis/spermatids. Functions as a foldase that refolds heat-denatured
-    proteins and suppresses polyglutamine aggregation in the cytosol, through
-    the canonical HSP70 ATPase-driven allosteric cycle: ATP binding promotes
-    an open SBD lid conformation permissive for substrate binding, ATP
-    hydrolysis promotes lid closure and higher client affinity, and nucleotide
-    exchange (mediated by BAG-family and HSP110-type NEFs) resets the cycle
-    (DOI:10.14712/fb2024070030152). J-domain proteins (DNAJC7, DNAJC9)
-    stimulate ATP hydrolysis and deliver substrates. The crystal structure of
-    the HSPA1L ATPase domain has been solved at 1.80 angstrom resolution
-    (PDB:3GDQ; PMID:20072699). Unlike the closely related HSPA1A, HSPA1L is
-    generally not induced by heat shock, though context-dependent induction
-    (approximately 2.5-3.5-fold) has been observed in neuronal heat-stress
-    models (DOI:10.3390/biology12030416). HSPA1L expression is also regulated
-    by the METTL3-m6A epitranscriptomic axis in keratocyte fibrosis models
-    (DOI:10.1167/iovs.65.13.9).
+    Constitutively expressed HSP70-family ATP-dependent protein folding
+    chaperone enriched in testis/spermatids. By HSP70-family mechanism, HSPA1L
+    is inferred to bind exposed hydrophobic client segments through its
+    substrate-binding domain and use the canonical ATPase-driven allosteric
+    cycle to promote folding/refolding or triage. Direct HSPA1L-specific
+    biochemical and localization evidence is more limited than for HSPA1A/HSPA1B,
+    so stress-response and polyQ-suppression claims should be treated cautiously.
+    The crystal structure of the HSPA1L ATPase domain has been solved at 1.80
+    angstrom resolution (PDB:3GDQ; PMID:20072699). Unlike the closely related
+    HSPA1A, HSPA1L is generally not induced by heat shock, though context-dependent
+    induction has been observed in neuronal heat-stress models
+    (DOI:10.3390/biology12030416).
   molecular_function:
     id: GO:0044183
     label: protein folding chaperone
@@ -872,8 +869,6 @@ core_functions:
   locations:
   - id: GO:0005829
     label: cytosol
-  - id: GO:0005634
-    label: nucleus
   supported_by:
   - reference_id: PMID:21231916
     supporting_text: >-
@@ -885,6 +880,11 @@ core_functions:
     supporting_text: >-
       The Hsc70t gene is a Hsp70 homolog gene expressed constitutively in
       spermatids in mice.
+  - reference_id: file:human/HSPA1L/HSPA1L-deep-research-falcon.md
+    supporting_text: >-
+      HSPA1L is part of the HSP70 family of ATP-dependent molecular chaperones
+      that stabilize proteins against aggregation, promote folding of nascent
+      polypeptides, and support refolding or triage of misfolded proteins.
 - description: >-
     Positive regulator of PRKN (Parkin) translocation to damaged
     mitochondria, functioning as a chaperone that facilitates the
@@ -910,7 +910,15 @@ core_functions:
     supporting_text: >-
       We also discovered that HSPA1L (HSP70 family member) and BAG4 have
       mutually opposing roles in the regulation of parkin translocation.
+  - reference_id: file:human/HSPA1L/HSPA1L-deep-research-falcon.md
+    supporting_text: >-
+      Co-expression/network analysis in neuronal proteotoxic stress models links
+      HSPA1L with PRKN and STUB1, connecting HSPA1L to protein quality-control
+      pathways that interface with ubiquitination and mitophagy/autophagy.
 references:
+- id: file:human/HSPA1L/HSPA1L-deep-research-falcon.md
+  title: Falcon deep research report for HSPA1L
+  findings: []
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
     terms

--- a/genes/human/HSPA1L/HSPA1L-ai-review.yaml
+++ b/genes/human/HSPA1L/HSPA1L-ai-review.yaml
@@ -79,10 +79,10 @@ existing_annotations:
       supported by both phylogenetic inference and direct experimental evidence
       from Hageman et al. (2011) (PMID:21231916).
     supported_by:
-      - reference_id: PMID:21231916
+      - reference_id: PMID:20072699
         supporting_text: >-
-          Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding
-          genes and most of the corresponding proteins are localized in the cytosol.
+          In all ATPase domains except for that of HSPA5/BiP the products of
+          ATP hydrolysis, including inorganic phosphate, were observed.
 - term:
     id: GO:0005886
     label: plasma membrane

--- a/genes/human/HSPA6/HSPA6-ai-review.html
+++ b/genes/human/HSPA6/HSPA6-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>HSPA6</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P17066" target="_blank" class="term-link">
                         P17066
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>HSPA6 (also known as HSP70B&#39;) is a strictly stress-inducible member of the HSP70/HSPA molecular chaperone family. Unlike the constitutively expressed HSC70 or the basally expressed HSPA1A, HSPA6 shows no basal expression and is induced only at higher temperatures or under severe stress conditions (PMID:2327978). HSPA6 has the canonical HSP70 architecture: an N-terminal ATPase (nucleotide-binding) domain, a substrate- binding domain with a lid, and a C-terminal EEVD motif mediating co-chaperone interactions (DOI:10.3390/biom13040604). It functions as an ATP-dependent protein folding chaperone, cycling through ATP binding, hydrolysis, and ADP release to assist in protein folding and refolding, with J-domain proteins (HSP40/DNAJ) delivering clients and stimulating hydrolysis, and nucleotide exchange factors (BAG-family, HSPBP1, HSP110) promoting ADP release and client recycling (DOI:10.3390/biom13040604). In neuronal heat-stress models, HSPA6 is one of the most strongly induced HSP70 paralogs, showing approximately 13-14-fold induction under extreme heat vs approximately 2-3-fold under mild heat, with gene expression peaking at approximately 1 hour and protein at approximately 5-6 hours post-stress (DOI:10.3390/biology12030416). HSPA6 is co-expressed with key co-chaperones DNAJB1 (J-domain), BAG3 (NEF), and HSPH1/HSP110 (NEF) under stress, forming a coordinated inducible chaperone module for protein disaggregation and refolding (DOI:10.3390/biology12030416). Notably, HSPA6 displays substrate specificity distinct from other HSP70 family members; it cannot refold heat-denatured luciferase but can assist in reactivation of heat-unfolded p53, suggesting it has evolved to maintain specific critical functions under conditions of severe stress (PMID:21231916). HSPA6 has also been implicated in RTP1S-dependent trafficking of olfactory receptors, where co-expression of HSPA6 partially enhanced surface expression of an olfactory receptor by approximately 50-80%, interacting via its C-terminal domain with the RTP1S N-terminus (DOI:10.3390/ijms24097829). The HSPA6/HSP70B&#39; promoter has been exploited in synthetic biology as a thermal gene switch for remote control of mammalian cells via photothermal activation (DOI:10.1021/acssynbio.7b00455).</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,101 +758,101 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P17066" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P17066" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation of GO:0005634 (nucleus) based on phylogenetic inference from HSP70 family orthologs. Multiple HSP70 family members are known to localize to the nucleus, and the phylogenetic evidence is broad, including yeast, worm, fly, and mammalian orthologs. CD-CODE database entries for HSPA6 (P17066) include nuclear speckle and nucleolus localizations, providing indirect support. However, direct experimental evidence for nuclear localization of HSPA6 is limited. Khalouei et al. (2014) used YFP-tagged HSPA6 in neuronal cells and primarily observed cytoplasmic and centriolar localization after heat stress (PMID:24061851). IBA annotations are generally reliable and this is plausible for an HSP70 family member.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Nuclear localization is well-established for multiple HSP70 family members and the IBA phylogenetic inference is broadly supported. CD-CODE entries for P17066 list nuclear speckle and nucleolus localizations. While direct experimental evidence for HSPA6 nuclear localization is lacking in the available publications, the IBA inference is reasonable given the conserved family behavior.
+                            <strong>Reason:</strong> Nuclear localization is plausible by HSP70-family inference, but direct HSPA6-specific evidence is lacking in the available publications. The strongest HSPA6-specific localization evidence supports cytoplasmic and centriolar localization after heat stress, so nucleus should not be treated as a core HSPA6 location.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24061851" target="_blank" class="term-link">
                                         PMID:24061851
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Stable lines of human SH-SY5Y neuronal cells were established that expressed YFP-tagged protein products of the human inducible HSP70 genes HSPA6 (HSP70B&#39;) and HSPA1A (HSP70-1)</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -864,64 +864,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation of GO:0005737 (cytoplasm) based on phylogenetic inference. This is strongly supported by direct experimental data: Khalouei et al. (2014) showed YFP-tagged HSPA6 localizes in the cytoplasm of human neuronal cells (PMID:24061851), and Hageman et al. (2011) showed cytosolic localization consistent with cytoplasmic distribution (PMID:21231916). Also supported by the IDA annotation from PMID:24061851.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization is a core feature of HSP70 family members and is directly supported by experimental IDA evidence from PMID:24061851 showing HSPA6-YFP in the cytoplasm of neuronal cells. The IBA is consistent with multiple lines of evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24061851" target="_blank" class="term-link">
                                         PMID:24061851
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">YFP-tagged HSPA6 and HSPA1A rapidly appeared at centrioles in the cytoplasm of human neuronal cells</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -933,46 +933,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation of GO:0005886 (plasma membrane) based on phylogenetic inference. Some HSP70 family members have been reported at the plasma membrane, particularly HSPA1A in cancer cells. There is no direct experimental evidence for HSPA6 at the plasma membrane in available publications. The IBA phylogenetic support includes several orthologs. While plasma membrane localization is documented for some family members, this may not be a core localization for the strictly stress-inducible HSPA6.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Plasma membrane localization is documented for some HSP70 family members (e.g. HSPA1A in stressed/cancer cells), making the phylogenetic inference plausible. However, there is no direct evidence for HSPA6 at the plasma membrane and this is unlikely to be a core localization for this strictly stress-inducible member. The IBA is retained as non-core because the phylogenetic inference is reasonable but this is not experimentally validated for HSPA6.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -984,64 +984,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation of GO:0016887 (ATP hydrolysis activity) based on phylogenetic inference across HSP70 family members. This is a core molecular function of HSPA6, directly confirmed by Hageman et al. (2011), who demonstrated that HSPA6 possesses intrinsic ATPase activity as high as that of canonical HSPA1A when stimulated by J-proteins (PMID:21231916). Also supported by IDA evidence from the same publication and IEA from InterPro domain mapping.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATP hydrolysis is the central catalytic activity of HSP70 family chaperones. HSPA6 ATPase activity is directly demonstrated experimentally (PMID:21231916). The IBA annotation is fully consistent with both the biochemical data and the conserved HSP70 domain architecture.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSPA6 has a functional substrate-binding domain and possesses intrinsic ATPase activity that is as high as that of the canonical HSPA1A when stimulated by J-proteins</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
                                     GO:0031072
                                 </a>
                             </span>
                             <span class="term-label">heat shock protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1053,64 +1053,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation of GO:0031072 (heat shock protein binding) based on phylogenetic inference. This is directly supported by experimental IPI evidence from Hageman et al. (2011), who demonstrated physical interactions between HSPA6 and multiple J-domain co-chaperones (DNAJA1, DNAJA2, DNAJA4, DNAJB1, DNAJB4, DNAJB6, DNAJB2, and others) as well as co-chaperones like BAG1 and HSPBP1 (PMID:21231916). HSP70-J-protein interactions are central to the HSP70 chaperone cycle.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSP70 proteins functionally depend on interaction with J-domain co-chaperones (DNAJ proteins) and nucleotide exchange factors (BAG proteins, HSPBP1). Hageman et al. (2011) directly demonstrated these interactions for HSPA6 (PMID:21231916). The IBA is well-supported by experimental evidence and reflects a core aspect of HSP70 chaperone biology.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSPA6 has a functional substrate-binding domain and possesses intrinsic ATPase activity that is as high as that of the canonical HSPA1A when stimulated by J-proteins</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     GO:0044183
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1122,64 +1122,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation of GO:0044183 (protein folding chaperone) based on phylogenetic inference across HSP70 family members. This is the central molecular function of HSPA6. Hageman et al. (2011) demonstrated that purified HSPA6 can assist in reactivation of heat-unfolded p53, confirming active chaperone function (PMID:21231916). The ATPase activity and substrate-binding domain are functional. HSPA6 shows substrate specificity distinct from other HSP70 members (cannot refold luciferase but can refold p53), indicating a specialized chaperone role.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein folding chaperone activity is the core evolved function of HSPA6 as an HSP70 family member. This is directly supported by experimental evidence showing HSPA6 can assist in reactivation of heat-unfolded p53 in an ATP-dependent manner (PMID:21231916). The IBA annotation correctly captures this core function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">purified HSPA6 could not chaperone heat-unfolded luciferase but was able to assist in reactivation of heat-unfolded p53</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/HSPA6/HSPA6-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">HSPA6 is a prominent stress-inducible Hsp70 paralog whose chaperone role expands proteostasis capacity under proteotoxic stress.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1191,64 +1202,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation of GO:0005829 (cytosol) based on phylogenetic inference. This is directly supported by IDA evidence from Hageman et al. (2011), who showed cytosolic localization of HSPA6 (PMID:21231916). Consistent with the known localization of most HSP70 family members.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol is the primary localization for HSPA6 and most HSP70 family members. Directly supported by IDA evidence (PMID:21231916). The IBA annotation is consistent with experimental data.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1260,64 +1271,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation of GO:0042026 (protein refolding) based on phylogenetic inference. Directly supported by experimental IDA evidence from Hageman et al. (2011), who showed HSPA6 can assist in reactivation (refolding) of heat-unfolded p53 (PMID:21231916). However, HSPA6 showed notably limited refolding capability compared to other HSP70 members -- it could not refold heat-denatured luciferase and could not suppress polyQ aggregation. The refolding function appears to be substrate-specific rather than general.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein refolding is a core biological process for HSP70 chaperones. HSPA6 demonstrates refolding activity on at least one substrate (p53), although it shows substrate selectivity different from other family members (PMID:21231916). The IBA annotation is appropriate even though HSPA6 may have a narrower substrate range than other HSP70 members.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">purified HSPA6 could not chaperone heat-unfolded luciferase but was able to assist in reactivation of heat-unfolded p53</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000166" target="_blank" class="term-link">
                                     GO:0000166
                                 </a>
                             </span>
                             <span class="term-label">nucleotide binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1329,46 +1340,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of GO:0000166 (nucleotide binding) based on UniProtKB keyword mapping (KW-0547 Nucleotide-binding). This is a broad parent term. HSPA6 contains a well-characterized nucleotide-binding domain (NBD, residues 3-388) that binds ATP and ADP. The crystal structure of the ATPase domain (PDB:3FE1) confirms nucleotide binding (PMID:20072699). While correct, this is subsumed by the more specific ATP binding annotation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleotide binding is correct for HSPA6 and is confirmed by crystal structure data (PDB:3FE1, PMID:20072699). Although this is a broader term than ATP binding, IEA annotations at a broader level than more specific annotations are acceptable. The UniProt keyword mapping is accurate.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
                                     GO:0005524
                                 </a>
                             </span>
                             <span class="term-label">ATP binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1380,64 +1391,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of GO:0005524 (ATP binding) from combined automated annotation methods including InterPro domain mapping and UniProtKB keyword mapping. HSPA6 has a well-characterized ATP-binding domain (NBD, residues 3-388) with multiple ATP binding sites defined in UniProt (residues 14-17, 73, 204-206, 270-277, 341-344). The crystal structure of HSPA6 NBD in complex with ADP and phosphate (PDB:3FE1) directly confirms nucleotide binding (PMID:20072699). The original discovery paper (PMID:2327978) noted that HSP70B&#39; protein bound ATP.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATP binding is a core biochemical property of HSPA6, confirmed by crystal structure (PDB:3FE1), biochemical assays (PMID:21231916), and the original characterization showing the protein binds ATP (PMID:2327978). The IEA is accurate and well-supported.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/2327978" target="_blank" class="term-link">
                                         PMID:2327978
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">a more basic 70 kDa heat-shock protein that both the major stress-inducible HSP70 and constitutively expressed HSC70 heat-shock proteins, which in common with other heat-shock 70 kDa proteins bound ATP</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006986" target="_blank" class="term-link">
                                     GO:0006986
                                 </a>
                             </span>
                             <span class="term-label">response to unfolded protein</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1449,46 +1460,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of GO:0006986 (response to unfolded protein) generated by ARBA machine learning models. HSPA6 is a stress-inducible chaperone that is induced under severe stress conditions and participates in refolding of unfolded proteins (PMID:21231916). This annotation is consistent with the TAS annotation from PMID:2327978 for the same term. While HSPA6 is induced by heat stress rather than by unfolded proteins per se, the term is broadly appropriate for a heat shock protein that functions in protein quality control.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Response to unfolded protein is appropriate for HSPA6 as a stress-inducible molecular chaperone that participates in refolding denatured proteins. Consistent with the TAS annotation for the same term from PMID:2327978. The IEA prediction is reasonable.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1500,115 +1511,115 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of GO:0016887 (ATP hydrolysis activity) based on InterPro domain mapping (IPR013126 HSP70 family). HSPA6 contains the conserved HSP70 domain with ATPase activity, directly confirmed by Hageman et al. (2011), who showed HSPA6 has intrinsic ATPase activity as high as HSPA1A when stimulated by J-proteins (PMID:21231916). Also supported by IBA and IDA annotations for the same term.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATP hydrolysis activity is directly demonstrated for HSPA6 (PMID:21231916) and is correctly predicted from the HSP70 InterPro domain. The IEA is consistent with both IBA and IDA annotations for the same term.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSPA6 has a functional substrate-binding domain and possesses intrinsic ATPase activity that is as high as that of the canonical HSPA1A when stimulated by J-proteins</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019899" target="_blank" class="term-link">
                                     GO:0019899
                                 </a>
                             </span>
                             <span class="term-label">enzyme binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P17066" data-a="GO:0019899" data-r="GO_REF:0000117" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P17066" data-a="GO:0019899" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of GO:0019899 (enzyme binding) generated by ARBA machine learning models. HSPA6 interacts with METTL21A, a methyltransferase that trimethylates HSPA6 at Lys-563 (PMID:23921388). This makes the annotation technically correct. However, &#39;enzyme binding&#39; is a vague term that does not convey informative molecular function. The more specific IPI annotation for the same term from PMID:23921388 captures the METTL21A interaction. The IEA adds no additional information.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> The enzyme binding annotation is technically correct as HSPA6 is a substrate of the methyltransferase METTL21A (PMID:23921388). While vague, this IEA annotation is consistent with the IPI annotation from the same reference. Acceptable as a broad IEA that subsumes the more specific experimental annotation.
+                            <strong>Reason:</strong> HSPA6 is a substrate of the methyltransferase METTL21A, so the interaction is real, but this reflects a modification event rather than HSPA6 performing enzyme binding as a core molecular function. The broad IEA should be kept only as a non-core interaction context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1620,46 +1631,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of GO:0042026 (protein refolding) generated by ARBA machine learning models. Consistent with IBA and IDA annotations for the same term. HSPA6 has been experimentally shown to assist in reactivation of heat-unfolded p53 (PMID:21231916), directly supporting this annotation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein refolding is directly demonstrated for HSPA6 (PMID:21231916). The IEA prediction is consistent with existing IBA and IDA annotations for the same term.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1671,86 +1682,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation of GO:0051082 (unfolded protein binding) was generated by ARBA machine learning models (GO_REF:0000117). GO:0051082 is being obsoleted (go-ontology#30962) because it conflates passive binding with active chaperone function. HSPA6 is a well-characterized HSP70 family ATP-dependent chaperone. The annotation should be replaced with GO:0044183 (protein folding chaperone), which correctly represents the active chaperone function demonstrated experimentally for HSPA6 (PMID:21231916). This IEA annotation will likely be automatically updated when GO:0051082 is obsoleted, but should be modified to GO:0044183 regardless.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 (unfolded protein binding) is scheduled for obsolescence (go-ontology#30962). HSPA6 functions as an ATP-dependent protein folding chaperone, not merely a passive binder of unfolded proteins. The ARBA-predicted annotation should be replaced with GO:0044183 (protein folding chaperone), consistent with the experimentally validated IDA evidence from PMID:21231916 showing HSPA6 assists in reactivation of heat-unfolded p53, and with the existing IBA annotation for GO:0044183.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">purified HSPA6 could not chaperone heat-unfolded luciferase but was able to assist in reactivation of heat-unfolded p53</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14743216" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14743216
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A physical and functional map of the human TNF-alpha/NF-kapp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1762,75 +1773,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation of GO:0005515 (protein binding) from Bouwmeester et al. (2004), a large-scale TAP-MS study mapping the TNF-alpha/NF-kappa B signaling pathway (PMID:14743216). HSPA6 (P17066) was identified as interacting with MAP3K14 (Q99558/NIK). This is a high-throughput interaction study; the interaction with MAP3K14 is recorded in IntAct. However, &#39;protein binding&#39; is uninformative as a molecular function term. HSP70 chaperones interact with many proteins as part of their chaperone function, and this interaction likely reflects HSPA6 acting as a chaperone or being co-purified rather than a specific functional interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative and does not convey specific molecular function. The interaction with MAP3K14 from a high-throughput TAP-MS study (PMID:14743216) likely reflects nonspecific chaperone-client or co-purification artifacts rather than a specific functional partnership. HSP70 proteins are well-known contaminants in affinity purification experiments. This annotation should be removed in favor of more informative terms like heat shock protein binding (GO:0031072) or protein folding chaperone (GO:0044183).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14743216" target="_blank" class="term-link">
                                         PMID:14743216
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">mapping of a protein interaction network around 32 known and candidate TNF-alpha/NF-kappa B pathway components by using an integrated approach comprising tandem affinity purification, liquid-chromatography tandem mass spectrometry, network analysis and directed functional perturbation studies</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21044950" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21044950
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Genome-wide YFP fluorescence complementation screen identifi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1842,75 +1853,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation of GO:0005515 (protein binding) from Lee et al. (2011), a genome-wide YFP fluorescence complementation (BiFC) screen for telomere regulators (PMID:21044950). HSPA6 was identified as interacting with TERF1 (P54274). This is a large-scale high-throughput screen examining ~12,000 human proteins. BiFC can trap transient or weak interactions but may also produce false positives due to irreversible YFP fragment complementation. The biological relevance of an HSPA6-TERF1 interaction is unclear. &#39;Protein binding&#39; is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative. The HSPA6-TERF1 interaction from a large-scale BiFC screen (PMID:21044950) is of uncertain biological significance. As the authors note, BiFC can trap weak/transient interactions and the identified proteins may associate under specific conditions or may be false positives. HSP70 chaperones interact broadly with client proteins and this likely represents nonspecific chaperone-client binding rather than a telomere-specific function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21044950" target="_blank" class="term-link">
                                         PMID:21044950
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">transient or weak interactions as well as low abundance regulators that may be lost during in vitro purification steps, can be &#34;trapped&#34; thanks to the cofolding of YFP fragments</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31980649" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31980649
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Extensive rewiring of the EGFR network in colorectal cancer ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1922,75 +1933,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation of GO:0005515 (protein binding) from Kennedy et al. (2020), a study on EGFR network rewiring in colorectal cancer cells expressing KRAS(G13D) (PMID:31980649). HSPA6 was identified as interacting with MAP3K14 (Q99558) in this proteomics study. This is a large-scale interaction study; HSP70 proteins are commonly identified as interactors in such studies due to their chaperone function. &#39;Protein binding&#39; is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative. The interaction detected in a large-scale network study (PMID:31980649) likely reflects HSPA6 chaperone activity on client proteins rather than a specific functional interaction. HSP70 proteins are frequently detected in interactome studies as nonspecific interactors or chaperone-client pairs.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/31980649" target="_blank" class="term-link">
                                         PMID:31980649
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Mapping &gt;6000 PPIs shows that this network is extensively rewired in cells expressing transforming levels of KRASG13D (mtKRAS)</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32296183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A reference map of the human binary protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -2002,75 +2013,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation of GO:0005515 (protein binding) from Luck et al. (2020), the Human Reference Interactome (HuRI) systematic yeast two-hybrid binary interactome mapping (PMID:32296183). Multiple interactions were detected for HSPA6 including with AHCYL1 (O43865), BAG4 (O95429), FLNA (P21333-2), PPIB (P23284), RPA1 (P27694), LGALS7B (P47929), COMMD6 (Q7Z4G1), KRT222 (Q8N1A0), C22orf15 (Q8WYQ4-2), and PRAP1 (Q96NZ9). The BAG4 interaction is notable as BAG proteins are known nucleotide exchange factors for HSP70 chaperones and this interaction is biologically meaningful. However, &#39;protein binding&#39; is uninformative. The BAG4 interaction would be better annotated under heat shock protein binding (GO:0031072).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative. While some interactions from HuRI may be biologically relevant (e.g., BAG4 as a nucleotide exchange factor), the generic &#39;protein binding&#39; term does not capture this specificity. HSP70 proteins interact broadly with many partners through their chaperone function. The BAG4 interaction is already better captured by the heat shock protein binding annotation (GO:0031072). The remaining interactions are likely chaperone-client interactions or Y2H artifacts.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                                         PMID:32296183
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HuRI is a systematic proteome-wide reference that links genomic variation to phenotypic outcomes</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2082,64 +2093,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation of GO:0016887 (ATP hydrolysis activity) from Hageman et al. (2011). This study directly demonstrated that HSPA6 possesses intrinsic ATPase activity that is as high as that of the canonical HSPA1A when stimulated by J-proteins (PMID:21231916). This is high-quality direct experimental evidence for a core molecular function of HSPA6.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is well-supported IDA evidence for a core molecular function. Hageman et al. (2011) directly measured HSPA6 ATPase activity and showed it is comparable to HSPA1A when stimulated by J-proteins (PMID:21231916). ATP hydrolysis is central to the HSP70 chaperone cycle and represents a core function of HSPA6.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSPA6 has a functional substrate-binding domain and possesses intrinsic ATPase activity that is as high as that of the canonical HSPA1A when stimulated by J-proteins</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
                                     GO:0005576
                                 </a>
                             </span>
                             <span class="term-label">extracellular region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6798748
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2151,46 +2162,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation of GO:0005576 (extracellular region) from Reactome pathway R-HSA-6798748 (Exocytosis of secretory granule lumen proteins). This annotation indicates HSPA6 is found in the extracellular space, presumably after release from neutrophil secretory granules. HSP70 proteins can be released extracellularly, particularly from immune cells. This is a plausible but non-core localization for HSPA6, which primarily functions as an intracellular chaperone.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Extracellular release of HSP70 family members from neutrophil granules is documented. However, this is not a core localization for HSPA6, which primarily functions as an intracellular stress-inducible chaperone. The Reactome pathway annotation is retained as non-core.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
                                     GO:0005576
                                 </a>
                             </span>
                             <span class="term-label">extracellular region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6800434
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2202,46 +2213,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation of GO:0005576 (extracellular region) from Reactome pathway R-HSA-6800434 (Exocytosis of ficolin-rich granule lumen proteins). Same rationale as the R-HSA-6798748 annotation above -- HSPA6 may be released extracellularly from neutrophil granules, but this is not a core localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Duplicate extracellular region annotation from a different Reactome pathway (ficolin-rich granule exocytosis). Same rationale as R-HSA-6798748: extracellular release is plausible but not a core localization for this intracellular chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034774" target="_blank" class="term-link">
                                     GO:0034774
                                 </a>
                             </span>
                             <span class="term-label">secretory granule lumen</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6798748
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2253,46 +2264,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation of GO:0034774 (secretory granule lumen) from Reactome pathway R-HSA-6798748 (Exocytosis of secretory granule lumen proteins). This indicates HSPA6 is found in neutrophil secretory granule lumens. HSP70 proteins have been detected in neutrophil granules. This is a specialized localization for an immune cell context, not a core localization for HSPA6.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Localization to neutrophil secretory granule lumen is plausible based on Reactome curation of neutrophil degranulation pathways. However, this is a specialized immune cell context and not a core localization for HSPA6, which primarily functions as a cytosolic stress-inducible chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1904813" target="_blank" class="term-link">
                                     GO:1904813
                                 </a>
                             </span>
                             <span class="term-label">ficolin-1-rich granule lumen</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6800434
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2304,57 +2315,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation of GO:1904813 (ficolin-1-rich granule lumen) from Reactome pathway R-HSA-6800434 (Exocytosis of ficolin-rich granule lumen proteins). This is a specific sub-type of neutrophil granule. Similar rationale to the secretory granule lumen annotation -- this is a specialized immune cell localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Ficolin-1-rich granule lumen is a specific neutrophil granule compartment. While plausible based on Reactome curation, this represents a specialized immune cell context rather than a core localization for the stress-inducible cytosolic chaperone HSPA6.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005814" target="_blank" class="term-link">
                                     GO:0005814
                                 </a>
                             </span>
                             <span class="term-label">centriole</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24061851" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24061851
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Stress-induced localization of HSPA6 (HSP70B&#39;) and HSPA1A (H...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2366,88 +2377,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation of GO:0005814 (centriole) from Khalouei et al. (2014), who demonstrated that YFP-tagged HSPA6 rapidly localizes to centrioles in human SH-SY5Y neuronal cells following thermal stress (PMID:24061851). HSPA6 showed more prolonged centriolar localization than HSPA1A and specifically targeted the proximal end of centrioles (identified by gamma-tubulin marker). The authors suggest this indicates the proximal end of centrioles may be a stress-sensitive site in neurons.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is well-supported IDA evidence showing stress-induced centriolar localization in neuronal cells (PMID:24061851). The localization was confirmed using YFP-tagged HSPA6 and co-localization with centrosome markers. The prolonged localization at centrioles compared to HSPA1A suggests a specific stress- protective role at this structure.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24061851" target="_blank" class="term-link">
                                         PMID:24061851
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">YFP-tagged HSPA6 and HSPA1A rapidly appeared at centrioles in the cytoplasm of human neuronal cells, with HSPA6 demonstrating a more prolonged signal compared to HSPA1A</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24061851" target="_blank" class="term-link">
                                         PMID:24061851
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The YFP-tagged HSP70 proteins targeted the proximal end of centrioles (identified by gamma-tubulin marker) rather than the distal end (centrin marker)</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034605" target="_blank" class="term-link">
                                     GO:0034605
                                 </a>
                             </span>
                             <span class="term-label">cellular response to heat</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21597468" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21597468
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Transformation of eEF1Bδ into heat-shock response transcript...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2459,155 +2470,155 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IMP annotation of GO:0034605 (cellular response to heat) from Kaitsuka et al. (2011) (PMID:21597468). This paper is about eEF1Bdelta (a translation elongation factor), not directly about HSPA6. The paper describes how eEF1BdeltaL induces HSE-containing genes including HSP70 genes in cooperation with HSF1. HSPA6 as a heat-inducible gene is expected to be among the targets induced. The connection to HSPA6 in this IMP annotation may derive from HSPA6 being used as a reporter or marker of the heat shock response. As an HSP70 gene strictly induced by heat stress, HSPA6 is clearly involved in cellular response to heat.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPA6 is a strictly heat-inducible gene that shows no basal expression and is only expressed under severe thermal stress (PMID:2327978). Cellular response to heat is a core biological process for HSPA6. While PMID:21597468 focuses on eEF1BdeltaL, HSPA6 involvement in the heat shock response is well-established and supported by multiple references.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/2327978" target="_blank" class="term-link">
                                         PMID:2327978
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSP70B&#39; mRNA was induced only at higher temperature and showed no basal expression</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019899" target="_blank" class="term-link">
                                     GO:0019899
                                 </a>
                             </span>
                             <span class="term-label">enzyme binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23921388
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of a novel human methylt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P17066" data-a="GO:0019899" data-r="PMID:23921388" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P17066" data-a="GO:0019899" data-r="PMID:23921388" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation of GO:0019899 (enzyme binding) from Jakobsson et al. (2013), who identified METTL21A (Q8WXB1) as the methyltransferase responsible for trimethylation of HSPA6 at Lys-563 (PMID:23921388). HSPA6 is a substrate of METTL21A, so this interaction is well-characterized. However, the term &#39;enzyme binding&#39; is somewhat vague. In this case, HSPA6 is the substrate of the methyltransferase, so the interaction is real and specific, but it reflects HSPA6 being modified rather than performing enzyme binding as a molecular function.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> The interaction between HSPA6 and METTL21A is directly demonstrated with biochemical evidence showing METTL21A trimethylates HSPA6 at Lys-563 (PMID:23921388). While &#39;enzyme binding&#39; is vague, the annotation correctly reflects a validated physical interaction with the methyltransferase. HSPA6 is a substrate in this context. The annotation is acceptable as it captures a real interaction.
+                            <strong>Reason:</strong> The interaction between HSPA6 and METTL21A is directly demonstrated with biochemical evidence showing METTL21A trimethylates HSPA6 at Lys-563 (PMID:23921388). The annotation reflects a validated physical interaction with the methyltransferase, but HSPA6 is a substrate in this context rather than an enzyme-binding factor, so this is non-core.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link">
                                         PMID:23921388
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we identified the methyltransferase METTL21A as the enzyme responsible for trimethylation of a conserved lysine residue found in several human Hsp70 (HSPA) proteins</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
                                     GO:0031072
                                 </a>
                             </span>
                             <span class="term-label">heat shock protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2619,75 +2630,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation of GO:0031072 (heat shock protein binding) from Hageman et al. (2011) (PMID:21231916). The GOA data shows interactions with multiple co-chaperones including DNAJA2 (O60884), DNAJB1 (P25685), DNAJB4 (Q9UDY4), DNAJB6 (O75190), DNAJB2 (P25686), DNAJA1 (P31689), DNAJA4 (Q8WW22), and others (Q7Z6W7/DNAJB12, Q8NHS0/DNAJB14). These are J-domain proteins (HSP40 family) that function as co-chaperones essential for the HSP70 chaperone cycle. This is a core molecular function for HSPA6.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSP70-J-protein (HSP40/DNAJ) interactions are essential for the HSP70 chaperone cycle. Hageman et al. (2011) directly demonstrated HSPA6 interactions with multiple J-domain co-chaperones including DNAJA1, DNAJA2, DNAJA4, DNAJB1, DNAJB2, DNAJB4, DNAJB6, and others (PMID:21231916). These interactions stimulate HSPA6 ATPase activity, confirming functional relevance. This is a core function annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSPA6 has a functional substrate-binding domain and possesses intrinsic ATPase activity that is as high as that of the canonical HSPA1A when stimulated by J-proteins</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2699,75 +2710,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation of GO:0042026 (protein refolding) from Hageman et al. (2011). The authors directly demonstrated that purified HSPA6 can assist in reactivation of heat-unfolded p53 in vitro (PMID:21231916). Notably, HSPA6 showed restricted substrate specificity -- it could not refold heat-denatured luciferase and could not suppress polyQ aggregation, unlike HSPA1A. This IDA evidence directly supports protein refolding activity with specific substrate selectivity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct experimental evidence from in vitro refolding assays demonstrates HSPA6 can refold heat-unfolded p53 (PMID:21231916). This is high-quality IDA evidence for a core biological process of HSPA6. The substrate specificity (p53 but not luciferase) highlights that HSPA6 has evolved specialized refolding function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">purified HSPA6 could not chaperone heat-unfolded luciferase but was able to assist in reactivation of heat-unfolded p53</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -2779,101 +2790,101 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962). HSPA6 is an HSP70 family member that functions as an ATP-dependent foldase chaperone, not merely a passive binder of unfolded proteins. Hageman et al. (2011) demonstrated that HSPA6 has a functional substrate-binding domain and intrinsic ATPase activity, and that purified HSPA6 could assist in reactivation of heat-unfolded p53 (PMID:21231916). These data support annotation to GO:0044183 (protein folding chaperone), which captures the active chaperone mechanism. The IBA annotation for GO:0044183 already exists for HSPA6 via phylogenetic inference, consistent with this replacement.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 (unfolded protein binding) is scheduled for obsolescence (go-ontology#30962) because it conflates passive binding of unfolded proteins with active chaperone function. HSPA6 is a bona fide ATP-dependent molecular chaperone of the HSP70 family. The original IDA evidence from PMID:21231916 demonstrates that HSPA6 possesses intrinsic ATPase activity stimulated by J-proteins and can assist in reactivation of heat-unfolded p53, which constitutes active chaperone function rather than mere unfolded protein binding. The correct replacement term is GO:0044183 (protein folding chaperone), defined as &#34;Binding to a protein or a protein-containing complex to assist the protein folding process.&#34; This term is already applied to HSPA6 via IBA (GO_REF:0000033).
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSPA6 has a functional substrate-binding domain and possesses intrinsic ATPase activity that is as high as that of the canonical HSPA1A when stimulated by J-proteins</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">purified HSPA6 could not chaperone heat-unfolded luciferase but was able to assist in reactivation of heat-unfolded p53</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070370" target="_blank" class="term-link">
                                     GO:0070370
                                 </a>
                             </span>
                             <span class="term-label">cellular heat acclimation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
+
                         <span class="not-badge" title="This is a NOT annotation - gene does NOT have this function">NOT</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2885,88 +2896,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NOT annotation for GO:0070370 (cellular heat acclimation) from Hageman et al. (2011) (PMID:21231916). The authors showed that siRNA-mediated blocking of HSPA6 did not impair the development of heat-induced thermotolerance, and that overexpression of HSPA6 did not protect cells from heat-induced cell death (unlike HSPA1A). This negative result is informative and demonstrates that despite being heat-inducible, HSPA6 does not contribute to acquired thermotolerance, distinguishing it functionally from HSPA1A.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is a well-supported NOT annotation based on direct experimental evidence. Hageman et al. (2011) demonstrated via both loss-of-function (siRNA knockdown) and gain-of-function (overexpression) experiments that HSPA6 does not contribute to cellular heat acclimation/thermotolerance (PMID:21231916). This negative annotation is informative and functionally distinguishes HSPA6 from HSPA1A.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">whereas overexpression of HSPA1A protected cells from heat-induced cell death, overexpression of HSPA6 did not</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">siRNA (small interfering RNA)-mediated blocking of HSPA6 did not impair the development of heat-induced thermotolerance</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24061851" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24061851
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Stress-induced localization of HSPA6 (HSP70B&#39;) and HSPA1A (H...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2978,75 +2989,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation of GO:0005737 (cytoplasm) from Khalouei et al. (2014). Using YFP-tagged HSPA6 in stable human SH-SY5Y neuronal cell lines, the authors observed HSPA6 in the cytoplasm following thermal stress (PMID:24061851). This is consistent with the IBA annotation for the same term and with the known cytoplasmic localization of HSP70 family members.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct experimental evidence using YFP-tagged HSPA6 confirms cytoplasmic localization in human neuronal cells (PMID:24061851). Cytoplasm is a core localization for HSPA6. Consistent with IBA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24061851" target="_blank" class="term-link">
                                         PMID:24061851
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">YFP-tagged HSPA6 and HSPA1A rapidly appeared at centrioles in the cytoplasm of human neuronal cells</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3058,75 +3069,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation of GO:0005829 (cytosol) from Hageman et al. (2011). The study establishes HSPA6 as a cytosolic HSP70 family member (PMID:21231916). Most HSP70/HSPA family members are cytosolic, and HSPA6 is described as such in this study. Consistent with the IBA annotation for the same term.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol is the primary localization for HSPA6 as established in PMID:21231916. This is consistent with the general cytosolic localization of HSP70 family members and with the IBA annotation. Core localization for HSPA6.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034605" target="_blank" class="term-link">
                                     GO:0034605
                                 </a>
                             </span>
                             <span class="term-label">cellular response to heat</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24061851" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24061851
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Stress-induced localization of HSPA6 (HSP70B&#39;) and HSPA1A (H...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3138,88 +3149,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation of GO:0034605 (cellular response to heat) from Khalouei et al. (2014). The authors showed that HSPA6 rapidly localizes to centrioles in human neuronal cells following thermal stress (PMID:24061851). HSPA6 is a strictly heat-inducible gene with no basal expression (PMID:2327978), and its rapid stress-induced relocalization to centrioles is a direct cellular response to heat.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPA6 is a strictly heat-inducible chaperone and its stress-induced localization to centrioles directly demonstrates cellular response to heat (PMID:24061851). Combined with the original characterization showing no basal expression and induction only at higher temperatures (PMID:2327978), cellular response to heat is a core process for HSPA6.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24061851" target="_blank" class="term-link">
                                         PMID:24061851
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Following a brief period of thermal stress, YFP-tagged HSPA6 and HSPA1A rapidly appeared at centrioles in the cytoplasm of human neuronal cells</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/2327978" target="_blank" class="term-link">
                                         PMID:2327978
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSP70B&#39; mRNA was induced only at higher temperature and showed no basal expression</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0072562" target="_blank" class="term-link">
                                     GO:0072562
                                 </a>
                             </span>
                             <span class="term-label">blood microparticle</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22516433" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22516433
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomic analysis of microvesicles from plasma of healthy d...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3231,75 +3242,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HDA annotation of GO:0072562 (blood microparticle) from Bastos-Amador et al. (2012), a proteomic analysis of microvesicles from plasma of healthy donors (PMID:22516433). HSPA6 was detected in blood microparticles by mass spectrometry. This is a high-throughput proteomics identification. HSP70 proteins are commonly found in extracellular vesicles, but this is not a core localization for HSPA6, which is primarily an intracellular stress-inducible chaperone.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Detection of HSPA6 in blood microparticles by HDA proteomics (PMID:22516433) is plausible given that HSP70 proteins are commonly found in extracellular vesicles. However, this is not a core localization for HSPA6. The annotation is retained as non-core. Note that HSP70 proteins are common contaminants in proteomic studies.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22516433" target="_blank" class="term-link">
                                         PMID:22516433
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We have detected 161 microvesicle-associated proteins, including many associated with the complement and coagulation signal-transduction cascades</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
                                     GO:0070062
                                 </a>
                             </span>
                             <span class="term-label">extracellular exosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19199708" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19199708
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomic analysis of human parotid gland exosomes by multid...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3311,75 +3322,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HDA annotation of GO:0070062 (extracellular exosome) from Gonzalez-Begne et al. (2009), a proteomic analysis of human parotid gland exosomes by MudPIT mass spectrometry (PMID:19199708). HSPA6 was identified among 491 exosomal proteins. HSP70 family proteins (including HSC70/HSPA8) are well-established exosome markers, so detection of HSPA6 is not surprising. However, this may reflect co-purification with other more abundant HSP70 family members, especially since HSPA6 has no basal expression and would not be expected in normal parotid exosomes unless the cells were stressed.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPA6 detection in exosomes (PMID:19199708) is plausible but raises questions given that HSPA6 has no basal expression (PMID:2327978). This may reflect cross-identification with other HSP70 family members given high sequence similarity, or the cells may have been under stress. HSP70 family members are common exosome cargo. Retained as non-core since extracellular exosome is not a core localization for HSPA6.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19199708" target="_blank" class="term-link">
                                         PMID:19199708
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we catalogued 491 proteins in the exosome fraction of human parotid saliva</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008180" target="_blank" class="term-link">
                                     GO:0008180
                                 </a>
                             </span>
                             <span class="term-label">COP9 signalosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18850735" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18850735
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Characterization of the human COP9 signalosome complex using...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -3391,75 +3402,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation of GO:0008180 (COP9 signalosome) from Fang et al. (2008), who performed proteomic characterization of the human COP9 signalosome using affinity purification and mass spectrometry (PMID:18850735). The GOA data shows this annotation uses the qualifier &#39;colocalizes_with&#39; rather than &#39;is_active_in&#39;, indicating HSPA6 was found co-localizing with the COP9 signalosome rather than being a core component. HSPA6 was likely identified as one of 52 putative CSN interacting proteins. HSP70 proteins are commonly identified in affinity purification experiments as chaperone-client interactions or co-purification artifacts.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPA6 was identified as co-localizing with the COP9 signalosome in a high-throughput AP-MS study (PMID:18850735). HSP70 chaperones are well-known co-purification contaminants in affinity purification experiments. The colocalizes_with qualifier is appropriate (not a core CSN component), but this likely represents a transient chaperone-client interaction rather than meaningful co-localization with the COP9 signalosome. This is an over-annotation of what is probably a non-specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/18850735" target="_blank" class="term-link">
                                         PMID:18850735
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">A total of 52 putative human CSN interacting proteins were identified, most of which are reported for the first time</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006986" target="_blank" class="term-link">
                                     GO:0006986
                                 </a>
                             </span>
                             <span class="term-label">response to unfolded protein</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/2327978" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:2327978
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The human heat-shock protein family. Expression of a novel h...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3471,61 +3482,61 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation of GO:0006986 (response to unfolded protein) from Leung et al. (1990), the original paper characterizing HSPA6/HSP70B&#39; (PMID:2327978). The paper showed that HSPA6 is a heat-inducible HSP70 family member with no basal expression, induced only at higher temperatures. As a stress-inducible molecular chaperone of the HSP70 family, HSPA6 participates in the cellular response to unfolded/denatured proteins generated by heat stress. The annotation is appropriate, though the direct connection to unfolded protein specifically (rather than heat stress generally) requires inference from the HSP70 function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPA6 is a heat-inducible HSP70 molecular chaperone (PMID:2327978) that functions in refolding denatured proteins (PMID:21231916). The response to unfolded protein annotation is appropriate because HSPA6 is induced under conditions that generate unfolded proteins (heat stress) and directly participates in their refolding. The TAS evidence from the original characterization paper is reasonable.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/2327978" target="_blank" class="term-link">
                                         PMID:2327978
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSP70B&#39; mRNA was induced only at higher temperature and showed no basal expression</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>Strictly stress-inducible ATP-dependent protein folding chaperone with substrate selectivity distinct from other HSP70 family members. HSPA6 shows no basal expression and is induced only under severe thermal stress, with approximately 13-14-fold induction under extreme heat vs approximately 2-3-fold under mild heat in neuronal models (DOI:10.3390/biology12030416). It possesses intrinsic ATPase activity comparable to HSPA1A when stimulated by J-domain co-chaperones, but displays restricted substrate specificity: it can refold heat-unfolded p53 but not heat-denatured luciferase, and does not suppress polyQ aggregation or confer thermotolerance. Under thermal stress, HSPA6 rapidly localizes to centrioles, suggesting a specific stress-protective role at this structure. HSPA6 operates as part of a coordinated inducible chaperone module with DNAJB1, BAG3, and HSPH1/HSP110 that expands folding and disaggregation capacity under proteotoxic stress (DOI:10.3390/biology12030416). The HSP70 chaperone cycle involves J-domain protein delivery of clients and stimulation of ATP hydrolysis, followed by nucleotide exchange factor-mediated ADP release and client recycling; HSP110 proteins cooperate with HSP70 and HSP40 to disaggregate and refold denatured proteins (DOI:10.3390/biom13040604). HSPA6 has also been implicated in RTP1S-dependent membrane protein trafficking, partially enhancing olfactory receptor surface expression by approximately 50-80% (DOI:10.3390/ijms24097829).</h3>
+                <h3>Strictly stress-inducible ATP-dependent protein folding chaperone with substrate selectivity distinct from other HSP70 family members. HSPA6 shows no basal expression and is induced only under severe thermal stress, with approximately 13-14-fold induction under extreme heat vs approximately 2-3-fold under mild heat in neuronal models (DOI:10.3390/biology12030416). It possesses intrinsic ATPase activity comparable to HSPA1A when stimulated by J-domain co-chaperones, but displays restricted substrate specificity: it can refold heat-unfolded p53 but not heat-denatured luciferase, and does not suppress polyQ aggregation or confer thermotolerance. Under thermal stress, HSPA6 rapidly localizes to centrioles, suggesting a specific stress-protective role at this structure. Neuronal heat-stress studies place HSPA6 in a coordinated inducible chaperone module with DNAJB1, BAG3, and HSPH1/HSP110, but that co-expression context should not be read as direct evidence that HSPA6 itself performs disaggregation (DOI:10.3390/biology12030416). The HSP70 chaperone cycle involves J-domain protein delivery of clients and stimulation of ATP hydrolysis, followed by nucleotide exchange factor-mediated ADP release and client recycling; HSP110 proteins cooperate with HSP70 and HSP40 to disaggregate and refold denatured proteins (DOI:10.3390/biom13040604). HSPA6 has also been implicated in RTP1S-dependent membrane protein trafficking, partially enhancing olfactory receptor surface expression by approximately 50-80% (DOI:10.3390/ijms24097829).</h3>
                 <span class="vote-buttons" data-g="P17066" data-a="FUNCTION: Strictly stress-inducible ATP-dependent protein fo..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -3534,610 +3545,629 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                 protein refolding
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034605" target="_blank" class="term-link">
                                 cellular response to heat
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006986" target="_blank" class="term-link">
                                 response to unfolded protein
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005814" target="_blank" class="term-link">
                                 centriole
                             </a>
                         </span>
-                        
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
-                                nucleus
-                            </a>
-                        </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                 PMID:21231916
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">purified HSPA6 could not chaperone heat-unfolded luciferase but was able to assist in reactivation of heat-unfolded p53</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                 PMID:21231916
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">HSPA6 has a functional substrate-binding domain and possesses intrinsic ATPase activity that is as high as that of the canonical HSPA1A when stimulated by J-proteins</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/2327978" target="_blank" class="term-link">
                                 PMID:2327978
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">HSP70B&#39; mRNA was induced only at higher temperature and showed no basal expression</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24061851" target="_blank" class="term-link">
                                 PMID:24061851
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">YFP-tagged HSPA6 and HSPA1A rapidly appeared at centrioles in the cytoplasm of human neuronal cells, with HSPA6 demonstrating a more prolonged signal compared to HSPA1A</div>
-                        
+
                     </li>
-                    
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/HSPA6/HSPA6-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">HSPA6 is a prominent stress-inducible HSP70 paralog that is co-expressed with DNAJB1, BAG3, and HSPH1 in neuronal heat-stress models, consistent with participation in an inducible proteostasis module.</div>
+
+                    </li>
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/HSPA6/HSPA6-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for HSPA6</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14743216" target="_blank" class="term-link">
                             PMID:14743216
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A physical and functional map of the human TNF-alpha/NF-kappa B signal transduction pathway.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18850735" target="_blank" class="term-link">
                             PMID:18850735
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Characterization of the human COP9 signalosome complex using affinity purification and mass spectrometry.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19199708" target="_blank" class="term-link">
                             PMID:19199708
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteomic analysis of human parotid gland exosomes by multidimensional protein identification technology (MudPIT).</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20072699" target="_blank" class="term-link">
                             PMID:20072699
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Crystal structures of the ATPase domains of four human Hsp70 isoforms.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21044950" target="_blank" class="term-link">
                             PMID:21044950
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Genome-wide YFP fluorescence complementation screen identifies new regulators for telomere signaling in human cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                             PMID:21231916
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The diverse members of the mammalian HSP70 machine show distinct chaperone-like activities.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21597468" target="_blank" class="term-link">
                             PMID:21597468
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Transformation of eEF1Bδ into heat-shock response transcription factor by alternative splicing.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22516433" target="_blank" class="term-link">
                             PMID:22516433
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteomic analysis of microvesicles from plasma of healthy donors reveals high individual variability.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/2327978" target="_blank" class="term-link">
                             PMID:2327978
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The human heat-shock protein family. Expression of a novel heat-inducible HSP70 (HSP70B&#39;) and isolation of its cDNA and genomic DNA.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link">
                             PMID:23921388
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Identification and characterization of a novel human methyltransferase modulating Hsp70 protein function through lysine methylation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24061851" target="_blank" class="term-link">
                             PMID:24061851
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Stress-induced localization of HSPA6 (HSP70B&#39;) and HSPA1A (HSP70-1) proteins to centrioles in human neuronal cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/31980649" target="_blank" class="term-link">
                             PMID:31980649
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Extensive rewiring of the EGFR network in colorectal cancer cells expressing transforming levels of KRAS(G13D).</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                             PMID:32296183
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A reference map of the human binary protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6798748
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Exocytosis of secretory granule lumen proteins</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6800434
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Exocytosis of ficolin-rich granule lumen proteins</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.3390/biology12030416
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Profiling the Hsp70 Chaperone Network in Heat-Induced Proteotoxic Stress Models of Human Neurons</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSPA6 was among the most strongly induced HSP70 paralogs in neuronal heat-stress models, with approximately 13-14-fold induction under extreme heat vs approximately 2-3-fold under mild heat. Gene expression peaked at approximately 1 hour and protein at approximately 5-6 hours post-stress. Co-expressed with DNAJB1, BAG3, and HSPH1/HSP110 as a coordinated inducible chaperone module.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.3390/biom13040604
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Is It Still Possible to Think about HSP70 as a Therapeutic Target in Onco-Hematological Diseases?</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Describes canonical HSP70 architecture including N-terminal ATPase domain, substrate-binding domain with lid, and C-terminal EEVD motif. J-domain proteins deliver clients and stimulate hydrolysis; NEFs (BAG-family, HSPBP1) promote ADP release. HSP110 proteins cooperate with HSP70 and HSP40 for disaggregation. HSP70 inhibitors have not reached the clinic despite extensive preclinical work.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.3390/ijms24097829
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Identification and characterization of proteins that are involved in RTP1S-dependent transport of olfactory receptors</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSPA6 was biotinylated by RTP1S-AirID (proximity-labeling), indicating physical proximity. Co-expression of HSPA6 partially enhanced surface expression of olfactory receptor Olfr544 by approximately 50-80%. RTP1S N-terminus interacts with HSPA6 C-terminal domain; the olfactory receptor itself did not significantly interact with HSPA6, suggesting indirect trafficking role via RTP1S.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.3390/cancers16030638
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The Interplay between Heat Shock Proteins and Cancer Pathogenesis</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Updated 2024 review of HSP70 family in cancer biology. Summarizes co-chaperone regulation (DNAJ/HSP40, BAG proteins, HSP110, CHIP) and HSF1-driven transcriptional control. Supports consensus that inducible HSP70 family members like HSPA6 contribute to tumor phenotypes when dysregulated.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1021/acssynbio.7b00455
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Remote Control of Mammalian Cells with Heat-Triggered Gene Switches and Photothermal Pulse Trains</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Uses the HSPA6/HSP70B&#39; promoter as a thermal gene switch for remote control of mammalian cells. In vivo photothermal activation demonstrated with gold nanorods and near-infrared laser. Demonstrates HSPA6 promoter as a clinically relevant interface for spatially restricted transgene expression in cell therapies.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1186/s13018-023-03690-z
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">BARX1 promotes osteosarcoma cell proliferation and invasion by regulating HSPA6 expression</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">BARX1 overexpression increases HSPA6 expression (RNA-seq, qPCR, Western blot). Dual-luciferase reporter supports direct regulation at HSPA6 promoter. Silencing HSPA6 attenuates BARX1-driven osteosarcoma proliferation and migration/invasion in vitro.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -4434,9 +4464,9 @@ A 2024 review in Cancers emphasizes the centrality of HSPs as ATP-dependent chap
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -4448,7 +4478,7 @@ A 2024 review in Cancers emphasizes the centrality of HSPs as ATP-dependent chap
                 <pre><code>id: P17066
 gene_symbol: HSPA6
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -4499,13 +4529,13 @@ existing_annotations:
       primarily observed cytoplasmic and centriolar localization after heat stress
       (PMID:24061851). IBA annotations are generally reliable and this is plausible
       for an HSP70 family member.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Nuclear localization is well-established for multiple HSP70 family members and
-      the IBA phylogenetic inference is broadly supported. CD-CODE entries for P17066
-      list nuclear speckle and nucleolus localizations. While direct experimental
-      evidence for HSPA6 nuclear localization is lacking in the available publications,
-      the IBA inference is reasonable given the conserved family behavior.
+      Nuclear localization is plausible by HSP70-family inference, but direct
+      HSPA6-specific evidence is lacking in the available publications. The
+      strongest HSPA6-specific localization evidence supports cytoplasmic and
+      centriolar localization after heat stress, so nucleus should not be treated
+      as a core HSPA6 location.
     supported_by:
     - reference_id: PMID:24061851
       supporting_text: &gt;-
@@ -4635,6 +4665,10 @@ existing_annotations:
       supporting_text: &gt;-
         purified HSPA6 could not chaperone heat-unfolded luciferase but was able to
         assist in reactivation of heat-unfolded p53
+    - reference_id: file:human/HSPA6/HSPA6-deep-research-falcon.md
+      supporting_text: &gt;-
+        HSPA6 is a prominent stress-inducible Hsp70 paralog whose chaperone role
+        expands proteostasis capacity under proteotoxic stress.
 - term:
     id: GO:0005829
     label: cytosol
@@ -4785,12 +4819,12 @@ existing_annotations:
       molecular function. The more specific IPI annotation for the same term from
       PMID:23921388 captures the METTL21A interaction. The IEA adds no additional
       information.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      The enzyme binding annotation is technically correct as HSPA6 is a substrate of
-      the methyltransferase METTL21A (PMID:23921388). While vague, this IEA annotation
-      is consistent with the IPI annotation from the same reference. Acceptable as a
-      broad IEA that subsumes the more specific experimental annotation.
+      HSPA6 is a substrate of the methyltransferase METTL21A, so the interaction
+      is real, but this reflects a modification event rather than HSPA6 performing
+      enzyme binding as a core molecular function. The broad IEA should be kept
+      only as a non-core interaction context.
 - term:
     id: GO:0042026
     label: protein refolding
@@ -5124,14 +5158,13 @@ existing_annotations:
       binding&#39; is somewhat vague. In this case, HSPA6 is the substrate of the
       methyltransferase, so the interaction is real and specific, but it reflects HSPA6
       being modified rather than performing enzyme binding as a molecular function.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
       The interaction between HSPA6 and METTL21A is directly demonstrated with
       biochemical evidence showing METTL21A trimethylates HSPA6 at Lys-563
-      (PMID:23921388). While &#39;enzyme binding&#39; is vague, the annotation correctly
-      reflects a validated physical interaction with the methyltransferase. HSPA6 is
-      a substrate in this context. The annotation is acceptable as it captures a real
-      interaction.
+      (PMID:23921388). The annotation reflects a validated physical interaction
+      with the methyltransferase, but HSPA6 is a substrate in this context rather
+      than an enzyme-binding factor, so this is non-core.
     supported_by:
     - reference_id: PMID:23921388
       supporting_text: &gt;-
@@ -5459,10 +5492,10 @@ core_functions:
     luciferase, and does not suppress polyQ aggregation or confer
     thermotolerance. Under thermal stress, HSPA6 rapidly localizes to
     centrioles, suggesting a specific stress-protective role at this
-    structure. HSPA6 operates as part of a coordinated inducible chaperone
-    module with DNAJB1, BAG3, and HSPH1/HSP110 that expands folding and
-    disaggregation capacity under proteotoxic stress
-    (DOI:10.3390/biology12030416). The HSP70 chaperone cycle involves J-domain
+    structure. Neuronal heat-stress studies place HSPA6 in a coordinated
+    inducible chaperone module with DNAJB1, BAG3, and HSPH1/HSP110, but that
+    co-expression context should not be read as direct evidence that HSPA6
+    itself performs disaggregation (DOI:10.3390/biology12030416). The HSP70 chaperone cycle involves J-domain
     protein delivery of clients and stimulation of ATP hydrolysis, followed by
     nucleotide exchange factor-mediated ADP release and client recycling;
     HSP110 proteins cooperate with HSP70 and HSP40 to disaggregate and refold
@@ -5485,8 +5518,6 @@ core_functions:
     label: cytosol
   - id: GO:0005814
     label: centriole
-  - id: GO:0005634
-    label: nucleus
   supported_by:
   - reference_id: PMID:21231916
     supporting_text: &gt;-
@@ -5506,7 +5537,15 @@ core_functions:
       YFP-tagged HSPA6 and HSPA1A rapidly appeared at centrioles in the cytoplasm
       of human neuronal cells, with HSPA6 demonstrating a more prolonged signal
       compared to HSPA1A
+  - reference_id: file:human/HSPA6/HSPA6-deep-research-falcon.md
+    supporting_text: &gt;-
+      HSPA6 is a prominent stress-inducible HSP70 paralog that is co-expressed
+      with DNAJB1, BAG3, and HSPH1 in neuronal heat-stress models, consistent
+      with participation in an inducible proteostasis module.
 references:
+- id: file:human/HSPA6/HSPA6-deep-research-falcon.md
+  title: Falcon deep research report for HSPA6
+  findings: []
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
     terms
@@ -5642,7 +5681,7 @@ references:
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/HSPA6/HSPA6-ai-review.yaml
+++ b/genes/human/HSPA6/HSPA6-ai-review.yaml
@@ -1,7 +1,7 @@
 id: P17066
 gene_symbol: HSPA6
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -52,13 +52,13 @@ existing_annotations:
       primarily observed cytoplasmic and centriolar localization after heat stress
       (PMID:24061851). IBA annotations are generally reliable and this is plausible
       for an HSP70 family member.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
-      Nuclear localization is well-established for multiple HSP70 family members and
-      the IBA phylogenetic inference is broadly supported. CD-CODE entries for P17066
-      list nuclear speckle and nucleolus localizations. While direct experimental
-      evidence for HSPA6 nuclear localization is lacking in the available publications,
-      the IBA inference is reasonable given the conserved family behavior.
+      Nuclear localization is plausible by HSP70-family inference, but direct
+      HSPA6-specific evidence is lacking in the available publications. The
+      strongest HSPA6-specific localization evidence supports cytoplasmic and
+      centriolar localization after heat stress, so nucleus should not be treated
+      as a core HSPA6 location.
     supported_by:
     - reference_id: PMID:24061851
       supporting_text: >-
@@ -188,6 +188,10 @@ existing_annotations:
       supporting_text: >-
         purified HSPA6 could not chaperone heat-unfolded luciferase but was able to
         assist in reactivation of heat-unfolded p53
+    - reference_id: file:human/HSPA6/HSPA6-deep-research-falcon.md
+      supporting_text: >-
+        HSPA6 is a prominent stress-inducible Hsp70 paralog whose chaperone role
+        expands proteostasis capacity under proteotoxic stress.
 - term:
     id: GO:0005829
     label: cytosol
@@ -338,12 +342,12 @@ existing_annotations:
       molecular function. The more specific IPI annotation for the same term from
       PMID:23921388 captures the METTL21A interaction. The IEA adds no additional
       information.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
-      The enzyme binding annotation is technically correct as HSPA6 is a substrate of
-      the methyltransferase METTL21A (PMID:23921388). While vague, this IEA annotation
-      is consistent with the IPI annotation from the same reference. Acceptable as a
-      broad IEA that subsumes the more specific experimental annotation.
+      HSPA6 is a substrate of the methyltransferase METTL21A, so the interaction
+      is real, but this reflects a modification event rather than HSPA6 performing
+      enzyme binding as a core molecular function. The broad IEA should be kept
+      only as a non-core interaction context.
 - term:
     id: GO:0042026
     label: protein refolding
@@ -677,14 +681,13 @@ existing_annotations:
       binding' is somewhat vague. In this case, HSPA6 is the substrate of the
       methyltransferase, so the interaction is real and specific, but it reflects HSPA6
       being modified rather than performing enzyme binding as a molecular function.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
       The interaction between HSPA6 and METTL21A is directly demonstrated with
       biochemical evidence showing METTL21A trimethylates HSPA6 at Lys-563
-      (PMID:23921388). While 'enzyme binding' is vague, the annotation correctly
-      reflects a validated physical interaction with the methyltransferase. HSPA6 is
-      a substrate in this context. The annotation is acceptable as it captures a real
-      interaction.
+      (PMID:23921388). The annotation reflects a validated physical interaction
+      with the methyltransferase, but HSPA6 is a substrate in this context rather
+      than an enzyme-binding factor, so this is non-core.
     supported_by:
     - reference_id: PMID:23921388
       supporting_text: >-
@@ -1012,10 +1015,10 @@ core_functions:
     luciferase, and does not suppress polyQ aggregation or confer
     thermotolerance. Under thermal stress, HSPA6 rapidly localizes to
     centrioles, suggesting a specific stress-protective role at this
-    structure. HSPA6 operates as part of a coordinated inducible chaperone
-    module with DNAJB1, BAG3, and HSPH1/HSP110 that expands folding and
-    disaggregation capacity under proteotoxic stress
-    (DOI:10.3390/biology12030416). The HSP70 chaperone cycle involves J-domain
+    structure. Neuronal heat-stress studies place HSPA6 in a coordinated
+    inducible chaperone module with DNAJB1, BAG3, and HSPH1/HSP110, but that
+    co-expression context should not be read as direct evidence that HSPA6
+    itself performs disaggregation (DOI:10.3390/biology12030416). The HSP70 chaperone cycle involves J-domain
     protein delivery of clients and stimulation of ATP hydrolysis, followed by
     nucleotide exchange factor-mediated ADP release and client recycling;
     HSP110 proteins cooperate with HSP70 and HSP40 to disaggregate and refold
@@ -1038,8 +1041,6 @@ core_functions:
     label: cytosol
   - id: GO:0005814
     label: centriole
-  - id: GO:0005634
-    label: nucleus
   supported_by:
   - reference_id: PMID:21231916
     supporting_text: >-
@@ -1059,7 +1060,15 @@ core_functions:
       YFP-tagged HSPA6 and HSPA1A rapidly appeared at centrioles in the cytoplasm
       of human neuronal cells, with HSPA6 demonstrating a more prolonged signal
       compared to HSPA1A
+  - reference_id: file:human/HSPA6/HSPA6-deep-research-falcon.md
+    supporting_text: >-
+      HSPA6 is a prominent stress-inducible HSP70 paralog that is co-expressed
+      with DNAJB1, BAG3, and HSPH1 in neuronal heat-stress models, consistent
+      with participation in an inducible proteostasis module.
 references:
+- id: file:human/HSPA6/HSPA6-deep-research-falcon.md
+  title: Falcon deep research report for HSPA6
+  findings: []
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
     terms

--- a/genes/human/HSPA8/HSPA8-ai-review.html
+++ b/genes/human/HSPA8/HSPA8-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>HSPA8</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P11142" target="_blank" class="term-link">
                         P11142
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>HSPA8 (also known as HSC70 or HSP73) is a constitutively expressed member of the HSP70 family of molecular chaperones. It functions as an ATP-dependent foldase chaperone that uses nucleotide-driven conformational changes to bind and release unfolded or misfolded substrate proteins, promoting their correct folding. HSPA8 plays central roles in protein quality control, chaperone-mediated autophagy (CMA) where it recognizes KFERQ motifs on substrate proteins for lysosomal degradation, clathrin coat disassembly, ER-associated degradation (ERAD), protein disaggregation, and as a component of the spliceosomal PRP19-CDC5L complex. Unlike the stress-inducible HSPA1A, HSPA8 is constitutively expressed and is the primary HSP70 family member involved in housekeeping chaperone functions.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,46 +795,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is found in the nucleus, supported by IBA and confirmed by IDA (PMID:20176811) showing it is a component of the nuclear PRP19-CDC5L spliceosomal complex.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Multiple lines of evidence confirm nuclear localization of HSPA8, including its role in the PRP19-CDC5L complex (PMID:20176811) and stress-induced nuclear accumulation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -846,46 +846,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is primarily cytoplasmic as the constitutive HSP70 chaperone, well-established by IBA and multiple experimental studies.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization is a core feature of HSPA8/HSC70, the constitutive cytosolic HSP70 family member.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -897,46 +897,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 localizes to the plasma membrane where it can act as a cell surface receptor for LPS and interacts with IGSF8/EWI-2 on dendritic cells (PMID:11276205, PMID:17785435).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Plasma membrane localization is supported by IBA and experimental evidence showing HSPA8 at the cell surface in dendritic cells and other cell types.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -948,46 +948,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ATP hydrolysis is a core enzymatic activity of HSPA8 (EC 3.6.4.10), driving the chaperone cycle. J-domain co-chaperones stimulate this ATPase activity over 1000-fold.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATP hydrolysis activity is the central enzymatic function of HSPA8/HSC70, as confirmed by its EC classification and extensive biochemical characterization (PMID:12526792).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
                                     GO:0031072
                                 </a>
                             </span>
                             <span class="term-label">heat shock protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -999,46 +999,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 binds multiple heat shock proteins including HSP90, HSPB8, and various J-domain co-chaperones (DNAJ family members) as part of its chaperone machine.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Heat shock protein binding is a core functional property of HSPA8, which operates in complexes with HSP90, small HSPs, and J-domain proteins.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     GO:0044183
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1050,46 +1050,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein folding chaperone activity is the primary molecular function of HSPA8/HSC70. It binds client polypeptides through its substrate-binding domain and assists their folding through ATP-driven conformational cycles.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is the core molecular function of HSPA8 as a constitutive HSP70 family chaperone, extensively documented in the literature.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/HSPA8/HSPA8-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">HSPA8 encodes constitutive Hsc70, a central Hsp70 chaperone that uses ATP-dependent cycles to bind and release client polypeptides and maintain proteostasis.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1101,46 +1117,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is primarily a cytosolic protein, confirmed by IBA and multiple experimental studies (PMID:21231916).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol is the primary subcellular location where HSPA8 performs its housekeeping chaperone functions.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0072318" target="_blank" class="term-link">
                                     GO:0072318
                                 </a>
                             </span>
                             <span class="term-label">clathrin coat disassembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1152,46 +1168,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8/HSC70 is essential for clathrin coat disassembly, working with auxilin (DNAJC6) to uncoat clathrin-coated vesicles via ATP-dependent disassembly (PMID:8524399).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Clathrin coat disassembly is a well-established core function of HSPA8, demonstrated by Ungewickell et al. 1995 (PMID:8524399).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1203,46 +1219,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 participates in protein refolding, including refolding of heat-denatured substrates, demonstrated experimentally with luciferase refolding assays (PMID:21231916).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein refolding is a well-documented core activity of the HSP70 chaperone machine, confirmed by direct assay evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007165" target="_blank" class="term-link">
                                     GO:0007165
                                 </a>
                             </span>
                             <span class="term-label">signal transduction</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000108
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1254,46 +1270,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Signal transduction is overly broad for HSPA8. While HSPA8 modulates some signaling pathways (e.g., HSF1 regulation, NLRP3 inflammasome), its primary role is as a chaperone, not a signaling molecule.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPA8 is a molecular chaperone, not a signaling protein. The IEA annotation to signal transduction is too broad and does not capture the specific mechanistic role of HSPA8.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000166" target="_blank" class="term-link">
                                     GO:0000166
                                 </a>
                             </span>
                             <span class="term-label">nucleotide binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1305,97 +1321,97 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 binds ATP and ADP through its nucleotide-binding domain (NBD), which drives the chaperone conformational cycle.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleotide binding is a core biochemical property of HSPA8, required for its chaperone function. While more general than ATP binding (GO:0005524), it is accurate.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001664" target="_blank" class="term-link">
                                     GO:0001664
                                 </a>
                             </span>
                             <span class="term-label">G protein-coupled receptor binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="P11142" data-a="GO:0001664" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P11142" data-a="GO:0001664" data-r="GO_REF:0000117" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> HSPA8 was reported to interact with CXCR4 in LPS receptor complexes (PMID:11276205). This is a non-core interaction likely related to its cell-surface localization.
+                            <strong>Summary:</strong> This IEA annotation may reflect reported HSPA8 interactions with GPCR-context clients or receptor complexes, but the cited CXCR4/LPS source is not available in the local publication cache. The separately reviewed PMID:12150907 Pael-R/GPR37 annotation provides a better-supported GPCR-client context.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> While experimentally supported, GPCR binding is not a core function of HSPA8. The IEA annotation captures a peripheral interaction.
+                            <strong>Reason:</strong> GPCR binding is not a core HSPA8 function, and the local evidence available here is insufficient to verify the specific CXCR4/LPS claim.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
                                     GO:0005524
                                 </a>
                             </span>
                             <span class="term-label">ATP binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1407,46 +1423,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ATP binding is a core biochemical activity of HSPA8, required for its chaperone cycle. Crystallographic structures confirm the ATP-binding pocket in the NBD.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATP binding is essential for HSPA8 function, confirmed by crystal structures (PDB entries) and biochemical assays.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005681" target="_blank" class="term-link">
                                     GO:0005681
                                 </a>
                             </span>
                             <span class="term-label">spliceosomal complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1458,46 +1474,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is a component of the PRP19-CDC5L spliceosomal complex, confirmed by IDA (PMID:20176811).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Spliceosomal complex membership is supported by direct experimental evidence (PMID:20176811) showing HSPA8 co-purifies with PRP19-CDC5L.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005730" target="_blank" class="term-link">
                                     GO:0005730
                                 </a>
                             </span>
                             <span class="term-label">nucleolus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1509,46 +1525,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Nucleolar localization of HSPA8 from IEA mapping. While HSPA8 is found in the nucleus, nucleolar localization is plausible given HSPA8&#39;s role as a broadly distributed chaperone, but not specifically validated as a core localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> IEA-derived annotation. HSPA8 is found in the nucleus but nucleolar localization is not a primary site of function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1560,46 +1576,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytoplasmic localization of HSPA8 is well-established and redundant with the IBA annotation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Correct annotation, consistent with IBA and experimental evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
                                     GO:0005765
                                 </a>
                             </span>
                             <span class="term-label">lysosomal membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1611,46 +1627,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 associates with the lysosomal membrane during CMA, where it delivers KFERQ-motif substrates to LAMP2A for translocation (PMID:11559757).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Lysosomal membrane localization is a core feature of HSPA8&#39;s role in CMA, supported by experimental evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1662,46 +1678,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Plasma membrane localization of HSPA8 is supported by IBA and experimental evidence (PMID:11276205, PMID:17785435).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent with IBA annotation and experimental data showing HSPA8 at cell surface.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006397" target="_blank" class="term-link">
                                     GO:0006397
                                 </a>
                             </span>
                             <span class="term-label">mRNA processing</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1713,46 +1729,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 participates in mRNA processing as a component of the PRP19-CDC5L spliceosomal complex (PMID:20176811, PMID:23742842).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Supported by HSPA8&#39;s established role in the PRP19-CDC5L complex involved in splicing.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006914" target="_blank" class="term-link">
                                     GO:0006914
                                 </a>
                             </span>
                             <span class="term-label">autophagy</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1764,46 +1780,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is central to chaperone-mediated autophagy (CMA), recognizing KFERQ-motif substrates and delivering them to LAMP2A at the lysosomal membrane (PMID:2799391).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Autophagy involvement is a core function of HSPA8 through its essential role in CMA.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008380" target="_blank" class="term-link">
                                     GO:0008380
                                 </a>
                             </span>
                             <span class="term-label">RNA splicing</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1815,46 +1831,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is involved in RNA splicing as part of the PRP19-CDC5L spliceosomal complex (PMID:20176811).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Supported by HSPA8&#39;s established role in the spliceosome.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009968" target="_blank" class="term-link">
                                     GO:0009968
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of signal transduction</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1866,46 +1882,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 negatively regulates some signaling pathways, such as repressing HSF1 transcriptional activity (PMID:9499401) and limiting NLRP3 inflammasome activation via CMA (PMID:36586411).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> A non-core but documented consequence of HSPA8&#39;s chaperone activity, particularly in HSF1 feedback regulation and NLRP3 degradation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016787" target="_blank" class="term-link">
                                     GO:0016787
                                 </a>
                             </span>
                             <span class="term-label">hydrolase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1917,46 +1933,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 has hydrolase activity (ATP hydrolysis, EC 3.6.4.10). This is a parent term of the more specific GO:0016887 (ATP hydrolysis activity).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accurate but general; more specific ATP hydrolysis activity terms also annotated. Acceptable as a broader IEA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1968,46 +1984,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ATP hydrolysis activity is a core enzymatic function of HSPA8, redundant with the IBA annotation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Correct IEA annotation consistent with the IBA annotation for this core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
                                     GO:0031072
                                 </a>
                             </span>
                             <span class="term-label">heat shock protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2019,46 +2035,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Heat shock protein binding is well-established for HSPA8, which interacts with HSP90, HSPB8, and multiple DNAJ family members.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent with IBA annotation and extensive experimental evidence for HSP interactions.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031625" target="_blank" class="term-link">
                                     GO:0031625
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin protein ligase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2070,46 +2086,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 binds the E3 ubiquitin ligase CHIP/STUB1, which ubiquitinates Hsc70-bound misfolded substrates to target them for proteasomal degradation (PMID:12150907, PMID:16207813).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Well-established interaction between HSPA8 and CHIP/STUB1 E3 ligase that is central to the chaperone-ubiquitin-proteasome triage pathway.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031647" target="_blank" class="term-link">
                                     GO:0031647
                                 </a>
                             </span>
                             <span class="term-label">regulation of protein stability</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2121,46 +2137,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 regulates protein stability by either promoting correct folding or targeting misfolded proteins for degradation via CHIP-mediated ubiquitination or CMA.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core consequence of HSPA8&#39;s chaperone function in protein quality control.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033554" target="_blank" class="term-link">
                                     GO:0033554
                                 </a>
                             </span>
                             <span class="term-label">cellular response to stress</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2172,46 +2188,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 responds to cellular stress by increasing chaperone activity, though unlike HSPA1A it is constitutively expressed rather than stress-induced.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPA8 is a constitutive chaperone that participates in stress responses, including regulating HSF1 during heat shock attenuation (PMID:9499401).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0039531" target="_blank" class="term-link">
                                     GO:0039531
                                 </a>
                             </span>
                             <span class="term-label">regulation of cytoplasmic pattern recognition receptor signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2223,46 +2239,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 modulates pattern recognition receptor signaling, including NLRP3 inflammasome regulation via CMA-mediated degradation of NLRP3 (PMID:36586411).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> A non-core but documented consequence of HSPA8&#39;s CMA activity on NLRP3 turnover.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2274,46 +2290,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein refolding is a core function of HSPA8, consistent with IBA and IDA evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Redundant with IBA annotation; correct.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042470" target="_blank" class="term-link">
                                     GO:0042470
                                 </a>
                             </span>
                             <span class="term-label">melanosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2325,46 +2341,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 was identified in melanosomes by proteomic analysis (PMID:17081065). This likely reflects its role as an abundant chaperone found in many compartments.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> IEA-based from subcellular location mapping. HSPA8 is an abundant protein found in many subcellular fractions; melanosome localization is not a core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043254" target="_blank" class="term-link">
                                     GO:0043254
                                 </a>
                             </span>
                             <span class="term-label">regulation of protein-containing complex assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2376,97 +2392,97 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 regulates protein complex assembly, including clathrin lattice disassembly and CMA translocation complex assembly/disassembly.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent with HSPA8&#39;s established roles in clathrin uncoating and CMA complex regulation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046034" target="_blank" class="term-link">
                                     GO:0046034
                                 </a>
                             </span>
                             <span class="term-label">ATP metabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P11142" data-a="GO:0046034" data-r="GO_REF:0000117" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P11142" data-a="GO:0046034" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> HSPA8 is involved in ATP metabolism through its ATPase cycle that drives chaperone function.
+                            <strong>Summary:</strong> HSPA8 hydrolyzes ATP as part of its chaperone cycle, but ATP metabolism as a broad biological process overstates HSPA8 as an ATP-metabolism gene. The relevant activity is already captured by ATP hydrolysis activity and ATP-dependent chaperone molecular-function annotations.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Accurate description of HSPA8&#39;s ATP-dependent chaperone mechanism.
+                            <strong>Reason:</strong> This broad BP parent is less informative than the molecular-function terms that describe HSPA8&#39;s ATPase-driven chaperone cycle.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -2478,57 +2494,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted. HSPA8 functions as a protein folding chaperone, binding unfolded/misfolded substrates via its SBD to assist their correct folding through ATP-driven conformational cycles.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted as part of the unfolded protein binding obsoletion project. The correct replacement for HSPA8 is GO:0044183 (protein folding chaperone) since HSPA8/HSC70 binds client polypeptides to assist their folding, not merely to bind unfolded proteins. More specifically, GO:0140662 (ATP-dependent protein folding chaperone) is the most appropriate term.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051129" target="_blank" class="term-link">
                                     GO:0051129
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of cellular component organization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2540,46 +2556,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 negatively regulates cellular component organization, e.g. through clathrin coat disassembly and prevention of protein aggregation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> A broad annotation capturing indirect consequences of HSPA8&#39;s chaperone activities.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0055131" target="_blank" class="term-link">
                                     GO:0055131
                                 </a>
                             </span>
                             <span class="term-label">C3HC4-type RING finger domain binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2591,46 +2607,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 binds C3HC4-type RING finger domains, consistent with its interaction with CHIP/STUB1 E3 ligase and RNF207 (PMID:25281747).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Reflects the functional interaction between HSPA8 and RING-type E3 ligases.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071383" target="_blank" class="term-link">
                                     GO:0071383
                                 </a>
                             </span>
                             <span class="term-label">cellular response to steroid hormone stimulus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2642,46 +2658,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 participates in steroid hormone receptor chaperoning as part of the HSP70/HSP90 chaperone machine that folds and activates steroid hormone receptors.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> A non-core function reflecting HSPA8&#39;s role in the HSP90 chaperone cycle for steroid hormone receptors.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0072318" target="_blank" class="term-link">
                                     GO:0072318
                                 </a>
                             </span>
                             <span class="term-label">clathrin coat disassembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2693,46 +2709,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Clathrin coat disassembly is a core function of HSPA8, consistent with IBA and IDA evidence (PMID:8524399).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Redundant with IBA annotation; correct.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140545" target="_blank" class="term-link">
                                     GO:0140545
                                 </a>
                             </span>
                             <span class="term-label">ATP-dependent protein disaggregase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2744,46 +2760,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 has ATP-dependent protein disaggregase activity, working with HSP110 (HSPH1) to disaggregate protein aggregates (PMID:22990239, PMID:23921388).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Supported by direct experimental evidence showing HSPA8+HSP110 disaggregase activity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902903" target="_blank" class="term-link">
                                     GO:1902903
                                 </a>
                             </span>
                             <span class="term-label">regulation of supramolecular fiber organization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2795,46 +2811,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 modulates supramolecular fiber organization, possibly through prevention of amyloid/aggregate formation (PMID:23921388).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> A non-core consequence of HSPA8&#39;s disaggregase and anti-aggregation chaperone activities.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1904813" target="_blank" class="term-link">
                                     GO:1904813
                                 </a>
                             </span>
                             <span class="term-label">ficolin-1-rich granule lumen</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2846,46 +2862,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is found in ficolin-1-rich granule lumen in neutrophils, likely reflecting its presence as an abundant protein in secretory granules.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> IEA annotation reflecting proteomic detection in a specialized granule compartment; not a core localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990904" target="_blank" class="term-link">
                                     GO:1990904
                                 </a>
                             </span>
                             <span class="term-label">ribonucleoprotein complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2897,57 +2913,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is found in ribonucleoprotein complexes, including IMP1 mRNP granules (PMID:17289661) and the PRP19-CDC5L spliceosomal complex.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Supported by proteomic identification in mRNP granules and the spliceosome.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14743216" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14743216
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A physical and functional map of the human TNF-alpha/NF-kapp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -2959,57 +2975,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:14743216. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15047060" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15047060
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Analysis of proteins copurifying with the CD4/lck complex us...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -3021,57 +3037,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:15047060. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15048123" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15048123
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Abi1 is essential for the formation and activation of a WAVE...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -3083,57 +3099,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:15048123. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15657067" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15657067
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphotyrosine signaling networks in epidermal growth facto...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -3145,57 +3161,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:15657067. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16049941" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16049941
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A pilot proteomic study of amyloid precursor interactors in ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -3207,57 +3223,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:16049941. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16169070" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16169070
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A human protein-protein interaction network: a resource for ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -3269,57 +3285,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:16169070. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16189514" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16189514
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Towards a proteome-scale map of the human protein-protein in...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -3331,57 +3347,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:16189514. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16275660" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16275660
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification of VCP/p97, carboxyl terminus of Hsp70-intera...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -3393,57 +3409,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:16275660. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16293251" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16293251
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     CHIP interacts with heat shock factor 1 during heat stress.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -3455,57 +3471,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:16293251. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17022977" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17022977
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification of Hsc70 as an influenza virus matrix protein...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -3517,57 +3533,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:17022977. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17332742" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17332742
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Composition and three-dimensional EM structure of double aff...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -3579,57 +3595,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:17332742. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17400507" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17400507
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification of potential protein interactors of Lrrk2.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -3641,57 +3657,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:17400507. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17620599" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17620599
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional specialization of beta-arrestin interactions reve...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -3703,57 +3719,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:17620599. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18457437" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18457437
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification of intracellular proteins associated with the...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -3765,57 +3781,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:18457437. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19338310" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19338310
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Streamline proteomic approach for characterizing protein-pro...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -3827,57 +3843,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:19338310. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19800331" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19800331
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Short peptides derived from the BAG-1 C-terminus inhibit the...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -3889,57 +3905,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:19800331. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20195357" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20195357
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A comprehensive resource of interacting protein regions for ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -3951,57 +3967,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:20195357. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20391533" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20391533
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomic analysis reveals novel binding partners of MIP-T3 ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4013,57 +4029,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:20391533. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20618441" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20618441
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     CHIP participates in protein triage decisions by preferentia...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4075,57 +4091,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:20618441. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22085931" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22085931
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Optimal functional levels of activation-induced deaminase sp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4137,57 +4153,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:22085931. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22365833" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22365833
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dynamic protein-protein interaction wiring of the human spli...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4199,57 +4215,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:22365833. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22645275" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22645275
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification of novel ATP13A2 interactors and their role i...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4261,57 +4277,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:22645275. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22990239" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22990239
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Metazoan Hsp70 machines use Hsp110 to power protein disaggre...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4323,57 +4339,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:22990239. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23414517" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23414517
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A human skeletal muscle interactome centered on proteins inv...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4385,57 +4401,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:23414517. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23455607" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23455607
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interplay of LRRK2 with chaperone-mediated autophagy.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4447,57 +4463,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:23455607. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23523103" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23523103
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Lysine-5 acetylation negatively regulates lactate dehydrogen...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4509,57 +4525,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:23523103. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24136289" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24136289
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and comparative analysis of hepatitis C virus...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4571,57 +4587,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:24136289. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24189400" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24189400
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Perturbation of the mutated EGFR interactome identifies vuln...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4633,57 +4649,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:24189400. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24510904" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24510904
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Unbiased screen for interactors of leucine-rich repeat kinas...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4695,57 +4711,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:24510904. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24658140" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24658140
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The mammalian-membrane two-hybrid assay (MaMTH) for probing ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4757,57 +4773,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:24658140. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24947832" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24947832
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Differential protein-protein interactions of LRRK1 and LRRK2...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4819,57 +4835,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:24947832. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25416956
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A proteome-scale map of the human interactome network.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4881,57 +4897,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:25416956. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25502805" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25502805
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A massively parallel pipeline to clone DNA variants and exam...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4943,57 +4959,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:25502805. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25609649" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25609649
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomic analyses reveal distinct chromatin-associated and ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -5005,57 +5021,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:25609649. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25910212
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Widespread macromolecular interaction perturbations in human...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -5067,57 +5083,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:25910212. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25959826" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25959826
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Quantitative interaction proteomics of neurodegenerative dis...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -5129,57 +5145,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:25959826. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26871637" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26871637
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Widespread Expansion of Protein Interaction Capabilities by ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -5191,57 +5207,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:26871637. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27107014" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27107014
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An inter-species protein-protein interaction network across ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -5253,57 +5269,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:27107014. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28514442
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Architecture of the human interactome defines protein commun...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -5315,57 +5331,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:28514442. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/29519959" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:29519959
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     P62/SQSTM1 is a novel leucine-rich repeat kinase 2 (LRRK2) s...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -5377,57 +5393,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:29519959. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/29568061" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:29568061
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An AP-MS- and BioID-compatible MAC-tag enables comprehensive...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -5439,57 +5455,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:29568061. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/29764935" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:29764935
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The disorderly conduct of Hsc70 and its interaction with the...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -5501,57 +5517,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:29764935. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30021884" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30021884
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Histone Interaction Landscapes Visualized by Crosslinking Ma...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -5563,57 +5579,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:30021884. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30827827" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30827827
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A Legionella pneumophila Kinase Phosphorylates the Hsp70 Cha...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -5625,57 +5641,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:30827827. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31273097" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31273097
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The heme-regulated inhibitor is a cytosolic sensor of protei...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -5687,57 +5703,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:31273097. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31980649" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31980649
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Extensive rewiring of the EGFR network in colorectal cancer ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -5749,57 +5765,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:31980649. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32296183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A reference map of the human binary protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -5811,57 +5827,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:32296183. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32814053
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interactome Mapping Provides a Network of Neurodegenerative ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -5873,57 +5889,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:32814053. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -5935,57 +5951,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:33961781. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:35271311
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     OpenCell: Endogenous tagging for the cartography of human ce...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -5997,57 +6013,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:35271311. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:40205054
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Multimodal cell maps as a foundation for structural and func...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -6059,46 +6075,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:40205054. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071383" target="_blank" class="term-link">
                                     GO:0071383
                                 </a>
                             </span>
                             <span class="term-label">cellular response to steroid hormone stimulus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371497
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -6110,46 +6126,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 participates in the HSP90 chaperone cycle for steroid hormone receptors (Reactome). This is a non-core chaperoning role.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Well-documented role of HSP70/HSP90 machinery in steroid hormone receptor maturation but not a core defining function of HSPA8.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061024" target="_blank" class="term-link">
                                     GO:0061024
                                 </a>
                             </span>
                             <span class="term-label">membrane organization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-199991
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -6161,57 +6177,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is involved in membrane organization through its role in clathrin-mediated vesicle trafficking and uncoating (Reactome:R-HSA-199991).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> A broad process annotation capturing the consequence of HSPA8&#39;s clathrin uncoating activity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000398" target="_blank" class="term-link">
                                     GO:0000398
                                 </a>
                             </span>
                             <span class="term-label">mRNA splicing, via spliceosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23742842" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23742842
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Splicing and beyond: the many faces of the Prp19 complex.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6223,57 +6239,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 participates in mRNA splicing as a component of the PRP19-CDC5L complex (PMID:20176811, PMID:23742842).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Supported by HSPA8&#39;s established membership in the spliceosomal PRP19-CDC5L complex.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17289661" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17289661
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular composition of IMP1 ribonucleoprotein granules.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6285,57 +6301,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 identified in cytoplasmic IMP1 mRNP granules by mass spectrometry (PMID:17289661).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct experimental confirmation of cytoplasmic localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030674" target="_blank" class="term-link">
                                     GO:0030674
                                 </a>
                             </span>
                             <span class="term-label">protein-macromolecule adaptor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/40281343" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:40281343
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     PSAT1 impairs ferroptosis and reduces immunotherapy efficacy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6347,57 +6363,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 functions as a protein-macromolecule adaptor, connecting substrate proteins to the degradation/autophagy machinery (PMID:40281343). In CMA, it bridges KFERQ-motif substrates to LAMP2A.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Adaptor activity accurately describes HSPA8&#39;s role in CMA where it recognizes substrates and delivers them to LAMP2A, and in ERAD where it connects substrates to the ubiquitin-proteasome system.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061684" target="_blank" class="term-link">
                                     GO:0061684
                                 </a>
                             </span>
                             <span class="term-label">chaperone-mediated autophagy</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/40281343" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:40281343
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     PSAT1 impairs ferroptosis and reduces immunotherapy efficacy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6409,57 +6425,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> CMA function of HSPA8 confirmed by IDA in the context of ferroptosis regulation (PMID:40281343).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Further experimental confirmation of HSPA8&#39;s core CMA function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0160020" target="_blank" class="term-link">
                                     GO:0160020
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of ferroptosis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/40281343" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:40281343
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     PSAT1 impairs ferroptosis and reduces immunotherapy efficacy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -6471,57 +6487,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 promotes ferroptosis through CMA-mediated degradation of GPX4 in the context of PSAT1 regulation (PMID:40281343). This is a downstream consequence of CMA activity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Ferroptosis regulation is a specific downstream outcome of HSPA8&#39;s CMA activity, not a core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061684" target="_blank" class="term-link">
                                     GO:0061684
                                 </a>
                             </span>
                             <span class="term-label">chaperone-mediated autophagy</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25719862" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25719862
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Modulation of deregulated chaperone-mediated autophagy by a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6533,57 +6549,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> CMA is a core function of HSPA8, which recognizes KFERQ-motif substrates and delivers them to LAMP2A. PMID:25719862 demonstrates P140 peptide modulates CMA through HSPA8.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CMA is one of the most well-established and defining functions of HSPA8/HSC70.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0101031" target="_blank" class="term-link">
                                     GO:0101031
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25719862" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25719862
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Modulation of deregulated chaperone-mediated autophagy by a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6595,57 +6611,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 forms part of protein folding chaperone complexes, including with HSP90, co-chaperones, and client proteins (PMID:25719862).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization reflecting HSPA8&#39;s function in multi-chaperone complexes.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
                                     GO:0140662
                                 </a>
                             </span>
                             <span class="term-label">ATP-dependent protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25719862" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25719862
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Modulation of deregulated chaperone-mediated autophagy by a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6657,57 +6673,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is an ATP-dependent protein folding chaperone, the most specific and accurate MF term for its primary molecular function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0140662 is the ideal MF term for HSPA8, capturing both its ATP-dependent mechanism and chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/39225180" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:39225180
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     ABHD8 antagonizes inflammation by facilitating chaperone-med...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -6719,57 +6735,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:39225180. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030335" target="_blank" class="term-link">
                                     GO:0030335
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of cell migration</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17785435" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17785435
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     EWI-2/CD316 is an inducible receptor of HSPA8 on human dendr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -6781,75 +6797,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Extracellular HSPA8 acts as a ligand for EWI-2/CD316 on dendritic cells, enhancing CCL21-dependent cell migration (PMID:17785435).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> A non-core extracellular signaling function of HSPA8 in the immune system.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17785435" target="_blank" class="term-link">
                                         PMID:17785435
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The ligation of EWI-2 enhanced the CCL21/SLC-dependent migration of activated mature dendritic cells but attenuated their antigen-specific stimulatory capacities</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048018" target="_blank" class="term-link">
                                     GO:0048018
                                 </a>
                             </span>
                             <span class="term-label">receptor ligand activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17785435" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17785435
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     EWI-2/CD316 is an inducible receptor of HSPA8 on human dendr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -6861,64 +6877,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Extracellular HSPA8 acts as a ligand for the EWI-2/CD316 receptor on dendritic cells (PMID:17785435).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> A non-core extracellular function; receptor ligand activity is atypical for a cytosolic chaperone but documented for the extracellular pool of HSPA8.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17785435" target="_blank" class="term-link">
                                         PMID:17785435
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">human heat shock protein A8 (HSPA8), a member of the hsp70 family, was identified as the ligand for EWI-2</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371422
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6930,46 +6946,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ATP hydrolysis is the core enzymatic activity of HSPA8, driving the chaperone cycle. Reactome pathway confirms this.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core enzymatic function of HSPA8, well-established.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8868658
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6981,57 +6997,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ATP hydrolysis is the core enzymatic activity of HSPA8, driving the chaperone cycle. Reactome pathway confirms this.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core enzymatic function of HSPA8, well-established.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0072318" target="_blank" class="term-link">
                                     GO:0072318
                                 </a>
                             </span>
                             <span class="term-label">clathrin coat disassembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/8524399" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:8524399
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Role of auxilin in uncoating clathrin-coated vesicles.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7043,75 +7059,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Seminal paper demonstrating HSPA8/HSC70 mediates clathrin coat disassembly together with auxilin. Auxilin recruits HSC70 to clathrin lattices and the J-domain stimulates ATP-dependent disassembly (PMID:8524399).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct experimental demonstration of HSPA8&#39;s core role in clathrin uncoating.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8524399" target="_blank" class="term-link">
                                         PMID:8524399
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Clathrin-coated vesicles transport selected integral membrane proteins from the cell surface and the trans-Golgi network to the endosomal system</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32671205" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32671205
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A micropeptide encoded by lncRNA MIR155HG suppresses autoimm...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -7123,57 +7139,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:32671205. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26775844" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26775844
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Salivary protein histatin 3 regulates cell proliferation by ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -7185,57 +7201,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:26775844. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
                                     GO:0005765
                                 </a>
                             </span>
                             <span class="term-label">lysosomal membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11559757" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11559757
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A molecular chaperone complex at the lysosomal membrane is r...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7247,75 +7263,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 localizes to the lysosomal membrane as part of the CMA translocation complex (PMID:11559757).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct experimental evidence for lysosomal membrane localization in CMA.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11559757" target="_blank" class="term-link">
                                         PMID:11559757
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">A molecular chaperone complex at the lysosomal membrane is required for protein translocation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030674" target="_blank" class="term-link">
                                     GO:0030674
                                 </a>
                             </span>
                             <span class="term-label">protein-macromolecule adaptor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11559757" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11559757
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A molecular chaperone complex at the lysosomal membrane is r...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7327,57 +7343,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 functions as a protein-macromolecule adaptor, connecting substrate proteins to the degradation/autophagy machinery (PMID:11559757). In CMA, it bridges KFERQ-motif substrates to LAMP2A.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Adaptor activity accurately describes HSPA8&#39;s role in CMA where it recognizes substrates and delivers them to LAMP2A, and in ERAD where it connects substrates to the ubiquitin-proteasome system.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030674" target="_blank" class="term-link">
                                     GO:0030674
                                 </a>
                             </span>
                             <span class="term-label">protein-macromolecule adaptor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/2799391" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:2799391
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A role for a 70-kilodalton heat shock protein in lysosomal d...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7389,57 +7405,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 functions as a protein-macromolecule adaptor, connecting substrate proteins to the degradation/autophagy machinery (PMID:2799391). In CMA, it bridges KFERQ-motif substrates to LAMP2A.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Adaptor activity accurately describes HSPA8&#39;s role in CMA where it recognizes substrates and delivers them to LAMP2A, and in ERAD where it connects substrates to the ubiquitin-proteasome system.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030674" target="_blank" class="term-link">
                                     GO:0030674
                                 </a>
                             </span>
                             <span class="term-label">protein-macromolecule adaptor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/36586411" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:36586411
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Palmitoylation prevents sustained inflammation by limiting N...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7451,57 +7467,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 functions as a protein-macromolecule adaptor, connecting substrate proteins to the degradation/autophagy machinery (PMID:36586411). In CMA, it bridges KFERQ-motif substrates to LAMP2A.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Adaptor activity accurately describes HSPA8&#39;s role in CMA where it recognizes substrates and delivers them to LAMP2A, and in ERAD where it connects substrates to the ubiquitin-proteasome system.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061740" target="_blank" class="term-link">
                                     GO:0061740
                                 </a>
                             </span>
                             <span class="term-label">protein targeting to lysosome involved in chaperone-mediated autophagy</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11559757" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11559757
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A molecular chaperone complex at the lysosomal membrane is r...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7513,57 +7529,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 targets proteins to lysosomes for CMA-mediated degradation by recognizing KFERQ motifs and delivering substrates to LAMP2A (PMID:11559757).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core CMA function of HSPA8 demonstrated by direct assay.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061740" target="_blank" class="term-link">
                                     GO:0061740
                                 </a>
                             </span>
                             <span class="term-label">protein targeting to lysosome involved in chaperone-mediated autophagy</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/36586411" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:36586411
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Palmitoylation prevents sustained inflammation by limiting N...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7575,57 +7591,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 targets palmitoylated NLRP3 to lysosomes for CMA-mediated degradation, limiting inflammasome activation (PMID:36586411).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Further demonstration of HSPA8&#39;s CMA substrate-targeting function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1900226" target="_blank" class="term-link">
                                     GO:1900226
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of NLRP3 inflammasome complex assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/36586411" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:36586411
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Palmitoylation prevents sustained inflammation by limiting N...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -7637,46 +7653,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 negatively regulates NLRP3 inflammasome assembly by targeting palmitoylated NLRP3 for CMA-mediated degradation (PMID:36586411).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> A specific downstream consequence of HSPA8&#39;s CMA activity on a particular substrate (NLRP3), not a core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061635" target="_blank" class="term-link">
                                     GO:0061635
                                 </a>
                             </span>
                             <span class="term-label">regulation of protein complex stability</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7688,57 +7704,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 regulates protein complex stability, inferred from sequence similarity. Consistent with its roles in complex assembly/disassembly.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ISS annotation consistent with known functions of HSPA8 in protein complex remodeling.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1904589" target="_blank" class="term-link">
                                     GO:1904589
                                 </a>
                             </span>
                             <span class="term-label">regulation of protein import</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20176123" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20176123
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Chaperone-mediated autophagy: molecular mechanisms and physi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -7750,57 +7766,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 regulates protein import including delivery of preproteins to Tom70 at the mitochondrial import receptor (PMID:12526792) and CMA substrate import at lysosomes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Reflects HSPA8&#39;s role in protein targeting to mitochondria and lysosomes, but is a broad annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/35044787" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:35044787
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Loss-of-function mutations in the co-chaperone protein BAG5 ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -7812,57 +7828,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:35044787. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33857403" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33857403
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     DNAJC9 integrates heat shock molecular chaperones into the h...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -7874,57 +7890,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:33857403. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140545" target="_blank" class="term-link">
                                     GO:0140545
                                 </a>
                             </span>
                             <span class="term-label">ATP-dependent protein disaggregase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23921388
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of a novel human methylt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7936,57 +7952,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 has ATP-dependent disaggregase activity, working with HSPH1/HSP110 to solubilize protein aggregates (PMID:23921388). Methylation at K561 modulates this activity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core chaperone function demonstrated by direct assay. The disaggregase complex (HSPA8+HSPH1+DNAJ) is a mammalian equivalent of the yeast Hsp104 disaggregase.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18320024" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18320024
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The human TPR protein TTC4 is a putative Hsp90 co-chaperone ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -7998,57 +8014,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:18320024. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23801752" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23801752
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Histone deacetylase 10 promotes autophagy-mediated cell surv...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -8060,57 +8076,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:23801752. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/29601588" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:29601588
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     ZMYND10 stabilizes intermediate chain proteins in the cytopl...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -8122,57 +8138,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:29601588. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25760597" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25760597
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structural and functional analysis of Hikeshi, a new nuclear...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -8184,57 +8200,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:25760597. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045296" target="_blank" class="term-link">
                                     GO:0045296
                                 </a>
                             </span>
                             <span class="term-label">cadherin binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25468996" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25468996
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     E-cadherin interactome complexity and robustness resolved by...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -8246,57 +8262,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cadherin binding from high-throughput data (PMID:25468996). HSPA8 is an abundant protein that co-purifies with many complexes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Likely non-specific; HSPA8&#39;s abundance leads to co-purification in many proteomic datasets.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030674" target="_blank" class="term-link">
                                     GO:0030674
                                 </a>
                             </span>
                             <span class="term-label">protein-macromolecule adaptor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16207813" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16207813
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     BAG-2 acts as an inhibitor of the chaperone-associated ubiqu...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -8308,57 +8324,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 adaptor function demonstrated through interaction data (PMID:16207813). HSPA8 bridges substrates to the CHIP E3 ligase for ubiquitination.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPA8 functions as an adaptor connecting client proteins to the ubiquitin-proteasome degradation machinery.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031625" target="_blank" class="term-link">
                                     GO:0031625
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin protein ligase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16207813" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16207813
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     BAG-2 acts as an inhibitor of the chaperone-associated ubiqu...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -8370,57 +8386,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 binds ubiquitin protein ligases including CHIP/STUB1 and Parkin (PMID:16207813), linking chaperone activity to ubiquitin-dependent degradation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core functional interaction between HSPA8 and E3 ligases in protein quality control.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16207813" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16207813
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     BAG-2 acts as an inhibitor of the chaperone-associated ubiqu...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -8432,57 +8448,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 binds other folding chaperones including BAG2, which inhibits the CHIP-HSPA8 complex (PMID:16207813).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core interaction of HSPA8 with co-chaperones.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0101031" target="_blank" class="term-link">
                                     GO:0101031
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16207813" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16207813
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     BAG-2 acts as an inhibitor of the chaperone-associated ubiqu...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -8494,57 +8510,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 forms protein folding chaperone complexes with BAG2 and CHIP/STUB1, demonstrated by interaction data (PMID:16207813).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core complex formation for HSPA8&#39;s chaperone-ubiquitin triage function. BAG-2 acts as an inhibitor of the chaperone-associated ubiquitin ligase CHIP.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24122553" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24122553
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The co-chaperone DNAJC12 binds to Hsc70 and is upregulated b...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -8556,57 +8572,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:24122553. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21148293" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21148293
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The endoplasmic reticulum-associated Hsp40 DNAJB12 and Hsc70...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -8618,57 +8634,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:21148293. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21150129" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21150129
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A novel ER J-protein DNAJB12 accelerates ER-associated degra...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -8680,57 +8696,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:21150129. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27916661" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27916661
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tetrameric Assembly of K(+) Channels Requires ER-Located Cha...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -8742,57 +8758,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:27916661. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27103069" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27103069
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Loss of C9ORF72 impairs autophagy and synergizes with polyQ ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -8804,57 +8820,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:27103069. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24318877" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24318877
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Binding of human nucleotide exchange factors to heat shock p...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -8866,57 +8882,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:24318877. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27708256" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27708256
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     ARD1-mediated Hsp70 acetylation balances stress-induced prot...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -8928,57 +8944,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:27708256. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15708368" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15708368
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Small glutamine-rich tetratricopeptide repeat-containing pro...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -8990,57 +9006,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:15708368. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9499401" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9499401
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular chaperones as HSF1-specific transcriptional repres...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -9052,57 +9068,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:9499401. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23431407" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23431407
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Distinct roles of molecular chaperones HSP90α and HSP90β in ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -9114,57 +9130,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:23431407. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061740" target="_blank" class="term-link">
                                     GO:0061740
                                 </a>
                             </span>
                             <span class="term-label">protein targeting to lysosome involved in chaperone-mediated autophagy</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26212789" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26212789
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Chaperone-mediated autophagy prevents apoptosis by degrading...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -9176,46 +9192,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8&#39;s role in CMA-mediated lysosomal targeting demonstrated by mutant phenotype analysis (PMID:26212789).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Mutant phenotype evidence supporting HSPA8&#39;s CMA function in targeting BBC3/PUMA for degradation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8932221
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -9227,46 +9243,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is found in the nucleoplasm as part of the PRP19-CDC5L spliceosomal complex and HSF1 regulatory complexes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization is consistent with HSPA8&#39;s roles in splicing and HSF1 regulation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
                                     GO:0005576
                                 </a>
                             </span>
                             <span class="term-label">extracellular region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6798748
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -9278,46 +9294,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is found in the extracellular region, including secretory granule contents and ficolin-1-rich granules released by neutrophils.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Extracellular localization of HSPA8 is documented but represents a non-core localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
                                     GO:0005576
                                 </a>
                             </span>
                             <span class="term-label">extracellular region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6800434
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -9329,46 +9345,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is found in the extracellular region, including secretory granule contents and ficolin-1-rich granules released by neutrophils.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Extracellular localization of HSPA8 is documented but represents a non-core localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034774" target="_blank" class="term-link">
                                     GO:0034774
                                 </a>
                             </span>
                             <span class="term-label">secretory granule lumen</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6798748
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -9380,46 +9396,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is found in secretory granule lumen (Reactome). This reflects its presence as a protein released during degranulation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Not a core localization for HSPA8&#39;s primary chaperone functions.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1904813" target="_blank" class="term-link">
                                     GO:1904813
                                 </a>
                             </span>
                             <span class="term-label">ficolin-1-rich granule lumen</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6800434
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -9431,57 +9447,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is found in ficolin-1-rich granule lumen (Reactome), reflecting its presence in neutrophil granules.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Specialized localization not central to HSPA8&#39;s primary functions.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24787902" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24787902
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional and molecular features of the calmodulin-interact...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -9493,57 +9509,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:24787902. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009267" target="_blank" class="term-link">
                                     GO:0009267
                                 </a>
                             </span>
                             <span class="term-label">cellular response to starvation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20176123" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20176123
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Chaperone-mediated autophagy: molecular mechanisms and physi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -9555,57 +9571,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> CMA is upregulated during starvation, and HSPA8 is the key chaperone recognizing CMA substrates. This indirectly involves HSPA8 in the starvation response.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPA8 participates in starvation response through CMA, which is upregulated under nutrient deprivation (PMID:20176123).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061684" target="_blank" class="term-link">
                                     GO:0061684
                                 </a>
                             </span>
                             <span class="term-label">chaperone-mediated autophagy</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20176123" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20176123
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Chaperone-mediated autophagy: molecular mechanisms and physi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -9617,46 +9633,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> CMA is a core function of HSPA8 per the review by Cuervo and Dice (PMID:20176123).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Authoritative review confirming HSPA8&#39;s essential role in CMA.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
                                     GO:0005765
                                 </a>
                             </span>
                             <span class="term-label">lysosomal membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -9668,46 +9684,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Lysosomal membrane localization inferred from orthologs, consistent with IDA evidence (PMID:11559757).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent with direct experimental evidence for HSPA8 at lysosomal membrane.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061684" target="_blank" class="term-link">
                                     GO:0061684
                                 </a>
                             </span>
                             <span class="term-label">chaperone-mediated autophagy</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -9719,46 +9735,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> CMA involvement inferred from orthologs, consistent with extensive direct evidence for HSPA8 in CMA.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent with HSPA8&#39;s well-established role in CMA.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1904764" target="_blank" class="term-link">
                                     GO:1904764
                                 </a>
                             </span>
                             <span class="term-label">chaperone-mediated autophagy translocation complex disassembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -9770,57 +9786,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 participates in disassembly of the CMA translocation complex at the lysosomal membrane, inferred from orthologs.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent with known role of lumenal HSPA8 in CMA complex dynamics.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061740" target="_blank" class="term-link">
                                     GO:0061740
                                 </a>
                             </span>
                             <span class="term-label">protein targeting to lysosome involved in chaperone-mediated autophagy</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/2799391" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:2799391
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A role for a 70-kilodalton heat shock protein in lysosomal d...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -9832,57 +9848,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> The seminal paper by Chiang et al. 1989 (PMID:2799391) first identified the 70 kDa heat shock protein&#39;s role in lysosomal degradation, establishing HSPA8&#39;s function in CMA.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Foundational discovery of HSPA8&#39;s role in CMA-mediated lysosomal targeting.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043254" target="_blank" class="term-link">
                                     GO:0043254
                                 </a>
                             </span>
                             <span class="term-label">regulation of protein-containing complex assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20176123" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20176123
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Chaperone-mediated autophagy: molecular mechanisms and physi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -9894,57 +9910,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 regulates assembly/disassembly of protein complexes including the CMA translocation complex and clathrin lattices (PMID:20176123).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core function related to HSPA8&#39;s role in complex remodeling.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098575" target="_blank" class="term-link">
                                     GO:0098575
                                 </a>
                             </span>
                             <span class="term-label">lumenal side of lysosomal membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20176123" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20176123
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Chaperone-mediated autophagy: molecular mechanisms and physi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -9956,57 +9972,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is found on the lumenal side of the lysosomal membrane where it assists in CMA translocation complex disassembly and substrate unfolding (PMID:20176123).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Documented localization of HSPA8 at lysosomal lumen, essential for CMA.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031647" target="_blank" class="term-link">
                                     GO:0031647
                                 </a>
                             </span>
                             <span class="term-label">regulation of protein stability</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26212789" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26212789
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Chaperone-mediated autophagy prevents apoptosis by degrading...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10018,57 +10034,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 regulates protein stability through CMA, as demonstrated by its role in BBC3/PUMA degradation preventing apoptosis (PMID:26212789).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimental evidence via mutant phenotype for HSPA8&#39;s role in protein stability regulation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26212789" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26212789
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Chaperone-mediated autophagy prevents apoptosis by degrading...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -10080,57 +10096,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:26212789. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25719862" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25719862
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Modulation of deregulated chaperone-mediated autophagy by a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -10142,57 +10158,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:25719862. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25719862" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25719862
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Modulation of deregulated chaperone-mediated autophagy by a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10204,57 +10220,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Direct assay evidence for HSPA8&#39;s protein refolding activity (PMID:25719862). HSPA8 assists refolding of heat-denatured substrates.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core chaperone function of HSPA8 demonstrated experimentally.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043202" target="_blank" class="term-link">
                                     GO:0043202
                                 </a>
                             </span>
                             <span class="term-label">lysosomal lumen</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25719862" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25719862
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Modulation of deregulated chaperone-mediated autophagy by a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10266,57 +10282,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is present in the lysosomal lumen where it participates in CMA substrate unfolding and translocation complex disassembly (PMID:25719862).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Supported by HSPA8&#39;s established role in the lumenal side of CMA.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
                                     GO:0031072
                                 </a>
                             </span>
                             <span class="term-label">heat shock protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17182002" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17182002
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HDJC9, a novel human type C DnaJ/HSP40 member interacts with...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10328,119 +10344,119 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 binds heat shock proteins including DNAJ family members (PMID:17182002), which are essential co-chaperones.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core functional interactions with co-chaperones.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046034" target="_blank" class="term-link">
                                     GO:0046034
                                 </a>
                             </span>
                             <span class="term-label">ATP metabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23921388
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of a novel human methylt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P11142" data-a="GO:0046034" data-r="PMID:23921388" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P11142" data-a="GO:0046034" data-r="PMID:23921388" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> HSPA8 is involved in ATP metabolism through its ATPase activity, confirmed by direct assay (PMID:23921388).
+                            <strong>Summary:</strong> HSPA8 hydrolyzes ATP as part of its chaperone cycle, but GO:0046034 is a broad ATP metabolic process term. The direct molecular activity is already represented by ATP hydrolysis activity and ATP-dependent chaperone terms.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Core metabolic consequence of HSPA8&#39;s ATPase activity.
+                            <strong>Reason:</strong> HSPA8 should not be treated as a core ATP-metabolism gene simply because its chaperone cycle consumes ATP.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0055131" target="_blank" class="term-link">
                                     GO:0055131
                                 </a>
                             </span>
                             <span class="term-label">C3HC4-type RING finger domain binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25281747" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25281747
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     RING finger protein RNF207, a novel regulator of cardiac exc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10452,57 +10468,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 binds C3HC4-type RING finger domain of RNF207, a cardiac excitation regulator (PMID:25281747).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Demonstrates HSPA8&#39;s interaction with RING-type E3 ligases beyond CHIP.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14532270" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14532270
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A product of the human gene adjacent to parkin is a componen...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -10514,57 +10530,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:14532270. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001664" target="_blank" class="term-link">
                                     GO:0001664
                                 </a>
                             </span>
                             <span class="term-label">G protein-coupled receptor binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12150907" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12150907
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     CHIP is associated with Parkin, a gene responsible for famil...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -10576,57 +10592,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> HSPA8 binds CXCR4 as part of LPS receptor cluster and interacts with CHIP/Parkin (PMID:12150907).
+                            <strong>Summary:</strong> PMID:12150907 describes Hsp70 in a complex with CHIP, Parkin, and the unfolded Pael receptor/Pael-R (GPR37), supporting a GPCR-client interaction in a ubiquitin-dependent quality-control context. The paper does not support the CXCR4/LPS receptor-cluster wording previously used here.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Non-core interaction; HSPA8 is a chaperone, not primarily a GPCR-binding protein.
+                            <strong>Reason:</strong> This is a non-core chaperone/client interaction involving Pael-R/GPR37 and Parkin/CHIP-mediated quality control, not a general GPCR-binding function.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12150907" target="_blank" class="term-link">
+                                        PMID:12150907
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">CHIP, Hsp70, Parkin, and Pael-R formed a complex in vitro and in vivo.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031625" target="_blank" class="term-link">
                                     GO:0031625
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin protein ligase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12150907" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12150907
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     CHIP is associated with Parkin, a gene responsible for famil...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10638,57 +10672,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 binds ubiquitin protein ligases including CHIP/STUB1 and Parkin (PMID:12150907), linking chaperone activity to ubiquitin-dependent degradation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core functional interaction between HSPA8 and E3 ligases in protein quality control.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005925" target="_blank" class="term-link">
                                     GO:0005925
                                 </a>
                             </span>
                             <span class="term-label">focal adhesion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21423176" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21423176
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Analysis of the myosin-II-responsive focal adhesion proteome...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -10700,57 +10734,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Focal adhesion localization from high-throughput proteomics (PMID:21423176). Likely reflects HSPA8&#39;s cytoplasmic abundance.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HDA from mass spectrometry; HSPA8 is not known to have specific focal adhesion functions.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
                                     GO:0070062
                                 </a>
                             </span>
                             <span class="term-label">extracellular exosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23533145
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     In-depth proteomic analyses of exosomes isolated from expres...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -10762,57 +10796,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 detected in extracellular exosomes by high-throughput proteomics (PMID:23533145). HSPA8 is consistently found in exosome preparations across multiple studies.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Non-core localization. HSPA8 is one of the most frequently identified exosomal proteins.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
                                     GO:0070062
                                 </a>
                             </span>
                             <span class="term-label">extracellular exosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21235781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21235781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human saliva, plasma and breast milk exosomes contain RNA: u...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -10824,57 +10858,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 identified in extracellular exosomes by direct assay (PMID:21235781). HSPA8 is one of the most commonly found proteins in exosome proteomics.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Non-core localization. HSPA8 is abundantly found in exosomes but this reflects its high cellular abundance.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
                                     GO:0070062
                                 </a>
                             </span>
                             <span class="term-label">extracellular exosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19028452" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19028452
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomic profiling of human plasma exosomes identifies PPAR...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -10886,57 +10920,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 identified in extracellular exosomes by direct assay (PMID:19028452). HSPA8 is one of the most commonly found proteins in exosome proteomics.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Non-core localization. HSPA8 is abundantly found in exosomes but this reflects its high cellular abundance.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
                                     GO:0016020
                                 </a>
                             </span>
                             <span class="term-label">membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19946888
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Defining the membrane proteome of NK cells.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -10948,57 +10982,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 associates with membranes including lysosomal, plasma, and ER membranes, consistent with its chaperone roles in these compartments.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Broad but accurate annotation for a chaperone with multiple membrane-associated functions.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005615" target="_blank" class="term-link">
                                     GO:0005615
                                 </a>
                             </span>
                             <span class="term-label">extracellular space</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16502470" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16502470
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human colostrum: identification of minor proteins in the aqu...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -11010,57 +11044,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 detected in extracellular space (colostrum) by proteomics (PMID:16502470). Consistent with extracellular localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Non-core localization supported by multiple proteomic studies.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15936278" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15936278
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HSJ1 is a neuronal shuttling factor for the sorting of chape...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -11072,57 +11106,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:15936278. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
                                     GO:0005524
                                 </a>
                             </span>
                             <span class="term-label">ATP binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23921388
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of a novel human methylt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -11134,57 +11168,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ATP binding by HSPA8 confirmed by direct assay (PMID:23921388).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core biochemical property of HSPA8.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019899" target="_blank" class="term-link">
                                     GO:0019899
                                 </a>
                             </span>
                             <span class="term-label">enzyme binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23921388
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of a novel human methylt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -11196,57 +11230,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 binds enzymes including METTL21A methyltransferase that modulates HSPA8 function (PMID:23921388).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Functional interaction with the enzyme that methylates HSPA8 at K561.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
                                     GO:0031072
                                 </a>
                             </span>
                             <span class="term-label">heat shock protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23921388
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of a novel human methylt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -11258,57 +11292,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 binds heat shock proteins including DNAJ family members (PMID:23921388), which are essential co-chaperones.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core functional interactions with co-chaperones.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902904" target="_blank" class="term-link">
                                     GO:1902904
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of supramolecular fiber organization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23921388
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of a novel human methylt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -11320,57 +11354,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 negatively regulates supramolecular fiber organization, preventing aggregation of alpha-synuclein fibrils (PMID:23921388).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Specific consequence of HSPA8&#39;s disaggregase activity on amyloid fibrils.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -11382,57 +11416,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosolic localization of HSPA8 confirmed by direct assay (PMID:21231916).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization supported by multiple lines of evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -11444,57 +11478,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Direct assay evidence for HSPA8&#39;s protein refolding activity (PMID:21231916). HSPA8 assists refolding of heat-denatured substrates.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core chaperone function of HSPA8 demonstrated experimentally.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -11506,68 +11540,68 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted. HSPA8 functions as a protein folding chaperone, binding unfolded/misfolded substrates via its SBD to assist their correct folding through ATP-driven conformational cycles.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted as part of the unfolded protein binding obsoletion project. The correct replacement for HSPA8 is GO:0044183 (protein folding chaperone) since HSPA8/HSC70 binds client polypeptides to assist their folding, not merely to bind unfolded proteins. More specifically, GO:0140662 (ATP-dependent protein folding chaperone) is the most appropriate term.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003723" target="_blank" class="term-link">
                                     GO:0003723
                                 </a>
                             </span>
                             <span class="term-label">RNA binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22658674" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22658674
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Insights into RNA biology from an atlas of mammalian mRNA-bi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -11579,57 +11613,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> RNA binding detected by high-throughput methods (PMID:22658674). Consistent with HSPA8&#39;s role in mRNP granules and spliceosome.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Non-core function; HSPA8 associates with RNA-containing complexes but is not primarily an RNA-binding protein.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003723" target="_blank" class="term-link">
                                     GO:0003723
                                 </a>
                             </span>
                             <span class="term-label">RNA binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22681889" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22681889
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The mRNA-bound proteome and its global occupancy profile on ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -11641,57 +11675,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> RNA binding detected by high-throughput methods (PMID:22681889). Consistent with HSPA8&#39;s role in mRNP granules and spliceosome.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Non-core function; HSPA8 associates with RNA-containing complexes but is not primarily an RNA-binding protein.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0072562" target="_blank" class="term-link">
                                     GO:0072562
                                 </a>
                             </span>
                             <span class="term-label">blood microparticle</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22516433" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22516433
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomic analysis of microvesicles from plasma of healthy d...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -11703,46 +11737,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 detected in blood microparticles by proteomics (PMID:22516433).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Non-core localization reflecting HSPA8&#39;s presence in extracellular particles.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371467
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -11754,46 +11788,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is found in the nucleoplasm as part of the PRP19-CDC5L spliceosomal complex and HSF1 regulatory complexes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization is consistent with HSPA8&#39;s roles in splicing and HSF1 regulation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371518
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -11805,46 +11839,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is found in the nucleoplasm as part of the PRP19-CDC5L spliceosomal complex and HSF1 regulatory complexes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization is consistent with HSPA8&#39;s roles in splicing and HSF1 regulation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371554
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -11856,46 +11890,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is found in the nucleoplasm as part of the PRP19-CDC5L spliceosomal complex and HSF1 regulatory complexes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization is consistent with HSPA8&#39;s roles in splicing and HSF1 regulation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5082356
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -11907,46 +11941,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is found in the nucleoplasm as part of the PRP19-CDC5L spliceosomal complex and HSF1 regulatory complexes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization is consistent with HSPA8&#39;s roles in splicing and HSF1 regulation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5082369
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -11958,46 +11992,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is found in the nucleoplasm as part of the PRP19-CDC5L spliceosomal complex and HSF1 regulatory complexes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization is consistent with HSPA8&#39;s roles in splicing and HSF1 regulation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5082384
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -12009,46 +12043,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is found in the nucleoplasm as part of the PRP19-CDC5L spliceosomal complex and HSF1 regulatory complexes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization is consistent with HSPA8&#39;s roles in splicing and HSF1 regulation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9770131
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -12060,46 +12094,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is found in the nucleoplasm as part of the PRP19-CDC5L spliceosomal complex and HSF1 regulatory complexes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization is consistent with HSPA8&#39;s roles in splicing and HSF1 regulation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9770141
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -12111,46 +12145,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is found in the nucleoplasm as part of the PRP19-CDC5L spliceosomal complex and HSF1 regulatory complexes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization is consistent with HSPA8&#39;s roles in splicing and HSF1 regulation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9770145
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -12162,46 +12196,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is found in the nucleoplasm as part of the PRP19-CDC5L spliceosomal complex and HSF1 regulatory complexes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization is consistent with HSPA8&#39;s roles in splicing and HSF1 regulation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9770236
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -12213,46 +12247,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is found in the nucleoplasm as part of the PRP19-CDC5L spliceosomal complex and HSF1 regulatory complexes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization is consistent with HSPA8&#39;s roles in splicing and HSF1 regulation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9770847
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -12264,46 +12298,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is found in the nucleoplasm as part of the PRP19-CDC5L spliceosomal complex and HSF1 regulatory complexes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization is consistent with HSPA8&#39;s roles in splicing and HSF1 regulation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9772351
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -12315,46 +12349,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is found in the nucleoplasm as part of the PRP19-CDC5L spliceosomal complex and HSF1 regulatory complexes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization is consistent with HSPA8&#39;s roles in splicing and HSF1 regulation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9794542
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -12366,57 +12400,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is found in the nucleoplasm as part of the PRP19-CDC5L spliceosomal complex and HSF1 regulatory complexes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization is consistent with HSPA8&#39;s roles in splicing and HSF1 regulation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
                                     GO:0070062
                                 </a>
                             </span>
                             <span class="term-label">extracellular exosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19199708" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19199708
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomic analysis of human parotid gland exosomes by multid...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -12428,57 +12462,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 detected in extracellular exosomes by high-throughput proteomics (PMID:19199708). HSPA8 is consistently found in exosome preparations across multiple studies.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Non-core localization. HSPA8 is one of the most frequently identified exosomal proteins.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
                                     GO:0070062
                                 </a>
                             </span>
                             <span class="term-label">extracellular exosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19056867
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Large-scale proteomics and phosphoproteomics of urinary exos...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -12490,57 +12524,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 detected in extracellular exosomes by high-throughput proteomics (PMID:19056867). HSPA8 is consistently found in exosome preparations across multiple studies.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Non-core localization. HSPA8 is one of the most frequently identified exosomal proteins.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0023026" target="_blank" class="term-link">
                                     GO:0023026
                                 </a>
                             </span>
                             <span class="term-label">MHC class II protein complex binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20458337" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20458337
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     MHC class II-associated proteins in B-cell exosomes and pote...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -12552,57 +12586,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 associates with MHC class II complexes in B-cell exosomes (PMID:20458337). May relate to antigen chaperoning.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Non-core interaction potentially relevant to antigen presentation via exosomes.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
                                     GO:0070062
                                 </a>
                             </span>
                             <span class="term-label">extracellular exosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20458337" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20458337
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     MHC class II-associated proteins in B-cell exosomes and pote...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -12614,46 +12648,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 detected in extracellular exosomes by high-throughput proteomics (PMID:20458337). HSPA8 is consistently found in exosome preparations across multiple studies.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Non-core localization. HSPA8 is one of the most frequently identified exosomal proteins.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-888589
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -12665,46 +12699,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Plasma membrane localization of HSPA8, supported by its role in clathrin-coated vesicle dynamics at the plasma membrane.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent with HSPA8&#39;s role in clathrin coat disassembly at the plasma membrane.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061202" target="_blank" class="term-link">
                                     GO:0061202
                                 </a>
                             </span>
                             <span class="term-label">clathrin-sculpted gamma-aminobutyric acid transport vesicle membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-888589
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -12716,46 +12750,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is found at clathrin-sculpted GABA transport vesicle membranes (Reactome), reflecting its general role in clathrin-coated vesicle dynamics.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Specific vesicle type annotation from Reactome; reflects general clathrin uncoating function applied to neuronal vesicles.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061202" target="_blank" class="term-link">
                                     GO:0061202
                                 </a>
                             </span>
                             <span class="term-label">clathrin-sculpted gamma-aminobutyric acid transport vesicle membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-917744
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -12767,46 +12801,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is found at clathrin-sculpted GABA transport vesicle membranes (Reactome), reflecting its general role in clathrin-coated vesicle dynamics.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Specific vesicle type annotation from Reactome; reflects general clathrin uncoating function applied to neuronal vesicles.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371422
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -12818,46 +12852,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization confirmed by multiple Reactome pathways. HSPA8 is primarily cytosolic.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization of HSPA8, consistent with IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371503
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -12869,46 +12903,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization confirmed by multiple Reactome pathways. HSPA8 is primarily cytosolic.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization of HSPA8, consistent with IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371590
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -12920,46 +12954,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization confirmed by multiple Reactome pathways. HSPA8 is primarily cytosolic.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization of HSPA8, consistent with IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-421836
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -12971,46 +13005,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization confirmed by multiple Reactome pathways. HSPA8 is primarily cytosolic.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization of HSPA8, consistent with IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-432688
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -13022,46 +13056,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization confirmed by multiple Reactome pathways. HSPA8 is primarily cytosolic.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization of HSPA8, consistent with IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-450551
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -13073,46 +13107,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization confirmed by multiple Reactome pathways. HSPA8 is primarily cytosolic.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization of HSPA8, consistent with IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-450580
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -13124,46 +13158,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization confirmed by multiple Reactome pathways. HSPA8 is primarily cytosolic.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization of HSPA8, consistent with IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5618085
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -13175,46 +13209,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization confirmed by multiple Reactome pathways. HSPA8 is primarily cytosolic.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization of HSPA8, consistent with IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5618098
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -13226,46 +13260,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization confirmed by multiple Reactome pathways. HSPA8 is primarily cytosolic.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization of HSPA8, consistent with IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5618105
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -13277,46 +13311,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization confirmed by multiple Reactome pathways. HSPA8 is primarily cytosolic.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization of HSPA8, consistent with IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5618107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -13328,46 +13362,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization confirmed by multiple Reactome pathways. HSPA8 is primarily cytosolic.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization of HSPA8, consistent with IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5618110
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -13379,46 +13413,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization confirmed by multiple Reactome pathways. HSPA8 is primarily cytosolic.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization of HSPA8, consistent with IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6797269
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -13430,46 +13464,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization confirmed by multiple Reactome pathways. HSPA8 is primarily cytosolic.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization of HSPA8, consistent with IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8868658
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -13481,46 +13515,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization confirmed by multiple Reactome pathways. HSPA8 is primarily cytosolic.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization of HSPA8, consistent with IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8868660
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -13532,46 +13566,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization confirmed by multiple Reactome pathways. HSPA8 is primarily cytosolic.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization of HSPA8, consistent with IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9835411
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -13583,57 +13617,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytosol localization confirmed by multiple Reactome pathways. HSPA8 is primarily cytosolic.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization of HSPA8, consistent with IBA and IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
                                     GO:0070062
                                 </a>
                             </span>
                             <span class="term-label">extracellular exosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21362503" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21362503
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Protein profile of exosomes from trabecular meshwork cells.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -13645,57 +13679,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 detected in extracellular exosomes by high-throughput proteomics (PMID:21362503). HSPA8 is consistently found in exosome preparations across multiple studies.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Non-core localization. HSPA8 is one of the most frequently identified exosomal proteins.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000974" target="_blank" class="term-link">
                                     GO:0000974
                                 </a>
                             </span>
                             <span class="term-label">Prp19 complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20176811" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20176811
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular architecture of the human Prp19/CDC5L complex.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -13707,57 +13741,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is a component of the PRP19-CDC5L complex, demonstrated by mass spectrometry and biochemical characterization (PMID:20176811).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct experimental evidence for HSPA8 membership in this spliceosomal complex.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20176811" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20176811
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular architecture of the human Prp19/CDC5L complex.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -13769,57 +13803,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Nuclear localization of HSPA8 demonstrated in the context of the PRP19-CDC5L complex (PMID:20176811).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Confirmed by direct assay in the spliceosome study.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10954706" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10954706
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification of Mrj, a DnaJ/Hsp40 family protein, as a ker...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -13831,57 +13865,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:10954706. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10722728" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10722728
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The MSG1 non-DNA-binding transactivator binds to the p300/CB...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -13893,57 +13927,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:10722728. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045892" target="_blank" class="term-link">
                                     GO:0045892
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of DNA-templated transcription</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10722728" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10722728
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The MSG1 non-DNA-binding transactivator binds to the p300/CB...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -13955,75 +13989,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 suppresses Smad-mediated transcription by sequestering MSG1/CITED1 (PMID:10722728). This is a non-core regulatory consequence of HSPA8&#39;s protein binding activity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Transcriptional regulation is not a core function of HSPA8 but reflects its ability to modulate transcription factor activity through client binding.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10722728" target="_blank" class="term-link">
                                         PMID:10722728
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Hsc70 heat-shock cognate protein also forms complex with MSG1 in vivo, suppressing both binding of MSG1 to p300/CBP and enhancement of Smad-mediated transcription by MSG1.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9305631" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9305631
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     BAG-1 modulates the chaperone activity of Hsp70/Hsc70.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -14035,57 +14069,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:9305631. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990904" target="_blank" class="term-link">
                                     GO:1990904
                                 </a>
                             </span>
                             <span class="term-label">ribonucleoprotein complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17289661" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17289661
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular composition of IMP1 ribonucleoprotein granules.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -14097,57 +14131,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 is found in ribonucleoprotein complexes including IMP1 mRNP granules (PMID:17289661).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct experimental identification by mass spectrometry in mRNP granules.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16531398" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16531398
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tid1 isoforms are mitochondrial DnaJ-like chaperones with un...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -14159,57 +14193,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:16531398. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14557246
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     AIP is a mitochondrial import mediator that binds to both im...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -14221,57 +14255,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding annotation from PMID:14557246. HSP70 chaperones bind many client proteins and co-chaperones; this annotation is uninformative without specifying the nature of the interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 (protein binding) is uninformative for a molecular chaperone that by definition interacts with many substrate proteins and co-chaperones. More specific MF terms such as GO:0044183 (protein folding chaperone), GO:0051087 (protein-folding chaperone binding), GO:0031072 (heat shock protein binding), or GO:0030674 (protein-macromolecule adaptor activity) are preferable depending on the specific interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006986" target="_blank" class="term-link">
                                     GO:0006986
                                 </a>
                             </span>
                             <span class="term-label">response to unfolded protein</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11093761" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11093761
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular and functional characterization of HSC54, a novel ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -14283,57 +14317,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HSPA8 responds to unfolded proteins as a constitutive molecular chaperone. PMID:11093761 characterizes HSC54, a variant of HSPA8.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core function of HSPA8 as a chaperone that recognizes and responds to unfolded proteins.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/8530083" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:8530083
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Localization of the gene encoding the human heat shock cogna...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -14345,57 +14379,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ATP hydrolysis activity of HSPA8, referenced from PMID:8530083 describing HSP73 gene localization and function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core enzymatic activity of HSPA8.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/8530083" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:8530083
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Localization of the gene encoding the human heat shock cogna...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -14407,32 +14441,32 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein folding is a core biological process of HSPA8, which assists nascent and misfolded proteins to achieve their native conformations.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Central biological process function of HSPA8 as a molecular chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>HSPA8/HSC70 is a constitutive ATP-dependent molecular chaperone that binds unfolded/misfolded client polypeptides through its substrate-binding domain (SBD) and assists their folding through iterative cycles of ATP binding, hydrolysis, and ADP release in the nucleotide-binding domain (NBD). This is the primary molecular function of HSPA8.</h3>
                 <span class="vote-buttons" data-g="P11142" data-a="FUNCTION: HSPA8/HSC70 is a constitutive ATP-dependent molecu..." data-r="" data-act="CORE_FUNCTION">
@@ -14440,10 +14474,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -14452,54 +14486,72 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                 protein folding
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                 protein refolding
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/HSPA8/HSPA8-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">HSPA8 encodes the constitutive cytosolic Hsp70 isoform Hsc70, which uses ATP-dependent cycles to bind and release client polypeptides, preventing aggregation, aiding folding, remodeling complexes, and routing damaged proteins for clearance.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>ATP hydrolysis (EC 3.6.4.10) is the core enzymatic activity driving HSPA8&#39;s chaperone cycle. J-domain co-chaperones (DNAJ family) stimulate this ATPase activity over 1000-fold, coupling substrate recognition to high-affinity client binding.</h3>
                 <span class="vote-buttons" data-g="P11142" data-a="FUNCTION: ATP hydrolysis (EC 3.6.4.10) is the core enzymatic..." data-r="" data-act="CORE_FUNCTION">
@@ -14507,10 +14559,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -14519,35 +14571,53 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
 
-                
+
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/HSPA8/HSPA8-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">The nucleotide-binding domain binds and hydrolyzes ATP, and J-domain proteins can stimulate Hsp70/Hsc70 ATPase activity by more than 1,000-fold.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>HSPA8 is the essential substrate-recognition chaperone in CMA, recognizing KFERQ-like pentapeptide motifs on cytosolic proteins and delivering them to LAMP2A at the lysosomal membrane for translocation and degradation. This adaptor activity bridges CMA substrates to the lysosomal translocation machinery.</h3>
                 <span class="vote-buttons" data-g="P11142" data-a="FUNCTION: HSPA8 is the essential substrate-recognition chape..." data-r="" data-act="CORE_FUNCTION">
@@ -14555,10 +14625,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -14567,54 +14637,72 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061684" target="_blank" class="term-link">
                                 chaperone-mediated autophagy
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061740" target="_blank" class="term-link">
                                 protein targeting to lysosome involved in chaperone-mediated autophagy
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
                                 lysosomal membrane
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/HSPA8/HSPA8-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Hsc70/HspA8 is the substrate-recognition chaperone in chaperone-mediated autophagy, selecting proteins with KFERQ-like motifs and delivering them to lysosomal LAMP2A for translocation and degradation.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>HSPA8 mediates ATP-dependent disassembly of clathrin lattices on coated vesicles, working with auxilin (DNAJC6) or GAK as J-domain co-chaperones. The chaperone function is applied to clathrin triskelions as substrates.</h3>
                 <span class="vote-buttons" data-g="P11142" data-a="FUNCTION: HSPA8 mediates ATP-dependent disassembly of clathr..." data-r="" data-act="CORE_FUNCTION">
@@ -14622,10 +14710,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -14634,48 +14722,66 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0072318" target="_blank" class="term-link">
                                 clathrin coat disassembly
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/HSPA8/HSPA8-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Hsc70 is a clathrin-binding/uncoating ATPase in clathrin-mediated endocytosis, with clathrin listed among Hsp70 substrates and auxilin/GAK acting as J-domain co-chaperones.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>HSPA8 collaborates with HSP110/HSPH1 and DNAJ co-chaperones to form a mammalian disaggregase complex that solubilizes protein aggregates including amyloid fibrils. This represents a core proteostasis function.</h3>
                 <span class="vote-buttons" data-g="P11142" data-a="FUNCTION: HSPA8 collaborates with HSP110/HSPH1 and DNAJ co-c..." data-r="" data-act="CORE_FUNCTION">
@@ -14683,10 +14789,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -14695,2484 +14801,2516 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
 
-                
+
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
-        </div>
-        
-    </div>
-    
 
-    
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/HSPA8/HSPA8-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">HspA8 functions in proteostasis pathways including folding, refolding, disaggregation with partners, chaperone-mediated autophagy, and other selective autophagy routes.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/HSPA8/HSPA8-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for HSPA8</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
                             GO_REF:0000024
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000108.md" target="_blank" class="term-link">
                             GO_REF:0000108
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Automatic assignment of GO terms using logical inference, based on on inter-ontology links</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10722728" target="_blank" class="term-link">
                             PMID:10722728
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The MSG1 non-DNA-binding transactivator binds to the p300/CBP coactivators, enhancing their functional link to the Smad transcription factors.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10954706" target="_blank" class="term-link">
                             PMID:10954706
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Identification of Mrj, a DnaJ/Hsp40 family protein, as a keratin 8/18 filament regulatory protein.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11093761" target="_blank" class="term-link">
                             PMID:11093761
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Molecular and functional characterization of HSC54, a novel variant of human heat-shock cognate protein 70.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11559757" target="_blank" class="term-link">
                             PMID:11559757
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A molecular chaperone complex at the lysosomal membrane is required for protein translocation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12150907" target="_blank" class="term-link">
                             PMID:12150907
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">CHIP is associated with Parkin, a gene responsible for familial Parkinson&#39;s disease, and enhances its ubiquitin ligase activity.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14532270" target="_blank" class="term-link">
                             PMID:14532270
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A product of the human gene adjacent to parkin is a component of Lewy bodies and suppresses Pael receptor-induced cell death.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link">
                             PMID:14557246
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">AIP is a mitochondrial import mediator that binds to both import receptor Tom20 and preproteins.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14743216" target="_blank" class="term-link">
                             PMID:14743216
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A physical and functional map of the human TNF-alpha/NF-kappa B signal transduction pathway.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15047060" target="_blank" class="term-link">
                             PMID:15047060
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Analysis of proteins copurifying with the CD4/lck complex using one-dimensional polyacrylamide gel electrophoresis and mass spectrometry: comparison with affinity-tag based protein detection and evaluation of different solubilization methods.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15048123" target="_blank" class="term-link">
                             PMID:15048123
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Abi1 is essential for the formation and activation of a WAVE2 signalling complex.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15657067" target="_blank" class="term-link">
                             PMID:15657067
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Phosphotyrosine signaling networks in epidermal growth factor receptor overexpressing squamous carcinoma cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15708368" target="_blank" class="term-link">
                             PMID:15708368
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Small glutamine-rich tetratricopeptide repeat-containing protein is composed of three structural units with distinct functions.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15936278" target="_blank" class="term-link">
                             PMID:15936278
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSJ1 is a neuronal shuttling factor for the sorting of chaperone clients to the proteasome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16049941" target="_blank" class="term-link">
                             PMID:16049941
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A pilot proteomic study of amyloid precursor interactors in Alzheimer&#39;s disease.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16169070" target="_blank" class="term-link">
                             PMID:16169070
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A human protein-protein interaction network: a resource for annotating the proteome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16189514" target="_blank" class="term-link">
                             PMID:16189514
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Towards a proteome-scale map of the human protein-protein interaction network.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16207813" target="_blank" class="term-link">
                             PMID:16207813
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">BAG-2 acts as an inhibitor of the chaperone-associated ubiquitin ligase CHIP.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16275660" target="_blank" class="term-link">
                             PMID:16275660
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Identification of VCP/p97, carboxyl terminus of Hsp70-interacting protein (CHIP), and amphiphysin II interaction partners using membrane-based human proteome arrays.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16293251" target="_blank" class="term-link">
                             PMID:16293251
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">CHIP interacts with heat shock factor 1 during heat stress.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16502470" target="_blank" class="term-link">
                             PMID:16502470
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Human colostrum: identification of minor proteins in the aqueous phase by proteomics.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16531398" target="_blank" class="term-link">
                             PMID:16531398
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Tid1 isoforms are mitochondrial DnaJ-like chaperones with unique carboxyl termini that determine cytosolic fate.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17022977" target="_blank" class="term-link">
                             PMID:17022977
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Identification of Hsc70 as an influenza virus matrix protein (M1) binding factor involved in the virus life cycle.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17182002" target="_blank" class="term-link">
                             PMID:17182002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HDJC9, a novel human type C DnaJ/HSP40 member interacts with and cochaperones HSP70 through the J domain.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17289661" target="_blank" class="term-link">
                             PMID:17289661
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Molecular composition of IMP1 ribonucleoprotein granules.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17332742" target="_blank" class="term-link">
                             PMID:17332742
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Composition and three-dimensional EM structure of double affinity-purified, human prespliceosomal A complexes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17400507" target="_blank" class="term-link">
                             PMID:17400507
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Identification of potential protein interactors of Lrrk2.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17620599" target="_blank" class="term-link">
                             PMID:17620599
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Functional specialization of beta-arrestin interactions revealed by proteomic analysis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17785435" target="_blank" class="term-link">
                             PMID:17785435
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">EWI-2/CD316 is an inducible receptor of HSPA8 on human dendritic cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18320024" target="_blank" class="term-link">
                             PMID:18320024
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The human TPR protein TTC4 is a putative Hsp90 co-chaperone which interacts with CDC6 and shows alterations in transformed cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18457437" target="_blank" class="term-link">
                             PMID:18457437
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Identification of intracellular proteins associated with the EBV-encoded nuclear antigen 5 using an efficient TAP procedure and FT-ICR mass spectrometry.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19028452" target="_blank" class="term-link">
                             PMID:19028452
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteomic profiling of human plasma exosomes identifies PPARgamma as an exosome-associated protein.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link">
                             PMID:19056867
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Large-scale proteomics and phosphoproteomics of urinary exosomes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19199708" target="_blank" class="term-link">
                             PMID:19199708
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteomic analysis of human parotid gland exosomes by multidimensional protein identification technology (MudPIT).</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19338310" target="_blank" class="term-link">
                             PMID:19338310
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Streamline proteomic approach for characterizing protein-protein interaction network in a RAD52 protein complex.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19800331" target="_blank" class="term-link">
                             PMID:19800331
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Short peptides derived from the BAG-1 C-terminus inhibit the interaction between BAG-1 and HSC70 and decrease breast cancer cell growth.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
                             PMID:19946888
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Defining the membrane proteome of NK cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20176123" target="_blank" class="term-link">
                             PMID:20176123
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Chaperone-mediated autophagy: molecular mechanisms and physiological relevance.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20176811" target="_blank" class="term-link">
                             PMID:20176811
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Molecular architecture of the human Prp19/CDC5L complex.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20195357" target="_blank" class="term-link">
                             PMID:20195357
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A comprehensive resource of interacting protein regions for refining human transcription factor networks.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20391533" target="_blank" class="term-link">
                             PMID:20391533
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteomic analysis reveals novel binding partners of MIP-T3 in human cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20458337" target="_blank" class="term-link">
                             PMID:20458337
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">MHC class II-associated proteins in B-cell exosomes and potential functional implications for exosome biogenesis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20618441" target="_blank" class="term-link">
                             PMID:20618441
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">CHIP participates in protein triage decisions by preferentially ubiquitinating Hsp70-bound substrates.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21148293" target="_blank" class="term-link">
                             PMID:21148293
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The endoplasmic reticulum-associated Hsp40 DNAJB12 and Hsc70 cooperate to facilitate RMA1 E3-dependent degradation of nascent CFTRDeltaF508.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21150129" target="_blank" class="term-link">
                             PMID:21150129
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A novel ER J-protein DNAJB12 accelerates ER-associated degradation of membrane proteins including CFTR.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                             PMID:21231916
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The diverse members of the mammalian HSP70 machine show distinct chaperone-like activities.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21235781" target="_blank" class="term-link">
                             PMID:21235781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Human saliva, plasma and breast milk exosomes contain RNA: uptake by macrophages.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21362503" target="_blank" class="term-link">
                             PMID:21362503
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Protein profile of exosomes from trabecular meshwork cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21423176" target="_blank" class="term-link">
                             PMID:21423176
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Analysis of the myosin-II-responsive focal adhesion proteome reveals a role for β-Pix in negative regulation of focal adhesion maturation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22085931" target="_blank" class="term-link">
                             PMID:22085931
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Optimal functional levels of activation-induced deaminase specifically require the Hsp40 DnaJa1.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22365833" target="_blank" class="term-link">
                             PMID:22365833
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dynamic protein-protein interaction wiring of the human spliceosome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22516433" target="_blank" class="term-link">
                             PMID:22516433
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteomic analysis of microvesicles from plasma of healthy donors reveals high individual variability.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22645275" target="_blank" class="term-link">
                             PMID:22645275
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Identification of novel ATP13A2 interactors and their role in α-synuclein misfolding and toxicity.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22658674" target="_blank" class="term-link">
                             PMID:22658674
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Insights into RNA biology from an atlas of mammalian mRNA-binding proteins.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22681889" target="_blank" class="term-link">
                             PMID:22681889
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The mRNA-bound proteome and its global occupancy profile on protein-coding transcripts.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22990239" target="_blank" class="term-link">
                             PMID:22990239
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Metazoan Hsp70 machines use Hsp110 to power protein disaggregation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23414517" target="_blank" class="term-link">
                             PMID:23414517
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A human skeletal muscle interactome centered on proteins involved in muscular dystrophies: LGMD interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23431407" target="_blank" class="term-link">
                             PMID:23431407
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Distinct roles of molecular chaperones HSP90α and HSP90β in the biogenesis of KCNQ4 channels.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23455607" target="_blank" class="term-link">
                             PMID:23455607
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interplay of LRRK2 with chaperone-mediated autophagy.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23523103" target="_blank" class="term-link">
                             PMID:23523103
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Lysine-5 acetylation negatively regulates lactate dehydrogenase A and is decreased in pancreatic cancer.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link">
                             PMID:23533145
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">In-depth proteomic analyses of exosomes isolated from expressed prostatic secretions in urine.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23742842" target="_blank" class="term-link">
                             PMID:23742842
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Splicing and beyond: the many faces of the Prp19 complex.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23801752" target="_blank" class="term-link">
                             PMID:23801752
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Histone deacetylase 10 promotes autophagy-mediated cell survival.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link">
                             PMID:23921388
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Identification and characterization of a novel human methyltransferase modulating Hsp70 protein function through lysine methylation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24122553" target="_blank" class="term-link">
                             PMID:24122553
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The co-chaperone DNAJC12 binds to Hsc70 and is upregulated by endoplasmic reticulum stress.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24136289" target="_blank" class="term-link">
                             PMID:24136289
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Identification and comparative analysis of hepatitis C virus-host cell protein interactions.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24189400" target="_blank" class="term-link">
                             PMID:24189400
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Perturbation of the mutated EGFR interactome identifies vulnerabilities and resistance mechanisms.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24318877" target="_blank" class="term-link">
                             PMID:24318877
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Binding of human nucleotide exchange factors to heat shock protein 70 (Hsp70) generates functionally distinct complexes in vitro.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24510904" target="_blank" class="term-link">
                             PMID:24510904
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Unbiased screen for interactors of leucine-rich repeat kinase 2 supports a common pathway for sporadic and familial Parkinson disease.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24658140" target="_blank" class="term-link">
                             PMID:24658140
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The mammalian-membrane two-hybrid assay (MaMTH) for probing membrane-protein interactions in human cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24787902" target="_blank" class="term-link">
                             PMID:24787902
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Functional and molecular features of the calmodulin-interacting protein IQCG required for haematopoiesis in zebrafish.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24947832" target="_blank" class="term-link">
                             PMID:24947832
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Differential protein-protein interactions of LRRK1 and LRRK2 indicate roles in distinct cellular signaling pathways.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25281747" target="_blank" class="term-link">
                             PMID:25281747
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RING finger protein RNF207, a novel regulator of cardiac excitation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
                             PMID:25416956
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A proteome-scale map of the human interactome network.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25468996" target="_blank" class="term-link">
                             PMID:25468996
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">E-cadherin interactome complexity and robustness resolved by quantitative proteomics.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25502805" target="_blank" class="term-link">
                             PMID:25502805
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A massively parallel pipeline to clone DNA variants and examine molecular phenotypes of human disease mutations.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25609649" target="_blank" class="term-link">
                             PMID:25609649
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteomic analyses reveal distinct chromatin-associated and soluble transcription factor complexes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25719862" target="_blank" class="term-link">
                             PMID:25719862
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Modulation of deregulated chaperone-mediated autophagy by a phosphopeptide.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25760597" target="_blank" class="term-link">
                             PMID:25760597
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Structural and functional analysis of Hikeshi, a new nuclear transport receptor of Hsp70s.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link">
                             PMID:25910212
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Widespread macromolecular interaction perturbations in human genetic disorders.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25959826" target="_blank" class="term-link">
                             PMID:25959826
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Quantitative interaction proteomics of neurodegenerative disease proteins.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26212789" target="_blank" class="term-link">
                             PMID:26212789
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Chaperone-mediated autophagy prevents apoptosis by degrading BBC3/PUMA.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26775844" target="_blank" class="term-link">
                             PMID:26775844
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Salivary protein histatin 3 regulates cell proliferation by enhancing p27(Kip1) and heat shock cognate protein 70 ubiquitination.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26871637" target="_blank" class="term-link">
                             PMID:26871637
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Widespread Expansion of Protein Interaction Capabilities by Alternative Splicing.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27103069" target="_blank" class="term-link">
                             PMID:27103069
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Loss of C9ORF72 impairs autophagy and synergizes with polyQ Ataxin-2 to induce motor neuron dysfunction and cell death.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27107014" target="_blank" class="term-link">
                             PMID:27107014
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An inter-species protein-protein interaction network across vast evolutionary distance.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27708256" target="_blank" class="term-link">
                             PMID:27708256
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ARD1-mediated Hsp70 acetylation balances stress-induced protein refolding and degradation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27916661" target="_blank" class="term-link">
                             PMID:27916661
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Tetrameric Assembly of K(+) Channels Requires ER-Located Chaperone Proteins.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/2799391" target="_blank" class="term-link">
                             PMID:2799391
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A role for a 70-kilodalton heat shock protein in lysosomal degradation of intracellular proteins.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
                             PMID:28514442
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/29519959" target="_blank" class="term-link">
                             PMID:29519959
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">P62/SQSTM1 is a novel leucine-rich repeat kinase 2 (LRRK2) substrate that enhances neuronal toxicity.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/29568061" target="_blank" class="term-link">
                             PMID:29568061
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An AP-MS- and BioID-compatible MAC-tag enables comprehensive mapping of protein interactions and subcellular localizations.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/29601588" target="_blank" class="term-link">
                             PMID:29601588
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ZMYND10 stabilizes intermediate chain proteins in the cytoplasmic pre-assembly of dynein arms.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/29764935" target="_blank" class="term-link">
                             PMID:29764935
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The disorderly conduct of Hsc70 and its interaction with the Alzheimer&#39;s-related Tau protein.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/30021884" target="_blank" class="term-link">
                             PMID:30021884
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Histone Interaction Landscapes Visualized by Crosslinking Mass Spectrometry in Intact Cell Nuclei.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/30827827" target="_blank" class="term-link">
                             PMID:30827827
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A Legionella pneumophila Kinase Phosphorylates the Hsp70 Chaperone Family to Inhibit Eukaryotic Protein Synthesis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/31273097" target="_blank" class="term-link">
                             PMID:31273097
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The heme-regulated inhibitor is a cytosolic sensor of protein misfolding that controls innate immune signaling.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/31980649" target="_blank" class="term-link">
                             PMID:31980649
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Extensive rewiring of the EGFR network in colorectal cancer cells expressing transforming levels of KRAS(G13D).</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                             PMID:32296183
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A reference map of the human binary protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32671205" target="_blank" class="term-link">
                             PMID:32671205
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A micropeptide encoded by lncRNA MIR155HG suppresses autoimmune inflammation via modulating antigen presentation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
                             PMID:32814053
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33857403" target="_blank" class="term-link">
                             PMID:33857403
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">DNAJC9 integrates heat shock molecular chaperones into the histone chaperone network.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/35044787" target="_blank" class="term-link">
                             PMID:35044787
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Loss-of-function mutations in the co-chaperone protein BAG5 cause dilated cardiomyopathy requiring heart transplantation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link">
                             PMID:35271311
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">OpenCell: Endogenous tagging for the cartography of human cellular organization.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/36586411" target="_blank" class="term-link">
                             PMID:36586411
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Palmitoylation prevents sustained inflammation by limiting NLRP3 inflammasome activation through chaperone-mediated autophagy.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/39225180" target="_blank" class="term-link">
                             PMID:39225180
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ABHD8 antagonizes inflammation by facilitating chaperone-mediated autophagy-mediated degradation of NLRP3.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
                             PMID:40205054
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/40281343" target="_blank" class="term-link">
                             PMID:40281343
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">PSAT1 impairs ferroptosis and reduces immunotherapy efficacy via GPX4 hydroxylation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/8524399" target="_blank" class="term-link">
                             PMID:8524399
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Role of auxilin in uncoating clathrin-coated vesicles.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/8530083" target="_blank" class="term-link">
                             PMID:8530083
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Localization of the gene encoding the human heat shock cognate protein, HSP73, to chromosome 11.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9305631" target="_blank" class="term-link">
                             PMID:9305631
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">BAG-1 modulates the chaperone activity of Hsp70/Hsc70.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9499401" target="_blank" class="term-link">
                             PMID:9499401
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Molecular chaperones as HSF1-specific transcriptional repressors.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-199991
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Membrane Trafficking</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371422
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ATP hydrolysis by HSP70</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371467
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">SIRT1 deacetylates HSF1</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371497
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP90 chaperone cycle for steroid hormone receptors (SHR) in the presence of ligand</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371503
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">STIP1(HOP) binds HSP90 and HSP70:HSP40:nascent protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371518
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">SIRT1 binds to HSF1</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371554
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSF1 acetylation at Lys80</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371590
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP70 binds to HSP40:nascent protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-421836
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">trans-Golgi Network Derived Vesicle Uncoating</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-432688
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">trans-Golgi Network Derived Lysosomal Vesicle Uncoating</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-450551
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">AUF1 binds translation and heat shock proteins</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-450580
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">AUF1 (hnRNP D0) is ubiquitinylated</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5082356
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSF1-mediated gene expression</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5082369
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Acetylated HSF1 dissociates from DNA</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5082384
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP70:DNAJB1 binds HSF1</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5618085
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">FKBP4 binds HSP90:ATP:STIP1:HSP70:nascent protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5618098
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">p23 (PTGES3) binds HSP90:ATP:FKBP5:nascent protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5618105
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">FKBP5 binds HSP90:ATP:STIP1:HSP70:nascent protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5618107
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ATP binding to HSP90 triggers conformation change</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5618110
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">p23 (PTGES3) binds HSP90:ATP:FKBP4:nascent protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6797269
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Expression of HSPA8, ALOX15</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6798748
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Exocytosis of secretory granule lumen proteins</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6800434
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Exocytosis of ficolin-rich granule lumen proteins</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8868658
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSPA8-mediated ATP hydrolysis promotes vesicle uncoating</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8868660
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Auxilin recruits HSPA8:ATP to the clathrin-coated vesicle</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-888589
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Release of GABA at the synapse</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8932221
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">METTL21A transfers 3xCH3 from 3xAdoMet to HSPA8</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-917744
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">GABA loaded synaptic vesicle Docking and Priming</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9770131
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Formation of the Spliceosomal B* complex</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9770141
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Formation of the Spliceosomal C* complex</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9770145
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Formation of the Spliceosomal Bact complex</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9770236
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Formation of the Spliceosomal P complex and exon ligation</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9770847
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Spliceosomal P complex dissociates yielding the intron-containing complex (ILS) and the spliced mRNP (new)</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9772351
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Disassembly of the Intron Lariat Spliceosome (new)</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9794542
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Formation of the Spliceosomal C complex containing intron lariat</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9835411
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">FA core complex:HSP70s binds PKR</div>
-                
-                
+
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -17374,9 +17512,9 @@ this with annotations you find in gene/protein databases, but these can be outda
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -17388,7 +17526,7 @@ this with annotations you find in gene/protein databases, but these can be outda
                 <pre><code>id: P11142
 gene_symbol: HSPA8
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -17471,6 +17609,12 @@ existing_annotations:
     action: ACCEPT
     reason: This is the core molecular function of HSPA8 as a constitutive HSP70 family chaperone, extensively documented
       in the literature.
+    supported_by:
+    - reference_id: file:human/HSPA8/HSPA8-deep-research-falcon.md
+      supporting_text: &gt;-
+        HSPA8 encodes constitutive Hsc70, a central Hsp70 chaperone that uses
+        ATP-dependent cycles to bind and release client polypeptides and maintain
+        proteostasis.
 - term:
     id: GO:0005829
     label: cytosol
@@ -17530,11 +17674,15 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: HSPA8 was reported to interact with CXCR4 in LPS receptor complexes (PMID:11276205). This is a non-core interaction
-      likely related to its cell-surface localization.
-    action: KEEP_AS_NON_CORE
-    reason: While experimentally supported, GPCR binding is not a core function of HSPA8. The IEA annotation captures a peripheral
-      interaction.
+    summary: &gt;-
+      This IEA annotation may reflect reported HSPA8 interactions with GPCR-context
+      clients or receptor complexes, but the cited CXCR4/LPS source is not available
+      in the local publication cache. The separately reviewed PMID:12150907 Pael-R/GPR37
+      annotation provides a better-supported GPCR-client context.
+    action: UNDECIDED
+    reason: &gt;-
+      GPCR binding is not a core HSPA8 function, and the local evidence available
+      here is insufficient to verify the specific CXCR4/LPS claim.
 - term:
     id: GO:0005524
     label: ATP binding
@@ -17741,9 +17889,15 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: HSPA8 is involved in ATP metabolism through its ATPase cycle that drives chaperone function.
-    action: ACCEPT
-    reason: Accurate description of HSPA8&#39;s ATP-dependent chaperone mechanism.
+    summary: &gt;-
+      HSPA8 hydrolyzes ATP as part of its chaperone cycle, but ATP metabolism as
+      a broad biological process overstates HSPA8 as an ATP-metabolism gene. The
+      relevant activity is already captured by ATP hydrolysis activity and
+      ATP-dependent chaperone molecular-function annotations.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      This broad BP parent is less informative than the molecular-function terms
+      that describe HSPA8&#39;s ATPase-driven chaperone cycle.
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -19282,9 +19436,14 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:23921388
   review:
-    summary: HSPA8 is involved in ATP metabolism through its ATPase activity, confirmed by direct assay (PMID:23921388).
-    action: ACCEPT
-    reason: Core metabolic consequence of HSPA8&#39;s ATPase activity.
+    summary: &gt;-
+      HSPA8 hydrolyzes ATP as part of its chaperone cycle, but GO:0046034 is a
+      broad ATP metabolic process term. The direct molecular activity is already
+      represented by ATP hydrolysis activity and ATP-dependent chaperone terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      HSPA8 should not be treated as a core ATP-metabolism gene simply because
+      its chaperone cycle consumes ATP.
 - term:
     id: GO:0055131
     label: C3HC4-type RING finger domain binding
@@ -19313,9 +19472,19 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:12150907
   review:
-    summary: HSPA8 binds CXCR4 as part of LPS receptor cluster and interacts with CHIP/Parkin (PMID:12150907).
+    summary: &gt;-
+      PMID:12150907 describes Hsp70 in a complex with CHIP, Parkin, and the
+      unfolded Pael receptor/Pael-R (GPR37), supporting a GPCR-client interaction
+      in a ubiquitin-dependent quality-control context. The paper does not support
+      the CXCR4/LPS receptor-cluster wording previously used here.
     action: KEEP_AS_NON_CORE
-    reason: Non-core interaction; HSPA8 is a chaperone, not primarily a GPCR-binding protein.
+    reason: &gt;-
+      This is a non-core chaperone/client interaction involving Pael-R/GPR37 and
+      Parkin/CHIP-mediated quality control, not a general GPCR-binding function.
+    supported_by:
+    - reference_id: PMID:12150907
+      supporting_text: &gt;-
+        CHIP, Hsp70, Parkin, and Pael-R formed a complex in vitro and in vivo.
 - term:
     id: GO:0031625
     label: ubiquitin protein ligase binding
@@ -19980,6 +20149,9 @@ existing_annotations:
     action: ACCEPT
     reason: Central biological process function of HSPA8 as a molecular chaperone.
 references:
+- id: file:human/HSPA8/HSPA8-deep-research-falcon.md
+  title: Falcon deep research report for HSPA8
+  findings: []
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
   findings: []
@@ -20485,6 +20657,13 @@ core_functions:
   locations:
   - id: GO:0005829
     label: cytosol
+  supported_by:
+  - reference_id: file:human/HSPA8/HSPA8-deep-research-falcon.md
+    supporting_text: &gt;-
+      HSPA8 encodes the constitutive cytosolic Hsp70 isoform Hsc70, which uses
+      ATP-dependent cycles to bind and release client polypeptides, preventing
+      aggregation, aiding folding, remodeling complexes, and routing damaged
+      proteins for clearance.
 - molecular_function:
     id: GO:0016887
     label: ATP hydrolysis activity
@@ -20494,6 +20673,11 @@ core_functions:
   locations:
   - id: GO:0005829
     label: cytosol
+  supported_by:
+  - reference_id: file:human/HSPA8/HSPA8-deep-research-falcon.md
+    supporting_text: &gt;-
+      The nucleotide-binding domain binds and hydrolyzes ATP, and J-domain
+      proteins can stimulate Hsp70/Hsc70 ATPase activity by more than 1,000-fold.
 - molecular_function:
     id: GO:0030674
     label: protein-macromolecule adaptor activity
@@ -20509,6 +20693,12 @@ core_functions:
   locations:
   - id: GO:0005765
     label: lysosomal membrane
+  supported_by:
+  - reference_id: file:human/HSPA8/HSPA8-deep-research-falcon.md
+    supporting_text: &gt;-
+      Hsc70/HspA8 is the substrate-recognition chaperone in chaperone-mediated
+      autophagy, selecting proteins with KFERQ-like motifs and delivering them
+      to lysosomal LAMP2A for translocation and degradation.
 - molecular_function:
     id: GO:0140662
     label: ATP-dependent protein folding chaperone
@@ -20521,6 +20711,12 @@ core_functions:
   locations:
   - id: GO:0005829
     label: cytosol
+  supported_by:
+  - reference_id: file:human/HSPA8/HSPA8-deep-research-falcon.md
+    supporting_text: &gt;-
+      Hsc70 is a clathrin-binding/uncoating ATPase in clathrin-mediated
+      endocytosis, with clathrin listed among Hsp70 substrates and auxilin/GAK
+      acting as J-domain co-chaperones.
 - molecular_function:
     id: GO:0140545
     label: ATP-dependent protein disaggregase activity
@@ -20530,13 +20726,19 @@ core_functions:
   locations:
   - id: GO:0005829
     label: cytosol
+  supported_by:
+  - reference_id: file:human/HSPA8/HSPA8-deep-research-falcon.md
+    supporting_text: &gt;-
+      HspA8 functions in proteostasis pathways including folding, refolding,
+      disaggregation with partners, chaperone-mediated autophagy, and other
+      selective autophagy routes.
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/HSPA8/HSPA8-ai-review.html
+++ b/genes/human/HSPA8/HSPA8-ai-review.html
@@ -1363,10 +1363,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-undecided">
-                            UNDECIDED
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P11142" data-a="GO:0001664" data-r="GO_REF:0000117" data-act="UNDECIDED">
+                        <span class="vote-buttons" data-g="P11142" data-a="GO:0001664" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1379,7 +1379,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> GPCR binding is not a core HSPA8 function, and the local evidence available here is insufficient to verify the specific CXCR4/LPS claim.
+                            <strong>Reason:</strong> GPCR binding is not a core HSPA8 function. The accessible Pael-R/GPR37 evidence supports a chaperone-client quality-control interaction rather than a general GPCR-binding role, so this IEA term overstates the biological meaning of the interaction.
                         </div>
 
 
@@ -10583,10 +10583,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P11142" data-a="GO:0001664" data-r="PMID:12150907" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P11142" data-a="GO:0001664" data-r="PMID:12150907" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -10599,7 +10599,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> This is a non-core chaperone/client interaction involving Pael-R/GPR37 and Parkin/CHIP-mediated quality control, not a general GPCR-binding function.
+                            <strong>Reason:</strong> This is a specific chaperone/client quality-control interaction involving unfolded Pael-R/GPR37 and Parkin/CHIP, not evidence that GPCR binding is a biologically meaningful HSPA8 molecular function.
                         </div>
 
 
@@ -14841,6 +14841,19 @@
 
                     </li>
 
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22990239" target="_blank" class="term-link">
+                                PMID:22990239
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Hsp110 member of the Hsp70 superfamily remodels the human Hsp70-Hsp40 system to efficiently disaggregate and refold aggregates of heat and chemically denatured proteins in vitro and in cell extracts.</div>
+
+                    </li>
+
                 </ul>
             </div>
 
@@ -17679,10 +17692,12 @@ existing_annotations:
       clients or receptor complexes, but the cited CXCR4/LPS source is not available
       in the local publication cache. The separately reviewed PMID:12150907 Pael-R/GPR37
       annotation provides a better-supported GPCR-client context.
-    action: UNDECIDED
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      GPCR binding is not a core HSPA8 function, and the local evidence available
-      here is insufficient to verify the specific CXCR4/LPS claim.
+      GPCR binding is not a core HSPA8 function. The accessible Pael-R/GPR37
+      evidence supports a chaperone-client quality-control interaction rather
+      than a general GPCR-binding role, so this IEA term overstates the biological
+      meaning of the interaction.
 - term:
     id: GO:0005524
     label: ATP binding
@@ -19477,10 +19492,11 @@ existing_annotations:
       unfolded Pael receptor/Pael-R (GPR37), supporting a GPCR-client interaction
       in a ubiquitin-dependent quality-control context. The paper does not support
       the CXCR4/LPS receptor-cluster wording previously used here.
-    action: KEEP_AS_NON_CORE
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      This is a non-core chaperone/client interaction involving Pael-R/GPR37 and
-      Parkin/CHIP-mediated quality control, not a general GPCR-binding function.
+      This is a specific chaperone/client quality-control interaction involving
+      unfolded Pael-R/GPR37 and Parkin/CHIP, not evidence that GPCR binding is a
+      biologically meaningful HSPA8 molecular function.
     supported_by:
     - reference_id: PMID:12150907
       supporting_text: &gt;-
@@ -20732,6 +20748,11 @@ core_functions:
       HspA8 functions in proteostasis pathways including folding, refolding,
       disaggregation with partners, chaperone-mediated autophagy, and other
       selective autophagy routes.
+  - reference_id: PMID:22990239
+    supporting_text: &gt;-
+      Hsp110 member of the Hsp70 superfamily remodels the human Hsp70-Hsp40
+      system to efficiently disaggregate and refold aggregates of heat and
+      chemically denatured proteins in vitro and in cell extracts.
 </code></pre>
             </div>
         </details>

--- a/genes/human/HSPA8/HSPA8-ai-review.yaml
+++ b/genes/human/HSPA8/HSPA8-ai-review.yaml
@@ -1,7 +1,7 @@
 id: P11142
 gene_symbol: HSPA8
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -84,6 +84,12 @@ existing_annotations:
     action: ACCEPT
     reason: This is the core molecular function of HSPA8 as a constitutive HSP70 family chaperone, extensively documented
       in the literature.
+    supported_by:
+    - reference_id: file:human/HSPA8/HSPA8-deep-research-falcon.md
+      supporting_text: >-
+        HSPA8 encodes constitutive Hsc70, a central Hsp70 chaperone that uses
+        ATP-dependent cycles to bind and release client polypeptides and maintain
+        proteostasis.
 - term:
     id: GO:0005829
     label: cytosol
@@ -143,11 +149,15 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: HSPA8 was reported to interact with CXCR4 in LPS receptor complexes (PMID:11276205). This is a non-core interaction
-      likely related to its cell-surface localization.
-    action: KEEP_AS_NON_CORE
-    reason: While experimentally supported, GPCR binding is not a core function of HSPA8. The IEA annotation captures a peripheral
-      interaction.
+    summary: >-
+      This IEA annotation may reflect reported HSPA8 interactions with GPCR-context
+      clients or receptor complexes, but the cited CXCR4/LPS source is not available
+      in the local publication cache. The separately reviewed PMID:12150907 Pael-R/GPR37
+      annotation provides a better-supported GPCR-client context.
+    action: UNDECIDED
+    reason: >-
+      GPCR binding is not a core HSPA8 function, and the local evidence available
+      here is insufficient to verify the specific CXCR4/LPS claim.
 - term:
     id: GO:0005524
     label: ATP binding
@@ -354,9 +364,15 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: HSPA8 is involved in ATP metabolism through its ATPase cycle that drives chaperone function.
-    action: ACCEPT
-    reason: Accurate description of HSPA8's ATP-dependent chaperone mechanism.
+    summary: >-
+      HSPA8 hydrolyzes ATP as part of its chaperone cycle, but ATP metabolism as
+      a broad biological process overstates HSPA8 as an ATP-metabolism gene. The
+      relevant activity is already captured by ATP hydrolysis activity and
+      ATP-dependent chaperone molecular-function annotations.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      This broad BP parent is less informative than the molecular-function terms
+      that describe HSPA8's ATPase-driven chaperone cycle.
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -1895,9 +1911,14 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:23921388
   review:
-    summary: HSPA8 is involved in ATP metabolism through its ATPase activity, confirmed by direct assay (PMID:23921388).
-    action: ACCEPT
-    reason: Core metabolic consequence of HSPA8's ATPase activity.
+    summary: >-
+      HSPA8 hydrolyzes ATP as part of its chaperone cycle, but GO:0046034 is a
+      broad ATP metabolic process term. The direct molecular activity is already
+      represented by ATP hydrolysis activity and ATP-dependent chaperone terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      HSPA8 should not be treated as a core ATP-metabolism gene simply because
+      its chaperone cycle consumes ATP.
 - term:
     id: GO:0055131
     label: C3HC4-type RING finger domain binding
@@ -1926,9 +1947,19 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:12150907
   review:
-    summary: HSPA8 binds CXCR4 as part of LPS receptor cluster and interacts with CHIP/Parkin (PMID:12150907).
+    summary: >-
+      PMID:12150907 describes Hsp70 in a complex with CHIP, Parkin, and the
+      unfolded Pael receptor/Pael-R (GPR37), supporting a GPCR-client interaction
+      in a ubiquitin-dependent quality-control context. The paper does not support
+      the CXCR4/LPS receptor-cluster wording previously used here.
     action: KEEP_AS_NON_CORE
-    reason: Non-core interaction; HSPA8 is a chaperone, not primarily a GPCR-binding protein.
+    reason: >-
+      This is a non-core chaperone/client interaction involving Pael-R/GPR37 and
+      Parkin/CHIP-mediated quality control, not a general GPCR-binding function.
+    supported_by:
+    - reference_id: PMID:12150907
+      supporting_text: >-
+        CHIP, Hsp70, Parkin, and Pael-R formed a complex in vitro and in vivo.
 - term:
     id: GO:0031625
     label: ubiquitin protein ligase binding
@@ -2593,6 +2624,9 @@ existing_annotations:
     action: ACCEPT
     reason: Central biological process function of HSPA8 as a molecular chaperone.
 references:
+- id: file:human/HSPA8/HSPA8-deep-research-falcon.md
+  title: Falcon deep research report for HSPA8
+  findings: []
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
   findings: []
@@ -3098,6 +3132,13 @@ core_functions:
   locations:
   - id: GO:0005829
     label: cytosol
+  supported_by:
+  - reference_id: file:human/HSPA8/HSPA8-deep-research-falcon.md
+    supporting_text: >-
+      HSPA8 encodes the constitutive cytosolic Hsp70 isoform Hsc70, which uses
+      ATP-dependent cycles to bind and release client polypeptides, preventing
+      aggregation, aiding folding, remodeling complexes, and routing damaged
+      proteins for clearance.
 - molecular_function:
     id: GO:0016887
     label: ATP hydrolysis activity
@@ -3107,6 +3148,11 @@ core_functions:
   locations:
   - id: GO:0005829
     label: cytosol
+  supported_by:
+  - reference_id: file:human/HSPA8/HSPA8-deep-research-falcon.md
+    supporting_text: >-
+      The nucleotide-binding domain binds and hydrolyzes ATP, and J-domain
+      proteins can stimulate Hsp70/Hsc70 ATPase activity by more than 1,000-fold.
 - molecular_function:
     id: GO:0030674
     label: protein-macromolecule adaptor activity
@@ -3122,6 +3168,12 @@ core_functions:
   locations:
   - id: GO:0005765
     label: lysosomal membrane
+  supported_by:
+  - reference_id: file:human/HSPA8/HSPA8-deep-research-falcon.md
+    supporting_text: >-
+      Hsc70/HspA8 is the substrate-recognition chaperone in chaperone-mediated
+      autophagy, selecting proteins with KFERQ-like motifs and delivering them
+      to lysosomal LAMP2A for translocation and degradation.
 - molecular_function:
     id: GO:0140662
     label: ATP-dependent protein folding chaperone
@@ -3134,6 +3186,12 @@ core_functions:
   locations:
   - id: GO:0005829
     label: cytosol
+  supported_by:
+  - reference_id: file:human/HSPA8/HSPA8-deep-research-falcon.md
+    supporting_text: >-
+      Hsc70 is a clathrin-binding/uncoating ATPase in clathrin-mediated
+      endocytosis, with clathrin listed among Hsp70 substrates and auxilin/GAK
+      acting as J-domain co-chaperones.
 - molecular_function:
     id: GO:0140545
     label: ATP-dependent protein disaggregase activity
@@ -3143,3 +3201,9 @@ core_functions:
   locations:
   - id: GO:0005829
     label: cytosol
+  supported_by:
+  - reference_id: file:human/HSPA8/HSPA8-deep-research-falcon.md
+    supporting_text: >-
+      HspA8 functions in proteostasis pathways including folding, refolding,
+      disaggregation with partners, chaperone-mediated autophagy, and other
+      selective autophagy routes.

--- a/genes/human/HSPA8/HSPA8-ai-review.yaml
+++ b/genes/human/HSPA8/HSPA8-ai-review.yaml
@@ -154,10 +154,12 @@ existing_annotations:
       clients or receptor complexes, but the cited CXCR4/LPS source is not available
       in the local publication cache. The separately reviewed PMID:12150907 Pael-R/GPR37
       annotation provides a better-supported GPCR-client context.
-    action: UNDECIDED
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      GPCR binding is not a core HSPA8 function, and the local evidence available
-      here is insufficient to verify the specific CXCR4/LPS claim.
+      GPCR binding is not a core HSPA8 function. The accessible Pael-R/GPR37
+      evidence supports a chaperone-client quality-control interaction rather
+      than a general GPCR-binding role, so this IEA term overstates the biological
+      meaning of the interaction.
 - term:
     id: GO:0005524
     label: ATP binding
@@ -1952,10 +1954,11 @@ existing_annotations:
       unfolded Pael receptor/Pael-R (GPR37), supporting a GPCR-client interaction
       in a ubiquitin-dependent quality-control context. The paper does not support
       the CXCR4/LPS receptor-cluster wording previously used here.
-    action: KEEP_AS_NON_CORE
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      This is a non-core chaperone/client interaction involving Pael-R/GPR37 and
-      Parkin/CHIP-mediated quality control, not a general GPCR-binding function.
+      This is a specific chaperone/client quality-control interaction involving
+      unfolded Pael-R/GPR37 and Parkin/CHIP, not evidence that GPCR binding is a
+      biologically meaningful HSPA8 molecular function.
     supported_by:
     - reference_id: PMID:12150907
       supporting_text: >-
@@ -3207,3 +3210,8 @@ core_functions:
       HspA8 functions in proteostasis pathways including folding, refolding,
       disaggregation with partners, chaperone-mediated autophagy, and other
       selective autophagy routes.
+  - reference_id: PMID:22990239
+    supporting_text: >-
+      Hsp110 member of the Hsp70 superfamily remodels the human Hsp70-Hsp40
+      system to efficiently disaggregate and refold aggregates of heat and
+      chemically denatured proteins in vitro and in cell extracts.

--- a/publications/PMID_1700760.md
+++ b/publications/PMID_1700760.md
@@ -1,0 +1,46 @@
+---
+pmid: '1700760'
+title: Structure and expression of the three MHC-linked HSP70 genes.
+authors:
+- Milner CM
+- Campbell RD
+journal: Immunogenetics
+year: '1990'
+full_text_available: false
+doi: 10.1007/BF00187095
+---
+
+# Structure and expression of the three MHC-linked HSP70 genes.
+**Authors:** Milner CM, Campbell RD
+**Journal:** Immunogenetics (1990)
+**DOI:** [10.1007/BF00187095](https://doi.org/10.1007/BF00187095)
+
+## Abstract
+
+1. Immunogenetics. 1990;32(4):242-51. doi: 10.1007/BF00187095.
+
+Structure and expression of the three MHC-linked HSP70 genes.
+
+Milner CM(1), Campbell RD.
+
+Author information:
+(1)Department of Biochemistry, University of Oxford, England.
+
+A duplicated locus encoding the major heat shock-induced protein HSP70 is 
+located in the major histocompatibility complex (MHC) class III region 92 
+kilobases (kb) telomeric to the C2 gene. Nucleotide sequence analysis of the two 
+intronless genes, HSP70-1 and HSP70-2, has shown that they encode an identical 
+protein product of 641 amino acids. A third intronless gene, HSP70-Hom, has also 
+been identified 4 kb telomeric to the HSP70-1 gene. This encodes a more basic 
+protein of 641 amino acids which has 90% sequence similarity with HSP70-1. In 
+order to investigate the expression of the three (MHC)-linked HSP70 genes 
+individually by northern blot analysis, we have isolated locus-specific probes 
+from the 3' untranslated regions of the genes. The HSP70-1 and HSP70-2 genes 
+have been shown to be expressed at high levels as a approximately 2.4 kb mRNA in 
+cells heat-shocked at 42 degrees C. HSP70-1 is also expressed constitutively at 
+very low levels. The HSP70-Hom gene, which has no heat shock consensus sequence 
+in its 5' flanking sequence, is expressed as a approximately 3 kb mRNA at low 
+levels both constitutively and following heat shock.
+
+DOI: 10.1007/BF00187095
+PMID: 1700760 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary

- Complete human reviews for HSPA1A, HSPA1B, HSPA1L, HSPA6, and HSPA8.
- Integrate Falcon deep research into representative annotation decisions, references, and core function summaries.
- Tighten paralog-specific HSP70 evidence handling after subagent review, especially HSPA1A/HSPA1B/HSPA6/HSPA8 evidence mismatches.
- Regenerate the five gene review HTML pages.

## Review and validation

- Subagent review completed for each gene; all five approved after fixes.
- `just validate human HSPA1A`
- `just validate human HSPA1B`
- `just validate human HSPA1L`
- `just validate human HSPA6`
- `just validate human HSPA8`
- `just render human HSPA1A HSPA1B HSPA1L HSPA6 HSPA8` via per-gene render loop
- `just pytest` passed: 255 passed, 40 deselected, 6 warnings
- `just mypy` passed: no issues found in 68 source files
- `git diff --check` passed

## Notes

Some HSPA1A/HSPA1B validation warnings remain intentionally because individual PMID-backed rows with paralog-mismatched evidence were downgraded or removed while other evidence rows for the same GO terms remain supported.