### PR TITLE
[codex] Review human chaperone batch 08

### DIFF
--- a/genes/human/AHSA1/AHSA1-ai-review.html
+++ b/genes/human/AHSA1/AHSA1-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>AHSA1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/O95433" target="_blank" class="term-link">
                         O95433
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>Activator of 90 kDa heat shock protein ATPase homolog 1 (AHA1/AHSA1) is the most potent known stimulator of HSP90 ATP hydrolysis, functioning as an HSP90 co-chaperone that accelerates the HSP90 conformational/ATPase cycle. AHSA1 is a two-domain protein (N-terminal and C-terminal) connected by a flexible linker; the N-terminal domain binds the HSP90 middle domain via conserved NxNNWHW and RKxK motifs (required for maximal ATPase stimulation and catalytic-loop positioning), while the C-terminal domain stabilizes the dimerized HSP90 N-terminal domains (DOI:10.1038/s44319-024-00193-8). AHSA1 is ~30-fold less abundant than HSP90 and can act asymmetrically, with a single AHSA1 molecule sufficient to stimulate HSP90 ATPase activity. One or two AHSA1 molecules can bind per HSP90 dimer, with stoichiometry differentially regulating HSP90 properties (DOI:10.1016/j.bpj.2023.07.020). AHSA1 competes with inhibitory co-chaperones FNIP1 and TSC1 for HSP90 binding, providing reciprocal regulation of client protein chaperoning. A metazoan-specific N-terminal intrinsic chaperone domain (ICD, aa ~1-20) both confers HSP90-independent holdase activity (preventing aggregation of model substrates) and dampens ATPase stimulation by interfering with NxNNWHW function, also controlling regulated recruitment to HSP90 in cells (DOI:10.1038/s44319-024-00193-8). AHSA1 modulates maturation of HSP90 clients including kinases, steroid receptors, and Dicer1 (affecting microRNA biogenesis) (DOI:10.1093/nar/gkac528). AHSA1 is being explored as a therapeutic target in multiple myeloma (bufalin/KU-177 binding at K137), cystic fibrosis (CFTR proteostasis), and neurodegeneration (tauopathies) (DOI:10.1186/s13046-021-02220-1, DOI:10.3389/fnmol.2024.1509280).</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
                                     GO:0001671
                                 </a>
                             </span>
                             <span class="term-label">ATPase activator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,77 +795,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for ATPase activator activity based on phylogenetic inference (PANTHER). This is the core molecular function of AHSA1. Aha1 was identified as the activator of Hsp90 ATPase in yeast and human, stimulating ATPase activity 5-fold in vitro (PMID:12604615) and confirmed across multiple studies (PMID:12504007, PMID:29127155, PMID:27353360). The IBA annotation is well supported by conserved function across yeast (S. cerevisiae Aha1, Hch1) and S. pombe orthologs included in the PANTHER family.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATPase activator activity is the primary, evolutionarily conserved molecular function of AHSA1. Multiple independent experimental studies confirm this function (PMID:12504007, PMID:12604615, PMID:27353360, PMID:29127155), and the IBA phylogenetic inference is sound, supported by orthologs in yeast.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12504007" target="_blank" class="term-link">
                                         PMID:12504007
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">A ubiquitous family of stress-regulated proteins have been identified (Aha1, activator of Hsp90 ATPase) that bind directly to Hsp90 and are required for the in vivo Hsp90-dependent activation of clients such as v-Src, implicating them as cochaperones of the Hsp90 system.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12604615" target="_blank" class="term-link">
                                         PMID:12604615
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Aha1 but not Hch1 stimulated the intrinsic ATPase activity of Hsp90 5-fold</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/AHSA1/AHSA1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">AHSA1 is the HSP90 co-chaperone that potently stimulates HSP90 ATPase activity by promoting the closed, N-terminally dimerized state and engaging catalytic elements of HSP90.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -877,46 +888,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for cytosol localization based on phylogenetic inference. AHSA1 is predominantly cytosolic, consistent with its role as an HSP90 co-chaperone. UniProt records cytoplasm/cytosol as the primary subcellular location (PMID:11554768), and HPA immunofluorescence data supports cytosol localization (GO_REF:0000052).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol is the well-established primary localization of AHSA1, consistent with its function as an HSP90 co-chaperone in the cytoplasm. Supported by IDA from HPA and UniProt subcellular location annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -928,77 +939,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for protein folding based on phylogenetic inference. AHSA1 participates in protein folding indirectly by stimulating the HSP90 ATPase cycle, which is required for HSP90-dependent client protein maturation. Yeast Aha1 deletion impairs activation of the Hsp90 client v-Src (PMID:12504007, PMID:12604615), and human AHSA1 competes with inhibitory co-chaperones to regulate HSP90 client chaperoning (PMID:27353360, PMID:29127155). The term is at an appropriate level of generality for the biological process.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein folding is an appropriate biological process for AHSA1, which participates in HSP90-mediated client protein folding/maturation by stimulating the HSP90 chaperone cycle. The IBA inference is supported by experimental evidence in yeast and human showing that Aha1 is required for efficient activation of Hsp90 clients.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12604615" target="_blank" class="term-link">
                                         PMID:12604615
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Aha1 and Hch1 contributed to efficient activation of the heterologous Hsp90 client protein v-Src</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/29127155" target="_blank" class="term-link">
                                         PMID:29127155
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Tsc1 is a new co-chaperone for Hsp90 that inhibits its ATPase activity ... prevents the activating co-chaperone Aha1 from binding the middle domain of Hsp90</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
                                     GO:0001671
                                 </a>
                             </span>
                             <span class="term-label">ATPase activator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1010,46 +1021,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for ATPase activator activity inferred from InterPro domain IPR015310 (AHSA1-like_N). This is consistent with the core function of AHSA1 and is well supported by experimental evidence across multiple publications.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The InterPro-to-GO mapping is correct. The AHSA1 N-terminal domain (Aha1_N, Pfam PF09229) is the domain responsible for binding the HSP90 middle domain and stimulating ATPase activity (PMID:12604615). This IEA annotation is redundant with the IBA and IDA annotations but correctly captures the function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
                                     GO:0005783
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1061,46 +1072,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for ER localization mapped from UniProt subcellular location. UniProt notes that AHSA1 &#34;may transiently interact with the endoplasmic reticulum&#34; based on PMID:11554768 (Sevier and Machamer 2001), which identified AHSA1 (then called p38) as interacting with VSV G glycoprotein. The ER localization is likely a minor or transient association rather than a primary localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The ER association is based on early work showing AHSA1 interacts with VSV G glycoprotein and may transiently associate with the ER (PMID:11554768). This is not a core localization for AHSA1, whose primary function occurs in the cytosol. The UniProt annotation itself qualifies this as transient.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1112,46 +1123,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for cytosol localization mapped from UniProt subcellular location vocabulary. Consistent with the primary localization of AHSA1 and supported by IDA (HPA) and IBA evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol is the well-established primary localization of AHSA1. This IEA annotation is consistent with the IDA and IBA annotations for the same term and is correctly mapped from UniProt subcellular location.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1163,57 +1174,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for protein-folding chaperone binding inferred from InterPro domain IPR015310. AHSA1 directly binds HSP90, which is a protein-folding chaperone, so this annotation is accurate. The binding is well characterized: the N-terminal domain of AHSA1 binds the middle domain of HSP90 (PMID:12604615), and the C-terminal domain stabilizes the dimerized N-terminal domains of HSP90 (PMID:33808352).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> AHSA1 is a well-established HSP90-binding co-chaperone. The InterPro-to-GO mapping correctly captures the chaperone binding function. This is supported by multiple experimental studies (PMID:12504007, PMID:12604615, PMID:27353360, PMID:29127155).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12604615" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12604615
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Aha1 binds to the middle domain of Hsp90, contributes to cli...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1225,86 +1236,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI protein binding annotation from IntAct, based on Lotz et al. 2003, which demonstrated that Aha1 binds to the middle domain of Hsp90 using biochemical approaches including co-immunoprecipitation and direct binding assays. The WITH column indicates interaction with HSP90AA1 (P07900). While the interaction is real and well-characterized, &#34;protein binding&#34; is uninformative since the specific interaction is better captured by GO:0051879 (Hsp90 protein binding).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The underlying interaction with HSP90 is the core function of AHSA1 and is well-documented (PMID:12604615). However, GO:0005515 (protein binding) is too vague. The interaction is more precisely captured by GO:0051879 (Hsp90 protein binding), which is already annotated from other evidence.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051879" target="_blank" class="term-link">
                                     Hsp90 protein binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12604615" target="_blank" class="term-link">
                                         PMID:12604615
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We have identified Aha1 (activator of Hsp90 ATPase) and its relative Hch1 (high copy Hsp90 suppressor) as binding partners of Hsp90 in Saccharomyces cerevisiae. By using genetic and biochemical approaches, the middle domain of Hsp90 (amino acids 272-617) was found to mediate the interaction with Aha1 and Hch1.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16696853" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16696853
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A yeast 2-hybrid analysis of human GTP cyclohydrolase I prot...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1316,75 +1327,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI protein binding annotation from IntAct, based on Swick and Kapatos 2006, which identified AHSA1 as interacting with GCH1 (GTP cyclohydrolase I, P30793) using yeast two-hybrid screen and validated by GST pull-down assay. The authors note that &#34;the physiological relevance of the Aha1-GCH1 interaction requires further study&#34; and speculate it may recruit GCH1 into the eNOS/Hsp90 complex. This is a secondary, possibly indirect interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The interaction with GCH1 was detected by yeast two-hybrid and validated by GST pull-down (PMID:16696853), but its physiological relevance is uncertain. The authors themselves state the relevance &#34;requires further study.&#34; This may reflect indirect bridging through HSP90 rather than a direct functional interaction. Keeping as non-core since the interaction was validated but may not represent a core AHSA1 function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16696853" target="_blank" class="term-link">
                                         PMID:16696853
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The interaction of one of these clones, Activator of Heat Shock 90 kDa Protein (Aha1), with GCH1 was validated by glutathione-s-transferase (GST) pull-down assay. Although the physiological relevance of the Aha1-GCH1 interaction requires further study</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19875381" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19875381
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A proteomic investigation of ligand-dependent HSP90 complexe...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1396,86 +1407,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI protein binding annotation from IntAct, based on Gano and Simon 2010, which identified AHSA1 as a component of HSP90 complexes by tandem affinity purification and LC-MS/MS. The WITH column indicates interaction with HSP90AA1 (P07900). This is a high-throughput proteomics study that characterized the nucleotide-dependent HSP90 interactome. The AHSA1-HSP90 interaction is well established.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The interaction with HSP90 is the core function of AHSA1. GO:0005515 (protein binding) is uninformative; the specific interaction is better captured by GO:0051879 (Hsp90 protein binding).
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051879" target="_blank" class="term-link">
                                     Hsp90 protein binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19875381" target="_blank" class="term-link">
                                         PMID:19875381
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We identified 52 known and novel components of HSP90 complexes that are regulated by these ligands, including several co-chaperones.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20618441" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20618441
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     CHIP participates in protein triage decisions by preferentia...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1487,86 +1498,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI protein binding annotation from IntAct, based on Stankiewicz et al. 2010. The WITH column indicates interaction with HSP90AB1 (P08238). This study investigated CHIP-mediated ubiquitination and tested the influence of Aha1 on HSP90 ATPase activity in the context of CHIP. AHSA1 is mentioned as an HSP90 co-chaperone tested for its effect on CHIP function. The interaction with HSP90 is incidental to the main focus of the paper.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The interaction detected is between AHSA1 and HSP90AB1, which is the core binding partner. GO:0005515 is too vague; GO:0051879 (Hsp90 protein binding) is the appropriate specific term.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051879" target="_blank" class="term-link">
                                     Hsp90 protein binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20618441" target="_blank" class="term-link">
                                         PMID:20618441
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">CHIP did not influence the ATPase cycle of Hsp90 in the absence of co-chaperones or in the presence of the Hsp90 cochaperones Aha1 or p23.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25036637
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A quantitative chaperone interaction network reveals the arc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1578,68 +1589,68 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI protein binding annotation from IntAct, based on Taipale et al. 2014, a large-scale quantitative chaperone interaction network study. The WITH column indicates interaction with HSP90AB1 (P08238). This is a systematic proteomics study mapping chaperone-client interactions. AHSA1 was identified as part of the HSP90 interaction network.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The interaction detected is with HSP90AB1. GO:0005515 is too vague for AHSA1, whose binding to HSP90 is its core function. GO:0051879 (Hsp90 protein binding) is the appropriate specific term.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051879" target="_blank" class="term-link">
                                     Hsp90 protein binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30382094" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30382094
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structure and pro-toxic mechanism of the human Hsp90/PPIase/...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1651,86 +1662,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI protein binding annotation from IntAct, based on Oroz et al. 2018, which determined the solution structure of the human Hsp90/FKBP51/Tau complex. The WITH column indicates interaction with HSP90AB1 (P08238). AHSA1 is mentioned as restoring HSP90 ATPase activity that was decreased by FKBP51 binding. This is a functional assay demonstrating AHSA1&#39;s role as an HSP90 ATPase activator.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The interaction is with HSP90AB1 and reflects AHSA1&#39;s core function as an HSP90 co-chaperone. GO:0005515 is uninformative; GO:0051879 (Hsp90 protein binding) properly captures this interaction.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051879" target="_blank" class="term-link">
                                     Hsp90 protein binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30382094" target="_blank" class="term-link">
                                         PMID:30382094
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Hsp90 ATPase activity was restored by the addition of Aha1, a strong enhancer of Hsp90 ATPase activity through compaction of the Hsp90 conformation</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:35271311
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     OpenCell: Endogenous tagging for the cartography of human ce...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1742,57 +1753,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI protein binding annotation from IntAct, based on Cho et al. 2022 (OpenCell project), which used endogenous tagging and mass spectrometry to map protein-protein interactions across the human proteome. The WITH column indicates interactions with HSP90AA1 (P07900) and HSP90AB1 (P08238). This is a large-scale systematic study confirming the known AHSA1-HSP90 interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The interactions detected are with both HSP90 isoforms (HSP90AA1 and HSP90AB1), consistent with AHSA1&#39;s core function. GO:0005515 is too vague; GO:0051879 (Hsp90 protein binding) properly captures this.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051879" target="_blank" class="term-link">
                                     Hsp90 protein binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051879" target="_blank" class="term-link">
                                     GO:0051879
                                 </a>
                             </span>
                             <span class="term-label">Hsp90 protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1804,46 +1815,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for Hsp90 protein binding from combined automated methods (ARBA, mouse ortholog, Ensembl). This is well-supported by extensive experimental evidence: AHSA1 directly binds HSP90AA1 and HSP90AB1 (PMID:12504007, PMID:12604615, PMID:25486457, PMID:27353360, PMID:29127155). HSP90 binding is the core molecular interaction of AHSA1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Hsp90 protein binding is the core molecular interaction of AHSA1. The automated annotation is correct and supported by multiple independent experimental studies. AHSA1 binds both HSP90 isoforms through its N-terminal and C-terminal domains.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1855,57 +1866,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for cytosol localization from Human Protein Atlas (HPA) based on curation of immunofluorescence data. This is consistent with AHSA1&#39;s role as a cytosolic HSP90 co-chaperone and is supported by UniProt subcellular location annotation (PMID:11554768).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol is the primary localization of AHSA1, directly demonstrated by immunofluorescence (HPA) and consistent with its function as an HSP90 co-chaperone in the cytoplasm.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036506" target="_blank" class="term-link">
                                     GO:0036506
                                 </a>
                             </span>
                             <span class="term-label">maintenance of unfolded protein</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">EXP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/37486705" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:37486705
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human Aha1&#39;s N-terminal extension confers it holdase activit...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1917,88 +1928,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> EXP annotation for maintenance of unfolded protein from DisProt, based on Tang et al. 2023, which demonstrated that the N-terminal extension (M1-R16) of human Aha1 confers holdase activity in vitro. The holdase activity prevents aggregation of heat-denatured MBP but is abolished by high NaCl concentration. This activity is mediated by the N-terminal extension unique to higher eukaryote Aha1 proteins and is absent from the conserved core domains.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The holdase activity demonstrated in vitro maps to the N-terminal extension (M1-R16) unique to higher eukaryotes, not the conserved Aha1 core domains. The activity is abolished by high NaCl concentration, suggesting electrostatic-driven non-specific interactions (PMID:37486705). No in vivo evidence supports this as a physiological function. AHSA1&#39;s core function is HSP90 ATPase activation, not autonomous chaperone activity.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/37486705" target="_blank" class="term-link">
                                         PMID:37486705
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the highly conserved N-terminal extension spanning M1 to R16 in Aha1 from higher eukaryotes is responsible for the holdase activity of the protein</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/37486705" target="_blank" class="term-link">
                                         PMID:37486705
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">since the high concentration of NaCl could abolish the holdase activity of Aha1, the electrostatic interactions mediated by those charged residues in Aha1&#39;s N-terminal extension are thus indicated to play a crucial role in the substrate recognition</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036506" target="_blank" class="term-link">
                                     GO:0036506
                                 </a>
                             </span>
                             <span class="term-label">maintenance of unfolded protein</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/37486705" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:37486705
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human Aha1&#39;s N-terminal extension confers it holdase activit...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2010,75 +2021,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for maintenance of unfolded protein from DisProt, based on the same study as above (Tang et al. 2023). This is a duplicate annotation with different evidence code (IDA vs EXP) from the same reference, and the same concerns apply.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Same rationale as the EXP annotation from the same reference. The holdase activity is an in vitro observation dependent on the non-conserved N-terminal extension (M1-R16) and abolished by high salt, suggesting non-specific electrostatic interactions. Not established as a physiological function of AHSA1.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/37486705" target="_blank" class="term-link">
                                         PMID:37486705
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the highly conserved N-terminal extension spanning M1 to R16 in Aha1 from higher eukaryotes is responsible for the holdase activity of the protein</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     GO:0044183
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">EXP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33808352" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33808352
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Aha1 Exhibits Distinctive Dynamics Behavior and Chaperone-Li...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2090,88 +2101,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> EXP annotation for protein folding chaperone from DisProt, based on Hu et al. 2021, which demonstrated using NMR HSQC titrations and ThT assays that full-length human Aha1 interacts with alpha-synuclein and inhibits its aggregation in vitro. The chaperone-like activity requires the N-terminal extension (M1-W27) and/or C-terminal RLF motif, which are peripheral to the conserved core domains (PMID:33808352). The core construct Aha128-335 showed no significant interaction with alpha-synuclein.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The protein folding chaperone annotation for AHSA1 represents an over-annotation. The chaperone-like activity is an in vitro observation dependent on peripheral regions (N-terminal extension and C-terminal RLF motif) not present in the conserved Aha1 core. The core construct Aha128-335 showed no significant interaction with alpha-synuclein (PMID:33808352). No in vivo evidence supports autonomous chaperone function. AHSA1&#39;s established role is as an HSP90 ATPase activator co-chaperone, not as an independent protein folding chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/33808352" target="_blank" class="term-link">
                                         PMID:33808352
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Without the presence of M1-W27 fragment and RLF (R336L337F338) motif, no significant chemical shift perturbations were observed for the NMR resonances of the residues in Aha128-335 upon the addition of alpha-synuclein</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/33808352" target="_blank" class="term-link">
                                         PMID:33808352
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">extensive in vivo studies need to be conducted to precisely decipher the functional roles of Aha1 under different physiological and pathological conditions</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     GO:0044183
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33808352" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33808352
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Aha1 Exhibits Distinctive Dynamics Behavior and Chaperone-Li...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2183,75 +2194,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for protein folding chaperone from DisProt, based on the same study (Hu et al. 2021). This is a duplicate annotation with different evidence code (IDA vs EXP) from the same reference, and the same concerns apply.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Same rationale as the EXP annotation from the same reference. The chaperone-like activity depends on peripheral regions absent from the conserved Aha1 core, has no in vivo validation, and does not represent a core function of AHSA1.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/33808352" target="_blank" class="term-link">
                                         PMID:33808352
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Without the presence of M1-W27 fragment and RLF (R336L337F338) motif, no significant chemical shift perturbations were observed for the NMR resonances of the residues in Aha128-335 upon the addition of alpha-synuclein</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">EXP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33808352" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33808352
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Aha1 Exhibits Distinctive Dynamics Behavior and Chaperone-Li...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2263,114 +2274,114 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962). The annotation from DisProt is based on PMID:33808352 (Hu et al. 2021), which used NMR HSQC titrations and ThT assays to show that full-length human Aha1 interacts with intrinsically disordered alpha-synuclein and inhibits its aggregation in vitro. However, the core construct Aha128-335 (lacking the N-terminal M1-W27 extension and C-terminal RLF motif) showed no significant interaction with alpha-synuclein, indicating this is not a property of the conserved Aha1 core domains. The authors themselves describe this as &#34;chaperone-like activity&#34; and note that in vivo significance remains unestablished. AHSA1&#39;s primary, evolutionarily conserved function is as an HSP90 ATPase activator, not as an independent chaperone. The unfolded protein binding annotation is an over-annotation that conflates an in vitro observation with a core molecular function. Furthermore, GO:0051082 is scheduled for obsoletion. The holdase/chaperone-like activity demonstrated in vitro is better captured by the existing GO:0044183 (protein folding chaperone) and GO:0036506 (maintenance of unfolded protein) annotations already present on this gene.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> AHSA1 is primarily an HSP90 co-chaperone whose core function is stimulating HSP90 ATPase activity (PMID:12504007, PMID:29127155). The unfolded protein binding annotation is based on in vitro NMR titration experiments showing that full-length Aha1 interacts with alpha-synuclein (PMID:33808352), but this interaction depends on the N-terminal extension (M1-W27) and C-terminal RLF motif, which are peripheral to the conserved Aha1 domains and absent in lower eukaryotes. The authors state that &#34;extensive in vivo studies need to be conducted to precisely decipher the functional roles of Aha1 under different physiological and pathological conditions&#34; (PMID:33808352). A follow-up study (PMID:37486705) confirmed the holdase activity maps to the N-terminal extension (M1-R16) and is driven by electrostatic interactions that can be abolished by high NaCl concentration, suggesting non-specific binding. Additionally, GO:0051082 is being obsoleted. The chaperone-like activity is already captured by GO:0044183 and GO:0036506 annotations on this gene from the same research group.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/33808352" target="_blank" class="term-link">
                                         PMID:33808352
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Without the presence of M1-W27 fragment and RLF (R336L337F338) motif, no significant chemical shift perturbations were observed for the NMR resonances of the residues in Aha128−335 upon the addition of α-synuclein</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/33808352" target="_blank" class="term-link">
                                         PMID:33808352
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">In particular, since Aha1 has been reported to drive the production of pathological tau aggregates by acting as Hsp90&#39;s co-chaperone [59], which is in opposite to the inhibition effect of Aha1 on α-synuclein&#39;s aggregation observed by us, extensive in vivo studies need to be conducted to precisely decipher the functional roles of Aha1 under different physiological and pathological conditions.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/37486705" target="_blank" class="term-link">
                                         PMID:37486705
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the highly conserved N-terminal extension spanning M1 to R16 in Aha1 from higher eukaryotes is responsible for the holdase activity of the protein</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/37486705" target="_blank" class="term-link">
                                         PMID:37486705
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">since the high concentration of NaCl could abolish the holdase activity of Aha1, the electrostatic interactions mediated by those charged residues in Aha1&#39;s N-terminal extension are thus indicated to play a crucial role in the substrate recognition</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
                                     GO:0001671
                                 </a>
                             </span>
                             <span class="term-label">ATPase activator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/29127155" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:29127155
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tumor suppressor Tsc1 is a new Hsp90 co-chaperone that facil...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2382,75 +2393,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for ATPase activator activity based on Woodford et al. 2017, which showed that AHSA1 activates HSP90 ATPase activity and competes with the inhibitory co-chaperone TSC1 for binding to the HSP90 middle domain. Phosphorylation of Aha1-Y223 increases its affinity for HSP90 and displaces TSC1, providing a regulatory switch for the chaperone cycle. This is direct experimental evidence for the core function of AHSA1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is strong direct assay evidence for the core molecular function of AHSA1. The study demonstrates ATPase activation of HSP90 by AHSA1 and elucidates the regulatory mechanism involving phosphorylation of Y223 (PMID:29127155).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/29127155" target="_blank" class="term-link">
                                         PMID:29127155
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">phosphorylation of Aha1-Y223 increases its affinity for Hsp90 and displaces Tsc1, thereby providing a mechanism for equilibrium between binding of these two co-chaperones to Hsp90</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032781" target="_blank" class="term-link">
                                     GO:0032781
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of ATP-dependent activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/29127155" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:29127155
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tumor suppressor Tsc1 is a new Hsp90 co-chaperone that facil...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2462,75 +2473,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for positive regulation of ATP-dependent activity based on Woodford et al. 2017. AHSA1 stimulates the ATPase activity of HSP90, which is an ATP-dependent molecular chaperone. This annotation captures the regulatory biological process aspect of AHSA1&#39;s core function. The term is appropriate as AHSA1 positively regulates HSP90&#39;s ATP-dependent chaperone cycle.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This annotation accurately captures the biological process corresponding to AHSA1&#39;s core molecular function. AHSA1 positively regulates HSP90&#39;s ATP-dependent chaperone cycle by stimulating its ATPase activity (PMID:29127155, PMID:12504007, PMID:27353360).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/29127155" target="_blank" class="term-link">
                                         PMID:29127155
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Tsc1 is a new co-chaperone for Hsp90 that inhibits its ATPase activity ... prevents the activating co-chaperone Aha1 from binding the middle domain of Hsp90. Conversely, phosphorylation of Aha1-Y223 increases its affinity for Hsp90 and displaces Tsc1</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045296" target="_blank" class="term-link">
                                     GO:0045296
                                 </a>
                             </span>
                             <span class="term-label">cadherin binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25468996" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25468996
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     E-cadherin interactome complexity and robustness resolved by...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -2542,57 +2553,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HDA annotation for cadherin binding from BHF-UCL, based on Guo et al. 2014, a large-scale quantitative proteomics study of the E-cadherin interactome using proximity biotinylation. AHSA1 was identified among 561 proteins in the vicinity of the cytoplasmic tail of E-cadherin. This is a high-throughput proximity labeling approach that detects proteins near E-cadherin, not necessarily direct binding partners. AHSA1 has no known functional relationship to cadherins, and its presence may reflect its abundance as a cytoplasmic chaperone co-factor.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cadherin binding is not a plausible molecular function for AHSA1, an HSP90 co-chaperone. The HDA evidence comes from proximity biotinylation proteomics (PMID:25468996), which identifies proteins in the general vicinity of E-cadherin, not direct binding partners. AHSA1 is an abundant cytosolic protein and likely a background hit. There is no functional relationship between AHSA1 and cadherin biology.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051879" target="_blank" class="term-link">
                                     GO:0051879
                                 </a>
                             </span>
                             <span class="term-label">Hsp90 protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/29127155" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:29127155
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tumor suppressor Tsc1 is a new Hsp90 co-chaperone that facil...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2604,75 +2615,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for Hsp90 protein binding based on Woodford et al. 2017, with interaction partner HSP90AA1 (P07900). This study demonstrated that AHSA1 binds to the middle domain of HSP90, and this interaction is enhanced by phosphorylation of Aha1-Y223. AHSA1 competes with TSC1 for HSP90 binding. This is the core molecular interaction of AHSA1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Hsp90 protein binding is the core molecular interaction of AHSA1, directly demonstrated by biochemical assays including binding competition with TSC1 (PMID:29127155). The interaction is mediated by the N-terminal domain of AHSA1 binding the HSP90 middle domain, and the C-terminal domain stabilizing the HSP90 N-terminal domain dimer.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/29127155" target="_blank" class="term-link">
                                         PMID:29127155
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The C-terminal domain of Tsc1 (998-1,164 aa) forms a homodimer and binds to both protomers of the Hsp90 middle domain. This ensures inhibition of both subunits of the Hsp90 dimer and prevents the activating co-chaperone Aha1 from binding the middle domain of Hsp90.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25486457" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25486457
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Middle domain of human Hsp90 isoforms differentially binds A...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -2684,86 +2695,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI protein binding annotation from UniProt, based on Synoradzki and Bieganowski 2015, which demonstrated that Aha1 interacts preferentially with HSP90alpha (HSP90AA1) over HSP90beta (HSP90AB1), with the distinction depending on the middle domain of HSP90. The WITH column indicates interactions with both HSP90AA1 (P07900) and HSP90AB1 (P08238). This study provides insight into isoform-specific binding of AHSA1 to HSP90.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The interactions detected are with both HSP90 isoforms, which is the core binding function of AHSA1. GO:0005515 is too vague; GO:0051879 (Hsp90 protein binding) is the appropriate specific term.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051879" target="_blank" class="term-link">
                                     Hsp90 protein binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/25486457" target="_blank" class="term-link">
                                         PMID:25486457
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the Hsp90 co-chaperone Aha1 interacts preferentially with Hsp90alpha. The distinction depends on the middle domain of Hsp90.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
                                     GO:0001671
                                 </a>
                             </span>
                             <span class="term-label">ATPase activator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27353360" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27353360
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The FNIP co-chaperones decelerate the Hsp90 chaperone cycle ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2775,75 +2786,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for ATPase activator activity based on Woodford et al. 2016, which showed that AHSA1 competes with the inhibitory FNIP co-chaperones for HSP90 binding, providing a reciprocal regulatory mechanism. The paper demonstrates AHSA1&#39;s role as an ATPase activator in the context of competition with FNIP1/FNIP2.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct experimental evidence for AHSA1&#39;s core function as an HSP90 ATPase activator. The study demonstrates that FNIPs compete with the activating co-chaperone Aha1 for binding to HSP90 (PMID:27353360), confirming AHSA1&#39;s role in activating the HSP90 ATPase cycle.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/27353360" target="_blank" class="term-link">
                                         PMID:27353360
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">FNIPs compete with the activating co-chaperone Aha1 for binding to Hsp90, thereby providing a reciprocal regulatory mechanism for chaperoning of client proteins</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27353360" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27353360
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The FNIP co-chaperones decelerate the Hsp90 chaperone cycle ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -2855,86 +2866,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI protein binding annotation from UniProt, based on Woodford et al. 2016. The WITH column indicates interactions with HSP90AA1 (P07900) and FNIP1 (Q8NFG4). The interaction with HSP90AA1 is AHSA1&#39;s core function. The interaction with FNIP1 reflects the competitive binding relationship at the HSP90 middle domain rather than a direct AHSA1-FNIP1 interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The primary interaction detected is with HSP90AA1, which is AHSA1&#39;s core binding partner. GO:0005515 is too vague. The HSP90 binding is captured by GO:0051879. The interaction with FNIP1 (Q8NFG4) is indirect, reflecting competitive binding to HSP90 rather than direct AHSA1-FNIP1 binding.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051879" target="_blank" class="term-link">
                                     Hsp90 protein binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/27353360" target="_blank" class="term-link">
                                         PMID:27353360
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">FNIPs compete with the activating co-chaperone Aha1 for binding to Hsp90, thereby providing a reciprocal regulatory mechanism for chaperoning of client proteins</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27353360" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27353360
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The FNIP co-chaperones decelerate the Hsp90 chaperone cycle ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2946,75 +2957,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for protein-folding chaperone binding based on Woodford et al. 2016, which demonstrated AHSA1 binding to HSP90. Since HSP90 is a protein-folding chaperone, this annotation is accurate and represents AHSA1&#39;s core interaction with HSP90.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> AHSA1 directly binds HSP90, which is a protein-folding chaperone. This annotation correctly captures AHSA1&#39;s core interaction and is supported by direct biochemical evidence (PMID:27353360).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/27353360" target="_blank" class="term-link">
                                         PMID:27353360
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">FNIPs compete with the activating co-chaperone Aha1 for binding to Hsp90, thereby providing a reciprocal regulatory mechanism for chaperoning of client proteins</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
                                     GO:0070062
                                 </a>
                             </span>
                             <span class="term-label">extracellular exosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19056867
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Large-scale proteomics and phosphoproteomics of urinary exos...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3026,57 +3037,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HDA annotation for extracellular exosome localization based on Gonzales et al. 2009, a large-scale proteomics study of urinary exosomes that identified 1132 proteins. AHSA1 was detected among these proteins. This is a high-throughput proteomics study, and the presence of AHSA1 in exosomes likely reflects its high abundance as a cytoplasmic protein rather than a specific exosome localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> AHSA1 was detected in urinary exosomes by mass spectrometry (PMID:19056867). While the detection is real, exosome localization is not a core function or localization of AHSA1. Many abundant cytoplasmic proteins are detected in exosome proteomics studies. This is a minor, non-functional localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
                                     GO:0001671
                                 </a>
                             </span>
                             <span class="term-label">ATPase activator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12504007" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12504007
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Activation of the ATPase activity of hsp90 by the stress-reg...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3088,75 +3099,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for ATPase activator activity based on Panaretou et al. 2002, the foundational study that identified Aha1 as an activator of Hsp90 ATPase. This study demonstrated that Aha1 binds directly to Hsp90 and stimulates its ATPase activity in vitro, and is required for in vivo Hsp90-dependent activation of clients such as v-Src. This is the primary publication establishing AHSA1&#39;s core function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is the foundational study that defined AHSA1&#39;s core function as an HSP90 ATPase activator (PMID:12504007). Direct experimental evidence including in vitro ATPase assays and in vivo client activation assays.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12504007" target="_blank" class="term-link">
                                         PMID:12504007
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">A ubiquitous family of stress-regulated proteins have been identified (Aha1, activator of Hsp90 ATPase) that bind directly to Hsp90 and are required for the in vivo Hsp90-dependent activation of clients such as v-Src, implicating them as cochaperones of the Hsp90 system. In vitro, Aha1 and its shorter homolog, Hch1, stimulate the inherent ATPase activity of yeast and human Hsp90.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12504007" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12504007
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Activation of the ATPase activity of hsp90 by the stress-reg...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3168,50 +3179,50 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for protein-folding chaperone binding based on Panaretou et al. 2002, which demonstrated that Aha1 binds directly to Hsp90. Since HSP90 is a protein-folding chaperone, this annotation correctly captures the core binding interaction of AHSA1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> AHSA1 directly binds HSP90, a protein-folding chaperone, as demonstrated by the foundational study (PMID:12504007). This is a core interaction of AHSA1.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12504007" target="_blank" class="term-link">
                                         PMID:12504007
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">A ubiquitous family of stress-regulated proteins have been identified (Aha1, activator of Hsp90 ATPase) that bind directly to Hsp90</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>AHSA1 (AHA1) is the most potent known stimulator of HSP90 ATP hydrolysis, functioning as an HSP90 co-chaperone that accelerates the HSP90 conformational/ATPase cycle via conserved NxNNWHW and RKxK motifs in its N-terminal domain, which engage the HSP90 middle domain and catalytic loop (residues 370-390). The C-terminal domain stabilizes the dimerized HSP90 N-terminal domains. AHSA1 can bind asymmetrically (one molecule sufficient for stimulation) or as two molecules per HSP90 dimer with distinct functional outcomes (DOI:10.1016/j.bpj.2023.07.020). A metazoan-specific ICD (aa ~1-20) confers HSP90-independent holdase activity and negatively regulates ATPase stimulation (DOI:10.1038/s44319-024-00193-8). AHSA1 competes with inhibitory co-chaperones TSC1 and FNIP1/FNIP2 for HSP90 binding, and phosphorylation of Aha1-Y223 modulates the competition by increasing affinity for HSP90. AHSA1 influences maturation of diverse HSP90 clients including kinases, steroid receptors, and Dicer1 (affecting microRNA biogenesis) (DOI:10.1093/nar/gkac528).</h3>
                 <span class="vote-buttons" data-g="O95433" data-a="FUNCTION: AHSA1 (AHA1) is the most potent known stimulator o..." data-r="" data-act="CORE_FUNCTION">
@@ -3219,10 +3230,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -3231,606 +3242,642 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                 protein folding
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032781" target="_blank" class="term-link">
                                 positive regulation of ATP-dependent activity
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12504007" target="_blank" class="term-link">
                                 PMID:12504007
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">A ubiquitous family of stress-regulated proteins have been identified (Aha1, activator of Hsp90 ATPase) that bind directly to Hsp90 and are required for the in vivo Hsp90-dependent activation of clients such as v-Src.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12604615" target="_blank" class="term-link">
                                 PMID:12604615
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">Aha1 but not Hch1 stimulated the intrinsic ATPase activity of Hsp90 5-fold.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
+                            file:human/AHSA1/AHSA1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Falcon synthesis identifies AHSA1/AHA1 as an HSP90 co-chaperone whose primary molecular function is stimulation of the HSP90 conformational/ATPase cycle, with recent evidence for a metazoan N-terminal regulatory/holdase element.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/29127155" target="_blank" class="term-link">
                                 PMID:29127155
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">phosphorylation of Aha1-Y223 increases its affinity for Hsp90 and displaces Tsc1, thereby providing a mechanism for equilibrium between binding of these two co-chaperones to Hsp90.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27353360" target="_blank" class="term-link">
                                 PMID:27353360
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">FNIPs compete with the activating co-chaperone Aha1 for binding to Hsp90, thereby providing a reciprocal regulatory mechanism for chaperoning of client proteins.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
                             GO_REF:0000052
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/AHSA1/AHSA1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research synthesis for AHSA1</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">AHSA1/AHA1 is a cytosolic HSP90 co-chaperone and the most potent known stimulator of HSP90 ATP hydrolysis, with recent work defining ICD, NxNNWHW, and RKxK motif contributions.</div>
+
+                        <div class="finding-text">"AHSA1 (also called AHA1) encodes a conserved HSP90 co-chaperone that is the most potent known stimulator of HSP90 ATP hydrolysis."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12504007" target="_blank" class="term-link">
                             PMID:12504007
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Activation of the ATPase activity of hsp90 by the stress-regulated cochaperone aha1.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12604615" target="_blank" class="term-link">
                             PMID:12604615
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Aha1 binds to the middle domain of Hsp90, contributes to client protein activation, and stimulates the ATPase activity of the molecular chaperone.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16696853" target="_blank" class="term-link">
                             PMID:16696853
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A yeast 2-hybrid analysis of human GTP cyclohydrolase I protein interactions.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link">
                             PMID:19056867
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Large-scale proteomics and phosphoproteomics of urinary exosomes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19875381" target="_blank" class="term-link">
                             PMID:19875381
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A proteomic investigation of ligand-dependent HSP90 complexes reveals CHORDC1 as a novel ADP-dependent HSP90-interacting protein.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20618441" target="_blank" class="term-link">
                             PMID:20618441
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">CHIP participates in protein triage decisions by preferentially ubiquitinating Hsp70-bound substrates.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link">
                             PMID:25036637
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A quantitative chaperone interaction network reveals the architecture of cellular protein homeostasis pathways.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25468996" target="_blank" class="term-link">
                             PMID:25468996
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">E-cadherin interactome complexity and robustness resolved by quantitative proteomics.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25486457" target="_blank" class="term-link">
                             PMID:25486457
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Middle domain of human Hsp90 isoforms differentially binds Aha1 in human cells and alters Hsp90 activity in yeast.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27353360" target="_blank" class="term-link">
                             PMID:27353360
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The FNIP co-chaperones decelerate the Hsp90 chaperone cycle and enhance drug binding.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/29127155" target="_blank" class="term-link">
                             PMID:29127155
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Tumor suppressor Tsc1 is a new Hsp90 co-chaperone that facilitates folding of kinase and non-kinase clients.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/30382094" target="_blank" class="term-link">
                             PMID:30382094
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Structure and pro-toxic mechanism of the human Hsp90/PPIase/Tau complex.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33808352" target="_blank" class="term-link">
                             PMID:33808352
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Aha1 Exhibits Distinctive Dynamics Behavior and Chaperone-Like Activity.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link">
                             PMID:35271311
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">OpenCell: Endogenous tagging for the cartography of human cellular organization.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/37486705" target="_blank" class="term-link">
                             PMID:37486705
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Human Aha1&#39;s N-terminal extension confers it holdase activity in vitro.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1038/s44319-024-00193-8
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Recruitment of Ahsa1 to Hsp90 is regulated by a conserved peptide that inhibits ATPase stimulation.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">AHSA1 contains a metazoan-specific intrinsic chaperone domain (ICD, aa ~1-20) that dampens ATPase stimulation by interfering with NxNNWHW function and controls regulated recruitment to HSP90</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">NxNNWHW and RKxK are conserved motifs central to AHSA1 ATPase stimulatory function; RKxK stabilizes the HSP90 catalytic loop to facilitate ATP hydrolysis</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1016/j.bpj.2023.07.020
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Aha1 regulates Hsp90&#39;s conformation and function in a stoichiometry-dependent way.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">One or two Aha1 molecules can bind per HSP90 dimer, with binding stoichiometry differentially regulating HSP90 conformational properties and ATPase activity</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1093/nar/gkac528
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP90 and Aha1 modulate microRNA maturation through promoting the folding of Dicer1.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSP90 and AHA1 modulate microRNA maturation by promoting folding and stability of Dicer1; AHA1 depletion reduces Dicer1 protein and mature miRNA levels</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1186/s13046-021-02220-1
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">AHSA1 is a promising therapeutic target for cellular proliferation and proteasome inhibitor resistance in multiple myeloma.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">AHSA1 binds bufalin at K137; the inhibitor KU-177 targets the same site, reduces AHSA1-HSP90A interaction, and reverses proteasome inhibitor resistance in multiple myeloma</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.3389/fnmol.2024.1509280
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The role of Aha1 in cancer and neurodegeneration.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Review framing Aha1 dysregulation as a driver of disease phenotypes in cancer, cystic fibrosis, and neurodegeneration via HSP90 proteostasis network imbalance</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSP90/Aha1 protein-protein interaction interface proposed as a therapeutic target with potential to spare essential baseline HSP90 functions</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1038/s41580-023-00640-9
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Structural and functional complexity of HSP90 in cellular homeostasis and disease.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Authoritative review noting co-chaperone regulation by AHA1 contributes to HSP90 functional complexity in disease and discusses chemical inhibition of the Aha1-HSP90 complex</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -4128,9 +4175,9 @@ this with annotations you find in gene/protein databases, but these can be outda
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -4142,7 +4189,7 @@ this with annotations you find in gene/protein databases, but these can be outda
                 <pre><code>id: O95433
 gene_symbol: AHSA1
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -4208,6 +4255,11 @@ existing_annotations:
         supporting_text: &gt;-
           Aha1 but not Hch1 stimulated the intrinsic ATPase activity of Hsp90
           5-fold
+      - reference_id: file:human/AHSA1/AHSA1-deep-research-falcon.md
+        supporting_text: &gt;-
+          AHSA1 is the HSP90 co-chaperone that potently stimulates HSP90 ATPase
+          activity by promoting the closed, N-terminally dimerized state and
+          engaging catalytic elements of HSP90.
 - term:
     id: GO:0005829
     label: cytosol
@@ -5028,6 +5080,12 @@ core_functions:
     - reference_id: PMID:12604615
       supporting_text: &gt;-
         Aha1 but not Hch1 stimulated the intrinsic ATPase activity of Hsp90 5-fold.
+    - reference_id: file:human/AHSA1/AHSA1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Falcon synthesis identifies AHSA1/AHA1 as an HSP90 co-chaperone whose
+        primary molecular function is stimulation of the HSP90
+        conformational/ATPase cycle, with recent evidence for a metazoan
+        N-terminal regulatory/holdase element.
     - reference_id: PMID:29127155
       supporting_text: &gt;-
         phosphorylation of Aha1-Y223 increases its affinity for Hsp90 and displaces
@@ -5057,6 +5115,16 @@ references:
 - id: GO_REF:0000120
   title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
+- id: file:human/AHSA1/AHSA1-deep-research-falcon.md
+  title: Falcon deep research synthesis for AHSA1
+  findings:
+  - statement: &gt;-
+      AHSA1/AHA1 is a cytosolic HSP90 co-chaperone and the most potent known
+      stimulator of HSP90 ATP hydrolysis, with recent work defining ICD,
+      NxNNWHW, and RKxK motif contributions.
+    supporting_text: &gt;-
+      AHSA1 (also called AHA1) encodes a conserved HSP90 co-chaperone that is
+      the most potent known stimulator of HSP90 ATP hydrolysis.
 - id: PMID:12504007
   title: Activation of the ATPase activity of hsp90 by the stress-regulated cochaperone
     aha1.
@@ -5171,7 +5239,7 @@ references:
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/AHSA1/AHSA1-ai-review.yaml
+++ b/genes/human/AHSA1/AHSA1-ai-review.yaml
@@ -1,7 +1,7 @@
 id: O95433
 gene_symbol: AHSA1
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -67,6 +67,11 @@ existing_annotations:
         supporting_text: >-
           Aha1 but not Hch1 stimulated the intrinsic ATPase activity of Hsp90
           5-fold
+      - reference_id: file:human/AHSA1/AHSA1-deep-research-falcon.md
+        supporting_text: >-
+          AHSA1 is the HSP90 co-chaperone that potently stimulates HSP90 ATPase
+          activity by promoting the closed, N-terminally dimerized state and
+          engaging catalytic elements of HSP90.
 - term:
     id: GO:0005829
     label: cytosol
@@ -887,6 +892,12 @@ core_functions:
     - reference_id: PMID:12604615
       supporting_text: >-
         Aha1 but not Hch1 stimulated the intrinsic ATPase activity of Hsp90 5-fold.
+    - reference_id: file:human/AHSA1/AHSA1-deep-research-falcon.md
+      supporting_text: >-
+        Falcon synthesis identifies AHSA1/AHA1 as an HSP90 co-chaperone whose
+        primary molecular function is stimulation of the HSP90
+        conformational/ATPase cycle, with recent evidence for a metazoan
+        N-terminal regulatory/holdase element.
     - reference_id: PMID:29127155
       supporting_text: >-
         phosphorylation of Aha1-Y223 increases its affinity for Hsp90 and displaces
@@ -916,6 +927,16 @@ references:
 - id: GO_REF:0000120
   title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
+- id: file:human/AHSA1/AHSA1-deep-research-falcon.md
+  title: Falcon deep research synthesis for AHSA1
+  findings:
+  - statement: >-
+      AHSA1/AHA1 is a cytosolic HSP90 co-chaperone and the most potent known
+      stimulator of HSP90 ATP hydrolysis, with recent work defining ICD,
+      NxNNWHW, and RKxK motif contributions.
+    supporting_text: >-
+      AHSA1 (also called AHA1) encodes a conserved HSP90 co-chaperone that is
+      the most potent known stimulator of HSP90 ATP hydrolysis.
 - id: PMID:12504007
   title: Activation of the ATPase activity of hsp90 by the stress-regulated cochaperone
     aha1.

--- a/genes/human/DNAJB8/DNAJB8-ai-review.html
+++ b/genes/human/DNAJB8/DNAJB8-ai-review.html
@@ -797,12 +797,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IBA annotation for cytoplasm localization is well supported. DNAJB8 is a cytoplasmic J-domain co-chaperone. Hageman et al. (PMID:21231916) showed by direct assay that DNAJB8 localizes to the cytosol (IDA for GO:0005829, cytosol). The IBA phylogenetic inference is consistent with experimental data for both DNAJB8 and its close paralogue DNAJB6, which is also cytoplasmic. Note that cytoplasm (GO:0005737) is broader than cytosol (GO:0005829) but the IBA annotation at this level is appropriate given the phylogenetic evidence base.
+                            <strong>Summary:</strong> IBA annotation for cytoplasm localization is well supported. DNAJB8 is a cytoplasmic J-domain co-chaperone. The GOA record includes IDA evidence for the more specific cytosol term (GO:0005829) from PMID:21231916, and the cached abstract states that most human HSP70/HSPA and HSP40/DNAJ proteins are localized in the cytosol. The IBA phylogenetic inference is consistent with experimental data for both DNAJB8 and its close paralogue DNAJB6, which is also cytoplasmic. Note that cytoplasm (GO:0005737) is broader than cytosol (GO:0005829) but the IBA annotation at this level is appropriate given the phylogenetic evidence base.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Cytoplasmic localization is confirmed by IDA evidence from PMID:21231916 for the more specific term cytosol (GO:0005829), and is consistent with the function of DNAJB8 as a cytoplasmic holdase chaperone that suppresses polyQ aggregation (PMID:20159555). The IBA inference is phylogenetically sound given conservation across DNAJB6/DNAJB8 orthologues.
+                            <strong>Reason:</strong> Cytoplasmic localization is consistent with the GOA IDA evidence from PMID:21231916 for the more specific term cytosol (GO:0005829), and with the function of DNAJB8 as a cytoplasmic holdase chaperone that suppresses polyQ aggregation (PMID:20159555). The IBA inference is phylogenetically sound given conservation across DNAJB6/DNAJB8 orthologues.
                         </div>
 
 
@@ -819,7 +819,7 @@
 
                                 </span>
 
-                                <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
+                                <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol.</div>
 
                             </div>
 
@@ -961,31 +961,18 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IBA annotation for nuclear localization is well supported. DNAJB8 has been shown to localize to the nucleus by IDA (PMID:21231916) and HDA (PMID:21630459, sperm nuclear proteomics). The IBA phylogenetic inference is consistent with experimental data for DNAJB8 itself and with the known nuclear localization of its close paralogue DNAJB6a.
+                            <strong>Summary:</strong> IBA annotation for nuclear localization is supported by HDA evidence from PMID:21630459, a sperm nuclear proteomics study, and by the GOA IDA record from PMID:21231916. The cached PMID:21231916 abstract available here does not include the localization figure, so the explicit text support below is the independent sperm nuclear proteomics evidence. The IBA phylogenetic inference is consistent with experimental data for DNAJB8 itself and with the known nuclear localization of its close paralogue DNAJB6a.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Nuclear localization of DNAJB8 is confirmed by multiple independent lines of evidence: IDA from PMID:21231916 (direct assay showing nuclear localization) and HDA from PMID:21630459 (identified in human sperm nuclear proteome). The IBA phylogenetic inference is consistent with these experimental observations and with the dual cytosol/nucleus localization pattern of the DNAJB6/B8 subfamily.
+                            <strong>Reason:</strong> Nuclear localization is supported by sperm nuclear proteomics (PMID:21630459) and is consistent with the GOA IDA localization record from PMID:21231916. The IBA phylogenetic inference is consistent with these observations and with the dual cytosol/nucleus localization pattern of the DNAJB6/B8 subfamily.
                         </div>
 
 
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
-                                        PMID:21231916
-                                    </a>
-
-                                </span>
-
-                                <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding.</div>
-
-                            </div>
 
                             <div class="support-item">
                                 <span class="support-ref">
@@ -1810,31 +1797,18 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IDA annotation for nuclear localization from Hageman et al. (PMID:21231916). This study examined the subcellular localization of overexpressed DNAJB8 using fluorescence microscopy or similar direct assays, demonstrating both nuclear and cytosolic localization. Nuclear localization is independently supported by the HDA annotation from PMID:21630459 (sperm nuclear proteomics) and the IBA phylogenetic inference. The close paralogue DNAJB6 also shows nuclear localization, with the DNAJB6a isoform being predominantly nuclear. DNAJB8 localizes to both cytosol and nucleus, consistent with the description in UniProt.
+                            <strong>Summary:</strong> IDA annotation for nuclear localization from Hageman et al. (PMID:21231916). The cached PMID:21231916 abstract available here does not include the localization figure, so the explicit text support below uses the independent HDA annotation from PMID:21630459 (sperm nuclear proteomics). The close paralogue DNAJB6 also shows nuclear localization, with the DNAJB6a isoform being predominantly nuclear. DNAJB8 localizes to both cytosol and nucleus, consistent with the description in UniProt.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Nuclear localization is directly demonstrated by Hageman et al. (PMID:21231916) and independently confirmed by sperm nuclear proteomics (PMID:21630459). The dual cytosol/nucleus localization is consistent with the known biology of the DNAJB6/B8 subfamily and with a potential role in nuclear proteostasis.
+                            <strong>Reason:</strong> Nuclear localization is represented in GOA by the IDA record from PMID:21231916 and independently supported by sperm nuclear proteomics (PMID:21630459). The dual cytosol/nucleus localization is consistent with the known biology of the DNAJB6/B8 subfamily and with a potential role in nuclear proteostasis.
                         </div>
 
 
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
-                                        PMID:21231916
-                                    </a>
-
-                                </span>
-
-                                <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding.</div>
-
-                            </div>
 
                             <div class="support-item">
                                 <span class="support-ref">
@@ -1903,12 +1877,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IDA annotation for cytosol localization from Hageman et al. (PMID:21231916). DNAJB8 was shown by direct assay to localize to the cytosol. This is consistent with its function as a cytoplasmic holdase chaperone that suppresses polyQ protein aggregation (PMID:20159555, PMID:23612975). The cytosol is the primary site where DNAJB8 encounters and binds aggregation-prone substrates. This is also consistent with the IBA annotation for the broader term cytoplasm (GO:0005737).
+                            <strong>Summary:</strong> IDA annotation for cytosol localization from Hageman et al. (PMID:21231916). The cached abstract states that most human HSP70/HSPA and HSP40/DNAJ proteins are cytosolic. This is consistent with its function as a cytoplasmic holdase chaperone that suppresses polyQ protein aggregation (PMID:20159555, PMID:23612975). The cytosol is the primary site where DNAJB8 encounters and binds aggregation-prone substrates. This is also consistent with the IBA annotation for the broader term cytoplasm (GO:0005737).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Cytosolic localization is directly demonstrated by Hageman et al. (PMID:21231916) and is consistent with the primary function of DNAJB8 as a cytoplasmic holdase chaperone. The cytosol is where polyQ-expanded proteins aggregate and where DNAJB8 exerts its anti-aggregation activity.
+                            <strong>Reason:</strong> Cytosolic localization is recorded by GOA from Hageman et al. (PMID:21231916) and is consistent with the primary function of DNAJB8 as a cytoplasmic holdase chaperone. The cytosol is where polyQ-expanded proteins aggregate and where DNAJB8 exerts its anti-aggregation activity.
                         </div>
 
 
@@ -1938,7 +1912,7 @@
 
                                 </span>
 
-                                <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding.</div>
+                                <div class="support-text">Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding genes and most of the corresponding proteins are localized in the cytosol.</div>
 
                             </div>
 
@@ -2219,12 +2193,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> HDA annotation for nuclear localization from de Mateo et al. (PMID:21630459), a proteomic characterization of the human sperm nucleus. DNAJB8 was identified among 403 proteins in isolated human sperm nuclei by LC-MS/MS. DNAJB8 is enriched in testis (HPA: tissue enriched in testis; Bgee: expressed in sperm), so its detection in the sperm nuclear proteome is biologically plausible. However, this is a high-throughput proteomics study and the nuclear detection could reflect a genuine nuclear pool or could be a consequence of the protein being highly abundant in testis. The nuclear localization is independently supported by IDA evidence from PMID:21231916. DNAJB8 is known to localize to both cytosol and nucleus.
+                            <strong>Summary:</strong> HDA annotation for nuclear localization from de Mateo et al. (PMID:21630459), a proteomic characterization of the human sperm nucleus. DNAJB8 was identified among 403 proteins in isolated human sperm nuclei by LC-MS/MS. DNAJB8 is enriched in testis (HPA: tissue enriched in testis; Bgee: expressed in sperm), so its detection in the sperm nuclear proteome is biologically plausible. However, this is a high-throughput proteomics study and the nuclear detection could reflect a genuine nuclear pool or could be a consequence of the protein being highly abundant in testis. The nuclear localization is consistent with the GOA IDA record from PMID:21231916. DNAJB8 is known to localize to both cytosol and nucleus.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> The HDA evidence from sperm nuclear proteomics is consistent with the IDA evidence for nuclear localization from PMID:21231916 and with the IBA phylogenetic inference. While high-throughput proteomics can have contaminants, the fact that DNAJB8 is testis-enriched and independently shown to be nuclear by direct assay supports the biological relevance of this detection. The annotation is well corroborated.
+                            <strong>Reason:</strong> The HDA evidence from sperm nuclear proteomics is consistent with the IDA localization record from PMID:21231916 and with the IBA phylogenetic inference. While high-throughput proteomics can have contaminants, the fact that DNAJB8 is testis-enriched and independently represented in GOA as nuclear by direct assay supports the biological relevance of this detection. The annotation is well corroborated.
                         </div>
 
 
@@ -2242,19 +2216,6 @@
                                 </span>
 
                                 <div class="support-text">With this approach, 403 different proteins have been identified from the isolated sperm nuclei. The most abundant family of proteins identified are the histones, for which several novel members had not been reported previously as present in the spermatogenic cell line or in the human mature spermatozoa.</div>
-
-                            </div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
-                                        PMID:21231916
-                                    </a>
-
-                                </span>
-
-                                <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding.</div>
 
                             </div>
 
@@ -3247,26 +3208,26 @@ existing_annotations:
   review:
     summary: &gt;-
       IBA annotation for cytoplasm localization is well supported. DNAJB8 is a
-      cytoplasmic J-domain co-chaperone. Hageman et al. (PMID:21231916) showed by
-      direct assay that DNAJB8 localizes to the cytosol (IDA for GO:0005829,
-      cytosol). The IBA phylogenetic inference is consistent with experimental
-      data for both DNAJB8 and its close paralogue DNAJB6, which is also
-      cytoplasmic. Note that cytoplasm (GO:0005737) is broader than cytosol
-      (GO:0005829) but the IBA annotation at this level is appropriate given the
-      phylogenetic evidence base.
+      cytoplasmic J-domain co-chaperone. The GOA record includes IDA evidence for
+      the more specific cytosol term (GO:0005829) from PMID:21231916, and the
+      cached abstract states that most human HSP70/HSPA and HSP40/DNAJ proteins
+      are localized in the cytosol. The IBA phylogenetic inference is consistent
+      with experimental data for both DNAJB8 and its close paralogue DNAJB6, which
+      is also cytoplasmic. Note that cytoplasm (GO:0005737) is broader than
+      cytosol (GO:0005829) but the IBA annotation at this level is appropriate
+      given the phylogenetic evidence base.
     action: ACCEPT
     reason: &gt;-
-      Cytoplasmic localization is confirmed by IDA evidence from PMID:21231916
-      for the more specific term cytosol (GO:0005829), and is consistent with the
+      Cytoplasmic localization is consistent with the GOA IDA evidence from
+      PMID:21231916 for the more specific term cytosol (GO:0005829), and with the
       function of DNAJB8 as a cytoplasmic holdase chaperone that suppresses polyQ
       aggregation (PMID:20159555). The IBA inference is phylogenetically sound
       given conservation across DNAJB6/DNAJB8 orthologues.
     supported_by:
     - reference_id: PMID:21231916
       supporting_text: &gt;-
-        Overexpressed chaperones that suppressed polyQ aggregation were found not
-        to be able to stimulate luciferase refolding. Inversely, chaperones that
-        supported luciferase refolding were poor suppressors of polyQ aggregation.
+        Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding
+        genes and most of the corresponding proteins are localized in the cytosol.
     - reference_id: PMID:20159555
       supporting_text: &gt;-
         members of a subclass of the DNAJB family (particularly DNAJB6b and
@@ -3316,24 +3277,21 @@ existing_annotations:
   original_reference_id: GO_REF:0000033
   review:
     summary: &gt;-
-      IBA annotation for nuclear localization is well supported. DNAJB8 has been
-      shown to localize to the nucleus by IDA (PMID:21231916) and HDA
-      (PMID:21630459, sperm nuclear proteomics). The IBA phylogenetic inference
-      is consistent with experimental data for DNAJB8 itself and with the known
-      nuclear localization of its close paralogue DNAJB6a.
+      IBA annotation for nuclear localization is supported by HDA evidence from
+      PMID:21630459, a sperm nuclear proteomics study, and by the GOA IDA record
+      from PMID:21231916. The cached PMID:21231916 abstract available here does
+      not include the localization figure, so the explicit text support below is
+      the independent sperm nuclear proteomics evidence. The IBA phylogenetic
+      inference is consistent with experimental data for DNAJB8 itself and with
+      the known nuclear localization of its close paralogue DNAJB6a.
     action: ACCEPT
     reason: &gt;-
-      Nuclear localization of DNAJB8 is confirmed by multiple independent lines
-      of evidence: IDA from PMID:21231916 (direct assay showing nuclear
-      localization) and HDA from PMID:21630459 (identified in human sperm nuclear
-      proteome). The IBA phylogenetic inference is consistent with these
-      experimental observations and with the dual cytosol/nucleus localization
-      pattern of the DNAJB6/B8 subfamily.
+      Nuclear localization is supported by sperm nuclear proteomics
+      (PMID:21630459) and is consistent with the GOA IDA localization record from
+      PMID:21231916. The IBA phylogenetic inference is consistent with these
+      observations and with the dual cytosol/nucleus localization pattern of the
+      DNAJB6/B8 subfamily.
     supported_by:
-    - reference_id: PMID:21231916
-      supporting_text: &gt;-
-        Overexpressed chaperones that suppressed polyQ aggregation were found not
-        to be able to stimulate luciferase refolding.
     - reference_id: PMID:21630459
       supporting_text: &gt;-
         403 different proteins have been identified from the isolated sperm
@@ -3666,26 +3624,20 @@ existing_annotations:
   review:
     summary: &gt;-
       IDA annotation for nuclear localization from Hageman et al.
-      (PMID:21231916). This study examined the subcellular localization of
-      overexpressed DNAJB8 using fluorescence microscopy or similar direct
-      assays, demonstrating both nuclear and cytosolic localization. Nuclear
-      localization is independently supported by the HDA annotation from
-      PMID:21630459 (sperm nuclear proteomics) and the IBA phylogenetic
-      inference. The close paralogue DNAJB6 also shows nuclear localization,
-      with the DNAJB6a isoform being predominantly nuclear. DNAJB8 localizes
-      to both cytosol and nucleus, consistent with the description in UniProt.
+      (PMID:21231916). The cached PMID:21231916 abstract available here does not
+      include the localization figure, so the explicit text support below uses
+      the independent HDA annotation from PMID:21630459 (sperm nuclear
+      proteomics). The close paralogue DNAJB6 also shows nuclear localization,
+      with the DNAJB6a isoform being predominantly nuclear. DNAJB8 localizes to
+      both cytosol and nucleus, consistent with the description in UniProt.
     action: ACCEPT
     reason: &gt;-
-      Nuclear localization is directly demonstrated by Hageman et al.
-      (PMID:21231916) and independently confirmed by sperm nuclear proteomics
+      Nuclear localization is represented in GOA by the IDA record from
+      PMID:21231916 and independently supported by sperm nuclear proteomics
       (PMID:21630459). The dual cytosol/nucleus localization is consistent with
-      the known biology of the DNAJB6/B8 subfamily and with a potential role
-      in nuclear proteostasis.
+      the known biology of the DNAJB6/B8 subfamily and with a potential role in
+      nuclear proteostasis.
     supported_by:
-    - reference_id: PMID:21231916
-      supporting_text: &gt;-
-        Overexpressed chaperones that suppressed polyQ aggregation were found not
-        to be able to stimulate luciferase refolding.
     - reference_id: PMID:21630459
       supporting_text: &gt;-
         403 different proteins have been identified from the isolated sperm
@@ -3698,17 +3650,18 @@ existing_annotations:
   review:
     summary: &gt;-
       IDA annotation for cytosol localization from Hageman et al.
-      (PMID:21231916). DNAJB8 was shown by direct assay to localize to the
-      cytosol. This is consistent with its function as a cytoplasmic holdase
+      (PMID:21231916). The cached abstract states that most human HSP70/HSPA and
+      HSP40/DNAJ proteins are cytosolic. This is consistent with its function as
+      a cytoplasmic holdase
       chaperone that suppresses polyQ protein aggregation (PMID:20159555,
       PMID:23612975). The cytosol is the primary site where DNAJB8 encounters
       and binds aggregation-prone substrates. This is also consistent with the
       IBA annotation for the broader term cytoplasm (GO:0005737).
     action: ACCEPT
     reason: &gt;-
-      Cytosolic localization is directly demonstrated by Hageman et al.
-      (PMID:21231916) and is consistent with the primary function of DNAJB8 as
-      a cytoplasmic holdase chaperone. The cytosol is where polyQ-expanded
+      Cytosolic localization is recorded by GOA from Hageman et al.
+      (PMID:21231916) and is consistent with the primary function of DNAJB8 as a
+      cytoplasmic holdase chaperone. The cytosol is where polyQ-expanded
       proteins aggregate and where DNAJB8 exerts its anti-aggregation activity.
     supported_by:
     - reference_id: PMID:20159555
@@ -3718,8 +3671,8 @@ existing_annotations:
         disease-associated polyglutamine proteins.
     - reference_id: PMID:21231916
       supporting_text: &gt;-
-        Overexpressed chaperones that suppressed polyQ aggregation were found not
-        to be able to stimulate luciferase refolding.
+        Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding
+        genes and most of the corresponding proteins are localized in the cytosol.
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -3847,16 +3800,16 @@ existing_annotations:
       is biologically plausible. However, this is a high-throughput proteomics
       study and the nuclear detection could reflect a genuine nuclear pool or
       could be a consequence of the protein being highly abundant in testis.
-      The nuclear localization is independently supported by IDA evidence from
+      The nuclear localization is consistent with the GOA IDA record from
       PMID:21231916. DNAJB8 is known to localize to both cytosol and nucleus.
     action: ACCEPT
     reason: &gt;-
       The HDA evidence from sperm nuclear proteomics is consistent with the IDA
-      evidence for nuclear localization from PMID:21231916 and with the IBA
-      phylogenetic inference. While high-throughput proteomics can have
+      localization record from PMID:21231916 and with the IBA phylogenetic
+      inference. While high-throughput proteomics can have
       contaminants, the fact that DNAJB8 is testis-enriched and independently
-      shown to be nuclear by direct assay supports the biological relevance of
-      this detection. The annotation is well corroborated.
+      represented in GOA as nuclear by direct assay supports the biological
+      relevance of this detection. The annotation is well corroborated.
     supported_by:
     - reference_id: PMID:21630459
       supporting_text: &gt;-
@@ -3865,10 +3818,6 @@ existing_annotations:
         are the histones, for which several novel members had not been reported
         previously as present in the spermatogenic cell line or in the human
         mature spermatozoa.
-    - reference_id: PMID:21231916
-      supporting_text: &gt;-
-        Overexpressed chaperones that suppressed polyQ aggregation were found not
-        to be able to stimulate luciferase refolding.
 - term:
     id: GO:0006457
     label: protein folding

--- a/genes/human/DNAJB8/DNAJB8-ai-review.html
+++ b/genes/human/DNAJB8/DNAJB8-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>DNAJB8</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/Q8NHS0" target="_blank" class="term-link">
                         Q8NHS0
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>DNAJB8 is a class B J-domain protein (Hsp40/DNAJ family, subfamily B) that functions as a potent holdase chaperone suppressing polyglutamine and other aggregation-prone protein aggregation. Its domain architecture comprises an N-terminal J-domain (JD), a G/F-rich region, an S/T-rich region containing the key 147-AFSSFN-152 steric-zipper oligomerization motif, and a C-terminal domain (CTD). A key regulatory mechanism is an intramolecular JD-CTD interaction that can sequester the JD surface and control Hsp70 recruitment as a reversible switch (DOI:10.1038/s41467-021-21147-x). Unlike canonical DNAJ co-chaperones that assist Hsp70-mediated protein refolding, DNAJB8 acts primarily as a holdase, with anti-aggregation activity largely independent of the J-domain residing in the C-terminal serine-rich (SSF-SST) region and C-terminal tail (PMID:20159555). DNAJB8 self-assembles into oligomeric puncta via the AFSSFN steric-zipper motif (resolved at 0.75 angstrom by MicroED, class 6 steric zipper), but engineered monomeric variants retain substrate binding and anti-aggregation function, demonstrating that oligomerization is mechanistically separable from chaperone activity (DOI:10.1016/j.str.2024.02.015). DNAJB8 uses distinct substrate-binding modes: a serine-rich stretch for fibrillar/amyloid aggregation suppression and a separate CTD TTK-LKS motif for amorphous inclusion suppression via Hsp70-dependent proteasomal degradation (DOI:10.1242/jcs.255596). DNAJB8 is also a cancer-testis antigen preferentially expressed in renal and colorectal cancer stem-like cells, controlling tumor-initiating capacity (DOI:10.1158/0008-5472.CAN-11-3062), and promotes oxaliplatin chemoresistance in colon cancer via TP53 stabilization leading to MDR1/P-gp upregulation (DOI:10.1038/s41419-022-04599-x). DNAJB8 is enriched in testis but expressed in multiple tissues, and localizes to both cytosol and nucleus.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,77 +795,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for cytoplasm localization is well supported. DNAJB8 is a cytoplasmic J-domain co-chaperone. Hageman et al. (PMID:21231916) showed by direct assay that DNAJB8 localizes to the cytosol (IDA for GO:0005829, cytosol). The IBA phylogenetic inference is consistent with experimental data for both DNAJB8 and its close paralogue DNAJB6, which is also cytoplasmic. Note that cytoplasm (GO:0005737) is broader than cytosol (GO:0005829) but the IBA annotation at this level is appropriate given the phylogenetic evidence base.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization is confirmed by IDA evidence from PMID:21231916 for the more specific term cytosol (GO:0005829), and is consistent with the function of DNAJB8 as a cytoplasmic holdase chaperone that suppresses polyQ aggregation (PMID:20159555). The IBA inference is phylogenetically sound given conservation across DNAJB6/DNAJB8 orthologues.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20159555" target="_blank" class="term-link">
                                         PMID:20159555
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">members of a subclass of the DNAJB family (particularly DNAJB6b and DNAJB8) are superior suppressors of aggregation and toxicity of disease-associated polyglutamine proteins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -877,77 +877,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for protein folding (GO:0006457) is broadly acceptable as DNAJB8 is a J-domain co-chaperone involved in proteostasis. However, DNAJB8 acts primarily as a holdase that suppresses aggregation of polyQ-expanded proteins rather than promoting productive protein folding (PMID:21231916, PMID:20159555). Hageman et al. (PMID:21231916) showed that chaperones suppressing polyQ aggregation (like DNAJB8) could not stimulate luciferase refolding, distinguishing holdase from foldase activities. The term protein folding is therefore somewhat imprecise for DNAJB8, but the broader proteostasis role is real. As an IBA annotation it represents a reasonable phylogenetic inference at an appropriate level of specificity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Although DNAJB8 is functionally a holdase rather than a canonical foldase, it participates in the broader protein folding quality control network as a J-domain co-chaperone. The IBA phylogenetic inference is sound for the DNAJB subfamily. The qualifier in GOA is &#39;involved_in&#39; which is appropriate for a chaperone that participates in protein folding pathways even if its specific role is aggregation suppression rather than productive folding. Experimental support comes from PMID:23612975 (IDA for the same term) and PMID:20159555.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23612975" target="_blank" class="term-link">
                                         PMID:23612975
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we expressed polyQ peptides in cells and show that their intracellular aggregation is prevented by DNAJB6 and DNAJB8, members of the DNAJ (Hsp40) chaperone family.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -959,77 +959,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for nuclear localization is well supported. DNAJB8 has been shown to localize to the nucleus by IDA (PMID:21231916) and HDA (PMID:21630459, sperm nuclear proteomics). The IBA phylogenetic inference is consistent with experimental data for DNAJB8 itself and with the known nuclear localization of its close paralogue DNAJB6a.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear localization of DNAJB8 is confirmed by multiple independent lines of evidence: IDA from PMID:21231916 (direct assay showing nuclear localization) and HDA from PMID:21630459 (identified in human sperm nuclear proteome). The IBA phylogenetic inference is consistent with these experimental observations and with the dual cytosol/nucleus localization pattern of the DNAJB6/B8 subfamily.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link">
                                         PMID:21630459
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">403 different proteins have been identified from the isolated sperm nuclei.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1041,77 +1041,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for protein-folding chaperone binding (GO:0051087) is well supported. DNAJB8 is a J-domain co-chaperone that physically interacts with Hsp70 family members (HSPA1A/P0DMV8, HSPA1B/P0DMV9, HSPA6/P17066) as shown by IPI evidence from PMID:21231916. The J-domain of DNAJB8 stimulates Hsp70 ATPase activity, which is the canonical mechanism of J-domain protein function. The IBA phylogenetic inference is consistent with this being a core function of J-domain proteins across the DNAJB subfamily.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Chaperone binding is a core molecular function of J-domain proteins. DNAJB8 contains a canonical J-domain (residues 3-69, UniProt) that mediates interaction with Hsp70 chaperones. IPI evidence from PMID:21231916 directly demonstrates physical interaction with multiple Hsp70 family members. The IBA phylogenetic inference is phylogenetically sound and at the right level of specificity.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20159555" target="_blank" class="term-link">
                                         PMID:20159555
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The antiaggregation activity is largely independent of the N-terminal Hsp70-interacting J-domain. Rather, a C-terminal serine-rich (SSF-SST) region and the C-terminal tail are essential.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     GO:0044183
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1123,77 +1123,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for protein folding chaperone (GO:0044183) is well supported and represents a core molecular function of DNAJB8. This term describes the activity of binding to a protein to assist the protein folding process, which is the canonical function of J-domain co-chaperones. DNAJB8 specifically acts as a holdase chaperone that binds polyQ-expanded proteins and other aggregation-prone substrates to prevent their aggregation (PMID:20159555, PMID:23612975). IDA evidence for this same term exists from PMID:23612975. The IBA phylogenetic inference is sound and at the right level of specificity for the DNAJB subfamily.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0044183 (protein folding chaperone) is the best available GO molecular function term for DNAJB8&#39;s holdase/anti-aggregation chaperone activity. DNAJB8 binds aggregation-prone substrates to prevent their misfolding and aggregation, which falls within the scope of this term. IDA evidence from PMID:23612975 independently supports this annotation. The IBA phylogenetic inference is consistent with the conserved chaperone function across the DNAJB6/B8 clade.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23612975" target="_blank" class="term-link">
                                         PMID:23612975
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we conclude that the mechanism of DNAJB6 and DNAJB8 is suppression of polyQ protein aggregation by directly binding the polyQ tract.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20159555" target="_blank" class="term-link">
                                         PMID:20159555
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">members of a subclass of the DNAJB family (particularly DNAJB6b and DNAJB8) are superior suppressors of aggregation and toxicity of disease-associated polyglutamine proteins.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/DNAJB8/DNAJB8-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Multiple studies place DNAJB8 among potent anti-aggregation DNAJBs, particularly against polyglutamine aggregation, with holdase activity that can be partly independent of canonical J-domain/Hsp70 co-chaperone action.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1205,88 +1216,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962). While DNAJB8 does bind unfolded/aggregation-prone substrates, this term does not accurately capture its functional activity. DNAJB8 is a holdase chaperone that binds polyQ-expanded proteins and other aggregation-prone substrates to prevent their aggregation, largely independently of Hsp70 (PMID:20159555). The best available replacement term is GO:0044183 (protein folding chaperone), which is already annotated via IBA and IDA evidence for this gene. Note that DNAJB8 is functionally a holdase rather than a foldase, but no dedicated holdase term currently exists in GO.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. DNAJB8 does bind unfolded/misfolded proteins, but this binding is in the context of its holdase chaperone activity -- it prevents aggregation of polyQ substrates rather than merely binding unfolded proteins passively. The recommended interim replacement is GO:0044183 (protein folding chaperone), which better captures the functional activity, though it is imprecise for a holdase. DNAJB8 already has GO:0044183 annotations (IBA and IDA), so this modification aligns the annotation set. Hageman et al. (PMID:20159555) showed that the anti-aggregation activity of DNAJB8 is largely independent of the J-domain and resides in the C-terminal serine-rich region, demonstrating direct substrate binding in a holdase capacity. Gillis et al. (PMID:23612975) confirmed that DNAJB6 and DNAJB8 inhibit polyQ peptide aggregation directly by binding the polyQ tract.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20159555" target="_blank" class="term-link">
                                         PMID:20159555
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">members of a subclass of the DNAJB family (particularly DNAJB6b and DNAJB8) are superior suppressors of aggregation and toxicity of disease-associated polyglutamine proteins. The antiaggregation activity is largely independent of the N-terminal Hsp70-interacting J-domain. Rather, a C-terminal serine-rich (SSF-SST) region and the C-terminal tail are essential. The SSF-SST region is involved in substrate binding, formation of polydisperse oligomeric complexes, and interaction with histone deacetylases (HDAC4, HDAC6, SIRT2).</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23612975" target="_blank" class="term-link">
                                         PMID:23612975
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we conclude that the mechanism of DNAJB6 and DNAJB8 is suppression of polyQ protein aggregation by directly binding the polyQ tract.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1298,64 +1309,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for cytoplasm localization from ARBA machine learning models. This is consistent with the IBA annotation for cytoplasm and the IDA annotation for the more specific term cytosol (GO:0005829) from PMID:21231916. The IEA annotation is broader than the experimentally determined cytosol localization but is not incorrect.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization is confirmed by IDA evidence for cytosol (PMID:21231916) and by IBA phylogenetic inference. The IEA annotation is redundant with but consistent with higher-quality evidence. Acceptable as a broader computational annotation that aligns with experimental data.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030544" target="_blank" class="term-link">
                                     GO:0030544
                                 </a>
                             </span>
                             <span class="term-label">Hsp70 protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1367,77 +1378,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for Hsp70 protein binding (GO:0030544) inferred from the InterPro domain IPR043183 (DNJB2/6-like). DNAJB8 contains a canonical J-domain (residues 3-69) that mediates physical interaction with Hsp70 family chaperones. Hageman et al. (PMID:21231916) demonstrated by IPI that DNAJB8 physically interacts with HSPA1A (P0DMV8), HSPA1B (P0DMV9), and HSPA6 (P17066), all Hsp70 family members. While the IPI annotations are curated under the broader GO:0051087 (protein-folding chaperone binding), Hsp70 binding is a well-established core function of J-domain proteins. This IEA annotation is more specific than GO:0051087 regarding the binding partner identity and is well supported.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Hsp70 binding is the canonical function of J-domain proteins. DNAJB8 has a well-characterized J-domain (UniProt domain annotation, residues 3-69) and IPI evidence from PMID:21231916 confirms physical interaction with three Hsp70 family members. The InterPro-based IEA inference from IPR043183 is correct and specific. Hageman et al. (PMID:20159555) further showed that while the antiaggregation activity of DNAJB8 is largely J-domain independent, the J-domain still mediates Hsp70 interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20159555" target="_blank" class="term-link">
                                         PMID:20159555
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The antiaggregation activity is largely independent of the N-terminal Hsp70-interacting J-domain. Rather, a C-terminal serine-rich (SSF-SST) region and the C-terminal tail are essential.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1449,88 +1460,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962). This IEA annotation was inferred from the InterPro domain IPR043183 (DNJB2/6-like), which is shared across DNAJB2, DNAJB6, and DNAJB8. While these proteins do interact with unfolded/misfolded substrates, the term fails to capture the functional nature of the interaction. DNAJB8 specifically acts as a holdase chaperone that suppresses aggregation of polyQ-expanded proteins by directly binding the polyQ tract (PMID:20159555, PMID:23612975). The best interim replacement is GO:0044183 (protein folding chaperone), noting that DNAJB8 is a holdase rather than a foldase and no dedicated holdase GO term currently exists.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. The InterPro-based IEA mapping from IPR043183 correctly identified that DNAJB8 interacts with unfolded substrates, but GO:0044183 (protein folding chaperone) is the recommended replacement that better captures the functional chaperone activity. DNAJB8 already has GO:0044183 annotations from both IBA and IDA evidence. Caveat: DNAJB8 functions as a holdase rather than a foldase -- it suppresses aggregation rather than promoting productive folding -- but GO currently lacks a dedicated holdase term.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20159555" target="_blank" class="term-link">
                                         PMID:20159555
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">members of a subclass of the DNAJB family (particularly DNAJB6b and DNAJB8) are superior suppressors of aggregation and toxicity of disease-associated polyglutamine proteins. The antiaggregation activity is largely independent of the N-terminal Hsp70-interacting J-domain.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23612975" target="_blank" class="term-link">
                                         PMID:23612975
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we conclude that the mechanism of DNAJB6 and DNAJB8 is suppression of polyQ protein aggregation by directly binding the polyQ tract.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1542,64 +1553,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for protein-folding chaperone binding from ARBA machine learning models. This is consistent with the IBA annotation and the IPI evidence from PMID:21231916 showing DNAJB8 physically interacts with Hsp70 chaperones (HSPA1A, HSPA1B, HSPA6). The computational inference is correct and redundant with higher-quality evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein-folding chaperone binding is well established for DNAJB8 through IPI evidence (PMID:21231916) and IBA phylogenetic inference. The IEA annotation is redundant with but consistent with these higher-quality annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090084" target="_blank" class="term-link">
                                     GO:0090084
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of inclusion body assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1611,88 +1622,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for negative regulation of inclusion body assembly from ARBA machine learning models. DNAJB8 is a potent suppressor of polyQ protein aggregation and inclusion body formation (PMID:20159555, PMID:23612975). Hageman et al. (PMID:20159555) demonstrated that DNAJB8 suppresses aggregation and toxicity of disease-associated polyglutamine proteins. Gillis et al. (PMID:23612975) showed that DNAJB8 prevents intracellular aggregation of polyQ peptides. This is a core function of DNAJB8 and the IEA annotation is well supported by IDA evidence from PMID:21231916 for the same term.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Negative regulation of inclusion body assembly is a core function of DNAJB8, supported by IDA evidence from PMID:21231916 and extensive experimental literature (PMID:20159555, PMID:23612975). The IEA annotation is redundant with but consistent with the higher-quality IDA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20159555" target="_blank" class="term-link">
                                         PMID:20159555
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">members of a subclass of the DNAJB family (particularly DNAJB6b and DNAJB8) are superior suppressors of aggregation and toxicity of disease-associated polyglutamine proteins.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23612975" target="_blank" class="term-link">
                                         PMID:23612975
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we expressed polyQ peptides in cells and show that their intracellular aggregation is prevented by DNAJB6 and DNAJB8, members of the DNAJ (Hsp40) chaperone family.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1704,88 +1715,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein-folding chaperone binding based on physical interaction evidence from Hageman et al. (PMID:21231916). The GOA records three separate IPI entries for this annotation, each with a different Hsp70 interacting partner: HSPA1A (UniProtKB:P0DMV8), HSPA1B (UniProtKB:P0DMV9), and HSPA6 (UniProtKB:P17066). This study systematically tested the chaperone activities of HSP70 and DNAJ family members and demonstrated physical interactions between DNAJB8 and these Hsp70 proteins. DNAJB8 contains a canonical J-domain (residues 3-69) that mediates Hsp70 interaction. This is a core molecular function of J-domain co-chaperones.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Physical interaction between DNAJB8 and Hsp70 chaperones is directly demonstrated by co-immunoprecipitation or equivalent assays in Hageman et al. (PMID:21231916). The J-domain of DNAJB8 is the canonical Hsp70 interaction module. This annotation is well supported and represents a core function. The term protein-folding chaperone binding (GO:0051087) is appropriate as it captures the interaction with Hsp70 chaperones, which are protein-folding chaperones.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20159555" target="_blank" class="term-link">
                                         PMID:20159555
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The antiaggregation activity is largely independent of the N-terminal Hsp70-interacting J-domain. Rather, a C-terminal serine-rich (SSF-SST) region and the C-terminal tail are essential.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1797,88 +1808,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for nuclear localization from Hageman et al. (PMID:21231916). This study examined the subcellular localization of overexpressed DNAJB8 using fluorescence microscopy or similar direct assays, demonstrating both nuclear and cytosolic localization. Nuclear localization is independently supported by the HDA annotation from PMID:21630459 (sperm nuclear proteomics) and the IBA phylogenetic inference. The close paralogue DNAJB6 also shows nuclear localization, with the DNAJB6a isoform being predominantly nuclear. DNAJB8 localizes to both cytosol and nucleus, consistent with the description in UniProt.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear localization is directly demonstrated by Hageman et al. (PMID:21231916) and independently confirmed by sperm nuclear proteomics (PMID:21630459). The dual cytosol/nucleus localization is consistent with the known biology of the DNAJB6/B8 subfamily and with a potential role in nuclear proteostasis.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link">
                                         PMID:21630459
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">403 different proteins have been identified from the isolated sperm nuclei.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1890,88 +1901,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for cytosol localization from Hageman et al. (PMID:21231916). DNAJB8 was shown by direct assay to localize to the cytosol. This is consistent with its function as a cytoplasmic holdase chaperone that suppresses polyQ protein aggregation (PMID:20159555, PMID:23612975). The cytosol is the primary site where DNAJB8 encounters and binds aggregation-prone substrates. This is also consistent with the IBA annotation for the broader term cytoplasm (GO:0005737).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosolic localization is directly demonstrated by Hageman et al. (PMID:21231916) and is consistent with the primary function of DNAJB8 as a cytoplasmic holdase chaperone. The cytosol is where polyQ-expanded proteins aggregate and where DNAJB8 exerts its anti-aggregation activity.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20159555" target="_blank" class="term-link">
                                         PMID:20159555
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">members of a subclass of the DNAJB family (particularly DNAJB6b and DNAJB8) are superior suppressors of aggregation and toxicity of disease-associated polyglutamine proteins.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1983,112 +1994,112 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 (unfolded protein binding) is being obsoleted (go-ontology#30962). This IDA annotation cites PMID:21231916 (Hageman et al. 2011), which demonstrated that different HSP70/DNAJ family members have distinct chaperone-like activities. Chaperones that suppressed polyQ aggregation (holdase activity) were found not to stimulate luciferase refolding (foldase activity), and vice versa (PMID:21231916). DNAJB8 falls in the holdase category. The earlier study by the same group (PMID:20159555, Hageman et al. 2010) specifically showed DNAJB8 is a superior suppressor of polyQ aggregation with activity largely independent of its J-domain. Gillis et al. (PMID:23612975) further confirmed that DNAJB8 suppresses polyQ protein aggregation by directly binding the polyQ tract. The best interim replacement is GO:0044183 (protein folding chaperone), with the caveat that DNAJB8 is a holdase, not a foldase, and no dedicated holdase GO term currently exists.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. The experimental evidence from Hageman et al. (PMID:21231916) demonstrated that DNAJB8 has chaperone-like holdase activity rather than mere unfolded protein binding. The study showed that chaperones suppressing polyQ aggregation could not stimulate luciferase refolding, establishing a functional distinction between holdase and foldase activities. GO:0044183 (protein folding chaperone) is the best available replacement term, though it is imprecise for a holdase. DNAJB8 already has GO:0044183 annotations from IBA and IDA (PMID:23612975) evidence. The IDA evidence supporting the original GO:0051082 annotation is consistent with chaperone activity and should be retained under the replacement term.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation. This was not related to client specificity itself, as the polyQ aggregation inhibitors often also suppressed heat-induced aggregation of luciferase.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20159555" target="_blank" class="term-link">
                                         PMID:20159555
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">members of a subclass of the DNAJB family (particularly DNAJB6b and DNAJB8) are superior suppressors of aggregation and toxicity of disease-associated polyglutamine proteins. The antiaggregation activity is largely independent of the N-terminal Hsp70-interacting J-domain. Rather, a C-terminal serine-rich (SSF-SST) region and the C-terminal tail are essential.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23612975" target="_blank" class="term-link">
                                         PMID:23612975
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we expressed polyQ peptides in cells and show that their intracellular aggregation is prevented by DNAJB6 and DNAJB8, members of the DNAJ (Hsp40) chaperone family. In contrast, HSPA/Hsp70 and DNAJB1, also members of the DNAJ chaperone family, did not prevent peptide-initiated aggregation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090084" target="_blank" class="term-link">
                                     GO:0090084
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of inclusion body assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2100,101 +2111,101 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for negative regulation of inclusion body assembly from Hageman et al. (PMID:21231916). This study demonstrated that DNAJB8 suppresses polyQ aggregation, which directly manifests as prevention of inclusion body formation. The earlier study by the same group (PMID:20159555) showed DNAJB8 is a superior suppressor of aggregation and toxicity of disease-associated polyglutamine proteins, with the antiaggregation activity residing in the C-terminal serine-rich region. Gillis et al. (PMID:23612975) independently confirmed that DNAJB8 prevents intracellular aggregation of polyQ peptides by directly binding the polyQ tract. This is a core function of DNAJB8 and the annotation is well supported by direct experimental evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Negative regulation of inclusion body assembly is directly demonstrated by multiple studies. Hageman et al. (PMID:21231916) showed DNAJB8 suppresses polyQ aggregation in cellular assays. The same group (PMID:20159555) established the mechanism involving C-terminal substrate binding and HDAC interactions. Gillis et al. (PMID:23612975) confirmed DNAJB8 prevents intracellular polyQ peptide aggregation. This is arguably the most distinctive and potent function of DNAJB8.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20159555" target="_blank" class="term-link">
                                         PMID:20159555
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">members of a subclass of the DNAJB family (particularly DNAJB6b and DNAJB8) are superior suppressors of aggregation and toxicity of disease-associated polyglutamine proteins. The antiaggregation activity is largely independent of the N-terminal Hsp70-interacting J-domain.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23612975" target="_blank" class="term-link">
                                         PMID:23612975
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we expressed polyQ peptides in cells and show that their intracellular aggregation is prevented by DNAJB6 and DNAJB8, members of the DNAJ (Hsp40) chaperone family. In contrast, HSPA/Hsp70 and DNAJB1, also members of the DNAJ chaperone family, did not prevent peptide-initiated aggregation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21630459
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomic characterization of the human sperm nucleus.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2206,88 +2217,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HDA annotation for nuclear localization from de Mateo et al. (PMID:21630459), a proteomic characterization of the human sperm nucleus. DNAJB8 was identified among 403 proteins in isolated human sperm nuclei by LC-MS/MS. DNAJB8 is enriched in testis (HPA: tissue enriched in testis; Bgee: expressed in sperm), so its detection in the sperm nuclear proteome is biologically plausible. However, this is a high-throughput proteomics study and the nuclear detection could reflect a genuine nuclear pool or could be a consequence of the protein being highly abundant in testis. The nuclear localization is independently supported by IDA evidence from PMID:21231916. DNAJB8 is known to localize to both cytosol and nucleus.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The HDA evidence from sperm nuclear proteomics is consistent with the IDA evidence for nuclear localization from PMID:21231916 and with the IBA phylogenetic inference. While high-throughput proteomics can have contaminants, the fact that DNAJB8 is testis-enriched and independently shown to be nuclear by direct assay supports the biological relevance of this detection. The annotation is well corroborated.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link">
                                         PMID:21630459
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">With this approach, 403 different proteins have been identified from the isolated sperm nuclei. The most abundant family of proteins identified are the histones, for which several novel members had not been reported previously as present in the spermatogenic cell line or in the human mature spermatozoa.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23612975" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23612975
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The DNAJB6 and DNAJB8 protein chaperones prevent intracellul...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2299,88 +2310,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for protein folding (GO:0006457) from Gillis et al. (PMID:23612975). The GOA qualifier is &#39;acts_upstream_of_or_within&#39;, which indicates involvement in the broader process. Gillis et al. demonstrated that DNAJB8 prevents intracellular aggregation of polyQ peptides by directly binding the polyQ tract, placing it in the protein folding quality control pathway. DNAJB8 functions as a holdase rather than a foldase -- Hageman et al. (PMID:21231916) showed that chaperones suppressing polyQ aggregation could not stimulate luciferase refolding. The term protein folding is therefore somewhat imprecise for DNAJB8, but the broader proteostasis role is real and the qualifier &#39;acts_upstream_of_or_within&#39; appropriately captures the indirect relationship.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> DNAJB8 is a J-domain co-chaperone that participates in protein folding quality control, specifically by preventing aggregation of misfolded proteins. The qualifier &#39;acts_upstream_of_or_within&#39; is appropriate as DNAJB8 acts within the protein folding process by suppressing aggregation rather than directly catalyzing productive folding. The IDA evidence from Gillis et al. (PMID:23612975) directly demonstrates this anti-aggregation activity in cellular assays with polyQ peptides.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23612975" target="_blank" class="term-link">
                                         PMID:23612975
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we expressed polyQ peptides in cells and show that their intracellular aggregation is prevented by DNAJB6 and DNAJB8, members of the DNAJ (Hsp40) chaperone family. In contrast, HSPA/Hsp70 and DNAJB1, also members of the DNAJ chaperone family, did not prevent peptide-initiated aggregation.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     GO:0044183
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23612975" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23612975
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The DNAJB6 and DNAJB8 protein chaperones prevent intracellul...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2392,63 +2403,63 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for protein folding chaperone (GO:0044183) from Gillis et al. (PMID:23612975). This study demonstrated that DNAJB8 prevents intracellular aggregation of polyQ peptides by directly binding the polyQ tract, establishing DNAJB8 as a chaperone that binds proteins to assist in the protein folding process (by preventing misfolding/aggregation). Hageman et al. (PMID:20159555) previously established that DNAJB8 is a superior suppressor of polyQ protein aggregation with activity residing in the C-terminal serine-rich region. This is a core molecular function of DNAJB8 and GO:0044183 is the best available GO term for its holdase chaperone activity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0044183 (protein folding chaperone) is the most appropriate molecular function term for DNAJB8. The IDA evidence from Gillis et al. (PMID:23612975) directly demonstrates that DNAJB8 binds polyQ substrates to prevent their aggregation, which falls within the scope of this term. This is also the recommended replacement term for the obsoleting GO:0051082 (unfolded protein binding). The annotation is independently supported by IBA phylogenetic inference for the same term.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23612975" target="_blank" class="term-link">
                                         PMID:23612975
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we conclude that the mechanism of DNAJB6 and DNAJB8 is suppression of polyQ protein aggregation by directly binding the polyQ tract.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20159555" target="_blank" class="term-link">
                                         PMID:20159555
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">members of a subclass of the DNAJB family (particularly DNAJB6b and DNAJB8) are superior suppressors of aggregation and toxicity of disease-associated polyglutamine proteins. The antiaggregation activity is largely independent of the N-terminal Hsp70-interacting J-domain.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>Holdase chaperone that potently suppresses aggregation of polyglutamine- expanded proteins and other aggregation-prone substrates. DNAJB8 uses at least two distinct substrate-binding modes: (1) a serine-rich stretch in the S/T-rich region for fibrillar/amyloid aggregation suppression by directly binding the polyQ tract, and (2) a separate C-terminal TTK-LKS motif for amorphous inclusion suppression via Hsp70-dependent proteasomal degradation (DOI:10.1242/jcs.255596). The anti-aggregation activity is largely independent of the N-terminal J-domain/HSP70-stimulating activity and requires interaction with histone deacetylases (HDAC4, HDAC6, SIRT2) (PMID:20159555). A key regulatory mechanism is an intramolecular JD-CTD interaction that sequesters the J-domain surface and controls Hsp70 recruitment as a reversible switch (DOI:10.1038/s41467-021-21147-x). DNAJB8 self-assembles into oligomeric puncta via an AFSSFN (147-152) steric-zipper motif (resolved at 0.75 angstrom by MicroED), but oligomerization is dispensable for substrate binding and anti-aggregation function (DOI:10.1016/j.str.2024.02.015). DNAJB8 cannot stimulate luciferase refolding, distinguishing its holdase mechanism from foldase-type chaperones (PMID:21231916).</h3>
                 <span class="vote-buttons" data-g="Q8NHS0" data-a="FUNCTION: Holdase chaperone that potently suppresses aggrega..." data-r="" data-act="CORE_FUNCTION">
@@ -2456,10 +2467,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -2468,391 +2479,427 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090084" target="_blank" class="term-link">
                                 negative regulation of inclusion body assembly
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                 protein folding
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                 nucleus
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20159555" target="_blank" class="term-link">
                                 PMID:20159555
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">members of a subclass of the DNAJB family (particularly DNAJB6b and DNAJB8) are superior suppressors of aggregation and toxicity of disease-associated polyglutamine proteins. The antiaggregation activity is largely independent of the N-terminal Hsp70-interacting J-domain. Rather, a C-terminal serine-rich (SSF-SST) region and the C-terminal tail are essential.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23612975" target="_blank" class="term-link">
                                 PMID:23612975
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">we conclude that the mechanism of DNAJB6 and DNAJB8 is suppression of polyQ protein aggregation by directly binding the polyQ tract.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                 PMID:21231916
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">Overexpressed chaperones that suppressed polyQ aggregation were found not to be able to stimulate luciferase refolding. Inversely, chaperones that supported luciferase refolding were poor suppressors of polyQ aggregation.</div>
-                        
+
                     </li>
-                    
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/DNAJB8/DNAJB8-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Falcon synthesis highlights DNAJB8 as a J-domain holdase chaperone with separable substrate-binding modes for amyloid/polyQ and amorphous aggregation suppression, plus regulated Hsp70 recruitment.</div>
+
+                    </li>
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/DNAJB8/DNAJB8-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research synthesis for DNAJB8</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">DNAJB8 is a J-domain holdase chaperone that suppresses polyglutamine and other aggregation-prone substrates, with recent work separating oligomerization from substrate binding and anti-aggregation activity.</div>
+
+                        <div class="finding-text">"Multiple studies place DNAJB8 among the most potent anti-aggregation DNAJBs, particularly against polyglutamine aggregation."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20159555" target="_blank" class="term-link">
                             PMID:20159555
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A DNAJB chaperone subfamily with HDAC-dependent activities suppresses toxic protein aggregation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                             PMID:21231916
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The diverse members of the mammalian HSP70 machine show distinct chaperone-like activities.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link">
                             PMID:21630459
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteomic characterization of the human sperm nucleus.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23612975" target="_blank" class="term-link">
                             PMID:23612975
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The DNAJB6 and DNAJB8 protein chaperones prevent intracellular aggregation of polyglutamine peptides.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1016/j.str.2024.02.015
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">DNAJB8 oligomerization is mediated by an aromatic-rich motif that is dispensable for substrate activity.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">AFSSFN (147-152) steric-zipper motif resolved at 0.75 angstrom by MicroED as a class 6 steric zipper stabilized by aromatic interactions (F148, F151); F151 is a primary driver of full-length DNAJB8 self-assembly.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Engineered monomeric DNAJB8 variants retain substrate binding and anti-aggregation function, demonstrating oligomerization is mechanistically separable from chaperone activity.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1038/s41467-021-21147-x
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Regulatory inter-domain interactions influence Hsp70 recruitment to the DnaJB8 chaperone.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Intramolecular JD-CTD interaction sequesters the J-domain surface, preventing Hsp70 interaction as a reversible regulatory switch controlling Hsp70 recruitment.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">DNAJB8-Clover forms juxtanuclear puncta in 39.2 +/- 3.1% of cells vs 0.44 +/- 0.50% for Clover control.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1242/jcs.255596
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">DNAJB chaperones suppress destabilised protein aggregation via a region distinct from that used to inhibit amyloidogenesis.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Distinct substrate-binding modes in DNAJB8: serine-rich stretch needed for fibrillar/amyloid aggregation suppression but not for FlucDM inclusion suppression; a separate CTD TTK-LKS motif is required for amorphous inclusion suppression via Hsp70-dependent proteasomal degradation.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1158/0008-5472.CAN-11-3062
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP DNAJB8 controls tumor-initiating ability in renal cancer stem-like cells.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">DNAJB8 preferentially expressed in renal cancer stem-like/cancer-initiating cell populations; overexpression increases side population fraction and tumor-initiating ability.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1038/s41419-022-04599-x
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">DNAJB8 in small extracellular vesicles promotes oxaliplatin resistance through TP53/MDR1 pathway in colon cancer.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">DNAJB8 interacts with TP53 and inhibits TP53 ubiquitination, stabilizing TP53 and leading to MDR1/P-gp upregulation and increased oxaliplatin resistance; sEV-mediated transfer propagates resistance.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1038/s41416-020-1017-1
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Development of an artificial antibody specific for HLA/peptide complex derived from cancer stem-like cell/cancer-initiating cell antigen DNAJB8.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Engineered antibodies targeting HLA-A24/DNAJB8-derived peptide complex achieve nanomolar affinity (KD 2.96-5.04 nM) and mediate CDC and bispecific antibody-dependent cellular cytotoxicity.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -3146,9 +3193,9 @@ Chaperone biology / structure:<br />
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -3160,7 +3207,7 @@ Chaperone biology / structure:<br />
                 <pre><code>id: Q8NHS0
 gene_symbol: DNAJB8
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -3358,6 +3405,12 @@ existing_annotations:
         members of a subclass of the DNAJB family (particularly DNAJB6b and
         DNAJB8) are superior suppressors of aggregation and toxicity of
         disease-associated polyglutamine proteins.
+    - reference_id: file:human/DNAJB8/DNAJB8-deep-research-falcon.md
+      supporting_text: &gt;-
+        Multiple studies place DNAJB8 among potent anti-aggregation DNAJBs,
+        particularly against polyglutamine aggregation, with holdase activity
+        that can be partly independent of canonical J-domain/Hsp70 co-chaperone
+        action.
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -3946,6 +3999,11 @@ core_functions:
       Overexpressed chaperones that suppressed polyQ aggregation were found not
       to be able to stimulate luciferase refolding. Inversely, chaperones that
       supported luciferase refolding were poor suppressors of polyQ aggregation.
+  - reference_id: file:human/DNAJB8/DNAJB8-deep-research-falcon.md
+    supporting_text: &gt;-
+      Falcon synthesis highlights DNAJB8 as a J-domain holdase chaperone with
+      separable substrate-binding modes for amyloid/polyQ and amorphous
+      aggregation suppression, plus regulated Hsp70 recruitment.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
@@ -3957,6 +4015,16 @@ references:
 - id: GO_REF:0000117
   title: Electronic Gene Ontology annotations created by ARBA machine learning models
   findings: []
+- id: file:human/DNAJB8/DNAJB8-deep-research-falcon.md
+  title: Falcon deep research synthesis for DNAJB8
+  findings:
+  - statement: &gt;-
+      DNAJB8 is a J-domain holdase chaperone that suppresses polyglutamine and
+      other aggregation-prone substrates, with recent work separating
+      oligomerization from substrate binding and anti-aggregation activity.
+    supporting_text: &gt;-
+      Multiple studies place DNAJB8 among the most potent anti-aggregation
+      DNAJBs, particularly against polyglutamine aggregation.
 - id: PMID:20159555
   title: A DNAJB chaperone subfamily with HDAC-dependent activities suppresses toxic
     protein aggregation.
@@ -4034,7 +4102,7 @@ references:
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/DNAJB8/DNAJB8-ai-review.yaml
+++ b/genes/human/DNAJB8/DNAJB8-ai-review.yaml
@@ -1,7 +1,7 @@
 id: Q8NHS0
 gene_symbol: DNAJB8
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -199,6 +199,12 @@ existing_annotations:
         members of a subclass of the DNAJB family (particularly DNAJB6b and
         DNAJB8) are superior suppressors of aggregation and toxicity of
         disease-associated polyglutamine proteins.
+    - reference_id: file:human/DNAJB8/DNAJB8-deep-research-falcon.md
+      supporting_text: >-
+        Multiple studies place DNAJB8 among potent anti-aggregation DNAJBs,
+        particularly against polyglutamine aggregation, with holdase activity
+        that can be partly independent of canonical J-domain/Hsp70 co-chaperone
+        action.
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -787,6 +793,11 @@ core_functions:
       Overexpressed chaperones that suppressed polyQ aggregation were found not
       to be able to stimulate luciferase refolding. Inversely, chaperones that
       supported luciferase refolding were poor suppressors of polyQ aggregation.
+  - reference_id: file:human/DNAJB8/DNAJB8-deep-research-falcon.md
+    supporting_text: >-
+      Falcon synthesis highlights DNAJB8 as a J-domain holdase chaperone with
+      separable substrate-binding modes for amyloid/polyQ and amorphous
+      aggregation suppression, plus regulated Hsp70 recruitment.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
@@ -798,6 +809,16 @@ references:
 - id: GO_REF:0000117
   title: Electronic Gene Ontology annotations created by ARBA machine learning models
   findings: []
+- id: file:human/DNAJB8/DNAJB8-deep-research-falcon.md
+  title: Falcon deep research synthesis for DNAJB8
+  findings:
+  - statement: >-
+      DNAJB8 is a J-domain holdase chaperone that suppresses polyglutamine and
+      other aggregation-prone substrates, with recent work separating
+      oligomerization from substrate binding and anti-aggregation activity.
+    supporting_text: >-
+      Multiple studies place DNAJB8 among the most potent anti-aggregation
+      DNAJBs, particularly against polyglutamine aggregation.
 - id: PMID:20159555
   title: A DNAJB chaperone subfamily with HDAC-dependent activities suppresses toxic
     protein aggregation.

--- a/genes/human/DNAJB8/DNAJB8-ai-review.yaml
+++ b/genes/human/DNAJB8/DNAJB8-ai-review.yaml
@@ -41,26 +41,26 @@ existing_annotations:
   review:
     summary: >-
       IBA annotation for cytoplasm localization is well supported. DNAJB8 is a
-      cytoplasmic J-domain co-chaperone. Hageman et al. (PMID:21231916) showed by
-      direct assay that DNAJB8 localizes to the cytosol (IDA for GO:0005829,
-      cytosol). The IBA phylogenetic inference is consistent with experimental
-      data for both DNAJB8 and its close paralogue DNAJB6, which is also
-      cytoplasmic. Note that cytoplasm (GO:0005737) is broader than cytosol
-      (GO:0005829) but the IBA annotation at this level is appropriate given the
-      phylogenetic evidence base.
+      cytoplasmic J-domain co-chaperone. The GOA record includes IDA evidence for
+      the more specific cytosol term (GO:0005829) from PMID:21231916, and the
+      cached abstract states that most human HSP70/HSPA and HSP40/DNAJ proteins
+      are localized in the cytosol. The IBA phylogenetic inference is consistent
+      with experimental data for both DNAJB8 and its close paralogue DNAJB6, which
+      is also cytoplasmic. Note that cytoplasm (GO:0005737) is broader than
+      cytosol (GO:0005829) but the IBA annotation at this level is appropriate
+      given the phylogenetic evidence base.
     action: ACCEPT
     reason: >-
-      Cytoplasmic localization is confirmed by IDA evidence from PMID:21231916
-      for the more specific term cytosol (GO:0005829), and is consistent with the
+      Cytoplasmic localization is consistent with the GOA IDA evidence from
+      PMID:21231916 for the more specific term cytosol (GO:0005829), and with the
       function of DNAJB8 as a cytoplasmic holdase chaperone that suppresses polyQ
       aggregation (PMID:20159555). The IBA inference is phylogenetically sound
       given conservation across DNAJB6/DNAJB8 orthologues.
     supported_by:
     - reference_id: PMID:21231916
       supporting_text: >-
-        Overexpressed chaperones that suppressed polyQ aggregation were found not
-        to be able to stimulate luciferase refolding. Inversely, chaperones that
-        supported luciferase refolding were poor suppressors of polyQ aggregation.
+        Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding
+        genes and most of the corresponding proteins are localized in the cytosol.
     - reference_id: PMID:20159555
       supporting_text: >-
         members of a subclass of the DNAJB family (particularly DNAJB6b and
@@ -110,24 +110,21 @@ existing_annotations:
   original_reference_id: GO_REF:0000033
   review:
     summary: >-
-      IBA annotation for nuclear localization is well supported. DNAJB8 has been
-      shown to localize to the nucleus by IDA (PMID:21231916) and HDA
-      (PMID:21630459, sperm nuclear proteomics). The IBA phylogenetic inference
-      is consistent with experimental data for DNAJB8 itself and with the known
-      nuclear localization of its close paralogue DNAJB6a.
+      IBA annotation for nuclear localization is supported by HDA evidence from
+      PMID:21630459, a sperm nuclear proteomics study, and by the GOA IDA record
+      from PMID:21231916. The cached PMID:21231916 abstract available here does
+      not include the localization figure, so the explicit text support below is
+      the independent sperm nuclear proteomics evidence. The IBA phylogenetic
+      inference is consistent with experimental data for DNAJB8 itself and with
+      the known nuclear localization of its close paralogue DNAJB6a.
     action: ACCEPT
     reason: >-
-      Nuclear localization of DNAJB8 is confirmed by multiple independent lines
-      of evidence: IDA from PMID:21231916 (direct assay showing nuclear
-      localization) and HDA from PMID:21630459 (identified in human sperm nuclear
-      proteome). The IBA phylogenetic inference is consistent with these
-      experimental observations and with the dual cytosol/nucleus localization
-      pattern of the DNAJB6/B8 subfamily.
+      Nuclear localization is supported by sperm nuclear proteomics
+      (PMID:21630459) and is consistent with the GOA IDA localization record from
+      PMID:21231916. The IBA phylogenetic inference is consistent with these
+      observations and with the dual cytosol/nucleus localization pattern of the
+      DNAJB6/B8 subfamily.
     supported_by:
-    - reference_id: PMID:21231916
-      supporting_text: >-
-        Overexpressed chaperones that suppressed polyQ aggregation were found not
-        to be able to stimulate luciferase refolding.
     - reference_id: PMID:21630459
       supporting_text: >-
         403 different proteins have been identified from the isolated sperm
@@ -460,26 +457,20 @@ existing_annotations:
   review:
     summary: >-
       IDA annotation for nuclear localization from Hageman et al.
-      (PMID:21231916). This study examined the subcellular localization of
-      overexpressed DNAJB8 using fluorescence microscopy or similar direct
-      assays, demonstrating both nuclear and cytosolic localization. Nuclear
-      localization is independently supported by the HDA annotation from
-      PMID:21630459 (sperm nuclear proteomics) and the IBA phylogenetic
-      inference. The close paralogue DNAJB6 also shows nuclear localization,
-      with the DNAJB6a isoform being predominantly nuclear. DNAJB8 localizes
-      to both cytosol and nucleus, consistent with the description in UniProt.
+      (PMID:21231916). The cached PMID:21231916 abstract available here does not
+      include the localization figure, so the explicit text support below uses
+      the independent HDA annotation from PMID:21630459 (sperm nuclear
+      proteomics). The close paralogue DNAJB6 also shows nuclear localization,
+      with the DNAJB6a isoform being predominantly nuclear. DNAJB8 localizes to
+      both cytosol and nucleus, consistent with the description in UniProt.
     action: ACCEPT
     reason: >-
-      Nuclear localization is directly demonstrated by Hageman et al.
-      (PMID:21231916) and independently confirmed by sperm nuclear proteomics
+      Nuclear localization is represented in GOA by the IDA record from
+      PMID:21231916 and independently supported by sperm nuclear proteomics
       (PMID:21630459). The dual cytosol/nucleus localization is consistent with
-      the known biology of the DNAJB6/B8 subfamily and with a potential role
-      in nuclear proteostasis.
+      the known biology of the DNAJB6/B8 subfamily and with a potential role in
+      nuclear proteostasis.
     supported_by:
-    - reference_id: PMID:21231916
-      supporting_text: >-
-        Overexpressed chaperones that suppressed polyQ aggregation were found not
-        to be able to stimulate luciferase refolding.
     - reference_id: PMID:21630459
       supporting_text: >-
         403 different proteins have been identified from the isolated sperm
@@ -492,17 +483,18 @@ existing_annotations:
   review:
     summary: >-
       IDA annotation for cytosol localization from Hageman et al.
-      (PMID:21231916). DNAJB8 was shown by direct assay to localize to the
-      cytosol. This is consistent with its function as a cytoplasmic holdase
+      (PMID:21231916). The cached abstract states that most human HSP70/HSPA and
+      HSP40/DNAJ proteins are cytosolic. This is consistent with its function as
+      a cytoplasmic holdase
       chaperone that suppresses polyQ protein aggregation (PMID:20159555,
       PMID:23612975). The cytosol is the primary site where DNAJB8 encounters
       and binds aggregation-prone substrates. This is also consistent with the
       IBA annotation for the broader term cytoplasm (GO:0005737).
     action: ACCEPT
     reason: >-
-      Cytosolic localization is directly demonstrated by Hageman et al.
-      (PMID:21231916) and is consistent with the primary function of DNAJB8 as
-      a cytoplasmic holdase chaperone. The cytosol is where polyQ-expanded
+      Cytosolic localization is recorded by GOA from Hageman et al.
+      (PMID:21231916) and is consistent with the primary function of DNAJB8 as a
+      cytoplasmic holdase chaperone. The cytosol is where polyQ-expanded
       proteins aggregate and where DNAJB8 exerts its anti-aggregation activity.
     supported_by:
     - reference_id: PMID:20159555
@@ -512,8 +504,8 @@ existing_annotations:
         disease-associated polyglutamine proteins.
     - reference_id: PMID:21231916
       supporting_text: >-
-        Overexpressed chaperones that suppressed polyQ aggregation were found not
-        to be able to stimulate luciferase refolding.
+        Humans contain many HSP (heat-shock protein) 70/HSPA- and HSP40/DNAJ-encoding
+        genes and most of the corresponding proteins are localized in the cytosol.
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -641,16 +633,16 @@ existing_annotations:
       is biologically plausible. However, this is a high-throughput proteomics
       study and the nuclear detection could reflect a genuine nuclear pool or
       could be a consequence of the protein being highly abundant in testis.
-      The nuclear localization is independently supported by IDA evidence from
+      The nuclear localization is consistent with the GOA IDA record from
       PMID:21231916. DNAJB8 is known to localize to both cytosol and nucleus.
     action: ACCEPT
     reason: >-
       The HDA evidence from sperm nuclear proteomics is consistent with the IDA
-      evidence for nuclear localization from PMID:21231916 and with the IBA
-      phylogenetic inference. While high-throughput proteomics can have
+      localization record from PMID:21231916 and with the IBA phylogenetic
+      inference. While high-throughput proteomics can have
       contaminants, the fact that DNAJB8 is testis-enriched and independently
-      shown to be nuclear by direct assay supports the biological relevance of
-      this detection. The annotation is well corroborated.
+      represented in GOA as nuclear by direct assay supports the biological
+      relevance of this detection. The annotation is well corroborated.
     supported_by:
     - reference_id: PMID:21630459
       supporting_text: >-
@@ -659,10 +651,6 @@ existing_annotations:
         are the histones, for which several novel members had not been reported
         previously as present in the spermatogenic cell line or in the human
         mature spermatozoa.
-    - reference_id: PMID:21231916
-      supporting_text: >-
-        Overexpressed chaperones that suppressed polyQ aggregation were found not
-        to be able to stimulate luciferase refolding.
 - term:
     id: GO:0006457
     label: protein folding

--- a/genes/human/HSPA2/HSPA2-ai-review.html
+++ b/genes/human/HSPA2/HSPA2-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>HSPA2</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P54652" target="_blank" class="term-link">
                         P54652
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>HSPA2 (Heat shock-related 70 kDa protein 2, also known as Hsp70-2) is a member of the HSP70/HSPA molecular chaperone family. It functions as an ATP-dependent foldase chaperone, assisting in the folding and refolding of proteins through cycles of ATP binding, hydrolysis, and ADP release mediated by co-chaperones including DNAJ family members, STIP1, HSPBP1, and HSP110- type NEFs (DOI:10.62347/cwpe7813). HSPA2 is constitutively expressed in most tissues, with especially high levels in testis and skeletal muscle (PMID:7829106). It plays a pivotal role in spermatogenesis and male meiosis, where it associates with synaptonemal complexes in the nucleus of meiotic spermatocytes and is required for meiotic progression (PMID:8622925). HSPA2 also supports sperm functional maturation, including cytoplasmic extrusion and plasma membrane remodeling required for zona pellucida binding competence (DOI:10.3390/ijms23126497). Quantitative immunofluorescence shows that hyaluronic acid (HA)-bound mature sperm are significantly enriched for HSPA2 positivity (68.9% vs 28.6% in uncapacitated sperm; DOI:10.1007/s43032-022-01031-9). Recent work demonstrates that HSPA2 is an extracellular vesicle (EV)-associated protein; proteotoxic stress (proteasome inhibition) shifts HSPA2 from intracellular pools to extracellular release in EVs, validated using CRISPR/ Cas9 HSPA2 knockout controls (DOI:10.1038/s41598-023-31962-5). Seminal plasma proteomics identifies HSPA2 as a biomarker of spermatogenic function, with 7.3-fold higher abundance in healthy controls vs Sertoli cell-only azoospermia (DOI:10.3389/fendo.2024.1327800). In cardio-metabolic contexts, circulating HSPA2 is elevated in diabetic myocardium and associated with increased incident heart failure and LV dysfunction (DOI:10.1093/cvr/cvae181). HSPA2 has a nucleotide-binding domain (NBD/ATPase domain) and a substrate-binding domain (SBD), which are allosterically coupled such that ATP hydrolysis increases affinity for client proteins. Its interaction network includes SHCBP1L, which supports spindle integrity during male meiosis (DOI:10.62347/cwpe7813).</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,64 +795,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation of HSPA2 to nucleus based on phylogenetic inference from multiple HSP70 orthologs across species. HSP70 family members are well documented to localize to the nucleus, particularly under stress conditions and during specific cell cycle stages. For HSPA2 specifically, the mouse ortholog (Hsp70-2/P17156) has been shown to associate with synaptonemal complexes in the nucleus of meiotic spermatocytes (PMID:8622925). HSPA2 was also detected in the human sperm nucleus by proteomics (PMID:21630459). The IBA annotation is well supported by phylogenetic evidence and consistent with known biology.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSP70 family members are known to localize to the nucleus. HSPA2 in particular is associated with synaptonemal complexes within the nucleus of meiotic spermatocytes (PMID:8622925), and was detected in the sperm nucleus proteome (PMID:21630459). The IBA annotation from phylogenetic inference is well supported.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8622925" target="_blank" class="term-link">
                                         PMID:8622925
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We previously found that HSP70-2 is associated with synaptonemal complexes in the nucleus of meiotic spermatocytes from mice and hamsters.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -864,64 +864,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation of HSPA2 to cytoplasm based on phylogenetic inference. HSP70 family members are predominantly cytoplasmic proteins. UniProt notes the subcellular location of HSPA2 as cytoplasm/cytoskeleton/spindle (UniProt P54652). Hageman et al. (PMID:21231916) expressed HSPA2 in cell culture and demonstrated cytoplasmic chaperone activities (luciferase refolding, polyQ aggregation suppression), confirming cytoplasmic localization. This is a well-supported core localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPA2 is a cytoplasmic chaperone as demonstrated by functional assays in the cytoplasm (PMID:21231916) and consistent with the known biology of HSP70 family members. The IBA phylogenetic annotation is correct.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -933,46 +933,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation of HSPA2 to plasma membrane based on phylogenetic inference. Several HSP70 family members have been shown to localize to the plasma membrane and cell surface, particularly under stress conditions. For HSPA2, the mouse ortholog (P17156) has been annotated to cell surface (GO_REF:0000107, Ensembl Compara). UniProt notes that HSPA2 is a component of the CatSper complex (by similarity), which is a sperm cell surface ion channel complex. The IBA annotation is plausible but plasma membrane localization is not a core feature of HSPA2 function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Plasma membrane localization of HSP70 family members is documented but is not the primary site of HSPA2 function. The main functional localizations are cytoplasm/cytosol and nucleus (synaptonemal complex). Plasma membrane association may relate to its role in the CatSper complex in sperm or stress-related surface presentation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -984,97 +984,97 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation of HSPA2 for ATP hydrolysis activity based on phylogenetic inference from HSP70 orthologs. ATP hydrolysis is the fundamental mechanistic step driving the HSP70 chaperone cycle. The N-terminal nucleotide-binding domain of HSPA2 (residues 2-389) binds and hydrolyzes ATP, and the crystal structure of the HSPA2 ATPase domain has been solved in complex with ADP and phosphate (PDB:3I33, PMID:20072699). UniProt describes the allosteric coupling between ATP hydrolysis and substrate binding (UniProt P54652). This is a core molecular function of HSPA2.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATP hydrolysis is the fundamental catalytic activity of all HSP70 family members, driving the chaperone cycle. The HSPA2 ATPase domain crystal structure confirms this activity (PDB:3I33, PMID:20072699). The IBA annotation is strongly supported by structural evidence on HSPA2 itself and conserved HSP70 mechanism.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
                                     GO:0031072
                                 </a>
                             </span>
                             <span class="term-label">heat shock protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P54652" data-a="GO:0031072" data-r="GO_REF:0000033" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P54652" data-a="GO:0031072" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IBA annotation of HSPA2 for heat shock protein binding based on phylogenetic inference. HSP70 family members interact extensively with co-chaperones including HSP40/DNAJ proteins, HSPBP1, and BAG domain proteins. HSPA2 has been shown by IPI evidence to interact with HSPBP1 (Q9NZL4) in multiple studies (PMID:16189514, PMID:16713569, PMID:25416956, PMID:28514442, PMID:33961781, PMID:35271311, PMID:40205054). HSPA2 also interacts with BAG4 (O95429) and DNAJA3 (UniProt P54652). These interactions with co-chaperones are integral to the HSP70 chaperone cycle.
+                            <strong>Summary:</strong> IBA annotation of HSPA2 for heat shock protein binding based on phylogenetic inference from HSP70-family proteins including HSPA1A, HSPA1B, HSPA6, HSPA8, and HSPA1L. This annotation should be interpreted as conserved binding within the heat-shock/chaperone network, not as a catch-all for HSPBP1, BAG4, or HSF2 interactions because those partners are not themselves heat shock proteins. Falcon synthesis also lists HSPA1A, HSPA8, and HSP90AA1 among HSPA2-associated chaperone-network proteins, but direct paralog-specific biochemical support remains less central than HSPA2&#39;s ATPase/foldase activity.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> HSP70 chaperones fundamentally depend on interactions with co-chaperones (HSP40/DNAJ, NEFs like HSPBP1 and BAG proteins) for their function. The extensive IPI evidence for HSPA2-HSPBP1 interaction across multiple studies validates this annotation. This is a core molecular function.
+                            <strong>Reason:</strong> The PANTHER IBA annotation is plausible for conserved HSP70 chaperone-network binding, but HSPBP1, BAG4, and HSF2 should not be used to justify GO:0031072 because those proteins are co-chaperones or transcription factors rather than heat shock proteins. Retain the term as non-core; the core molecular functions are ATP hydrolysis and protein folding chaperone activity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     GO:0044183
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1086,64 +1086,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation of HSPA2 as a protein folding chaperone based on phylogenetic inference from HSP70 orthologs including DnaK. This is the central molecular function of HSPA2. Hageman et al. (PMID:21231916) directly demonstrated that HSPA2 has chaperone activity by showing it supports refolding of heat-denatured luciferase and suppresses aggregation of polyQ-expanded Huntingtin. UniProt describes HSPA2 as a &#34;molecular chaperone implicated in a wide variety of cellular processes, including protection of the proteome from stress, folding and transport of newly synthesized polypeptides&#34; (UniProt P54652). This is the core molecular function annotation for HSPA2.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein folding chaperone activity is the core molecular function of HSPA2, directly demonstrated by in vitro assays (PMID:21231916) and consistent with the well-characterized HSP70 chaperone mechanism. The IBA annotation is strongly supported by both phylogenetic and experimental evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/HSPA2/HSPA2-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across recent primary studies, the most defensible primary function annotation is that HSPA2 is an ATP-dependent molecular chaperone supporting proteostasis (folding/refolding and quality control).</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1155,46 +1166,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation of HSPA2 to cytosol based on phylogenetic inference. HSPA2 is a cytosolic chaperone. This annotation is also supported by direct experimental evidence (IDA) from PMID:21231916, where HSPA2 was overexpressed and shown to function in the cytosol. The IBA annotation is consistent with the IDA evidence and with the known biology of HSP70 family members.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol is the primary functional compartment for HSPA2 chaperone activity, supported by both phylogenetic inference and direct experimental evidence (PMID:21231916 IDA). The IBA annotation is correct.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1206,64 +1217,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation of HSPA2 for involvement in protein refolding based on phylogenetic inference from HSP70 orthologs. Protein refolding is a core biological process mediated by HSP70 chaperones. Hageman et al. (PMID:21231916) directly demonstrated HSPA2 supports refolding of heat-denatured luciferase, providing experimental confirmation. This IBA annotation is strongly supported.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein refolding is a core function of HSP70 chaperones, directly demonstrated for HSPA2 by luciferase refolding assays (PMID:21231916). The IBA annotation is well supported by phylogenetic and experimental evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000166" target="_blank" class="term-link">
                                     GO:0000166
                                 </a>
                             </span>
                             <span class="term-label">nucleotide binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1275,46 +1286,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of HSPA2 for nucleotide binding based on UniProtKB/Swiss-Prot keyword mapping (KW-0547 Nucleotide-binding). HSPA2 has a well-characterized nucleotide-binding domain (residues 2-389) with multiple ATP binding sites confirmed by crystal structure (PDB:3I33). This is a correct but overly general annotation; GO:0005524 &#34;ATP binding&#34; is more specific and already annotated. Nonetheless, nucleotide binding is technically correct as a parent term.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleotide binding is correct for HSPA2, which has an N-terminal nucleotide-binding domain confirmed by crystal structure. While broader than the more specific ATP binding annotation (GO:0005524), it is not incorrect as an IEA annotation derived from keyword mapping.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
                                     GO:0005524
                                 </a>
                             </span>
                             <span class="term-label">ATP binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1326,46 +1337,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of HSPA2 for ATP binding based on combined automated annotation using InterPro (IPR013126 HSP70 family) and UniProtKB keyword (KW-0067 ATP-binding). The crystal structure of HSPA2 NBD in complex with ADP and phosphate (PDB:3I33, PMID:20072699) directly confirms ATP binding. UniProt annotates multiple ATP binding sites at residues 13-16, 72, 205-207, 271-278, and 342-345 (UniProt P54652). This is a well-supported core molecular function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATP binding is fundamental to HSPA2 function and is confirmed by crystal structure (PDB:3I33) and multiple annotated binding sites in the NBD domain. The IEA annotation is correct.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005819" target="_blank" class="term-link">
                                     GO:0005819
                                 </a>
                             </span>
                             <span class="term-label">spindle</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1377,46 +1388,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of HSPA2 to spindle based on UniProtKB/Swiss-Prot subcellular location vocabulary mapping. UniProt records HSPA2 subcellular location as &#34;Cytoplasm, cytoskeleton, spindle&#34; based on similarity to mouse Hsp70-2 (P17156). The mouse ortholog co-localizes with SHCBP1L at the spindle during meiosis. This is consistent with the meiotic spindle localization annotated elsewhere (GO:0072687). The more specific term GO:0072687 &#34;meiotic spindle&#34; is preferable, but spindle is not wrong as a broader term.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPA2 localizes to the meiotic spindle based on similarity data from the mouse ortholog (UniProt P17156). The broader term &#34;spindle&#34; is acceptable as an IEA annotation, though GO:0072687 &#34;meiotic spindle&#34; is more specific and also annotated.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006986" target="_blank" class="term-link">
                                     GO:0006986
                                 </a>
                             </span>
                             <span class="term-label">response to unfolded protein</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1428,46 +1439,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of HSPA2 for response to unfolded protein based on ARBA machine learning. As a member of the HSP70 chaperone family, HSPA2 is involved in the cellular response to unfolded proteins. UniProt describes HSPA2 as a molecular chaperone involved in &#34;protection of the proteome from stress&#34; and &#34;the re-folding of misfolded proteins&#34; (UniProt P54652). HSPA2 is constitutively expressed but its role in proteostasis is consistent with involvement in unfolded protein response.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPA2 is a molecular chaperone that assists in refolding of misfolded proteins and suppresses protein aggregation (PMID:21231916), which are key components of the response to unfolded protein. The IEA annotation is correct.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007283" target="_blank" class="term-link">
                                     GO:0007283
                                 </a>
                             </span>
                             <span class="term-label">spermatogenesis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1479,77 +1490,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of HSPA2 for involvement in spermatogenesis based on combined automated annotation using orthology to mouse Hsp70-2 (P17156) and UniProtKB keyword (KW-0744 Spermatogenesis). The mouse knockout study (PMID:8622925) directly demonstrated that Hsp70-2 disruption causes failed meiosis, germ cell apoptosis, and male infertility. HSPA2 is the human ortholog and is constitutively expressed at very high levels in testis (PMID:7829106). This is a core specialized function of HSPA2.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Spermatogenesis is a core specialized function of HSPA2, demonstrated by mouse knockout studies showing male infertility (PMID:8622925) and supported by high testicular expression (PMID:7829106). The IEA annotation is strongly supported.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8622925" target="_blank" class="term-link">
                                         PMID:8622925
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Male mice homozygous for the mutant allele (Hsp70-2 -/-) did not synthesize HSP70-2, lacked postmeiotic spermatids and mature sperm, and were infertile.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7829106" target="_blank" class="term-link">
                                         PMID:7829106
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSPA2 is constitutively expressed in most tissues, with very high levels in testis and skeletal muscle.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1561,46 +1572,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of HSPA2 for ATP hydrolysis activity based on InterPro record (IPR013126 HSP70 family) to GO term mapping. This is a duplicate of the IBA annotation for the same term (GO:0016887). ATP hydrolysis is the core catalytic activity of the HSP70 ATPase domain. The crystal structure of the HSPA2 ATPase domain (PDB:3I33) confirms this activity. Duplicate annotations with different evidence codes are acceptable.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATP hydrolysis activity is the core catalytic function of HSPA2, confirmed by crystal structure of the ATPase domain (PDB:3I33). The IEA from InterPro is correct and consistent with the IBA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019899" target="_blank" class="term-link">
                                     GO:0019899
                                 </a>
                             </span>
                             <span class="term-label">enzyme binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1612,46 +1623,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of HSPA2 for enzyme binding based on ARBA machine learning. HSPA2 interacts with METTL21A (HSPA-KMT), an enzyme that trimethylates Lys-564 of HSPA2 (PMID:23921388). This qualifies as enzyme binding. However, this is a somewhat uninformative term; the interaction with METTL21A is more accurately described as HSPA2 being a substrate of this methyltransferase rather than HSPA2 having &#34;enzyme binding&#34; as a core molecular function. As a chaperone, HSPA2 also interacts with numerous enzymes as clients.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Enzyme binding is technically correct (HSPA2 interacts with METTL21A methyltransferase, PMID:23921388), but it is not an informative description of HSPA2 core function. As a chaperone, HSPA2 binds many proteins including enzymes as clients or regulatory partners.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030154" target="_blank" class="term-link">
                                     GO:0030154
                                 </a>
                             </span>
                             <span class="term-label">cell differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1663,46 +1674,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of HSPA2 for cell differentiation based on UniProtKB keyword mapping (KW-0221 Differentiation). This is a very broad term. The differentiation keyword in UniProt for HSPA2 presumably relates to its role in spermatogenesis, specifically spermatid differentiation and development. The more specific terms GO:0007283 &#34;spermatogenesis&#34; and GO:0007286 &#34;spermatid development&#34; are already annotated and are more informative. Cell differentiation is too generic to be useful for HSPA2.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0030154 &#34;cell differentiation&#34; is too broad and uninformative for HSPA2. The relevant differentiation context is spermatogenesis/spermatid development, which is already captured by more specific annotations (GO:0007283, GO:0007286). This general term adds no useful information.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1714,46 +1725,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of HSPA2 for protein refolding based on ARBA machine learning. This is a duplicate of the IBA and IDA annotations for the same term. Protein refolding is a core function of HSPA2, directly demonstrated by luciferase refolding assays (PMID:21231916). The IEA annotation is correct and consistent with experimental evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein refolding is a core function of HSPA2, confirmed by experimental evidence (PMID:21231916 IDA) and phylogenetic inference (IBA). The IEA annotation is correct.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1765,433 +1776,378 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962) because the term describes binding rather than the actual molecular activity. HSPA2 is a bona fide ATP-dependent foldase chaperone, not merely a passive binder of unfolded proteins. The IEA annotation via ARBA machine learning correctly identifies the chaperone-related function but uses the wrong term. UniProt describes HSPA2 as a &#34;molecular chaperone implicated in a wide variety of cellular processes, including protection of the proteome from stress, folding and transport of newly synthesized polypeptides&#34; (UniProt P54652). The correct replacement is GO:0044183 &#34;protein folding chaperone&#34;, which already has an IBA annotation for this gene, further confirming the appropriateness of the replacement.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted per go-ontology#30962 because it conflates passive binding with active chaperone function. For HSP70 family members like HSPA2, the correct term is GO:0044183 &#34;protein folding chaperone&#34; (foldase), as the protein actively assists protein folding through ATP-dependent cycles. This IEA annotation should be replaced with the correct MF term.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16189514" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16189514
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Towards a proteome-scale map of the human protein-protein in...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P54652" data-a="GO:0005515" data-r="PMID:16189514" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="P54652" data-a="GO:0005515" data-r="PMID:16189514" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IPI annotation of HSPA2 for protein binding based on interaction with HSPBP1 (Q9NZL4) detected in Rual et al. (PMID:16189514), a proteome-scale yeast two-hybrid study of human protein-protein interactions. HSPBP1 is a known HSP70 co-chaperone/nucleotide exchange factor. The interaction between HSPA2 and HSPBP1 is functionally relevant and has been confirmed in multiple independent studies. However, &#34;protein binding&#34; is uninformative; this interaction is better captured by GO:0031072 &#34;heat shock protein binding&#34; (already annotated via IBA) or by the co-chaperone interaction context.
+                            <strong>Summary:</strong> IPI annotation of HSPA2 for protein binding based on interaction with HSPBP1 (Q9NZL4) detected in Rual et al. (PMID:16189514), a proteome-scale yeast two-hybrid study of human protein-protein interactions. HSPBP1 is a known HSP70 co-chaperone/nucleotide exchange factor. The interaction between HSPA2 and HSPBP1 is functionally relevant and has been confirmed in multiple independent studies. However, &#34;protein binding&#34; is uninformative and this co-chaperone/NEF interaction should not be replaced with heat shock protein binding because HSPBP1 is not an HSP.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> The interaction with HSPBP1 (a co-chaperone/NEF) is real and confirmed across multiple studies, but GO:0005515 &#34;protein binding&#34; is uninformative. This interaction is already captured by the more specific GO:0031072 &#34;heat shock protein binding&#34; IBA annotation. Replace with the more specific term.
+                            <strong>Reason:</strong> The interaction with HSPBP1 (a co-chaperone/NEF) is real and confirmed across multiple studies, but GO:0005515 &#34;protein binding&#34; is uninformative. GO:0031072 &#34;heat shock protein binding&#34; would be semantically incorrect here because HSPBP1 is not a heat shock protein. Mark as over-annotated rather than propose an incorrect replacement.
                         </div>
-                        
-                        
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-                            
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
-                                    heat shock protein binding
-                                </a>
-                            </span>
-                            
-                        </div>
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16713569" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16713569
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A protein-protein interaction network for human inherited at...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P54652" data-a="GO:0005515" data-r="PMID:16713569" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="P54652" data-a="GO:0005515" data-r="PMID:16713569" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IPI annotation of HSPA2 for protein binding based on interaction with HSPBP1 (Q9NZL4) detected in Lim et al. (PMID:16713569), a protein-protein interaction network study for inherited ataxias. This is another detection of the HSPA2-HSPBP1 co-chaperone interaction. As with the other HSPBP1 interaction entries, &#34;protein binding&#34; is uninformative and the interaction is better represented by GO:0031072 &#34;heat shock protein binding.&#34;
+                            <strong>Summary:</strong> IPI annotation of HSPA2 for protein binding based on interaction with HSPBP1 (Q9NZL4) detected in Lim et al. (PMID:16713569), a protein-protein interaction network study for inherited ataxias. This is another detection of the HSPA2-HSPBP1 co-chaperone interaction. As with the other HSPBP1 interaction entries, &#34;protein binding&#34; is uninformative but should not be replaced by heat shock protein binding because HSPBP1 is not an HSP.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Same rationale as the PMID:16189514 entry. HSPA2-HSPBP1 interaction is a co-chaperone interaction better described by GO:0031072 &#34;heat shock protein binding&#34; rather than the generic GO:0005515.
+                            <strong>Reason:</strong> Same rationale as the PMID:16189514 entry. HSPA2-HSPBP1 interaction is a co-chaperone/NEF interaction. GO:0005515 is uninformative, and GO:0031072 would be incorrect for this non-HSP partner.
                         </div>
-                        
-                        
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-                            
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
-                                    heat shock protein binding
-                                </a>
-                            </span>
-                            
-                        </div>
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25036637
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A quantitative chaperone interaction network reveals the arc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P54652" data-a="GO:0005515" data-r="PMID:25036637" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="P54652" data-a="GO:0005515" data-r="PMID:25036637" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation of HSPA2 for protein binding based on interactions detected in Taipale et al. (PMID:25036637), a quantitative chaperone interaction network study. The GOA data shows interactions with BAG4 (O95429), HSF2 (Q03933), and Q96BE0. BAG4 is a BAG domain co-chaperone that acts as a nucleotide exchange factor for HSP70s. HSF2 is a heat shock transcription factor. These are functionally relevant interactions for a chaperone. However, &#34;protein binding&#34; remains uninformative; these interactions reflect chaperone-co-chaperone interactions or client binding.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> The interactions with BAG4 (co-chaperone) and HSF2 are real and functionally relevant from a chaperone network study, but &#34;protein binding&#34; is uninformative. The BAG4 interaction is better described by GO:0031072 &#34;heat shock protein binding.&#34;
+                            <strong>Reason:</strong> The interactions with BAG4 (co-chaperone) and HSF2 are real and functionally relevant from a chaperone network study, but &#34;protein binding&#34; is uninformative. GO:0031072 is not an appropriate replacement because BAG4 is a BAG-domain nucleotide exchange factor/co-chaperone and HSF2 is a transcription factor, not a heat shock protein.
                         </div>
-                        
-                        
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-                            
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
-                                    heat shock protein binding
-                                </a>
-                            </span>
-                            
-                        </div>
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25416956
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A proteome-scale map of the human interactome network.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P54652" data-a="GO:0005515" data-r="PMID:25416956" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="P54652" data-a="GO:0005515" data-r="PMID:25416956" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation of HSPA2 for protein binding based on interactions with TRIM38 (O00635) and HSPBP1 (Q9NZL4) detected in Rolland et al. (PMID:25416956), a proteome-scale interactome mapping study. The HSPBP1 interaction is a well-validated co-chaperone interaction. TRIM38 is an E3 ubiquitin ligase; its interaction with HSPA2 could relate to chaperone- mediated targeting of substrates for ubiquitination. &#34;Protein binding&#34; is too generic for these functionally informative interactions.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Contains validated co-chaperone interaction (HSPBP1) and ubiquitin ligase interaction (TRIM38). GO:0005515 &#34;protein binding&#34; is uninformative; the HSPBP1 interaction is better captured by GO:0031072 &#34;heat shock protein binding.&#34;
+                            <strong>Reason:</strong> Contains validated co-chaperone interaction (HSPBP1) and ubiquitin ligase interaction (TRIM38). GO:0005515 &#34;protein binding&#34; is uninformative; the HSPBP1 interaction is not heat shock protein binding and the TRIM38 interaction lacks enough functional specificity for a better replacement.
                         </div>
-                        
-                        
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-                            
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
-                                    heat shock protein binding
-                                </a>
-                            </span>
-                            
-                        </div>
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28514442
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Architecture of the human interactome defines protein commun...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P54652" data-a="GO:0005515" data-r="PMID:28514442" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="P54652" data-a="GO:0005515" data-r="PMID:28514442" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation of HSPA2 for protein binding based on interaction with HSPBP1 (Q9NZL4) detected in Huttlin et al. (PMID:28514442), a study on the architecture of the human interactome. This is yet another independent confirmation of the HSPA2-HSPBP1 co-chaperone interaction. &#34;Protein binding&#34; is uninformative for this functionally well-characterized interaction.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Another confirmation of HSPA2-HSPBP1 co-chaperone interaction. GO:0005515 is uninformative; better captured by GO:0031072.
+                            <strong>Reason:</strong> Another confirmation of HSPA2-HSPBP1 co-chaperone interaction. GO:0005515 is uninformative, but GO:0031072 would be incorrect because HSPBP1 is not a heat shock protein.
                         </div>
-                        
-                        
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-                            
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
-                                    heat shock protein binding
-                                </a>
-                            </span>
-                            
-                        </div>
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31515488
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Extensive disruption of protein interactions by genetic vari...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2203,130 +2159,119 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation of HSPA2 for protein binding based on interaction with TRIM38 (O00635) detected in Sahni et al. (PMID:31515488), a large-scale study on disruption of protein interactions by genetic variants. TRIM38 is an E3 ubiquitin ligase, not a heat shock protein, so the interaction cannot be captured by GO:0031072. Without functional characterization of the HSPA2-TRIM38 pair, &#34;protein binding&#34; is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Single binary interaction with TRIM38 (an E3 ubiquitin ligase) detected in a high-throughput screen does not justify a specific molecular function annotation. GO:0031072 &#34;heat shock protein binding&#34; is biologically incorrect because TRIM38 is not an HSP. Mark as over-annotated rather than propose a replacement.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32296183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A reference map of the human binary protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P54652" data-a="GO:0005515" data-r="PMID:32296183" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="P54652" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation of HSPA2 for protein binding based on interaction with BAG4 (O95429) detected in Luck et al. (PMID:32296183), a reference map of the human binary protein interactome. BAG4 is a co-chaperone containing a BAG domain that functions as a nucleotide exchange factor for HSP70 proteins. This is a functionally relevant chaperone-co-chaperone interaction. &#34;Protein binding&#34; is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> BAG4 is an HSP70 co-chaperone; this interaction is functionally relevant and better described by GO:0031072 &#34;heat shock protein binding&#34; rather than the generic GO:0005515.
+                            <strong>Reason:</strong> BAG4 is an HSP70 co-chaperone; this interaction is functionally relevant but is not heat shock protein binding because BAG4 is a BAG-domain nucleotide exchange factor/co-chaperone. Mark the generic GO:0005515 annotation as over-annotated.
                         </div>
-                        
-                        
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-                            
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
-                                    heat shock protein binding
-                                </a>
-                            </span>
-                            
-                        </div>
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32814053
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interactome Mapping Provides a Network of Neurodegenerative ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2338,265 +2283,232 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation of HSPA2 for protein binding based on a large number of interactions detected in Mair et al. (PMID:32814053), an interactome mapping study focused on neurodegenerative disease proteins. The GOA data lists interactions with many partners including HTT (P42858), SSB, SOCS6, multiple zinc finger proteins, and others — predominantly non-HSP partners. Some of these (HTT) are likely chaperone-client interactions relevant to aggregation suppression, consistent with the role of HSPA2 in suppressing polyQ aggregation (PMID:21231916). However, many interactions from large-scale screens are non-specific or transient chaperone-client contacts, and the diverse partner set cannot be summarized by GO:0031072 &#34;heat shock protein binding&#34; (most partners are not HSPs).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The diverse, non-HSP-dominated set of partners in this large-scale interactome screen cannot be captured by GO:0031072. Functionally relevant chaperone-client and chaperone-co-chaperone interactions of HSPA2 are already represented by GO:0044183 (protein folding chaperone) and GO:0031072 (heat shock protein binding) annotations supported by better-characterised pairs. Mark this generic &#34;protein binding&#34; annotation as over-annotated.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P54652" data-a="GO:0005515" data-r="PMID:33961781" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="P54652" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation of HSPA2 for protein binding based on interactions with HSF2 (Q03933) and HSPBP1 (Q9NZL4) detected in Huttlin et al. (PMID:33961781), a dual proteome-scale network study. Both are functionally relevant interactions: HSPBP1 is a co-chaperone and HSF2 is a heat shock transcription factor that could be regulated by chaperone interactions. &#34;Protein binding&#34; is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Both interaction partners (HSPBP1 co-chaperone, HSF2 transcription factor) are functionally relevant. GO:0005515 is uninformative; these are better captured by GO:0031072.
+                            <strong>Reason:</strong> Both interaction partners (HSPBP1 co-chaperone, HSF2 transcription factor) are functionally relevant, but neither supports heat shock protein binding. GO:0005515 is therefore too generic and should be marked as over-annotated rather than modified to GO:0031072.
                         </div>
-                        
-                        
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-                            
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
-                                    heat shock protein binding
-                                </a>
-                            </span>
-                            
-                        </div>
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:35271311
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     OpenCell: Endogenous tagging for the cartography of human ce...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P54652" data-a="GO:0005515" data-r="PMID:35271311" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="P54652" data-a="GO:0005515" data-r="PMID:35271311" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation of HSPA2 for protein binding based on interaction with HSPBP1 (Q9NZL4) detected in Cho et al. (PMID:35271311), the OpenCell endogenous tagging study. This is another independent confirmation of the HSPA2-HSPBP1 co-chaperone interaction using endogenous tagging, a method less prone to overexpression artifacts. &#34;Protein binding&#34; is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Another independent confirmation of HSPA2-HSPBP1 interaction using endogenous tagging. GO:0005515 is uninformative; better captured by GO:0031072.
+                            <strong>Reason:</strong> Another independent confirmation of HSPA2-HSPBP1 interaction using endogenous tagging. GO:0005515 is uninformative, and GO:0031072 is not appropriate for the non-HSP co-chaperone HSPBP1.
                         </div>
-                        
-                        
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-                            
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
-                                    heat shock protein binding
-                                </a>
-                            </span>
-                            
-                        </div>
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:40205054
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Multimodal cell maps as a foundation for structural and func...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P54652" data-a="GO:0005515" data-r="PMID:40205054" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="P54652" data-a="GO:0005515" data-r="PMID:40205054" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation of HSPA2 for protein binding based on interactions with HSF2 (Q03933) and HSPBP1 (Q9NZL4) detected in Kim et al. (PMID:40205054), a multimodal cell mapping study. These are the same well-validated interaction partners seen across multiple studies. &#34;Protein binding&#34; is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Well-validated interactions with HSPBP1 and HSF2. GO:0005515 is uninformative; better captured by GO:0031072.
+                            <strong>Reason:</strong> Well-validated interactions with HSPBP1 and HSF2. GO:0005515 is uninformative, but these partners do not justify GO:0031072 because HSPBP1 is a co-chaperone/NEF and HSF2 is a transcription factor.
                         </div>
-                        
-                        
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-                            
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
-                                    heat shock protein binding
-                                </a>
-                            </span>
-                            
-                        </div>
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000795" target="_blank" class="term-link">
                                     GO:0000795
                                 </a>
                             </span>
                             <span class="term-label">synaptonemal complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2608,64 +2520,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of HSPA2 to synaptonemal complex based on Ensembl Compara orthology transfer from mouse Hsp70-2 (P17156). The mouse knockout study (PMID:8622925) directly demonstrated that HSP70-2 is associated with synaptonemal complexes in meiotic spermatocytes: &#34;We previously found that HSP70-2 is associated with synaptonemal complexes in the nucleus of meiotic spermatocytes from mice and hamsters. While synaptonemal complexes assembled in Hsp70-2 -/- spermatocytes, structural abnormalities became apparent in these cells by late prophase.&#34; This is a well-supported specialized localization for HSPA2 during male meiosis.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Synaptonemal complex localization is directly demonstrated for the mouse ortholog Hsp70-2 in meiotic spermatocytes (PMID:8622925) and is a key aspect of the specialized meiotic function of HSPA2. The IEA transfer from mouse is well justified.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8622925" target="_blank" class="term-link">
                                         PMID:8622925
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We previously found that HSP70-2 is associated with synaptonemal complexes in the nucleus of meiotic spermatocytes from mice and hamsters. While synaptonemal complexes assembled in Hsp70-2 -/- spermatocytes, structural abnormalities became apparent in these cells by late prophase</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001673" target="_blank" class="term-link">
                                     GO:0001673
                                 </a>
                             </span>
                             <span class="term-label">male germ cell nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2677,64 +2589,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of HSPA2 to male germ cell nucleus based on Ensembl Compara orthology transfer from mouse Hsp70-2 (P17156). The mouse ortholog has been demonstrated to localize within the nucleus of meiotic spermatocytes where it associates with synaptonemal complexes (PMID:8622925). HSPA2 was also detected in the human sperm nucleus proteome (PMID:21630459). This is a well-supported specialized localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Male germ cell nucleus localization is strongly supported by the mouse knockout study showing association with synaptonemal complexes in spermatocyte nuclei (PMID:8622925) and by proteomics detection in human sperm nuclei (PMID:21630459).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8622925" target="_blank" class="term-link">
                                         PMID:8622925
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSP70-2 is associated with synaptonemal complexes in the nucleus of meiotic spermatocytes from mice and hamsters.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009986" target="_blank" class="term-link">
                                     GO:0009986
                                 </a>
                             </span>
                             <span class="term-label">cell surface</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2746,46 +2658,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of HSPA2 to cell surface based on Ensembl Compara orthology transfer from mouse Hsp70-2 (P17156). HSP70 family members have been reported at the cell surface in various contexts, particularly in sperm cells where HSPA2 may be surface-exposed as part of the CatSper complex or other surface structures. This is consistent with the CatSper complex annotation and the plasma membrane IBA annotation. However, cell surface localization is not a core feature of HSPA2 function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cell surface localization is plausible for HSPA2, particularly in sperm cells, but is not a core functional localization. The primary functional compartments are cytosol and nucleus (synaptonemal complex).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036128" target="_blank" class="term-link">
                                     GO:0036128
                                 </a>
                             </span>
                             <span class="term-label">CatSper complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2797,46 +2709,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of HSPA2 as part of the CatSper complex based on Ensembl Compara orthology transfer from mouse Hsp70-2 (P17156). UniProt notes &#34;Component of the CatSper complex&#34; for HSPA2 (by similarity to mouse). CatSper is a sperm-specific calcium ion channel complex essential for sperm motility and male fertility. HSPA2 association with CatSper is consistent with its specialized role in spermatogenesis and sperm function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CatSper complex membership is supported by mouse ortholog data and UniProt annotation (by similarity). This is a specialized sperm function consistent with the spermatogenesis role, but is a secondary localization rather than a core molecular function annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048156" target="_blank" class="term-link">
                                     GO:0048156
                                 </a>
                             </span>
                             <span class="term-label">tau protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2848,97 +2760,97 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of HSPA2 for tau protein binding based on Ensembl Compara orthology transfer from rat Hspa2 (P14659). HSP70 family members, particularly HSPA8/Hsc70, have been shown to interact with tau and participate in its degradation through chaperone-mediated autophagy. However, this annotation is transferred from the rat ortholog and the tau binding evidence may be stronger for other HSP70 family members (particularly HSPA8). For HSPA2, tau binding would represent a general chaperone-client interaction rather than a specific function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Tau protein binding is likely a general chaperone-client interaction shared across HSP70 family members rather than a specific function of HSPA2. The annotation is transferred from rat and may be more relevant to HSPA8/Hsc70 which is the primary constitutive HSP70 in neurons. For HSPA2, which has a specialized testis/meiosis role, tau binding is not a core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P54652" data-a="GO:0051087" data-r="GO_REF:0000107" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P54652" data-a="GO:0051087" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IEA annotation of HSPA2 for protein-folding chaperone binding based on Ensembl Compara orthology transfer from rat Hspa2 (P14659). HSP70 family members interact extensively with co-chaperones (DNAJ/HSP40, HSPBP1, BAG domain proteins, HOP/STIP1). HSPA2 has demonstrated interactions with HSPBP1 across multiple studies (PMID:16189514, PMID:16713569, PMID:25416956, PMID:28514442, PMID:33961781, PMID:35271311, PMID:40205054) and with BAG4 (PMID:25036637, PMID:32296183) and DNAJA3 (PMID:32814053). This is a well-supported function. Note this describes HSPA2 binding to other chaperones (HSPA2 as the subject), which is essentially the reciprocal of heat shock protein binding.
+                            <strong>Summary:</strong> IEA annotation of HSPA2 for protein-folding chaperone binding based on Ensembl Compara orthology transfer from rat Hspa2 (P14659). HSP70 family members interact with true protein-folding chaperones such as DNAJ/HSP40 proteins and other HSP-family chaperones. HSPA2 has IntAct/UniProt evidence for DNAJA3 interaction and Falcon synthesis lists HSPA1A, HSPA8, and HSP90AA1 among HSPA2-associated chaperone-network proteins. HSPBP1 and BAG4 interactions are co-chaperone/NEF interactions and should not be used as direct support for this term.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> HSPA2 binding to co-chaperones (HSPBP1, BAG4, DNAJA3) is extensively documented by IPI evidence across multiple studies. This is a core aspect of HSP70 function.
+                            <strong>Reason:</strong> Retain as a plausible non-core chaperone-network binding annotation when restricted to true chaperone partners such as DNAJA3 and HSP-family proteins. The annotation should not be justified by HSPBP1 or BAG4 alone, because those are not protein-folding chaperones in the sense required by GO:0051087.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051861" target="_blank" class="term-link">
                                     GO:0051861
                                 </a>
                             </span>
                             <span class="term-label">glycolipid binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2950,46 +2862,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of HSPA2 for glycolipid binding based on Ensembl Compara orthology transfer from mouse Hsp70-2 (P17156). This annotation likely relates to the reported interaction of HSP70 family members with sulfogalactosylglycerolipid (SGG/seminolipid) on the sperm surface, which has been proposed to play a role in sperm-egg interaction. This is a specialized sperm biology function. However, glycolipid binding is not a well-established molecular function of HSPA2 based on direct evidence and may represent an over-annotation based on indirect or limited evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Glycolipid binding is a specialized annotation transferred from the mouse ortholog that is based on limited evidence about HSP70-seminolipid interactions on sperm surfaces. This is not a well-characterized core molecular function of HSPA2 and likely represents over-annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0072687" target="_blank" class="term-link">
                                     GO:0072687
                                 </a>
                             </span>
                             <span class="term-label">meiotic spindle</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3001,46 +2913,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of HSPA2 to meiotic spindle based on Ensembl Compara orthology transfer from mouse Hsp70-2 (P17156). UniProt notes that HSPA2 co-localizes with SHCBP1L at the spindle during meiosis (by similarity). This is consistent with the specialized meiotic function of HSPA2 in male germ cells. The more specific meiotic spindle term is appropriate given HSPA2&#39;s established role in male meiosis (PMID:8622925).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Meiotic spindle localization is supported by mouse ortholog data showing HSPA2 co-localizes with SHCBP1L at the spindle during meiosis (UniProt, by similarity to P17156). This is consistent with HSPA2&#39;s essential role in male meiosis (PMID:8622925).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007283" target="_blank" class="term-link">
                                     GO:0007283
                                 </a>
                             </span>
                             <span class="term-label">spermatogenesis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3052,64 +2964,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISS annotation of HSPA2 for spermatogenesis based on manual transfer from mouse ortholog Hsp70-2 (P17156). The mouse knockout study (PMID:8622925) definitively demonstrated that Hsp70-2 is required for spermatogenesis: male knockout mice lacked postmeiotic spermatids and mature sperm and were infertile. HSPA2 is the human ortholog with 98.2% amino acid identity (PMID:7829106). This is a core specialized function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Spermatogenesis is a core specialized function, directly demonstrated by mouse knockout (PMID:8622925). The ISS transfer from mouse is strongly justified by high sequence conservation (98.2% identity, PMID:7829106).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8622925" target="_blank" class="term-link">
                                         PMID:8622925
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Male mice homozygous for the mutant allele (Hsp70-2 -/-) did not synthesize HSP70-2, lacked postmeiotic spermatids and mature sperm, and were infertile.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0072687" target="_blank" class="term-link">
                                     GO:0072687
                                 </a>
                             </span>
                             <span class="term-label">meiotic spindle</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3121,46 +3033,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISS annotation of HSPA2 to meiotic spindle based on manual transfer from mouse ortholog Hsp70-2 (P17156). UniProt notes HSPA2 co-localizes with SHCBP1L at the spindle during meiosis (by similarity). This is a duplicate of the IEA annotation for the same term. Both are supported by the mouse ortholog data.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Meiotic spindle localization is well supported by mouse ortholog data (by similarity to P17156). The ISS annotation is correct and consistent with the IEA annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009408" target="_blank" class="term-link">
                                     GO:0009408
                                 </a>
                             </span>
                             <span class="term-label">response to heat</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3172,64 +3084,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISS annotation of HSPA2 for response to heat based on manual transfer from orthologs by AgBase. HSPA2 is a member of the HSP70 family, which are classically involved in the heat shock response. However, HSPA2 is notably constitutively expressed rather than heat-inducible. The original characterization (PMID:7829106) describes HSPA2 as constitutively expressed. UniProt keywords include &#34;Stress response&#34; but HSPA2 is not a canonical heat-inducible HSP70 (unlike HSPA1A/HSPA6). While HSPA2 likely participates in protein quality control during heat stress as a constitutive chaperone, &#34;response to heat&#34; may be somewhat misleading for a constitutively expressed member. This is a non-core annotation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPA2 is constitutively expressed (PMID:7829106) rather than heat-inducible, distinguishing it from canonical heat-inducible HSP70s like HSPA1A. It may participate in heat stress response through its constitutive chaperone activity, but &#34;response to heat&#34; is not a core or distinguishing function of HSPA2.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7829106" target="_blank" class="term-link">
                                         PMID:7829106
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSPA2 is constitutively expressed in most tissues, with very high levels in testis and skeletal muscle.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009409" target="_blank" class="term-link">
                                     GO:0009409
                                 </a>
                             </span>
                             <span class="term-label">response to cold</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -3241,57 +3153,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISS annotation of HSPA2 for response to cold based on manual transfer from orthologs by AgBase. HSP70 family members can be induced by various stresses including cold. However, HSPA2 is constitutively expressed (PMID:7829106) and there is limited direct evidence for its specific involvement in cold stress response in humans. This annotation likely derives from studies of HSP70 orthologs in other organisms (e.g., fish) where cold stress induces HSP70 expression. For HSPA2, this is at best a peripheral function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPA2 is constitutively expressed (PMID:7829106) and there is no strong evidence for specific involvement in cold stress response. This annotation likely derives from studies in distantly related organisms where HSP70 induction by cold is documented, but this is not a core or well-established function of human HSPA2.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
                                     GO:0016020
                                 </a>
                             </span>
                             <span class="term-label">membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19946888
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Defining the membrane proteome of NK cells.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3303,57 +3215,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HDA annotation of HSPA2 to membrane based on high-throughput proteomics of NK cell membranes (PMID:19946888). HSPA2 was detected in the membrane proteome of NK cells. HSP70 family members are known to associate with membranes, particularly under stress conditions, and have been detected on cell surfaces. However, &#34;membrane&#34; is a very broad cellular component term and membrane association is not a core localization of HSPA2.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPA2 detection in the membrane proteome of NK cells is plausible but represents a non-core localization. The term &#34;membrane&#34; is very broad, and HSPA2&#39;s primary functional localization is cytosol and nucleus (synaptonemal complex in meiosis).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019899" target="_blank" class="term-link">
                                     GO:0019899
                                 </a>
                             </span>
                             <span class="term-label">enzyme binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23921388
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of a novel human methylt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3365,75 +3277,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation of HSPA2 for enzyme binding based on its interaction with METTL21A (Q8WXB1, also known as HSPA-KMT) demonstrated in Jakobsson et al. (PMID:23921388). METTL21A was identified as the methyltransferase responsible for trimethylation of Lys-564 in HSPA2 and other HSP70 family members. The interaction was demonstrated both in vitro and in vivo, and the K564A mutation abolished methylation. This is a real enzyme-substrate interaction where HSPA2 is the substrate. However, &#34;enzyme binding&#34; is relatively uninformative; the biologically informative aspect is that HSPA2 is a substrate of METTL21A methyltransferase.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The interaction between HSPA2 and METTL21A (PMID:23921388) is real and well-characterized, but HSPA2 is the substrate rather than having enzyme binding as a core molecular function. This is a non-core annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link">
                                         PMID:23921388
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we identified the methyltransferase METTL21A as the enzyme responsible for trimethylation of a conserved lysine residue found in several human Hsp70 (HSPA) proteins</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3445,75 +3357,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation of HSPA2 to cytosol based on Hageman et al. (PMID:21231916), who demonstrated cytosolic chaperone activities of HSPA2 including luciferase refolding and polyQ aggregation suppression. These functional assays were performed in the cytosol of cultured cells. This is direct experimental evidence for cytosolic localization and is consistent with the IBA annotation for the same term.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization is directly demonstrated by functional chaperone assays (luciferase refolding, polyQ aggregation suppression) performed in the cytosol (PMID:21231916). This is a core localization for HSPA2.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3525,75 +3437,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation of HSPA2 for protein refolding based on Hageman et al. (PMID:21231916), who directly demonstrated that HSPA2 overexpression supports refolding of heat-denatured luciferase. This is direct experimental evidence from a systematic comparison of all mammalian HSP70 family members. HSPA2 was shown to be competent for luciferase refolding, confirming its function as a protein refolding chaperone.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct experimental evidence demonstrating HSPA2 supports luciferase refolding (PMID:21231916). This is a core biological process function of HSPA2 as an HSP70 chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -3605,99 +3517,99 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Hageman et al. (PMID:21231916) systematically compared the chaperone activities of mammalian HSP70 family members using functional assays for protein refolding and aggregation suppression. The study assessed HSPA2 and other HSPAs for &#34;refolding of heat-denatured luciferase&#34; and &#34;suppression of aggregation of a non-foldable polyQ-expanded Huntingtin fragment.&#34; These are assays of active chaperone function (foldase activity), not merely passive binding to unfolded substrates. HSPA2 was shown to support luciferase refolding and suppress protein aggregation, demonstrating it functions as an ATP-dependent protein folding chaperone. The annotation as GO:0051082 &#34;unfolded protein binding&#34; underrepresents this activity; the correct term is GO:0044183 &#34;protein folding chaperone.&#34; GO:0051082 is being obsoleted per go-ontology#30962.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The experimental evidence from PMID:21231916 demonstrates active chaperone function (refolding of denatured luciferase, suppression of polyQ aggregation), which is GO:0044183 &#34;protein folding chaperone&#34; activity, not merely passive binding to unfolded proteins (GO:0051082). Furthermore, GO:0051082 is being obsoleted (go-ontology#30962) with GO:0044183 as the recommended replacement for foldase-type chaperones. HSPA2 already has an IBA annotation for GO:0044183, and the IDA evidence from this paper directly supports that term.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">even within the highly sequence-conserved HSPA family, functional differentiation is larger than expected</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090084" target="_blank" class="term-link">
                                     GO:0090084
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of inclusion body assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21231916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The diverse members of the mammalian HSP70 machine show dist...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3709,75 +3621,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation of HSPA2 for negative regulation of inclusion body assembly based on Hageman et al. (PMID:21231916), who demonstrated that HSPA2 overexpression suppresses aggregation of a polyQ-expanded Huntingtin fragment. This suppression of protein aggregation (inclusion body formation) is a direct consequence of HSPA2 chaperone activity. The annotation accurately describes the experimental observation that HSPA2 can prevent inclusion body formation by maintaining client proteins in a soluble state.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Directly demonstrated by the polyQ aggregation suppression assay in PMID:21231916. Suppression of protein aggregation/inclusion body formation is a core chaperone function of HSPA2. This is a well-supported annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                         PMID:21231916
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21630459
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomic characterization of the human sperm nucleus.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3789,57 +3701,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HDA annotation of HSPA2 to nucleus based on proteomic characterization of the human sperm nucleus (PMID:21630459). HSPA2 was identified as a component of the sperm nucleus proteome by high-throughput mass spectrometry. This is consistent with HSPA2&#39;s known role in spermatogenesis and its association with synaptonemal complexes in the nucleus of meiotic spermatocytes (PMID:8622925). Nuclear localization is a well-supported aspect of HSPA2 biology.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPA2 was detected in the human sperm nucleus proteome (PMID:21630459), consistent with its role in meiotic spermatocyte nuclei where it associates with synaptonemal complexes (PMID:8622925). Nuclear localization is supported by multiple independent lines of evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0072562" target="_blank" class="term-link">
                                     GO:0072562
                                 </a>
                             </span>
                             <span class="term-label">blood microparticle</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22516433" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22516433
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomic analysis of microvesicles from plasma of healthy d...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3851,57 +3763,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HDA annotation of HSPA2 to blood microparticle based on proteomic analysis of plasma microvesicles (PMID:22516433). HSP70 proteins are commonly detected in extracellular vesicles and blood microparticles, likely reflecting their abundance and their role in extracellular signaling or stress response. Detection in blood microparticles is not a core functional localization for HSPA2.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Detection in blood microparticles is a common finding for abundant intracellular proteins in proteomics studies. This is not a core functional localization for HSPA2 but may reflect real biology (extracellular chaperone function or vesicular secretion).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
                                     GO:0070062
                                 </a>
                             </span>
                             <span class="term-label">extracellular exosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19056867
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Large-scale proteomics and phosphoproteomics of urinary exos...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3913,46 +3825,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HDA annotation of HSPA2 to extracellular exosome based on large-scale proteomics of urinary exosomes (PMID:19056867). HSP70 family members are among the most commonly detected proteins in exosome proteomics studies. While this may reflect real biology (HSP70s have roles in exosome biogenesis and can be secreted), it is not a core functional localization for HSPA2.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSP70 family members are commonly detected in exosome proteomics. While potentially real, extracellular exosome localization is not a core functional localization for HSPA2, whose primary functions are in cytosolic protein folding and meiotic spermatocyte biology.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036128" target="_blank" class="term-link">
                                     GO:0036128
                                 </a>
                             </span>
                             <span class="term-label">CatSper complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3964,57 +3876,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISS annotation of HSPA2 as part of the CatSper complex based on manual transfer from mouse ortholog Hsp70-2 (P17156). UniProt states &#34;Component of the CatSper complex&#34; for HSPA2 (by similarity). CatSper is a sperm-specific calcium channel complex essential for sperm motility and hyperactivation. HSPA2 association with CatSper is consistent with its specialized role in spermatogenesis and sperm function. This duplicates the IEA annotation for the same term.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CatSper complex membership is supported by mouse ortholog data and UniProt annotation. This is a specialized sperm function annotation that is consistent with HSPA2&#39;s role in spermatogenesis but is a secondary aspect of its biology.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006986" target="_blank" class="term-link">
                                     GO:0006986
                                 </a>
                             </span>
                             <span class="term-label">response to unfolded protein</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/7829106" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:7829106
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Cloning, sequencing, and mapping of the human chromosome 14 ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4026,75 +3938,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation of HSPA2 for response to unfolded protein based on Bonnycastle et al. (PMID:7829106), which cloned and characterized the HSPA2 gene. The paper describes HSPA2 as a member of the HSP70 family and notes its constitutive expression pattern. While the paper does not directly demonstrate response to unfolded protein, it characterizes HSPA2 as an HSP70 gene family member, and HSP70 proteins are fundamentally involved in the unfolded protein response. The TAS evidence code is appropriate for this inference based on family membership.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPA2 is an HSP70 family member (PMID:7829106) and involvement in response to unfolded protein is a fundamental function of this family. The TAS annotation is appropriate given the well-established role of HSP70 chaperones in proteostasis.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7829106" target="_blank" class="term-link">
                                         PMID:7829106
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">A genomic clone for the human heat shock protein (HSP) 70 gene located on chromosome 14 was isolated and sequenced. The gene, designated HSPA2, has a single open reading frame of 1917 bp that encodes a 639-amino acid protein</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/3037489" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:3037489
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structure and expression of a human gene coding for a 71 kd ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -4106,99 +4018,99 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PMID:3037489 (Dworniczak and Mirault, 1987) describes the structure and expression of a human gene coding for a 71 kDa heat shock cognate protein. The paper characterizes an hsc70 gene (likely HSPA8/HSC70, not HSPA2) as encoding a protein &#34;very likely to be identical to a clathrin uncoating ATPase recently identified as a member of the hsp70-like protein family.&#34; This TAS annotation to HSPA2 appears to have been made based on the general understanding that HSP70 family members bind unfolded proteins, but the paper actually describes HSPA8, not HSPA2 specifically. Regardless of the attribution, GO:0051082 is being obsoleted (go-ontology#30962) and the appropriate replacement for HSP70 foldase-type chaperones is GO:0044183 &#34;protein folding chaperone.&#34; HSPA2, like other HSP70 members, functions as an ATP-dependent foldase.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted (go-ontology#30962). The cited paper (PMID:3037489) describes a cognate hsc70 gene that may actually correspond to HSPA8 rather than HSPA2. Nonetheless, HSPA2 is a well-established HSP70 family member with documented foldase chaperone activity (PMID:21231916). The correct replacement term is GO:0044183 &#34;protein folding chaperone&#34;, reflecting the active ATP-dependent protein folding function of HSP70 family members.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/3037489" target="_blank" class="term-link">
                                         PMID:3037489
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">In all eukaryotes examined so far, hsp70 gene families include cognate genes (hsc70) encoding proteins of about 70 Kd which are expressed constitutively during normal growth and development</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/3037489" target="_blank" class="term-link">
                                         PMID:3037489
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The latter is very likely to be identical to a clathrin uncoating ATPase recently identified as a member of the hsp70-like protein family</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007140" target="_blank" class="term-link">
                                     GO:0007140
                                 </a>
                             </span>
                             <span class="term-label">male meiotic nuclear division</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/8622925" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:8622925
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Targeted gene disruption of Hsp70-2 results in failed meiosi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4210,88 +4122,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation of HSPA2 for male meiotic nuclear division based on Dix et al. (PMID:8622925). This landmark paper demonstrated that targeted disruption of the mouse Hsp70-2 gene resulted in failed meiosis in male germ cells. Knockout males &#34;lacked postmeiotic spermatids and mature sperm&#34; and &#34;development rarely progressed to the meiotic divisions.&#34; The study concluded that &#34;HSP70-2 participates in synaptonemal complex function during meiosis in male germ cells.&#34; This is a core specialized function of HSPA2.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Male meiotic nuclear division is a core specialized function of HSPA2, directly demonstrated by the mouse knockout study where loss of Hsp70-2 prevented meiotic progression (PMID:8622925). This is among the most well-supported annotations for HSPA2.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8622925" target="_blank" class="term-link">
                                         PMID:8622925
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Male mice homozygous for the mutant allele (Hsp70-2 -/-) did not synthesize HSP70-2, lacked postmeiotic spermatids and mature sperm, and were infertile.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8622925" target="_blank" class="term-link">
                                         PMID:8622925
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">These results suggest that HSP70-2 participates in synaptonemal complex function during meiosis in male germ cells and is linked to mechanisms that inhibit apoptosis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007286" target="_blank" class="term-link">
                                     GO:0007286
                                 </a>
                             </span>
                             <span class="term-label">spermatid development</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/8622925" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:8622925
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Targeted gene disruption of Hsp70-2 results in failed meiosi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4303,50 +4215,50 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation of HSPA2 for spermatid development based on Dix et al. (PMID:8622925). The mouse knockout study showed that Hsp70-2 -/- males &#34;lacked postmeiotic spermatids and mature sperm.&#34; This indicates that HSPA2 is required for the meiotic progression that precedes spermatid formation. However, the study shows that meiosis fails before spermatids are formed, so the absence of spermatids is an indirect consequence of failed meiosis rather than a direct role in spermatid development per se. The annotation is still appropriate under TAS evidence as a reasonable inference from the knockout phenotype.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Spermatid development failure is a consequence of HSPA2/Hsp70-2 loss (PMID:8622925). While the primary defect is in meiotic progression, the resulting absence of spermatids means HSPA2 is required for this process. The TAS evidence code is appropriate for this inference.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8622925" target="_blank" class="term-link">
                                         PMID:8622925
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Male mice homozygous for the mutant allele (Hsp70-2 -/-) did not synthesize HSP70-2, lacked postmeiotic spermatids and mature sperm, and were infertile. However, neither meiosis nor fertility was affected in female Hsp70-2 -/- mice.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>ATP-dependent protein folding chaperone that assists in refolding of heat-denatured proteins and suppresses aggregation of misfolded proteins (including polyQ-expanded substrates) in the cytosol, through cycles of ATP binding, hydrolysis, and ADP release mediated by J-domain and nucleotide exchange factor co-chaperones. The interaction network includes DNAJB12, STIP1, HSPBP1, HSPA1A, HSPA8, and HSP90AA1 (DOI:10.62347/cwpe7813). HSPA2 is also an extracellular vesicle (EV)- associated protein; proteotoxic stress can redistribute HSPA2 from intracellular pools to EVs (DOI:10.1038/s41598-023-31962-5). This provides a biological route for HSPA2 detection in biofluids and potential roles in intercellular communication.</h3>
                 <span class="vote-buttons" data-g="P54652" data-a="FUNCTION: ATP-dependent protein folding chaperone that assis..." data-r="" data-act="CORE_FUNCTION">
@@ -4354,10 +4266,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -4366,86 +4278,97 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                 protein refolding
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090084" target="_blank" class="term-link">
                                 negative regulation of inclusion body assembly
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006986" target="_blank" class="term-link">
                                 response to unfolded protein
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                 nucleus
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                                 PMID:21231916
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">we assessed the effect of overexpression of each of these HSPs on refolding of heat-denatured luciferase and on the suppression of aggregation of a non-foldable polyQ (polyglutamine)-expanded Huntingtin fragment</div>
-                        
+
                     </li>
-                    
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/HSPA2/HSPA2-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Falcon synthesis identifies HSPA2 as an HSP70-family ATP-dependent molecular chaperone supporting folding/refolding, protein quality control, and proteotoxic-stress-linked redistribution into extracellular vesicles.</div>
+
+                    </li>
+
                 </ul>
             </div>
-            
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>Essential chaperone for male meiosis and spermatogenesis. Associates with synaptonemal complexes during meiotic prophase and localizes to the meiotic spindle, where it is required for meiotic progression. Loss of the mouse ortholog Hsp70-2 causes failed meiosis, germ cell apoptosis, and male infertility. HSPA2 also supports post-meiotic sperm remodeling, including cytoplasmic extrusion and plasma membrane remodeling required for zona pellucida binding competence, with reported roles in enabling surface relocation of proteins needed for oocyte zona interaction during capacitation (DOI:10.3390/ijms23126497). Quantitative enrichment of HSPA2-positive cells in HA-bound sperm (68.9% vs 28.6% uncapacitated; DOI:10.1007/s43032-022-01031-9) connects HSPA2 with sperm functional maturity. HSPA2 interacts with SHCBP1L to support spindle integrity during male meiosis (DOI:10.62347/cwpe7813). Seminal plasma HSPA2 is a promising non-invasive biomarker for stratification of non-obstructive azoospermia, with 7.3-fold higher abundance in healthy controls vs Sertoli cell-only phenotype (DOI:10.3389/fendo.2024.1327800).</h3>
                 <span class="vote-buttons" data-g="P54652" data-a="FUNCTION: Essential chaperone for male meiosis and spermatog..." data-r="" data-act="CORE_FUNCTION">
@@ -4453,10 +4376,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -4465,1016 +4388,1041 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007140" target="_blank" class="term-link">
                                 male meiotic nuclear division
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007283" target="_blank" class="term-link">
                                 spermatogenesis
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007286" target="_blank" class="term-link">
                                 spermatid development
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000795" target="_blank" class="term-link">
                                 synaptonemal complex
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0072687" target="_blank" class="term-link">
                                 meiotic spindle
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001673" target="_blank" class="term-link">
                                 male germ cell nucleus
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/8622925" target="_blank" class="term-link">
                                 PMID:8622925
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">Male mice homozygous for the mutant allele (Hsp70-2 -/-) did not synthesize HSP70-2, lacked postmeiotic spermatids and mature sperm, and were infertile.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/8622925" target="_blank" class="term-link">
                                 PMID:8622925
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">These results suggest that HSP70-2 participates in synaptonemal complex function during meiosis in male germ cells and is linked to mechanisms that inhibit apoptosis.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/7829106" target="_blank" class="term-link">
                                 PMID:7829106
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">HSPA2 is constitutively expressed in most tissues, with very high levels in testis and skeletal muscle.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSPA2 is annotated to chaperone/ATPase-related GO terms via InterPro-to-GO mapping reflecting HSP70 family membership.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
                             GO_REF:0000024
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Manual transfer of experimentally-verified annotation by curator judgment of sequence similarity supports HSPA2 spermatogenesis-related and chaperone roles inferred from mouse Hspa2 orthology.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">PANTHER phylogenetic-tree annotation propagates conserved Hsp70 chaperone functions (ATP binding, ATP hydrolysis, protein folding chaperone, refolding, protein binding) to human HSPA2.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">UniProtKB keyword &#39;Nucleotide-binding&#39; maps to GO:0000166 nucleotide binding for HSPA2 based on its conserved HSP70 ATPase domain.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSPA2 UniProt subcellular location annotations (cytoplasm, nucleus) are mapped to corresponding GO cellular component terms.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
                             GO_REF:0000107
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Ensembl Compara orthology-based transfer propagates experimentally validated HSPA2 functions (spermatogenesis, meiotic regulation, chaperone activity) from mouse Hspa2 (Hsp70-2) orthologs.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">ARBA machine-learning model assigns HSPA2 to chaperone/cellular-stress GO terms based on HSP70 family signatures.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Combined automated IEA pipelines annotate HSPA2 with ATP binding, ATP hydrolysis activity, and protein folding terms from UniProt features.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/HSPA2/HSPA2-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research synthesis for HSPA2</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">HSPA2 is a human HSP70-family ATP-dependent molecular chaperone whose major supported roles are proteostasis, male germ-cell/sperm maturation, and extracellular vesicle-associated redistribution under proteotoxic stress.</div>
+
+                        <div class="finding-text">"Across recent primary studies, the most defensible &#34;primary function&#34; annotation is that HSPA2 is an ATP-dependent molecular chaperone supporting proteostasis (folding/refolding and quality control)."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16189514" target="_blank" class="term-link">
                             PMID:16189514
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Towards a proteome-scale map of the human protein-protein interaction network.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSPA2 was identified in a proteome-scale map of the human protein-protein interaction network.</div>
-                        
+
                         <div class="finding-text">"Towards a proteome-scale map of the human protein-protein interaction network."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16713569" target="_blank" class="term-link">
                             PMID:16713569
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A protein-protein interaction network for human inherited ataxias and disorders of Purkinje cell degeneration.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSPA2 was captured in a protein-protein interaction network curated for human inherited ataxias and disorders.</div>
-                        
+
                         <div class="finding-text">"A protein-protein interaction network for human inherited ataxias and disorders."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link">
                             PMID:19056867
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Large-scale proteomics and phosphoproteomics of urinary exosomes.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSPA2 is detected in urinary exosomes by large-scale proteomics, supporting an extracellular vesicle-associated pool.</div>
-                        
+
                         <div class="finding-text">"Large-scale proteomics and phosphoproteomics of urinary exosomes."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
                             PMID:19946888
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Defining the membrane proteome of NK cells.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSPA2 was detected in the membrane proteome of NK cells, consistent with cell-surface or membrane-associated chaperone pools.</div>
-                        
+
                         <div class="finding-text">"Defining the membrane proteome of NK cells."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21231916" target="_blank" class="term-link">
                             PMID:21231916
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The diverse members of the mammalian HSP70 machine show distinct chaperone-like activities.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSPA2 is part of the mammalian HSP70 machine and exhibits distinct chaperone-like activities including foldase and refolding capacities differentiated from other HSP70 paralogs.</div>
-                        
+
                         <div class="finding-text">"The diverse members of the mammalian HSP70 machine show distinct chaperone-like activities."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link">
                             PMID:21630459
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteomic characterization of the human sperm nucleus.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSPA2 is detected in proteomic characterization of the human sperm nucleus, consistent with its prominent expression and role in spermatogenesis.</div>
-                        
+
                         <div class="finding-text">"Proteomic characterization of the human sperm nucleus."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22516433" target="_blank" class="term-link">
                             PMID:22516433
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteomic analysis of microvesicles from plasma of healthy donors reveals high individual variability.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSPA2 was identified in plasma microvesicles from healthy donors, consistent with extracellular vesicle association.</div>
-                        
+
                         <div class="finding-text">"Proteomic analysis of microvesicles from plasma of healthy donors reveals."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23921388" target="_blank" class="term-link">
                             PMID:23921388
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Identification and characterization of a novel human methyltransferase modulating Hsp70 protein function through lysine methylation.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">A novel methyltransferase modulates HSP70 protein function through lysine methylation, with effects on the HSP70 family including HSPA2.</div>
-                        
+
                         <div class="finding-text">"Identification and characterization of a novel human methyltransferase modulating Hsp70 protein function through lysine methylation."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link">
                             PMID:25036637
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A quantitative chaperone interaction network reveals the architecture of cellular protein homeostasis pathways.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSPA2 is part of a quantitative chaperone interaction network defining the architecture of cellular protein homeostasis pathways.</div>
-                        
+
                         <div class="finding-text">"A quantitative chaperone interaction network reveals the architecture of cellular protein homeostasis pathways."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
                             PMID:25416956
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A proteome-scale map of the human interactome network.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSPA2 is included in a proteome-scale map of the human binary interactome.</div>
-                        
+
                         <div class="finding-text">"A proteome-scale map of the human interactome network."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
                             PMID:28514442
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSPA2 appears in a human interactome map defining protein communities and disease networks.</div>
-                        
+
                         <div class="finding-text">"Architecture of the human interactome defines protein communities and disease networks."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/3037489" target="_blank" class="term-link">
                             PMID:3037489
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Structure and expression of a human gene coding for a 71 kd heat shock &#39;cognate&#39; protein.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Structure and expression of an HSP70 &#39;cognate&#39; family member, contextualizing HSPA2 within the HSPA family architecture.</div>
-                        
+
                         <div class="finding-text">"Structure and expression of a human gene coding for a 71 kd heat shock &#39;cognate&#39;."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link">
                             PMID:31515488
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Extensive disruption of protein interactions by genetic variants across the allele frequency spectrum in human populations.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Genetic variants extensively disrupt HSPA2 protein interactions, supporting its broad chaperone-network role.</div>
-                        
+
                         <div class="finding-text">"Extensive disruption of protein interactions by genetic variants across the."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                             PMID:32296183
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A reference map of the human binary protein interactome.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSPA2 is included in a reference map of the human binary protein interactome.</div>
-                        
+
                         <div class="finding-text">"A reference map of the human binary protein interactome."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
                             PMID:32814053
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Interactome mapping highlights HSPA2 in a network of neurodegenerative disease proteins, consistent with chaperone roles in protein-aggregation pathology.</div>
-                        
+
                         <div class="finding-text">"Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSPA2 is part of dual proteome-scale networks revealing cell-specific remodeling of the human interactome.</div>
-                        
+
                         <div class="finding-text">"Dual proteome-scale networks reveal cell-specific remodeling of the human interactome."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link">
                             PMID:35271311
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">OpenCell: Endogenous tagging for the cartography of human cellular organization.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">OpenCell endogenous-tagging map places HSPA2 in cytoplasmic locations, supporting its primary cytosolic chaperone role.</div>
-                        
+
                         <div class="finding-text">"OpenCell: Endogenous tagging for the cartography of human cellular organization."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
                             PMID:40205054
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Multimodal cell maps integrating localization and interaction data place HSPA2 within structural/functional genomics modules consistent with chaperone network membership.</div>
-                        
+
                         <div class="finding-text">"Multimodal cell maps as a foundation for structural and functional genomics."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/7829106" target="_blank" class="term-link">
                             PMID:7829106
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Cloning, sequencing, and mapping of the human chromosome 14 heat shock protein gene (HSPA2).</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Cloning and chromosomal mapping of the human HSP70-2 (HSPA2) gene establishes the genomic identity of HSPA2 on chromosome 14.</div>
-                        
+
                         <div class="finding-text">"Cloning, sequencing, and mapping of the human chromosome 14 heat shock protein."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/8622925" target="_blank" class="term-link">
                             PMID:8622925
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Targeted gene disruption of Hsp70-2 results in failed meiosis, germ cell apoptosis, and male infertility.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Targeted disruption of mouse Hsp70-2 (HSPA2 ortholog) causes failed meiosis and germ-cell loss, providing in vivo IMP evidence for HSPA2 in spermatogenesis and meiotic progression.</div>
-                        
+
                         <div class="finding-text">"Targeted gene disruption of Hsp70-2 results in failed meiosis, germ cell."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1038/s41598-023-31962-5
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Heat shock protein A2 is a novel extracellular vesicle-associated protein</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Demonstrates HSPA2 is an EV-associated protein. Proteotoxic stress (proteasome inhibition with bortezomib) shifts HSPA2 from intracellular pools to extracellular release in EVs. Validated using CRISPR/Cas9 HSPA2 knockout pools and GFP-HSPA2 overexpression. EV mean size approximately 105.6 nm.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.3390/ijms23126497
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Targeted Analysis of HSP70 Isoforms in Human Spermatozoa in the Context of Capacitation and Motility</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSPA2 supports spermatogenesis and post-meiotic sperm remodeling, including cytoplasmic extrusion and plasma membrane remodeling required for zona pellucida binding competence. Roles in enabling surface relocation of proteins needed for oocyte zona interaction during capacitation.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1007/s43032-022-01031-9
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Molecular Chaperone HSPA2 Distribution During Hyaluronic Acid Selection in Human Sperm</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Quantified HSPA2 in human sperm (16 donors, approximately 19,200 sperm assessed). HA-bound sperm showed 68.9% HSPA2 positivity vs 28.6% uncapacitated and 22.9% capacitated (p&lt;0.001). HA-bound sperm fraction was 21.4 plus/minus 7.4%.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.3389/fendo.2024.1327800
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteomic biomarkers in seminal plasma as predictors of reproductive potential in azoospermic men</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Among 917 quantified proteins in seminal plasma proteomics, HSPA2 was more abundant in healthy controls than Sertoli cell-only phenotype (fold-change HC/SCO = 7.31, adjusted p=0.0217). Identifies HSPA2 as a promising non-invasive biomarker for spermatogenic function.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1093/cvr/cvae181
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The diabetic myocardial transcriptome reveals Erbb3 and Hspa2 as novel biomarkers of incident heart failure</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">GTEx analysis (425 RA and 428 LV samples) showed diabetes associated with higher Hspa2 expression in LV myocardium. Higher circulating HSPA2 (highest quartile) was associated with impaired LV contractility, higher LV mass, and increased incident heart failure and cardiovascular death.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.62347/cwpe7813
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Bioinformatics analysis and alternative polyadenylation in Heat Shock Proteins 70 (HSP70) family members</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Lists HSPA2-associated interactors including DNAJB12, STIP1, HSPBP1, HSPA1A, HSPA8, HSP90AA1. Notes HSPA2 role in spermatogenesis and proposed interaction with SHCBP1L to support spindle integrity during male meiosis.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Suggested Questions for Experts</h2>
-        
+
         <div class="question-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
                     <p><strong>Q:</strong> What client-protein specificity differentiates HSPA2 from constitutively expressed cytosolic HSP70s (e.g., HSPA8/HSC70, HSPA1A/B), particularly during spermatogenesis where HSPA2 is essential for meiotic progression?</p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="P54652" data-a="Q: What client-protein specificity differentiates HSP..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
@@ -5482,12 +5430,12 @@
                 </span>
             </div>
         </div>
-        
+
         <div class="question-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
                     <p><strong>Q:</strong> How is HSPA2 expression and substrate handover regulated during mammalian male germ-cell maturation, and which J-domain co-chaperones (DNAJA, DNAJB) and NEFs (BAG, HSPBP1) preferentially partner with HSPA2 in spermatocytes vs. somatic tissues?</p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="P54652" data-a="Q: How is HSPA2 expression and substrate handover reg..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
@@ -5495,12 +5443,12 @@
                 </span>
             </div>
         </div>
-        
+
         <div class="question-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
                     <p><strong>Q:</strong> What is the role of cell-surface and extracellular-vesicle-associated HSPA2 in sperm-egg recognition and reproductive fitness, and is it mechanistically distinct from HSPA1A/HSPA8 EV pools?</p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="P54652" data-a="Q: What is the role of cell-surface and extracellular..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
@@ -5508,22 +5456,22 @@
                 </span>
             </div>
         </div>
-        
-    </div>
-    
 
-    
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title">Suggested Experiments</h2>
-        
+
         <div class="experiment-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
-                    
+
                     <p><strong>Experiment:</strong> Reconstitute HSPA2 with cognate J-protein cochaperones and a panel of model clients, comparing ATP-driven foldase kinetics with HSPA1A and HSPA8 to define paralog-specific biochemical fingerprints.</p>
-                    
-                    
-                    
+
+
+
                 </div>
                 <span class="vote-buttons" data-g="P54652" data-a="EXPERIMENT: Reconstitute HSPA2 with cognate J-protein cochaper..." data-r="" data-act="EXPERIMENT">
                     <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
@@ -5531,15 +5479,15 @@
                 </span>
             </div>
         </div>
-        
+
         <div class="experiment-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
-                    
+
                     <p><strong>Experiment:</strong> Use spermatocyte/spermatid-specific HSPA2 conditional knockout or AID-tagged degron lines combined with quantitative proteomics to map stage-specific clientele and verify HSPA2-dependent meiotic factors.</p>
-                    
-                    
-                    
+
+
+
                 </div>
                 <span class="vote-buttons" data-g="P54652" data-a="EXPERIMENT: Use spermatocyte/spermatid-specific HSPA2 conditio..." data-r="" data-act="EXPERIMENT">
                     <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
@@ -5547,15 +5495,15 @@
                 </span>
             </div>
         </div>
-        
+
         <div class="experiment-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
-                    
+
                     <p><strong>Experiment:</strong> Profile extracellular vesicle HSPA2 from human seminal plasma in fertile vs sub-fertile cohorts, with controlled exposure of oocytes and sperm to recombinant HSPA2-loaded liposomes to test direct effects on fertilization.</p>
-                    
-                    
-                    
+
+
+
                 </div>
                 <span class="vote-buttons" data-g="P54652" data-a="EXPERIMENT: Profile extracellular vesicle HSPA2 from human sem..." data-r="" data-act="EXPERIMENT">
                     <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
@@ -5563,35 +5511,35 @@
                 </span>
             </div>
         </div>
-        
-    </div>
-    
 
-    
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title">Tags</h2>
         <div class="aliases">
-            
+
             <span class="badge">chaperone</span>
-            
+
             <span class="badge">hsp70</span>
-            
+
             <span class="badge">spermatogenesis</span>
-            
+
             <span class="badge">meiosis</span>
-            
+
         </div>
     </div>
-    
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -5875,9 +5823,9 @@ this with annotations you find in gene/protein databases, but these can be outda
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -5889,7 +5837,7 @@ this with annotations you find in gene/protein databases, but these can be outda
                 <pre><code>id: P54652
 gene_symbol: HSPA2
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -6030,19 +5978,22 @@ existing_annotations:
   review:
     summary: &gt;-
       IBA annotation of HSPA2 for heat shock protein binding based on
-      phylogenetic inference. HSP70 family members interact extensively with
-      co-chaperones including HSP40/DNAJ proteins, HSPBP1, and BAG domain
-      proteins. HSPA2 has been shown by IPI evidence to interact with HSPBP1
-      (Q9NZL4) in multiple studies (PMID:16189514, PMID:16713569, PMID:25416956,
-      PMID:28514442, PMID:33961781, PMID:35271311, PMID:40205054). HSPA2 also
-      interacts with BAG4 (O95429) and DNAJA3 (UniProt P54652). These
-      interactions with co-chaperones are integral to the HSP70 chaperone cycle.
-    action: ACCEPT
+      phylogenetic inference from HSP70-family proteins including HSPA1A,
+      HSPA1B, HSPA6, HSPA8, and HSPA1L. This annotation should be interpreted
+      as conserved binding within the heat-shock/chaperone network, not as a
+      catch-all for HSPBP1, BAG4, or HSF2 interactions because those partners
+      are not themselves heat shock proteins. Falcon synthesis also lists HSPA1A,
+      HSPA8, and HSP90AA1 among HSPA2-associated chaperone-network proteins,
+      but direct paralog-specific biochemical support remains less central than
+      HSPA2&#39;s ATPase/foldase activity.
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      HSP70 chaperones fundamentally depend on interactions with co-chaperones
-      (HSP40/DNAJ, NEFs like HSPBP1 and BAG proteins) for their function.
-      The extensive IPI evidence for HSPA2-HSPBP1 interaction across multiple
-      studies validates this annotation. This is a core molecular function.
+      The PANTHER IBA annotation is plausible for conserved HSP70
+      chaperone-network binding, but HSPBP1, BAG4, and HSF2 should not be used
+      to justify GO:0031072 because those proteins are co-chaperones or
+      transcription factors rather than heat shock proteins. Retain the term as
+      non-core; the core molecular functions are ATP hydrolysis and protein
+      folding chaperone activity.
 - term:
     id: GO:0044183
     label: protein folding chaperone
@@ -6074,6 +6025,11 @@ existing_annotations:
         refolding of heat-denatured luciferase and on the suppression of
         aggregation of a non-foldable polyQ (polyglutamine)-expanded
         Huntingtin fragment
+    - reference_id: file:human/HSPA2/HSPA2-deep-research-falcon.md
+      supporting_text: &gt;-
+        Across recent primary studies, the most defensible primary function
+        annotation is that HSPA2 is an ATP-dependent molecular chaperone
+        supporting proteostasis (folding/refolding and quality control).
 - term:
     id: GO:0005829
     label: cytosol
@@ -6343,19 +6299,16 @@ existing_annotations:
       yeast two-hybrid study of human protein-protein interactions. HSPBP1 is a
       known HSP70 co-chaperone/nucleotide exchange factor. The interaction between
       HSPA2 and HSPBP1 is functionally relevant and has been confirmed in multiple
-      independent studies. However, &#34;protein binding&#34; is uninformative; this
-      interaction is better captured by GO:0031072 &#34;heat shock protein binding&#34;
-      (already annotated via IBA) or by the co-chaperone interaction context.
-    action: MODIFY
+      independent studies. However, &#34;protein binding&#34; is uninformative and
+      this co-chaperone/NEF interaction should not be replaced with heat shock
+      protein binding because HSPBP1 is not an HSP.
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       The interaction with HSPBP1 (a co-chaperone/NEF) is real and confirmed
       across multiple studies, but GO:0005515 &#34;protein binding&#34; is uninformative.
-      This interaction is already captured by the more specific GO:0031072
-      &#34;heat shock protein binding&#34; IBA annotation. Replace with the more
-      specific term.
-    proposed_replacement_terms:
-    - id: GO:0031072
-      label: heat shock protein binding
+      GO:0031072 &#34;heat shock protein binding&#34; would be semantically incorrect
+      here because HSPBP1 is not a heat shock protein. Mark as over-annotated
+      rather than propose an incorrect replacement.
 - term:
     id: GO:0005515
     label: protein binding
@@ -6367,16 +6320,13 @@ existing_annotations:
       HSPBP1 (Q9NZL4) detected in Lim et al. (PMID:16713569), a protein-protein
       interaction network study for inherited ataxias. This is another detection
       of the HSPA2-HSPBP1 co-chaperone interaction. As with the other HSPBP1
-      interaction entries, &#34;protein binding&#34; is uninformative and the interaction
-      is better represented by GO:0031072 &#34;heat shock protein binding.&#34;
-    action: MODIFY
+      interaction entries, &#34;protein binding&#34; is uninformative but should not be
+      replaced by heat shock protein binding because HSPBP1 is not an HSP.
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       Same rationale as the PMID:16189514 entry. HSPA2-HSPBP1 interaction is
-      a co-chaperone interaction better described by GO:0031072 &#34;heat shock
-      protein binding&#34; rather than the generic GO:0005515.
-    proposed_replacement_terms:
-    - id: GO:0031072
-      label: heat shock protein binding
+      a co-chaperone/NEF interaction. GO:0005515 is uninformative, and
+      GO:0031072 would be incorrect for this non-HSP partner.
 - term:
     id: GO:0005515
     label: protein binding
@@ -6392,15 +6342,13 @@ existing_annotations:
       factor. These are functionally relevant interactions for a chaperone.
       However, &#34;protein binding&#34; remains uninformative; these interactions
       reflect chaperone-co-chaperone interactions or client binding.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       The interactions with BAG4 (co-chaperone) and HSF2 are real and
       functionally relevant from a chaperone network study, but &#34;protein
-      binding&#34; is uninformative. The BAG4 interaction is better described
-      by GO:0031072 &#34;heat shock protein binding.&#34;
-    proposed_replacement_terms:
-    - id: GO:0031072
-      label: heat shock protein binding
+      binding&#34; is uninformative. GO:0031072 is not an appropriate replacement
+      because BAG4 is a BAG-domain nucleotide exchange factor/co-chaperone and
+      HSF2 is a transcription factor, not a heat shock protein.
 - term:
     id: GO:0005515
     label: protein binding
@@ -6415,15 +6363,12 @@ existing_annotations:
       ubiquitin ligase; its interaction with HSPA2 could relate to chaperone-
       mediated targeting of substrates for ubiquitination. &#34;Protein binding&#34;
       is too generic for these functionally informative interactions.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       Contains validated co-chaperone interaction (HSPBP1) and ubiquitin ligase
       interaction (TRIM38). GO:0005515 &#34;protein binding&#34; is uninformative; the
-      HSPBP1 interaction is better captured by GO:0031072 &#34;heat shock protein
-      binding.&#34;
-    proposed_replacement_terms:
-    - id: GO:0031072
-      label: heat shock protein binding
+      HSPBP1 interaction is not heat shock protein binding and the TRIM38
+      interaction lacks enough functional specificity for a better replacement.
 - term:
     id: GO:0005515
     label: protein binding
@@ -6437,13 +6382,11 @@ existing_annotations:
       confirmation of the HSPA2-HSPBP1 co-chaperone interaction. &#34;Protein
       binding&#34; is uninformative for this functionally well-characterized
       interaction.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       Another confirmation of HSPA2-HSPBP1 co-chaperone interaction. GO:0005515
-      is uninformative; better captured by GO:0031072.
-    proposed_replacement_terms:
-    - id: GO:0031072
-      label: heat shock protein binding
+      is uninformative, but GO:0031072 would be incorrect because HSPBP1 is not
+      a heat shock protein.
 - term:
     id: GO:0005515
     label: protein binding
@@ -6477,14 +6420,12 @@ existing_annotations:
       a BAG domain that functions as a nucleotide exchange factor for HSP70
       proteins. This is a functionally relevant chaperone-co-chaperone
       interaction. &#34;Protein binding&#34; is uninformative.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       BAG4 is an HSP70 co-chaperone; this interaction is functionally relevant
-      and better described by GO:0031072 &#34;heat shock protein binding&#34; rather
-      than the generic GO:0005515.
-    proposed_replacement_terms:
-    - id: GO:0031072
-      label: heat shock protein binding
+      but is not heat shock protein binding because BAG4 is a BAG-domain
+      nucleotide exchange factor/co-chaperone. Mark the generic GO:0005515
+      annotation as over-annotated.
 - term:
     id: GO:0005515
     label: protein binding
@@ -6526,14 +6467,12 @@ existing_annotations:
       functionally relevant interactions: HSPBP1 is a co-chaperone and HSF2
       is a heat shock transcription factor that could be regulated by
       chaperone interactions. &#34;Protein binding&#34; is uninformative.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       Both interaction partners (HSPBP1 co-chaperone, HSF2 transcription factor)
-      are functionally relevant. GO:0005515 is uninformative; these are better
-      captured by GO:0031072.
-    proposed_replacement_terms:
-    - id: GO:0031072
-      label: heat shock protein binding
+      are functionally relevant, but neither supports heat shock protein binding.
+      GO:0005515 is therefore too generic and should be marked as
+      over-annotated rather than modified to GO:0031072.
 - term:
     id: GO:0005515
     label: protein binding
@@ -6546,14 +6485,11 @@ existing_annotations:
       endogenous tagging study. This is another independent confirmation of the
       HSPA2-HSPBP1 co-chaperone interaction using endogenous tagging, a method
       less prone to overexpression artifacts. &#34;Protein binding&#34; is uninformative.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       Another independent confirmation of HSPA2-HSPBP1 interaction using
-      endogenous tagging. GO:0005515 is uninformative; better captured by
-      GO:0031072.
-    proposed_replacement_terms:
-    - id: GO:0031072
-      label: heat shock protein binding
+      endogenous tagging. GO:0005515 is uninformative, and GO:0031072 is not
+      appropriate for the non-HSP co-chaperone HSPBP1.
 - term:
     id: GO:0005515
     label: protein binding
@@ -6566,13 +6502,11 @@ existing_annotations:
       a multimodal cell mapping study. These are the same well-validated
       interaction partners seen across multiple studies. &#34;Protein binding&#34;
       is uninformative.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       Well-validated interactions with HSPBP1 and HSF2. GO:0005515 is
-      uninformative; better captured by GO:0031072.
-    proposed_replacement_terms:
-    - id: GO:0031072
-      label: heat shock protein binding
+      uninformative, but these partners do not justify GO:0031072 because
+      HSPBP1 is a co-chaperone/NEF and HSF2 is a transcription factor.
 - term:
     id: GO:0000795
     label: synaptonemal complex
@@ -6698,19 +6632,19 @@ existing_annotations:
     summary: &gt;-
       IEA annotation of HSPA2 for protein-folding chaperone binding based on
       Ensembl Compara orthology transfer from rat Hspa2 (P14659). HSP70 family
-      members interact extensively with co-chaperones (DNAJ/HSP40, HSPBP1, BAG
-      domain proteins, HOP/STIP1). HSPA2 has demonstrated interactions with
-      HSPBP1 across multiple studies (PMID:16189514, PMID:16713569, PMID:25416956,
-      PMID:28514442, PMID:33961781, PMID:35271311, PMID:40205054) and with BAG4
-      (PMID:25036637, PMID:32296183) and DNAJA3 (PMID:32814053). This is a
-      well-supported function. Note this describes HSPA2 binding to other
-      chaperones (HSPA2 as the subject), which is essentially the reciprocal
-      of heat shock protein binding.
-    action: ACCEPT
+      members interact with true protein-folding chaperones such as DNAJ/HSP40
+      proteins and other HSP-family chaperones. HSPA2 has IntAct/UniProt
+      evidence for DNAJA3 interaction and Falcon synthesis lists HSPA1A, HSPA8,
+      and HSP90AA1 among HSPA2-associated chaperone-network proteins. HSPBP1
+      and BAG4 interactions are co-chaperone/NEF interactions and should not be
+      used as direct support for this term.
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      HSPA2 binding to co-chaperones (HSPBP1, BAG4, DNAJA3) is extensively
-      documented by IPI evidence across multiple studies. This is a core
-      aspect of HSP70 function.
+      Retain as a plausible non-core chaperone-network binding annotation when
+      restricted to true chaperone partners such as DNAJA3 and HSP-family
+      proteins. The annotation should not be justified by HSPBP1 or BAG4
+      alone, because those are not protein-folding chaperones in the sense
+      required by GO:0051087.
 - term:
     id: GO:0051861
     label: glycolipid binding
@@ -7260,6 +7194,12 @@ core_functions:
       refolding of heat-denatured luciferase and on the suppression of
       aggregation of a non-foldable polyQ (polyglutamine)-expanded
       Huntingtin fragment
+  - reference_id: file:human/HSPA2/HSPA2-deep-research-falcon.md
+    supporting_text: &gt;-
+      Falcon synthesis identifies HSPA2 as an HSP70-family ATP-dependent
+      molecular chaperone supporting folding/refolding, protein quality
+      control, and proteotoxic-stress-linked redistribution into extracellular
+      vesicles.
 - description: &gt;-
     Essential chaperone for male meiosis and spermatogenesis. Associates with
     synaptonemal complexes during meiotic prophase and localizes to the
@@ -7342,6 +7282,18 @@ references:
   title: Combined Automated Annotation using Multiple IEA Methods
   findings:
   - statement: Combined automated IEA pipelines annotate HSPA2 with ATP binding, ATP hydrolysis activity, and protein folding terms from UniProt features.
+- id: file:human/HSPA2/HSPA2-deep-research-falcon.md
+  title: Falcon deep research synthesis for HSPA2
+  findings:
+  - statement: &gt;-
+      HSPA2 is a human HSP70-family ATP-dependent molecular chaperone whose
+      major supported roles are proteostasis, male germ-cell/sperm maturation,
+      and extracellular vesicle-associated redistribution under proteotoxic
+      stress.
+    supporting_text: &gt;-
+      Across recent primary studies, the most defensible &#34;primary function&#34;
+      annotation is that HSPA2 is an ATP-dependent molecular chaperone
+      supporting proteostasis (folding/refolding and quality control).
 - id: PMID:16189514
   title: Towards a proteome-scale map of the human protein-protein interaction network.
   findings:
@@ -7527,7 +7479,7 @@ tags:
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/HSPA2/HSPA2-ai-review.yaml
+++ b/genes/human/HSPA2/HSPA2-ai-review.yaml
@@ -1,7 +1,7 @@
 id: P54652
 gene_symbol: HSPA2
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -142,19 +142,22 @@ existing_annotations:
   review:
     summary: >-
       IBA annotation of HSPA2 for heat shock protein binding based on
-      phylogenetic inference. HSP70 family members interact extensively with
-      co-chaperones including HSP40/DNAJ proteins, HSPBP1, and BAG domain
-      proteins. HSPA2 has been shown by IPI evidence to interact with HSPBP1
-      (Q9NZL4) in multiple studies (PMID:16189514, PMID:16713569, PMID:25416956,
-      PMID:28514442, PMID:33961781, PMID:35271311, PMID:40205054). HSPA2 also
-      interacts with BAG4 (O95429) and DNAJA3 (UniProt P54652). These
-      interactions with co-chaperones are integral to the HSP70 chaperone cycle.
-    action: ACCEPT
+      phylogenetic inference from HSP70-family proteins including HSPA1A,
+      HSPA1B, HSPA6, HSPA8, and HSPA1L. This annotation should be interpreted
+      as conserved binding within the heat-shock/chaperone network, not as a
+      catch-all for HSPBP1, BAG4, or HSF2 interactions because those partners
+      are not themselves heat shock proteins. Falcon synthesis also lists HSPA1A,
+      HSPA8, and HSP90AA1 among HSPA2-associated chaperone-network proteins,
+      but direct paralog-specific biochemical support remains less central than
+      HSPA2's ATPase/foldase activity.
+    action: KEEP_AS_NON_CORE
     reason: >-
-      HSP70 chaperones fundamentally depend on interactions with co-chaperones
-      (HSP40/DNAJ, NEFs like HSPBP1 and BAG proteins) for their function.
-      The extensive IPI evidence for HSPA2-HSPBP1 interaction across multiple
-      studies validates this annotation. This is a core molecular function.
+      The PANTHER IBA annotation is plausible for conserved HSP70
+      chaperone-network binding, but HSPBP1, BAG4, and HSF2 should not be used
+      to justify GO:0031072 because those proteins are co-chaperones or
+      transcription factors rather than heat shock proteins. Retain the term as
+      non-core; the core molecular functions are ATP hydrolysis and protein
+      folding chaperone activity.
 - term:
     id: GO:0044183
     label: protein folding chaperone
@@ -186,6 +189,11 @@ existing_annotations:
         refolding of heat-denatured luciferase and on the suppression of
         aggregation of a non-foldable polyQ (polyglutamine)-expanded
         Huntingtin fragment
+    - reference_id: file:human/HSPA2/HSPA2-deep-research-falcon.md
+      supporting_text: >-
+        Across recent primary studies, the most defensible primary function
+        annotation is that HSPA2 is an ATP-dependent molecular chaperone
+        supporting proteostasis (folding/refolding and quality control).
 - term:
     id: GO:0005829
     label: cytosol
@@ -455,19 +463,16 @@ existing_annotations:
       yeast two-hybrid study of human protein-protein interactions. HSPBP1 is a
       known HSP70 co-chaperone/nucleotide exchange factor. The interaction between
       HSPA2 and HSPBP1 is functionally relevant and has been confirmed in multiple
-      independent studies. However, "protein binding" is uninformative; this
-      interaction is better captured by GO:0031072 "heat shock protein binding"
-      (already annotated via IBA) or by the co-chaperone interaction context.
-    action: MODIFY
+      independent studies. However, "protein binding" is uninformative and
+      this co-chaperone/NEF interaction should not be replaced with heat shock
+      protein binding because HSPBP1 is not an HSP.
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
       The interaction with HSPBP1 (a co-chaperone/NEF) is real and confirmed
       across multiple studies, but GO:0005515 "protein binding" is uninformative.
-      This interaction is already captured by the more specific GO:0031072
-      "heat shock protein binding" IBA annotation. Replace with the more
-      specific term.
-    proposed_replacement_terms:
-    - id: GO:0031072
-      label: heat shock protein binding
+      GO:0031072 "heat shock protein binding" would be semantically incorrect
+      here because HSPBP1 is not a heat shock protein. Mark as over-annotated
+      rather than propose an incorrect replacement.
 - term:
     id: GO:0005515
     label: protein binding
@@ -479,16 +484,13 @@ existing_annotations:
       HSPBP1 (Q9NZL4) detected in Lim et al. (PMID:16713569), a protein-protein
       interaction network study for inherited ataxias. This is another detection
       of the HSPA2-HSPBP1 co-chaperone interaction. As with the other HSPBP1
-      interaction entries, "protein binding" is uninformative and the interaction
-      is better represented by GO:0031072 "heat shock protein binding."
-    action: MODIFY
+      interaction entries, "protein binding" is uninformative but should not be
+      replaced by heat shock protein binding because HSPBP1 is not an HSP.
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
       Same rationale as the PMID:16189514 entry. HSPA2-HSPBP1 interaction is
-      a co-chaperone interaction better described by GO:0031072 "heat shock
-      protein binding" rather than the generic GO:0005515.
-    proposed_replacement_terms:
-    - id: GO:0031072
-      label: heat shock protein binding
+      a co-chaperone/NEF interaction. GO:0005515 is uninformative, and
+      GO:0031072 would be incorrect for this non-HSP partner.
 - term:
     id: GO:0005515
     label: protein binding
@@ -504,15 +506,13 @@ existing_annotations:
       factor. These are functionally relevant interactions for a chaperone.
       However, "protein binding" remains uninformative; these interactions
       reflect chaperone-co-chaperone interactions or client binding.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
       The interactions with BAG4 (co-chaperone) and HSF2 are real and
       functionally relevant from a chaperone network study, but "protein
-      binding" is uninformative. The BAG4 interaction is better described
-      by GO:0031072 "heat shock protein binding."
-    proposed_replacement_terms:
-    - id: GO:0031072
-      label: heat shock protein binding
+      binding" is uninformative. GO:0031072 is not an appropriate replacement
+      because BAG4 is a BAG-domain nucleotide exchange factor/co-chaperone and
+      HSF2 is a transcription factor, not a heat shock protein.
 - term:
     id: GO:0005515
     label: protein binding
@@ -527,15 +527,12 @@ existing_annotations:
       ubiquitin ligase; its interaction with HSPA2 could relate to chaperone-
       mediated targeting of substrates for ubiquitination. "Protein binding"
       is too generic for these functionally informative interactions.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
       Contains validated co-chaperone interaction (HSPBP1) and ubiquitin ligase
       interaction (TRIM38). GO:0005515 "protein binding" is uninformative; the
-      HSPBP1 interaction is better captured by GO:0031072 "heat shock protein
-      binding."
-    proposed_replacement_terms:
-    - id: GO:0031072
-      label: heat shock protein binding
+      HSPBP1 interaction is not heat shock protein binding and the TRIM38
+      interaction lacks enough functional specificity for a better replacement.
 - term:
     id: GO:0005515
     label: protein binding
@@ -549,13 +546,11 @@ existing_annotations:
       confirmation of the HSPA2-HSPBP1 co-chaperone interaction. "Protein
       binding" is uninformative for this functionally well-characterized
       interaction.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
       Another confirmation of HSPA2-HSPBP1 co-chaperone interaction. GO:0005515
-      is uninformative; better captured by GO:0031072.
-    proposed_replacement_terms:
-    - id: GO:0031072
-      label: heat shock protein binding
+      is uninformative, but GO:0031072 would be incorrect because HSPBP1 is not
+      a heat shock protein.
 - term:
     id: GO:0005515
     label: protein binding
@@ -589,14 +584,12 @@ existing_annotations:
       a BAG domain that functions as a nucleotide exchange factor for HSP70
       proteins. This is a functionally relevant chaperone-co-chaperone
       interaction. "Protein binding" is uninformative.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
       BAG4 is an HSP70 co-chaperone; this interaction is functionally relevant
-      and better described by GO:0031072 "heat shock protein binding" rather
-      than the generic GO:0005515.
-    proposed_replacement_terms:
-    - id: GO:0031072
-      label: heat shock protein binding
+      but is not heat shock protein binding because BAG4 is a BAG-domain
+      nucleotide exchange factor/co-chaperone. Mark the generic GO:0005515
+      annotation as over-annotated.
 - term:
     id: GO:0005515
     label: protein binding
@@ -638,14 +631,12 @@ existing_annotations:
       functionally relevant interactions: HSPBP1 is a co-chaperone and HSF2
       is a heat shock transcription factor that could be regulated by
       chaperone interactions. "Protein binding" is uninformative.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
       Both interaction partners (HSPBP1 co-chaperone, HSF2 transcription factor)
-      are functionally relevant. GO:0005515 is uninformative; these are better
-      captured by GO:0031072.
-    proposed_replacement_terms:
-    - id: GO:0031072
-      label: heat shock protein binding
+      are functionally relevant, but neither supports heat shock protein binding.
+      GO:0005515 is therefore too generic and should be marked as
+      over-annotated rather than modified to GO:0031072.
 - term:
     id: GO:0005515
     label: protein binding
@@ -658,14 +649,11 @@ existing_annotations:
       endogenous tagging study. This is another independent confirmation of the
       HSPA2-HSPBP1 co-chaperone interaction using endogenous tagging, a method
       less prone to overexpression artifacts. "Protein binding" is uninformative.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
       Another independent confirmation of HSPA2-HSPBP1 interaction using
-      endogenous tagging. GO:0005515 is uninformative; better captured by
-      GO:0031072.
-    proposed_replacement_terms:
-    - id: GO:0031072
-      label: heat shock protein binding
+      endogenous tagging. GO:0005515 is uninformative, and GO:0031072 is not
+      appropriate for the non-HSP co-chaperone HSPBP1.
 - term:
     id: GO:0005515
     label: protein binding
@@ -678,13 +666,11 @@ existing_annotations:
       a multimodal cell mapping study. These are the same well-validated
       interaction partners seen across multiple studies. "Protein binding"
       is uninformative.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
       Well-validated interactions with HSPBP1 and HSF2. GO:0005515 is
-      uninformative; better captured by GO:0031072.
-    proposed_replacement_terms:
-    - id: GO:0031072
-      label: heat shock protein binding
+      uninformative, but these partners do not justify GO:0031072 because
+      HSPBP1 is a co-chaperone/NEF and HSF2 is a transcription factor.
 - term:
     id: GO:0000795
     label: synaptonemal complex
@@ -810,19 +796,19 @@ existing_annotations:
     summary: >-
       IEA annotation of HSPA2 for protein-folding chaperone binding based on
       Ensembl Compara orthology transfer from rat Hspa2 (P14659). HSP70 family
-      members interact extensively with co-chaperones (DNAJ/HSP40, HSPBP1, BAG
-      domain proteins, HOP/STIP1). HSPA2 has demonstrated interactions with
-      HSPBP1 across multiple studies (PMID:16189514, PMID:16713569, PMID:25416956,
-      PMID:28514442, PMID:33961781, PMID:35271311, PMID:40205054) and with BAG4
-      (PMID:25036637, PMID:32296183) and DNAJA3 (PMID:32814053). This is a
-      well-supported function. Note this describes HSPA2 binding to other
-      chaperones (HSPA2 as the subject), which is essentially the reciprocal
-      of heat shock protein binding.
-    action: ACCEPT
+      members interact with true protein-folding chaperones such as DNAJ/HSP40
+      proteins and other HSP-family chaperones. HSPA2 has IntAct/UniProt
+      evidence for DNAJA3 interaction and Falcon synthesis lists HSPA1A, HSPA8,
+      and HSP90AA1 among HSPA2-associated chaperone-network proteins. HSPBP1
+      and BAG4 interactions are co-chaperone/NEF interactions and should not be
+      used as direct support for this term.
+    action: KEEP_AS_NON_CORE
     reason: >-
-      HSPA2 binding to co-chaperones (HSPBP1, BAG4, DNAJA3) is extensively
-      documented by IPI evidence across multiple studies. This is a core
-      aspect of HSP70 function.
+      Retain as a plausible non-core chaperone-network binding annotation when
+      restricted to true chaperone partners such as DNAJA3 and HSP-family
+      proteins. The annotation should not be justified by HSPBP1 or BAG4
+      alone, because those are not protein-folding chaperones in the sense
+      required by GO:0051087.
 - term:
     id: GO:0051861
     label: glycolipid binding
@@ -1372,6 +1358,12 @@ core_functions:
       refolding of heat-denatured luciferase and on the suppression of
       aggregation of a non-foldable polyQ (polyglutamine)-expanded
       Huntingtin fragment
+  - reference_id: file:human/HSPA2/HSPA2-deep-research-falcon.md
+    supporting_text: >-
+      Falcon synthesis identifies HSPA2 as an HSP70-family ATP-dependent
+      molecular chaperone supporting folding/refolding, protein quality
+      control, and proteotoxic-stress-linked redistribution into extracellular
+      vesicles.
 - description: >-
     Essential chaperone for male meiosis and spermatogenesis. Associates with
     synaptonemal complexes during meiotic prophase and localizes to the
@@ -1454,6 +1446,18 @@ references:
   title: Combined Automated Annotation using Multiple IEA Methods
   findings:
   - statement: Combined automated IEA pipelines annotate HSPA2 with ATP binding, ATP hydrolysis activity, and protein folding terms from UniProt features.
+- id: file:human/HSPA2/HSPA2-deep-research-falcon.md
+  title: Falcon deep research synthesis for HSPA2
+  findings:
+  - statement: >-
+      HSPA2 is a human HSP70-family ATP-dependent molecular chaperone whose
+      major supported roles are proteostasis, male germ-cell/sperm maturation,
+      and extracellular vesicle-associated redistribution under proteotoxic
+      stress.
+    supporting_text: >-
+      Across recent primary studies, the most defensible "primary function"
+      annotation is that HSPA2 is an ATP-dependent molecular chaperone
+      supporting proteostasis (folding/refolding and quality control).
 - id: PMID:16189514
   title: Towards a proteome-scale map of the human protein-protein interaction network.
   findings:

--- a/genes/human/HSPB6/HSPB6-ai-review.html
+++ b/genes/human/HSPB6/HSPB6-ai-review.html
@@ -1073,7 +1073,7 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IBA annotation for protein refolding inferred from phylogenetic analysis of Drosophila sHSP orthologs. However, HSPB6 is specifically a holdase-type chaperone that prevents aggregation of unfolded substrates but does not actively refold them. PMID:24382496 describes HSPB6 as an &#34;ATP-independent&#34; sHSP that binds partially unfolded proteins to prevent their &#34;irreversible aggregation.&#34; Active refolding requires ATP-dependent chaperones such as HSP70. PMID:19464326 tested HSPB members for refolding activity using a luciferase refolding assay and found that HSPB1 and CRYAB &#34;chaperoned heat unfolded substrates and kept them folding competent&#34; but HSPB6 was not among those shown to support refolding independently. The term &#34;protein refolding&#34; implies an active refoldase activity that HSPB6 does not possess.
+                            <strong>Summary:</strong> IBA annotation for protein refolding inferred from phylogenetic analysis of Drosophila sHSP orthologs. However, HSPB6 is specifically a holdase-type chaperone that prevents aggregation of unfolded substrates but does not actively refold them. PMID:24382496 describes HSPB6 as an &#34;ATP-independent&#34; sHSP that binds partially unfolded proteins to prevent their &#34;irreversible aggregation.&#34; Active refolding requires ATP-dependent chaperones such as HSP70. The term &#34;protein refolding&#34; implies an active refoldase activity that HSPB6 does not possess.
                         </div>
 
 
@@ -1107,19 +1107,6 @@
                                 </span>
 
                                 <div class="support-text">ATP-independent small heat-shock proteins (sHSPs) are an essential component of the cellular chaperoning machinery. Under both normal and stress conditions, sHSPs bind partially unfolded proteins and prevent their irreversible aggregation.</div>
-
-                            </div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
-                                        PMID:19464326
-                                    </a>
-
-                                </span>
-
-                                <div class="support-text">Unlike HSPB1 and HSPB5, that chaperoned heat unfolded substrates and kept them folding competent, HSPB7 did not support refolding.</div>
 
                             </div>
 
@@ -1543,12 +1530,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IEA annotation transferred from rat ortholog P97541 via Ensembl Compara. HSPB6 is known to interact with several kinases: it is phosphorylated at Ser-16 by PKA (PMID:21334344), interacts with PDE4A and PDE4D which maintain its non-phosphorylated state (PMID:21334344), and interacts with PRKD1/PKD1 (PMID:26443497). UniProt confirms these interactions. While the annotation is technically correct in that HSPB6 binds protein kinases, the term is quite broad and does not capture the specific nature of these interactions (substrate of PKA, interaction partner of PKD1).
+                            <strong>Summary:</strong> IEA annotation transferred from rat ortholog P97541 via Ensembl Compara. HSPB6 is known to interact with several kinases: it is phosphorylated at Ser-16 by PKA (PMID:21334344), and interacts with PRKD1/PKD1 (PMID:26443497). UniProt confirms the kinase interaction context. While the annotation is technically correct in that HSPB6 binds protein kinases, the term is quite broad and does not capture the specific nature of these interactions (substrate of PKA, interaction partner of PKD1).
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> HSPB6 is a substrate of PKA and interacts with PKD1 and PDE4 family members. While &#34;protein kinase binding&#34; is a broad term, it correctly captures that HSPB6 physically interacts with kinases. The IEA transfer from rat is appropriate given the conserved function.
+                            <strong>Reason:</strong> HSPB6 is a substrate of PKA and interacts with PKD1. While &#34;protein kinase binding&#34; is a broad term, it correctly captures kinase-related physical interaction evidence. The IEA transfer from rat is appropriate given the conserved function.
                         </div>
 
 
@@ -3880,11 +3867,8 @@ existing_annotations:
       aggregation of unfolded substrates but does not actively refold them. PMID:24382496
       describes HSPB6 as an &#34;ATP-independent&#34; sHSP that binds partially unfolded proteins
       to prevent their &#34;irreversible aggregation.&#34; Active refolding requires ATP-dependent
-      chaperones such as HSP70. PMID:19464326 tested HSPB members for refolding activity
-      using a luciferase refolding assay and found that HSPB1 and CRYAB &#34;chaperoned heat
-      unfolded substrates and kept them folding competent&#34; but HSPB6 was not among those
-      shown to support refolding independently. The term &#34;protein refolding&#34; implies an
-      active refoldase activity that HSPB6 does not possess.
+      chaperones such as HSP70. The term &#34;protein refolding&#34; implies an active refoldase
+      activity that HSPB6 does not possess.
     action: MODIFY
     reason: &gt;-
       HSPB6 is a holdase chaperone, not a refoldase. It prevents aggregation but does not
@@ -3901,10 +3885,6 @@ existing_annotations:
           ATP-independent small heat-shock proteins (sHSPs) are an essential component of the
           cellular chaperoning machinery. Under both normal and stress conditions, sHSPs bind
           partially unfolded proteins and prevent their irreversible aggregation.
-      - reference_id: PMID:19464326
-        supporting_text: &gt;-
-          Unlike HSPB1 and HSPB5, that chaperoned heat unfolded substrates and kept them
-          folding competent, HSPB7 did not support refolding.
       - reference_id: file:human/HSPB6/HSPB6-deep-research-falcon.md
         supporting_text: &gt;-
           HSPB6 belongs to the small heat shock protein family and functions as
@@ -4061,17 +4041,16 @@ existing_annotations:
     summary: &gt;-
       IEA annotation transferred from rat ortholog P97541 via Ensembl Compara. HSPB6 is
       known to interact with several kinases: it is phosphorylated at Ser-16 by PKA
-      (PMID:21334344), interacts with PDE4A and PDE4D which maintain its non-phosphorylated
-      state (PMID:21334344), and interacts with PRKD1/PKD1 (PMID:26443497). UniProt
-      confirms these interactions. While the annotation is technically correct in that
-      HSPB6 binds protein kinases, the term is quite broad and does not capture the
-      specific nature of these interactions (substrate of PKA, interaction partner of PKD1).
+      (PMID:21334344), and interacts with PRKD1/PKD1 (PMID:26443497). UniProt
+      confirms the kinase interaction context. While the annotation is technically correct
+      in that HSPB6 binds protein kinases, the term is quite broad and does not capture
+      the specific nature of these interactions (substrate of PKA, interaction partner of
+      PKD1).
     action: ACCEPT
     reason: &gt;-
-      HSPB6 is a substrate of PKA and interacts with PKD1 and PDE4 family members.
-      While &#34;protein kinase binding&#34; is a broad term, it correctly captures that HSPB6
-      physically interacts with kinases. The IEA transfer from rat is appropriate given
-      the conserved function.
+      HSPB6 is a substrate of PKA and interacts with PKD1. While &#34;protein kinase binding&#34;
+      is a broad term, it correctly captures kinase-related physical interaction evidence.
+      The IEA transfer from rat is appropriate given the conserved function.
 - term:
     id: GO:0042803
     label: protein homodimerization activity

--- a/genes/human/HSPB6/HSPB6-ai-review.html
+++ b/genes/human/HSPB6/HSPB6-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>HSPB6</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/O14558" target="_blank" class="term-link">
                         O14558
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>HSPB6 (also known as HSP20 or HspB6) is a member of the small heat shock protein (sHSP) family. It functions as an ATP-independent molecular chaperone (holdase) that binds partially unfolded or denatured proteins to prevent their irreversible aggregation, maintaining them in a folding-competent state. Unlike ATP-dependent chaperones such as HSP70, HSPB6 does not actively refold substrates. HSPB6 exists primarily as a stable homodimer (the basic chaperoning subspecies), distinct from the larger polydisperse oligomers formed by CRYAB, and can form heterooligomers with HSPB1 and CRYAB. It is highly expressed in skeletal and smooth muscle, where its primary physiological role is as a signaling-responsive regulator of actin cytoskeletal dynamics: phosphorylation at Ser-16 by cAMP/PKA or cGMP/PKG creates a 14-3-3 binding site, and the resulting phospho-HSPB6/14-3-3 complex displaces phospho-cofilin from 14-3-3 sequestration, allowing cofilin activation, actin depolymerization, and Ca2+-independent smooth muscle relaxation (&#34;force suppression&#34;) (DOI:10.1152/ajplung.00235.2007, DOI:10.1152/physrev.00023.2010). In the heart, HSPB6 provides cardioprotection through inhibition of apoptosis (interactions with Akt, Bax, ASK1) and regulation of BECN1-mediated autophagy; the DCM-associated S10F variant impairs autophagy by promoting BECN1 ubiquitination and proteasomal degradation (DOI:10.1080/15548627.2017.1392420). HSPB6 also exhibits lipid-dependent chaperone activity, binding membrane lipids with Kd values of 0.045-0.095 micromolar and inhibiting lipid-induced alpha-synuclein aggregation at substoichiometric ratios (DOI:10.1016/j.isci.2024.110657). HSPB6 functions as a secreted cardiokine promoting angiogenesis via VEGFR2 activation.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043066" target="_blank" class="term-link">
                                     GO:0043066
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of apoptotic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,64 +795,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation inferred from phylogenetic analysis across sHSP family members including alpha-crystallins (CRYAA, CRYAB) and HSPA1A. HSPB6 has well-documented anti-apoptotic functions, particularly in cardiomyocytes. UniProt notes that phosphorylation at Ser-16 by PKA is required to protect cardiomyocytes from apoptosis. The P20L variant abolishes cardioprotective effects (PMID:18790732). HSPB6 overexpression protects hearts against ischemia/reperfusion injury, isoproterenol-triggered cardiac remodeling, endotoxin-induced myocardial dysfunction, and doxorubicin cardiotoxicity, largely through inhibition of cardiomyocyte death via interactions with Akt, Bax, and ASK1 (PMID:22427880). This IBA annotation at the general level of &#34;negative regulation of apoptotic process&#34; is appropriate as a broad characterization, though for HSPB6 the anti-apoptotic role is primarily cardiac-specific.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The anti-apoptotic function of HSPB6 is well supported by multiple lines of evidence. The IBA annotation is phylogenetically sound and confirmed by extensive experimental literature on cardioprotection. While a more specific cardiac term (GO:0010667) is also annotated, this broader term is appropriate as the core anti-apoptotic function may not be restricted solely to cardiac muscle cells.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22427880" target="_blank" class="term-link">
                                         PMID:22427880
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">These salutary effects of Hsp20 are largely attributed to the inhibition of cardiomyocyte death through multiple interactions with α-actin, α-actinin, Akt, Bax, NF-κB, 14-3-3γ, phosphodiesterase-4 (PDE4), and apoptosis signal-regulating kinase 1 (ASK1)</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -864,64 +864,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for cytoplasmic localization inferred from phylogenetic analysis across a broad set of sHSP family orthologs in fly, worm, mouse, rat, zebrafish, and human. HSPB6 cytoplasmic localization is directly supported by IDA evidence from PMID:19464326 (Vos et al., 2009) which used confocal microscopy of GFP-tagged HSPB members. UniProt confirms cytoplasmic localization for HSPB6. This is consistent with the known function of HSPB6 as a cytoplasmic holdase chaperone and its roles in smooth muscle relaxation and cardiac contractility.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization is a core feature of HSPB6 function, confirmed by direct experimental evidence (PMID:19464326) and consistent with its role as a cytoplasmic chaperone in muscle cells. The IBA annotation is well supported.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
                                         PMID:19464326
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">BACKGROUND: The HSPB family is one of the more diverse families within the group of HSP families. Some members have chaperone-like activities and/or play a role in cytoskeletal stabilization.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -933,64 +933,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for nuclear localization inferred from phylogenetic analysis across sHSP family members including CRYAA, CRYAB, HSPB1, and zebrafish orthologs. HSPB6 nuclear localization is directly supported by IDA evidence from PMID:19464326 (Vos et al., 2009), which showed that HSPB6 translocates to nuclear foci during heat shock. UniProt confirms nuclear localization with the note that HSPB6 translocates to nuclear foci during heat shock. This represents a stress-induced localization rather than constitutive residence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear localization is experimentally confirmed by PMID:19464326. While this is a stress-induced translocation rather than a constitutive feature, the IBA annotation at the level of GO:0005634 &#34;nucleus&#34; is appropriate. The more specific term GO:0016607 &#34;nuclear speck&#34; is also annotated via HPA data.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
                                         PMID:19464326
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Some members also show a dynamic, stress-induced translocation to SC35 splicing speckles.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009408" target="_blank" class="term-link">
                                     GO:0009408
                                 </a>
                             </span>
                             <span class="term-label">response to heat</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1002,64 +1002,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for response to heat inferred from phylogenetic analysis across sHSP family members in fly, worm, and zebrafish. As a member of the small heat shock protein family, HSPB6 is upregulated under heat stress conditions and translocates to nuclear foci during heat shock (PMID:19464326). The annotation is consistent with the core identity of HSPB6 as a heat shock protein. UniProt classifies it under the &#34;Stress response&#34; keyword. The chaperone activity of HSPB6 is measured in part by its ability to prevent heat-induced aggregation of substrates such as alcohol dehydrogenase (PMID:14717697).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Response to heat is a fundamental characteristic of the sHSP family. HSPB6 is a bona fide heat shock protein that is upregulated by heat stress and translocates to nuclear foci during heat shock. The IBA annotation is phylogenetically well supported and consistent with experimental data.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14717697" target="_blank" class="term-link">
                                         PMID:14717697
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">At pH 7.0-7.5, the chaperone activity of Hsp20 (measured by its ability to prevent the reduction-induced aggregation of insulin or heat-induced aggregation of yeast alcohol dehydrogenase) was similar to or higher than that of commercial alpha-crystallin.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1071,88 +1071,99 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for protein refolding inferred from phylogenetic analysis of Drosophila sHSP orthologs. However, HSPB6 is specifically a holdase-type chaperone that prevents aggregation of unfolded substrates but does not actively refold them. PMID:24382496 describes HSPB6 as an &#34;ATP-independent&#34; sHSP that binds partially unfolded proteins to prevent their &#34;irreversible aggregation.&#34; Active refolding requires ATP-dependent chaperones such as HSP70. PMID:19464326 tested HSPB members for refolding activity using a luciferase refolding assay and found that HSPB1 and CRYAB &#34;chaperoned heat unfolded substrates and kept them folding competent&#34; but HSPB6 was not among those shown to support refolding independently. The term &#34;protein refolding&#34; implies an active refoldase activity that HSPB6 does not possess.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPB6 is a holdase chaperone, not a refoldase. It prevents aggregation but does not actively refold substrates. The appropriate process term is GO:0006457 &#34;protein folding&#34; (which is already annotated via IDA from PMID:14717697), as HSPB6 participates in the protein folding process by maintaining substrates in a folding-competent state for downstream refolding by ATP-dependent chaperones.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     protein folding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24382496" target="_blank" class="term-link">
                                         PMID:24382496
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">ATP-independent small heat-shock proteins (sHSPs) are an essential component of the cellular chaperoning machinery. Under both normal and stress conditions, sHSPs bind partially unfolded proteins and prevent their irreversible aggregation.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
                                         PMID:19464326
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Unlike HSPB1 and HSPB5, that chaperoned heat unfolded substrates and kept them folding competent, HSPB7 did not support refolding.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/HSPB6/HSPB6-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">HSPB6 belongs to the small heat shock protein family and functions as an ATP-independent holdase chaperone rather than an active refoldase.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1164,88 +1175,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). This IBA annotation was inferred from phylogenetic analysis across the sHSP family, including alpha-crystallins and other small heat shock proteins. The annotation correctly captures that HSPB6 binds unfolded/denatured proteins, as demonstrated by chaperone assays showing it prevents reduction-induced aggregation of insulin and heat-induced aggregation of alcohol dehydrogenase (PMID:14717697). However, simple &#34;binding&#34; to unfolded proteins is not the correct GO representation of chaperone function. HSPB6 is a holdase-type chaperone that binds partially unfolded substrates to prevent aggregation in an ATP-independent manner (PMID:24382496). The best available replacement is GO:0044183 &#34;protein folding chaperone&#34;, which is already annotated to HSPB6 via IMP evidence (PMID:24382496). Note that GO:0044183 is an imperfect fit since HSPB6 is specifically a holdase (prevents aggregation) rather than an active refoldase, but no dedicated holdase term currently exists in GO.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is scheduled for obsoletion. The term &#34;unfolded protein binding&#34; conflates binding with chaperone function. HSPB6 does not merely bind unfolded proteins; it acts as a holdase chaperone preventing irreversible aggregation. GO:0044183 &#34;protein folding chaperone&#34; is the recommended interim replacement. A dedicated holdase activity term would be more precise but does not yet exist in GO.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24382496" target="_blank" class="term-link">
                                         PMID:24382496
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">ATP-independent small heat-shock proteins (sHSPs) are an essential component of the cellular chaperoning machinery. Under both normal and stress conditions, sHSPs bind partially unfolded proteins and prevent their irreversible aggregation.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14717697" target="_blank" class="term-link">
                                         PMID:14717697
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">At pH 7.0-7.5, the chaperone activity of Hsp20 (measured by its ability to prevent the reduction-induced aggregation of insulin or heat-induced aggregation of yeast alcohol dehydrogenase) was similar to or higher than that of commercial alpha-crystallin.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005212" target="_blank" class="term-link">
                                     GO:0005212
                                 </a>
                             </span>
                             <span class="term-label">structural constituent of eye lens</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1257,46 +1268,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation transferred from InterPro domain IPR003090 (Alpha-crystallin_N), which maps to GO:0005212 &#34;structural constituent of eye lens.&#34; While HSPB6 shares the alpha-crystallin domain with bona fide lens crystallins (CRYAA, CRYAB), HSPB6 is not expressed in the eye lens and does not function as a structural lens component. HSPB6 is predominantly expressed in skeletal muscle, smooth muscle, and cardiac tissue (UniProt: &#34;most highly expressed in muscle cells&#34;). The InterPro-to-GO mapping is overly broad, applying a lens-specific function to all alpha-crystallin domain-containing proteins.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPB6 is not a structural constituent of the eye lens. It shares the alpha-crystallin domain with lens crystallins but is expressed in muscle tissues, not the lens. This annotation results from an overly broad InterPro domain-to-GO term mapping. The alpha-crystallin domain confers chaperone activity across the sHSP family, but the lens structural function is specific to CRYAA and CRYAB.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
                                     GO:0005576
                                 </a>
                             </span>
                             <span class="term-label">extracellular region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1308,46 +1319,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation based on UniProtKB/Swiss-Prot subcellular location vocabulary mapping. UniProt confirms HSPB6 is &#34;Secreted&#34; based on PMID:22427880. This annotation is redundant with the IDA annotation for the same term from PMID:22427880. The extracellular localization reflects a non-constitutive, stress-enhanced secretion via exosomes from cardiomyocytes rather than the primary localization of HSPB6.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent with the IDA annotation for the same term, extracellular localization represents a specialized cardiac paracrine signaling role. HSPB6 is primarily a cytoplasmic/cytosolic protein, and its secretion via exosomes is a regulated process enhanced by stress. The IEA mapping is correct but this is a non-core localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1359,46 +1370,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation based on UniProtKB/Swiss-Prot subcellular location vocabulary mapping. UniProt confirms nuclear localization for HSPB6 based on PMID:19464326. This annotation is redundant with the IDA and IBA annotations for the same term but is independently acceptable as an automated mapping.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The IEA annotation correctly reflects the UniProt subcellular location annotation and is confirmed by IDA evidence from PMID:19464326. Redundancy with IDA and IBA annotations is acceptable.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1410,46 +1421,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation based on UniProtKB/Swiss-Prot subcellular location vocabulary mapping. UniProt confirms cytoplasmic localization for HSPB6 based on PMID:19464326. This annotation is redundant with the IDA and IBA annotations for the same term but is independently acceptable as an automated mapping.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The IEA annotation correctly reflects the UniProt subcellular location annotation and is confirmed by IDA evidence from PMID:19464326. Redundancy with IDA and IBA annotations is acceptable.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010667" target="_blank" class="term-link">
                                     GO:0010667
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of cardiac muscle cell apoptotic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1461,64 +1472,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation transferred from rat ortholog P97541 via Ensembl Compara. HSPB6 has well-documented cardioprotective anti-apoptotic functions. PMID:22427880 demonstrates that elevated intracellular Hsp20 protects hearts against various stress stimuli including myocardial ischemia/reperfusion injury through inhibition of cardiomyocyte death. UniProt notes that phosphorylation at Ser-16 is required to protect cardiomyocytes from apoptosis, and the P20L variant abolishes cardioprotective effects (PMID:18790732). This is a more specific child term of GO:0043066 and accurately reflects the cardiac-specific anti-apoptotic role of HSPB6.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While anti-apoptotic activity is an important function of HSPB6, the cardiac muscle cell specificity represents a tissue-specific manifestation rather than the core molecular function. The core function is the holdase chaperone activity. The cardioprotective role is a well-supported but downstream physiological consequence of HSPB6 chaperone activity and interactions.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22427880" target="_blank" class="term-link">
                                         PMID:22427880
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Over the past years, our laboratory has shown that elevated intracellular Hsp20 protects hearts against various stress stimuli including myocardial ischemia/reperfusion (I/R) injury</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019901" target="_blank" class="term-link">
                                     GO:0019901
                                 </a>
                             </span>
                             <span class="term-label">protein kinase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1530,46 +1541,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation transferred from rat ortholog P97541 via Ensembl Compara. HSPB6 is known to interact with several kinases: it is phosphorylated at Ser-16 by PKA (PMID:21334344), interacts with PDE4A and PDE4D which maintain its non-phosphorylated state (PMID:21334344), and interacts with PRKD1/PKD1 (PMID:26443497). UniProt confirms these interactions. While the annotation is technically correct in that HSPB6 binds protein kinases, the term is quite broad and does not capture the specific nature of these interactions (substrate of PKA, interaction partner of PKD1).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPB6 is a substrate of PKA and interacts with PKD1 and PDE4 family members. While &#34;protein kinase binding&#34; is a broad term, it correctly captures that HSPB6 physically interacts with kinases. The IEA transfer from rat is appropriate given the conserved function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042803" target="_blank" class="term-link">
                                     GO:0042803
                                 </a>
                             </span>
                             <span class="term-label">protein homodimerization activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1581,77 +1592,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation transferred from rat ortholog P97541 via Ensembl Compara. HSPB6 homodimerization is extensively characterized. PMID:24382496 solved the crystal structure of HSPB6 alpha-crystallin domain dimers and showed that HSPB6 forms stable homodimers in solution. PMID:14717697 showed that on size exclusion chromatography HSPB6 forms dimers with apparent molecular mass of 42 kDa after chemical crosslinking. This is also supported by ISS evidence from GO_REF:0000024. Homodimerization is a fundamental structural property of HSPB6.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Homodimerization is a core structural feature of HSPB6, extensively characterized by X-ray crystallography (PMID:24382496) and biochemical methods (PMID:14717697). The IEA transfer from rat is appropriate and confirmed by the ISS annotation and direct structural data.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24382496" target="_blank" class="term-link">
                                         PMID:24382496
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Here we focus on human HSPB6 which, despite having considerable homology to the α-crystallins in both the N-terminal region and the signature α-crystallin domain (ACD), only forms dimers in solution that represent the basic chaperoning subspecies.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14717697" target="_blank" class="term-link">
                                         PMID:14717697
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Chemical crosslinking resulted in the formation of dimers with an apparent molecular mass of 42 kDa.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1663,46 +1674,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation based on curation of immunofluorescence data from the Human Protein Atlas (HPA). Cytosolic localization is consistent with the known biology of HSPB6 as a soluble cytoplasmic chaperone. UniProt annotates HSPB6 to the cytoplasm. The cytosol is a more specific compartment within the cytoplasm and is the expected location for a soluble holdase chaperone that lacks membrane-targeting signals.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosolic localization is consistent with HSPB6 being a soluble, cytoplasmic holdase chaperone. HPA immunofluorescence data provides direct evidence. This is a more specific annotation than the broader &#34;cytoplasm&#34; annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016607" target="_blank" class="term-link">
                                     GO:0016607
                                 </a>
                             </span>
                             <span class="term-label">nuclear speck</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1714,75 +1725,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation based on HPA immunofluorescence data. PMID:19464326 (Vos et al., 2009) showed that several HSPB members, including HSPB6, translocate to SC35 splicing speckles (nuclear speckles) during heat shock. The paper primarily focused on HSPB7 as a constitutive SC35 speckle resident, while other members like HSPB6 showed stress-induced translocation. This localization appears to be a stress response rather than a constitutive feature.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear speck localization is experimentally supported by both HPA data and PMID:19464326. While stress-induced rather than constitutive, the localization is real and reproducible. Stress-induced translocation to nuclear speckles is a shared property among several sHSP family members.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
                                         PMID:19464326
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Some members also show a dynamic, stress-induced translocation to SC35 splicing speckles.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     GO:0044183
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24382496" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24382496
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular structure and dynamics of the dimeric human small ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1794,88 +1805,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IMP annotation from PMID:24382496 (Weeks et al., 2014). This study solved the crystal structure of HSPB6 and characterized its chaperoning properties through mutagenesis and functional assays. The paper demonstrated that HSPB6 forms dimers as the basic chaperoning subspecies and that mutations in the N-terminal domain (I3G/V5G) increase both self-association and chaperone activity. The study established that HSPB6 is an ATP-independent sHSP that binds partially unfolded proteins to prevent their irreversible aggregation. GO:0044183 &#34;protein folding chaperone&#34; is the best current GO term for this holdase activity, though HSPB6 specifically prevents aggregation rather than actively refolding substrates.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is the core molecular function of HSPB6. The IMP evidence from PMID:24382496 is strong, demonstrating through mutagenesis that structural features of HSPB6 directly correlate with chaperone activity. GO:0044183 is the best available GO term for holdase chaperone function, and this annotation correctly identifies the primary molecular function of HSPB6.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24382496" target="_blank" class="term-link">
                                         PMID:24382496
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">ATP-independent small heat-shock proteins (sHSPs) are an essential component of the cellular chaperoning machinery. Under both normal and stress conditions, sHSPs bind partially unfolded proteins and prevent their irreversible aggregation.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24382496" target="_blank" class="term-link">
                                         PMID:24382496
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">In solution, HSPB6 shows a strong attractive self-interaction, a property that correlates with its chaperoning activity.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071889" target="_blank" class="term-link">
                                     GO:0071889
                                 </a>
                             </span>
                             <span class="term-label">14-3-3 protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">EXP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28089448" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28089448
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structural Basis for the Interaction of a Human Small Heat S...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1887,88 +1898,244 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> EXP annotation from PMID:28089448 (Sluchanko et al., 2017). This study determined the crystal structure of the complete assembly of 14-3-3 dimer with full-length HSPB6 dimer, providing atomic resolution evidence for this interaction. The study showed that phosphorylation of HSPB6 within its intrinsically disordered N-terminal domain activates its interaction with 14-3-3, ultimately triggering smooth muscle relaxation. The interaction was further characterized using isothermal calorimetry, fluorescence spectroscopy, SAXS, and limited proteolysis. UniProt confirms the interaction of phosphorylated HSPB6 with YWHAZ (14-3-3 zeta).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The 14-3-3 protein binding activity of HSPB6 is supported by high-resolution structural evidence (crystal structure of the complex) and multiple biophysical methods. This phosphorylation-dependent interaction is a key regulatory mechanism linking HSPB6 to smooth muscle relaxation and is a well-characterized molecular function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/28089448" target="_blank" class="term-link">
                                         PMID:28089448
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Phosphorylation of the small heat shock protein, HSPB6, within its intrinsically disordered N-terminal domain activates its interaction with 14-3-3, ultimately triggering smooth muscle relaxation.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/28089448" target="_blank" class="term-link">
                                         PMID:28089448
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">This structure provides the first atomic resolution snapshot of a human small HSP in functional state, explains how 14-3-3 proteins sequester their regulatory partners, and can inform the design of small-molecule interaction modifiers to be used as myorelaxants.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044557" target="_blank" class="term-link">
+                                    GO:0044557
+                                </a>
+                            </span>
+                            <span class="term-label">relaxation of smooth muscle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            DOI:10.1152/ajplung.00235.2007
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="O14558" data-a="GO:0044557" data-r="DOI:10.1152/ajplung.00235.2007" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> HSPB6/HSP20 is a cyclic nucleotide kinase substrate whose Ser16 phosphorylation promotes smooth muscle relaxation through a 14-3-3/cofilin axis rather than through myosin light-chain dephosphorylation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the direct biological process described by the second core function. The existing apoptosis annotations capture cardioprotective effects, but they do not represent the primary smooth-muscle force suppression mechanism mediated by phospho-HSPB6.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    DOI:10.1152/ajplung.00235.2007
+
+                                </span>
+
+                                <div class="support-text">Activation of the PKA pathway led to relaxation of bovine ASM, which was associated with phosphorylation of HSP20 and dephosphorylation of cofilin.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/HSPB6/HSPB6-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A central concept for HSPB6 biology is phosphorylation at Ser16 by cyclic nucleotide-dependent kinases, which repeatedly correlates with smooth muscle relaxation and force suppression.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032956" target="_blank" class="term-link">
+                                    GO:0032956
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of actin cytoskeleton organization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            DOI:10.1152/ajplung.00235.2007
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="O14558" data-a="GO:0032956" data-r="DOI:10.1152/ajplung.00235.2007" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phosphorylated HSPB6 binds 14-3-3 proteins and promotes release and activation of cofilin, linking HSPB6 to actin filament fragmentation, stress-fiber disruption, and cytoskeletal remodeling during smooth muscle relaxation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The core 14-3-3/cofilin mechanism is best represented by actin cytoskeleton organization rather than apoptosis. This new annotation captures the direct pathway connecting phospho-HSPB6 binding to smooth-muscle force suppression.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    DOI:10.1152/ajplung.00235.2007
+
+                                </span>
+
+                                <div class="support-text">ISO-induced phosphorylation of HSP20 or synthetic phosphopeptide analogs of HSP20 decreases phosphorylation of cofilin and disrupts actin in ASM, suggesting that one possible mechanism by which HSP20 mediates ASM relaxation is via regulation of actin filament dynamics.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/HSPB6/HSPB6-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Release of cofilin allows its dephosphorylation and activation, promoting actin filament fragmentation and depolymerization tied to reduced stress fibers, focal adhesion disruption, and smooth muscle relaxation.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
                                     GO:0005576
                                 </a>
                             </span>
                             <span class="term-label">extracellular region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22427880" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22427880
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Hsp20 functions as a novel cardiokine in promoting angiogene...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1980,88 +2147,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from PMID:22427880 (Zhang et al., 2012). This study demonstrated that HSPB6 is actively secreted from cardiomyocytes via exosomes, independent of the classical ER-Golgi pathway. Circulating Hsp20 was increased in transgenic mice with cardiac-specific overexpression and was further elevated upon myocardial ischemia/reperfusion stress. The secreted HSPB6 functions as a cardiokine promoting angiogenesis via VEGFR2 activation. ELISA-based detection confirmed extracellular HSPB6 in both serum and culture media.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Extracellular secretion of HSPB6 is experimentally well supported but represents a specialized cardiac paracrine signaling role rather than the constitutive localization. HSPB6 is primarily a cytoplasmic/cytosolic protein, and its secretion via exosomes is a regulated process enhanced by stress. This is an important but non-core localization.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22427880" target="_blank" class="term-link">
                                         PMID:22427880
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we demonstrated that Hsp20 was secreted from adult rat cardiomyocytes via exosomes, independent of the classical ER-Golgi protein export pathway.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22427880" target="_blank" class="term-link">
                                         PMID:22427880
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">levels of circulating Hsp20 were increased by 3.4-fold in mice upon myocardial I/R insults, compared to the sham operation group</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14717697" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14717697
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Some properties of human small heat shock protein Hsp20 (Hsp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2073,75 +2240,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from PMID:14717697 (Bukach et al., 2004). This study characterized the chaperone activity of recombinant human Hsp20 (HSPB6) using standard chaperone assays. At neutral pH, HSPB6 prevented reduction-induced aggregation of insulin and heat-induced aggregation of yeast alcohol dehydrogenase with activity similar to or higher than commercial alpha-crystallin. HSPB6 participates in the protein folding process by maintaining substrates in a folding-competent state (holdase activity), though it does not actively refold them. GO:0006457 &#34;protein folding&#34; is appropriate as HSPB6 is part of the cellular protein folding machinery.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPB6 is an integral component of the protein folding machinery. While it functions as a holdase rather than a refoldase, it directly participates in protein folding by preventing irreversible aggregation and maintaining substrates in a folding-competent state for downstream refolding by ATP-dependent chaperones. The IDA evidence from standard chaperone assays is strong.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14717697" target="_blank" class="term-link">
                                         PMID:14717697
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">At pH 7.0-7.5, the chaperone activity of Hsp20 (measured by its ability to prevent the reduction-induced aggregation of insulin or heat-induced aggregation of yeast alcohol dehydrogenase) was similar to or higher than that of commercial alpha-crystallin.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045766" target="_blank" class="term-link">
                                     GO:0045766
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of angiogenesis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22427880" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22427880
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Hsp20 functions as a novel cardiokine in promoting angiogene...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2153,88 +2320,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from PMID:22427880 (Zhang et al., 2012). This study demonstrated that recombinant Hsp20 dose-dependently promoted HUVEC proliferation, migration, and tube formation. A protein binding assay revealed interaction between Hsp20 and VEGFR2, and blocking VEGFR2 with a neutralizing antibody or CBO-P11 inhibitor attenuated the pro-angiogenic effects. In vivo, cardiac-specific overexpression of Hsp20 significantly enhanced capillary density in transgenic hearts. The angiogenic function operates through secreted HSPB6 acting as a cardiokine via the VEGFR2/Akt/ERK signaling cascade.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While the pro-angiogenic function of secreted HSPB6 is well supported by in vitro and in vivo evidence, this represents a specialized paracrine signaling role of the secreted form rather than the core intracellular chaperone function. This is a downstream physiological consequence of HSPB6 secretion from cardiomyocytes and not part of its holdase chaperone activity.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22427880" target="_blank" class="term-link">
                                         PMID:22427880
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Hsp20 dose-dependently promoted the HUVEC proliferation, as measured by the MTS incorporation</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22427880" target="_blank" class="term-link">
                                         PMID:22427880
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">our findings demonstrate that Hsp20 serves as a novel cardiokine in regulating myocardial angiogenesis through activation of the VEGFR signaling cascade.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19845507" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19845507
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification of the key structural motifs involved in HspB...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -2246,112 +2413,112 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). This IDA annotation is based on PMID:19845507 (Fuchs et al., 2009), which demonstrated that HspB6 interacts with Bag3 through the conserved hydrophobic groove (beta4/beta8 strands) and that the HspB6-Bag3 complex promotes clearance of aggregated mutant huntingtin (Htt43Q). The paper describes sHSPs as proteins that &#34;bind to unfolded or misfolded proteins and protect them from aggregation.&#34; The study also showed that deletion of Bag3 IPV motifs suppresses HspB8 chaperone activity toward mutant Htt43Q, and that HspB6-Bag3 promotes clearance of aggregated Htt43Q. This demonstrates HSPB6 acts as a chaperone for misfolded substrates, not merely as a passive binder. The appropriate replacement is GO:0044183 &#34;protein folding chaperone&#34;. Note that HSPB6 is specifically a holdase chaperone (ATP-independent, prevents aggregation) but no dedicated holdase term exists in GO.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is scheduled for obsoletion. The experimental evidence in PMID:19845507 demonstrates that HSPB6 functions as a chaperone in complex with Bag3 to promote clearance of aggregation-prone substrates, which is better captured by GO:0044183 &#34;protein folding chaperone&#34; than by the obsoleting &#34;unfolded protein binding&#34; term. HSPB6 is a holdase-type chaperone but no specific holdase term exists in GO yet.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19845507" target="_blank" class="term-link">
                                         PMID:19845507
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">These proteins bind to unfolded or misfolded proteins and protect them from aggregation.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19845507" target="_blank" class="term-link">
                                         PMID:19845507
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HspB6-Bag3 promotes clearance of aggregated Htt43Q.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24382496" target="_blank" class="term-link">
                                         PMID:24382496
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">ATP-independent small heat-shock proteins (sHSPs) are an essential component of the cellular chaperoning machinery. Under both normal and stress conditions, sHSPs bind partially unfolded proteins and prevent their irreversible aggregation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23948568" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23948568
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structure and properties of G84R and L99M mutants of human s...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2363,75 +2530,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:23948568 (Nefedova et al., 2013) with interacting partner HSPB1 (P04792). The study investigated properties of G84R and L99M mutants of HspB1 and demonstrated that both wild-type and mutant HspB1 interact with HSPB6, forming heterooligomeric complexes. The neuropathy-associated mutants showed weakened interaction with HSPB6, forming only small heterooligomers. HSPB6 binding to HSPB1 (a chaperone) is well documented across multiple studies (PMID:14717697, PMID:21641913, PMID:27717639). The term &#34;protein-folding chaperone binding&#34; accurately describes the physical interaction of HSPB6 with the chaperone HSPB1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSPB6 interaction with HSPB1 (a protein-folding chaperone) is well established across multiple studies including structural characterization. The IPI evidence from PMID:23948568 is valid, demonstrating heterooligomer formation between HSPB6 and HSPB1. This interaction is functionally significant for the chaperone network.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23948568" target="_blank" class="term-link">
                                         PMID:23948568
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Both mutants weakly interact with HspB6 forming small heterooligomers and being unable to form large heterooligomers characteristic for the wild type HspB1.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19464326
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HSPB7 is a SC35 speckle resident small heat shock protein.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2443,75 +2610,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from PMID:19464326 (Vos et al., 2009). This study used confocal microscopy of GFP-tagged HSPB members to characterize their subcellular distribution. HSPB6 was found to translocate to nuclear foci during heat shock. UniProt confirms nuclear localization with the note that HSPB6 translocates to nuclear foci during heat shock. This represents stress-induced nuclear translocation rather than constitutive nuclear residence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear localization is directly demonstrated by confocal microscopy in PMID:19464326. While this is stress-induced, the localization is experimentally verified. The IDA evidence is appropriate for the GO:0005634 &#34;nucleus&#34; annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
                                         PMID:19464326
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Some members also show a dynamic, stress-induced translocation to SC35 splicing speckles.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19464326
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HSPB7 is a SC35 speckle resident small heat shock protein.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2523,64 +2690,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from PMID:19464326 (Vos et al., 2009). This study characterized subcellular distribution of HSPB family members using confocal microscopy of GFP-tagged proteins. HSPB6 showed cytoplasmic localization under basal conditions. This is consistent with HSPB6 being a soluble cytoplasmic holdase chaperone that functions in smooth and cardiac muscle cells.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization is directly demonstrated by confocal microscopy and is the primary constitutive localization of HSPB6. This is consistent with its role as a soluble chaperone and the UniProt annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
                                         PMID:19464326
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">BACKGROUND: The HSPB family is one of the more diverse families within the group of HSP families. Some members have chaperone-like activities and/or play a role in cytoskeletal stabilization.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042803" target="_blank" class="term-link">
                                     GO:0042803
                                 </a>
                             </span>
                             <span class="term-label">protein homodimerization activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2592,63 +2759,63 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISS annotation transferred from rat ortholog P97541 by curator judgment. HSPB6 homodimerization is extensively characterized for the human protein directly. PMID:24382496 solved the crystal structure of HSPB6 alpha-crystallin domain dimers and PMID:14717697 demonstrated dimer formation by chemical crosslinking. The ISS transfer is appropriate and confirmed by direct human protein data.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Homodimerization is a fundamental structural property of HSPB6. The ISS transfer from rat is correct and is further confirmed by direct structural evidence for the human protein (PMID:24382496, PMID:14717697). Keeping this alongside the IEA annotation provides independent evidence support.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24382496" target="_blank" class="term-link">
                                         PMID:24382496
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Here we focus on human HSPB6 which, despite having considerable homology to the α-crystallins in both the N-terminal region and the signature α-crystallin domain (ACD), only forms dimers in solution that represent the basic chaperoning subspecies.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14717697" target="_blank" class="term-link">
                                         PMID:14717697
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Chemical crosslinking resulted in the formation of dimers with an apparent molecular mass of 42 kDa.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>HSPB6 functions as an ATP-independent holdase chaperone that binds partially unfolded or denatured proteins to prevent their irreversible aggregation, maintaining substrates in a folding-competent state for downstream refolding by ATP-dependent chaperones such as HSP70. It exists primarily as a stable homodimer, which represents the basic chaperoning subspecies. Recent work demonstrates that HSPB6 also has lipid-dependent chaperone activity, binding membrane lipids with high affinity and inhibiting lipid-induced alpha-synuclein aggregation at substoichiometric ratios, suggesting a proteostasis role at membrane interfaces beyond its classical cytosolic holdase function (DOI:10.1016/j.isci.2024.110657).</h3>
                 <span class="vote-buttons" data-g="O14558" data-a="FUNCTION: HSPB6 functions as an ATP-independent holdase chap..." data-r="" data-act="CORE_FUNCTION">
@@ -2656,10 +2823,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -2668,87 +2835,98 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                 protein folding
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009408" target="_blank" class="term-link">
                                 response to heat
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24382496" target="_blank" class="term-link">
                                 PMID:24382496
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">ATP-independent small heat-shock proteins (sHSPs) are an essential component of the cellular chaperoning machinery. Under both normal and stress conditions, sHSPs bind partially unfolded proteins and prevent their irreversible aggregation.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14717697" target="_blank" class="term-link">
                                 PMID:14717697
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">At pH 7.0-7.5, the chaperone activity of Hsp20 (measured by its ability to prevent the reduction-induced aggregation of insulin or heat-induced aggregation of yeast alcohol dehydrogenase) was similar to or higher than that of commercial alpha-crystallin.</div>
-                        
+
                     </li>
-                    
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/HSPB6/HSPB6-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Falcon synthesis highlights HSPB6 as an ATP-independent holdase chaperone with recent lipid-dependent anti-aggregation evidence at membrane interfaces.</div>
+
+                    </li>
+
                 </ul>
             </div>
-            
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>HSPB6 binds 14-3-3 proteins (YWHAZ) in a phosphorylation-dependent manner (Ser-16 phosphorylation by PKA/PKG) to regulate smooth muscle relaxation and cardioprotection. The crystal structure of the complete 14-3-3/HSPB6 assembly has been solved, showing how phosphorylation within the intrinsically disordered N-terminal domain activates this interaction (PMID:28089448). The downstream mechanism involves competitive displacement of phospho-cofilin from 14-3-3 sequestration, allowing cofilin dephosphorylation/activation and subsequent actin filament fragmentation, depolymerization, and smooth muscle relaxation (&#34;force suppression&#34;) without requiring myosin light chain dephosphorylation (DOI:10.1152/ajplung.00235.2007, DOI:10.1152/physrev.00023.2010). This phospho-HSPB6/14-3-3/cofilin axis represents the primary physiological signaling role of HSPB6 in smooth muscle.</h3>
                 <span class="vote-buttons" data-g="O14558" data-a="FUNCTION: HSPB6 binds 14-3-3 proteins (YWHAZ) in a phosphory..." data-r="" data-act="CORE_FUNCTION">
@@ -2756,10 +2934,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -2768,454 +2946,485 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043066" target="_blank" class="term-link">
-                                negative regulation of apoptotic process
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044557" target="_blank" class="term-link">
+                                relaxation of smooth muscle
                             </a>
                         </span>
-                        
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032956" target="_blank" class="term-link">
+                                regulation of actin cytoskeleton organization
+                            </a>
+                        </span>
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                 cytoplasm
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28089448" target="_blank" class="term-link">
                                 PMID:28089448
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">Phosphorylation of the small heat shock protein, HSPB6, within its intrinsically disordered N-terminal domain activates its interaction with 14-3-3, ultimately triggering smooth muscle relaxation.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22427880" target="_blank" class="term-link">
                                 PMID:22427880
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">These salutary effects of Hsp20 are largely attributed to the inhibition of cardiomyocyte death through multiple interactions with alpha-actin, alpha-actinin, Akt, Bax, NF-kappaB, 14-3-3gamma, phosphodiesterase-4 (PDE4), and apoptosis signal-regulating kinase 1 (ASK1)</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
                             GO_REF:0000024
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
                             GO_REF:0000052
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
                             GO_REF:0000107
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/HSPB6/HSPB6-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research synthesis for HSPB6</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">HSPB6 is an ATP-independent small heat shock protein holdase with phosphorylation-regulated 14-3-3/cofilin signaling roles in smooth muscle relaxation and cardioprotection.</div>
+
+                        <div class="finding-text">"HSPB6 belongs to the small heat shock protein family. Functionally, sHSPs are ATP-independent &#34;holdase&#34; chaperones that can modulate proteostasis by binding aggregation-prone proteins."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14717697" target="_blank" class="term-link">
                             PMID:14717697
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Some properties of human small heat shock protein Hsp20 (HspB6).</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
                             PMID:19464326
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSPB7 is a SC35 speckle resident small heat shock protein.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19845507" target="_blank" class="term-link">
                             PMID:19845507
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Identification of the key structural motifs involved in HspB8/HspB6-Bag3 interaction.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22427880" target="_blank" class="term-link">
                             PMID:22427880
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Hsp20 functions as a novel cardiokine in promoting angiogenesis via activation of VEGFR2.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23948568" target="_blank" class="term-link">
                             PMID:23948568
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Structure and properties of G84R and L99M mutants of human small heat shock protein HspB1 correlating with motor neuropathy.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24382496" target="_blank" class="term-link">
                             PMID:24382496
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Molecular structure and dynamics of the dimeric human small heat shock protein HSPB6.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28089448" target="_blank" class="term-link">
                             PMID:28089448
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Structural Basis for the Interaction of a Human Small Heat Shock Protein with the 14-3-3 Universal Signaling Regulator.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1152/ajplung.00235.2007
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The small heat shock-related protein, HSP20, is a cAMP-dependent protein kinase substrate that is involved in airway smooth muscle relaxation</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">PKA phosphorylates HSPB6 at Ser16; phospho-HSPB6 binds 14-3-3gamma whereas non-phosphorylated HSPB6 does not</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Phospho-HSPB6 can displace phospho-cofilin from 14-3-3, allowing cofilin activation and actin depolymerization</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1152/physrev.00023.2010
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Large potentials of small heat shock proteins</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSPB6 mediates cyclic nucleotide-dependent force suppression in smooth muscle through phosphorylation-dependent actin remodeling via the 14-3-3/cofilin axis</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSPB6 associates with actin and alpha-actinin at low stoichiometry (monomer ratio less than 0.04); Ser16 phosphorylation causes dissociation</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1152/japplphysiol.01043.2004
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Transduction of phosphorylated heat shock-related protein 20 prevents vasospasm of human umbilical artery smooth muscle</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Cell-permeant phosphorylated HSPB6 constructs produce vasorelaxation and prevent vasospasm in human umbilical artery</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1080/15548627.2017.1392420
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Regulation of BECN1-mediated autophagy by HSPB6 - insights from a human HSPB6 S10F mutant</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">The DCM-associated S10F variant promotes BECN1 ubiquitination and proteasomal degradation, inhibiting autophagic flux and increasing apoptosis</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSPB6 S10F transgenic mice develop progressive cardiomyopathy with ejection fraction reduced to approximately 50 percent by 16 months and premature death</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1016/j.isci.2024.110657
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSPB6 - a lipid-dependent molecular chaperone inhibits alpha-synuclein aggregation</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSPB6 binds membrane lipids with Kd values of 0.045-0.095 micromolar across different organelle lipid compositions</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSPB6 abrogates lipid-induced alpha-synuclein aggregation at 1:100 HSPB6:alpha-syn ratio, acting at membrane-associated aggregation steps</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Aggregation half-time correlates with HSPB6 lipid affinity (Pearson r equals 0.85, p equals 0.0375)</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -3510,9 +3719,9 @@ this with annotations you find in gene/protein databases, but these can be outda
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -3524,7 +3733,7 @@ this with annotations you find in gene/protein databases, but these can be outda
                 <pre><code>id: O14558
 gene_symbol: HSPB6
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -3696,6 +3905,10 @@ existing_annotations:
         supporting_text: &gt;-
           Unlike HSPB1 and HSPB5, that chaperoned heat unfolded substrates and kept them
           folding competent, HSPB7 did not support refolding.
+      - reference_id: file:human/HSPB6/HSPB6-deep-research-falcon.md
+        supporting_text: &gt;-
+          HSPB6 belongs to the small heat shock protein family and functions as
+          an ATP-independent holdase chaperone rather than an active refoldase.
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -3998,6 +4211,63 @@ existing_annotations:
           partners, and can inform the design of small-molecule interaction modifiers to be
           used as myorelaxants.
 - term:
+    id: GO:0044557
+    label: relaxation of smooth muscle
+  evidence_type: IDA
+  original_reference_id: DOI:10.1152/ajplung.00235.2007
+  review:
+    summary: &gt;-
+      HSPB6/HSP20 is a cyclic nucleotide kinase substrate whose Ser16
+      phosphorylation promotes smooth muscle relaxation through a 14-3-3/cofilin
+      axis rather than through myosin light-chain dephosphorylation.
+    action: NEW
+    reason: &gt;-
+      This is the direct biological process described by the second core
+      function. The existing apoptosis annotations capture cardioprotective
+      effects, but they do not represent the primary smooth-muscle force
+      suppression mechanism mediated by phospho-HSPB6.
+    supported_by:
+      - reference_id: DOI:10.1152/ajplung.00235.2007
+        supporting_text: &gt;-
+          Activation of the PKA pathway led to relaxation of bovine ASM, which
+          was associated with phosphorylation of HSP20 and dephosphorylation of
+          cofilin.
+      - reference_id: file:human/HSPB6/HSPB6-deep-research-falcon.md
+        supporting_text: &gt;-
+          A central concept for HSPB6 biology is phosphorylation at Ser16 by
+          cyclic nucleotide-dependent kinases, which repeatedly correlates with
+          smooth muscle relaxation and force suppression.
+- term:
+    id: GO:0032956
+    label: regulation of actin cytoskeleton organization
+  evidence_type: IDA
+  original_reference_id: DOI:10.1152/ajplung.00235.2007
+  review:
+    summary: &gt;-
+      Phosphorylated HSPB6 binds 14-3-3 proteins and promotes release and
+      activation of cofilin, linking HSPB6 to actin filament fragmentation,
+      stress-fiber disruption, and cytoskeletal remodeling during smooth muscle
+      relaxation.
+    action: NEW
+    reason: &gt;-
+      The core 14-3-3/cofilin mechanism is best represented by actin
+      cytoskeleton organization rather than apoptosis. This new annotation
+      captures the direct pathway connecting phospho-HSPB6 binding to
+      smooth-muscle force suppression.
+    supported_by:
+      - reference_id: DOI:10.1152/ajplung.00235.2007
+        supporting_text: &gt;-
+          ISO-induced phosphorylation of HSP20 or synthetic phosphopeptide
+          analogs of HSP20 decreases phosphorylation of cofilin and disrupts
+          actin in ASM, suggesting that one possible mechanism by which HSP20
+          mediates ASM relaxation is via regulation of actin filament dynamics.
+      - reference_id: file:human/HSPB6/HSPB6-deep-research-falcon.md
+        supporting_text: &gt;-
+          Release of cofilin allows its dephosphorylation and activation,
+          promoting actin filament fragmentation and depolymerization tied to
+          reduced stress fibers, focal adhesion disruption, and smooth muscle
+          relaxation.
+- term:
     id: GO:0005576
     label: extracellular region
   evidence_type: IDA
@@ -4255,6 +4525,17 @@ references:
   title: Automatic transfer of experimentally verified manual GO annotation data to
     orthologs using Ensembl Compara
   findings: []
+- id: file:human/HSPB6/HSPB6-deep-research-falcon.md
+  title: Falcon deep research synthesis for HSPB6
+  findings:
+    - statement: &gt;-
+        HSPB6 is an ATP-independent small heat shock protein holdase with
+        phosphorylation-regulated 14-3-3/cofilin signaling roles in smooth
+        muscle relaxation and cardioprotection.
+      supporting_text: &gt;-
+        HSPB6 belongs to the small heat shock protein family. Functionally,
+        sHSPs are ATP-independent &#34;holdase&#34; chaperones that can modulate
+        proteostasis by binding aggregation-prone proteins.
 - id: PMID:14717697
   title: Some properties of human small heat shock protein Hsp20 (HspB6).
   findings: []
@@ -4354,6 +4635,11 @@ core_functions:
           the reduction-induced aggregation of insulin or heat-induced aggregation of yeast
           alcohol dehydrogenase) was similar to or higher than that of commercial
           alpha-crystallin.
+      - reference_id: file:human/HSPB6/HSPB6-deep-research-falcon.md
+        supporting_text: &gt;-
+          Falcon synthesis highlights HSPB6 as an ATP-independent holdase
+          chaperone with recent lipid-dependent anti-aggregation evidence at
+          membrane interfaces.
   - description: &gt;-
       HSPB6 binds 14-3-3 proteins (YWHAZ) in a phosphorylation-dependent manner
       (Ser-16 phosphorylation by PKA/PKG) to regulate smooth muscle relaxation and
@@ -4371,8 +4657,10 @@ core_functions:
       id: GO:0071889
       label: 14-3-3 protein binding
     directly_involved_in:
-      - id: GO:0043066
-        label: negative regulation of apoptotic process
+      - id: GO:0044557
+        label: relaxation of smooth muscle
+      - id: GO:0032956
+        label: regulation of actin cytoskeleton organization
     locations:
       - id: GO:0005737
         label: cytoplasm
@@ -4394,7 +4682,7 @@ core_functions:
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/HSPB6/HSPB6-ai-review.yaml
+++ b/genes/human/HSPB6/HSPB6-ai-review.yaml
@@ -1,7 +1,7 @@
 id: O14558
 gene_symbol: HSPB6
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -173,6 +173,10 @@ existing_annotations:
         supporting_text: >-
           Unlike HSPB1 and HSPB5, that chaperoned heat unfolded substrates and kept them
           folding competent, HSPB7 did not support refolding.
+      - reference_id: file:human/HSPB6/HSPB6-deep-research-falcon.md
+        supporting_text: >-
+          HSPB6 belongs to the small heat shock protein family and functions as
+          an ATP-independent holdase chaperone rather than an active refoldase.
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -475,6 +479,63 @@ existing_annotations:
           partners, and can inform the design of small-molecule interaction modifiers to be
           used as myorelaxants.
 - term:
+    id: GO:0044557
+    label: relaxation of smooth muscle
+  evidence_type: IDA
+  original_reference_id: DOI:10.1152/ajplung.00235.2007
+  review:
+    summary: >-
+      HSPB6/HSP20 is a cyclic nucleotide kinase substrate whose Ser16
+      phosphorylation promotes smooth muscle relaxation through a 14-3-3/cofilin
+      axis rather than through myosin light-chain dephosphorylation.
+    action: NEW
+    reason: >-
+      This is the direct biological process described by the second core
+      function. The existing apoptosis annotations capture cardioprotective
+      effects, but they do not represent the primary smooth-muscle force
+      suppression mechanism mediated by phospho-HSPB6.
+    supported_by:
+      - reference_id: DOI:10.1152/ajplung.00235.2007
+        supporting_text: >-
+          Activation of the PKA pathway led to relaxation of bovine ASM, which
+          was associated with phosphorylation of HSP20 and dephosphorylation of
+          cofilin.
+      - reference_id: file:human/HSPB6/HSPB6-deep-research-falcon.md
+        supporting_text: >-
+          A central concept for HSPB6 biology is phosphorylation at Ser16 by
+          cyclic nucleotide-dependent kinases, which repeatedly correlates with
+          smooth muscle relaxation and force suppression.
+- term:
+    id: GO:0032956
+    label: regulation of actin cytoskeleton organization
+  evidence_type: IDA
+  original_reference_id: DOI:10.1152/ajplung.00235.2007
+  review:
+    summary: >-
+      Phosphorylated HSPB6 binds 14-3-3 proteins and promotes release and
+      activation of cofilin, linking HSPB6 to actin filament fragmentation,
+      stress-fiber disruption, and cytoskeletal remodeling during smooth muscle
+      relaxation.
+    action: NEW
+    reason: >-
+      The core 14-3-3/cofilin mechanism is best represented by actin
+      cytoskeleton organization rather than apoptosis. This new annotation
+      captures the direct pathway connecting phospho-HSPB6 binding to
+      smooth-muscle force suppression.
+    supported_by:
+      - reference_id: DOI:10.1152/ajplung.00235.2007
+        supporting_text: >-
+          ISO-induced phosphorylation of HSP20 or synthetic phosphopeptide
+          analogs of HSP20 decreases phosphorylation of cofilin and disrupts
+          actin in ASM, suggesting that one possible mechanism by which HSP20
+          mediates ASM relaxation is via regulation of actin filament dynamics.
+      - reference_id: file:human/HSPB6/HSPB6-deep-research-falcon.md
+        supporting_text: >-
+          Release of cofilin allows its dephosphorylation and activation,
+          promoting actin filament fragmentation and depolymerization tied to
+          reduced stress fibers, focal adhesion disruption, and smooth muscle
+          relaxation.
+- term:
     id: GO:0005576
     label: extracellular region
   evidence_type: IDA
@@ -732,6 +793,17 @@ references:
   title: Automatic transfer of experimentally verified manual GO annotation data to
     orthologs using Ensembl Compara
   findings: []
+- id: file:human/HSPB6/HSPB6-deep-research-falcon.md
+  title: Falcon deep research synthesis for HSPB6
+  findings:
+    - statement: >-
+        HSPB6 is an ATP-independent small heat shock protein holdase with
+        phosphorylation-regulated 14-3-3/cofilin signaling roles in smooth
+        muscle relaxation and cardioprotection.
+      supporting_text: >-
+        HSPB6 belongs to the small heat shock protein family. Functionally,
+        sHSPs are ATP-independent "holdase" chaperones that can modulate
+        proteostasis by binding aggregation-prone proteins.
 - id: PMID:14717697
   title: Some properties of human small heat shock protein Hsp20 (HspB6).
   findings: []
@@ -831,6 +903,11 @@ core_functions:
           the reduction-induced aggregation of insulin or heat-induced aggregation of yeast
           alcohol dehydrogenase) was similar to or higher than that of commercial
           alpha-crystallin.
+      - reference_id: file:human/HSPB6/HSPB6-deep-research-falcon.md
+        supporting_text: >-
+          Falcon synthesis highlights HSPB6 as an ATP-independent holdase
+          chaperone with recent lipid-dependent anti-aggregation evidence at
+          membrane interfaces.
   - description: >-
       HSPB6 binds 14-3-3 proteins (YWHAZ) in a phosphorylation-dependent manner
       (Ser-16 phosphorylation by PKA/PKG) to regulate smooth muscle relaxation and
@@ -848,8 +925,10 @@ core_functions:
       id: GO:0071889
       label: 14-3-3 protein binding
     directly_involved_in:
-      - id: GO:0043066
-        label: negative regulation of apoptotic process
+      - id: GO:0044557
+        label: relaxation of smooth muscle
+      - id: GO:0032956
+        label: regulation of actin cytoskeleton organization
     locations:
       - id: GO:0005737
         label: cytoplasm

--- a/genes/human/HSPB6/HSPB6-ai-review.yaml
+++ b/genes/human/HSPB6/HSPB6-ai-review.yaml
@@ -148,11 +148,8 @@ existing_annotations:
       aggregation of unfolded substrates but does not actively refold them. PMID:24382496
       describes HSPB6 as an "ATP-independent" sHSP that binds partially unfolded proteins
       to prevent their "irreversible aggregation." Active refolding requires ATP-dependent
-      chaperones such as HSP70. PMID:19464326 tested HSPB members for refolding activity
-      using a luciferase refolding assay and found that HSPB1 and CRYAB "chaperoned heat
-      unfolded substrates and kept them folding competent" but HSPB6 was not among those
-      shown to support refolding independently. The term "protein refolding" implies an
-      active refoldase activity that HSPB6 does not possess.
+      chaperones such as HSP70. The term "protein refolding" implies an active refoldase
+      activity that HSPB6 does not possess.
     action: MODIFY
     reason: >-
       HSPB6 is a holdase chaperone, not a refoldase. It prevents aggregation but does not
@@ -169,10 +166,6 @@ existing_annotations:
           ATP-independent small heat-shock proteins (sHSPs) are an essential component of the
           cellular chaperoning machinery. Under both normal and stress conditions, sHSPs bind
           partially unfolded proteins and prevent their irreversible aggregation.
-      - reference_id: PMID:19464326
-        supporting_text: >-
-          Unlike HSPB1 and HSPB5, that chaperoned heat unfolded substrates and kept them
-          folding competent, HSPB7 did not support refolding.
       - reference_id: file:human/HSPB6/HSPB6-deep-research-falcon.md
         supporting_text: >-
           HSPB6 belongs to the small heat shock protein family and functions as
@@ -329,17 +322,16 @@ existing_annotations:
     summary: >-
       IEA annotation transferred from rat ortholog P97541 via Ensembl Compara. HSPB6 is
       known to interact with several kinases: it is phosphorylated at Ser-16 by PKA
-      (PMID:21334344), interacts with PDE4A and PDE4D which maintain its non-phosphorylated
-      state (PMID:21334344), and interacts with PRKD1/PKD1 (PMID:26443497). UniProt
-      confirms these interactions. While the annotation is technically correct in that
-      HSPB6 binds protein kinases, the term is quite broad and does not capture the
-      specific nature of these interactions (substrate of PKA, interaction partner of PKD1).
+      (PMID:21334344), and interacts with PRKD1/PKD1 (PMID:26443497). UniProt
+      confirms the kinase interaction context. While the annotation is technically correct
+      in that HSPB6 binds protein kinases, the term is quite broad and does not capture
+      the specific nature of these interactions (substrate of PKA, interaction partner of
+      PKD1).
     action: ACCEPT
     reason: >-
-      HSPB6 is a substrate of PKA and interacts with PKD1 and PDE4 family members.
-      While "protein kinase binding" is a broad term, it correctly captures that HSPB6
-      physically interacts with kinases. The IEA transfer from rat is appropriate given
-      the conserved function.
+      HSPB6 is a substrate of PKA and interacts with PKD1. While "protein kinase binding"
+      is a broad term, it correctly captures kinase-related physical interaction evidence.
+      The IEA transfer from rat is appropriate given the conserved function.
 - term:
     id: GO:0042803
     label: protein homodimerization activity

--- a/genes/human/PTGES3/PTGES3-ai-review.html
+++ b/genes/human/PTGES3/PTGES3-ai-review.html
@@ -1692,10 +1692,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q15185" data-a="GO:0006631" data-r="GO_REF:0000043" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q15185" data-a="GO:0006631" data-r="GO_REF:0000043" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1708,7 +1708,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Prostaglandins are eicosanoids derived from arachidonic acid (a fatty acid), so this broad IEA mapping is not incorrect. The more specific prostaglandin biosynthetic process annotation provides better specificity.
+                            <strong>Reason:</strong> PTGES3/cPGES converts PGH2 to PGE2 in prostanoid metabolism; it does not broadly participate in fatty acid metabolism. This parent term is therefore too broad for the terminal prostaglandin synthase activity, and the existing prostaglandin biosynthetic and metabolic process annotations provide better specificity.
                         </div>
 
 
@@ -8554,11 +8554,12 @@ existing_annotations:
       IEA annotation for fatty acid metabolic process from UniProt keyword mapping.
       Prostaglandins are derived from arachidonic acid, a fatty acid. PTGES3 catalyzes the
       terminal step converting PGH2 to PGE2.
-    action: ACCEPT
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      Prostaglandins are eicosanoids derived from arachidonic acid (a fatty acid), so
-      this broad IEA mapping is not incorrect. The more specific prostaglandin biosynthetic
-      process annotation provides better specificity.
+      PTGES3/cPGES converts PGH2 to PGE2 in prostanoid metabolism; it does not broadly
+      participate in fatty acid metabolism. This parent term is therefore too broad for
+      the terminal prostaglandin synthase activity, and the existing prostaglandin
+      biosynthetic and metabolic process annotations provide better specificity.
 - term:
     id: GO:0006633
     label: fatty acid biosynthetic process

--- a/genes/human/PTGES3/PTGES3-ai-review.html
+++ b/genes/human/PTGES3/PTGES3-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>PTGES3</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/Q15185" target="_blank" class="term-link">
                         Q15185
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>Dual-function protein (160 aa, ~18.7 kDa) that acts both as a cytosolic prostaglandin E synthase (cPGES) catalyzing the glutathione-dependent isomerization of PGH2 to PGE2, and as an HSP90 co-chaperone (p23) that stabilizes the HSP90-client protein complex in the ATP-bound closed conformation. As a co-chaperone, p23 inhibits/reduces HSP90 ATPase activity by stabilizing the &#34;closed 2&#34; conformational state, thereby regulating progression of the HSP90 chaperone cycle and shaping client maturation/release (DOI:10.1038/nrm.2017.20). PTGES3 participates in the maturation and stabilization of steroid hormone receptors, telomerase, and other HSP90 client proteins. As a PGE synthase, PTGES3/cPGES is functionally coupled with COX-1 (PTGS1) in preference to COX-2 for immediate PGE2 biosynthesis. Recent work reveals that PTGES3 can function as an HSP90-independent transcription factor for COX-2 (PTGS2) in lung adenocarcinoma, driven by succinate-dependent lysine succinylation (K7, K33, K79) that promotes nuclear translocation; nuclear p23 was detected in &gt;90% of tumor tissues versus ~5% of adjacent normal tissues (DOI:10.1126/sciadv.ade0387). PTGES3 can also interact with p53 independently of HSP90 and protect the aryl hydrocarbon receptor from degradation. Contains a CS domain (CHORD-containing proteins and SGT1 domain) in the N-terminal region mediating HSP90 binding and an unstructured acidic C-terminal tail important for its independent passive chaperoning activity preventing protein aggregation.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,64 +795,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation of PTGES3 to nucleus (GO:0005634) is phylogenetically inferred. PTGES3/p23 is predominantly cytoplasmic/cytosolic, but has been shown to localize to the nucleus, particularly when translocating with HSP90-client complexes such as steroid hormone receptors (PMID:12077419). Reactome documents multiple nuclear events involving PTGES3 (e.g., R-HSA-5618080 HSP90:ATP:p23:FKBP52:SHR:SH translocates to the nucleus). The HDA annotation from PMID:21630459 also detected PTGES3 in sperm nuclei by mass spectrometry.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear localization is well supported. PTGES3 translocates to the nucleus as part of HSP90-steroid receptor complexes and also localizes to genomic response elements in a hormone-dependent manner (PMID:12077419). Multiple Reactome pathways place PTGES3 in the nucleoplasm. The IBA annotation at the level of nucleus is appropriate.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12077419" target="_blank" class="term-link">
                                         PMID:12077419
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the p23 molecular chaperone localizes in vivo to genomic response elements in a hormone-dependent manner</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -864,77 +864,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for protein folding is phylogenetically supported. PTGES3/p23 is a core HSP90 co-chaperone that participates in the folding of steroid receptors and other HSP90 client proteins (PMID:10811660, PMID:10543959). It also has independent chaperone activity preventing aggregation of non-native proteins (PMID:10543959).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein folding is a well-established core function of PTGES3. As an HSP90 co-chaperone, p23 stabilizes the ATP-bound conformation of HSP90 needed for client protein folding (PMID:10811660). It also has independent passive chaperoning activity preventing heat-induced protein aggregation (PMID:10811660). This annotation is also supported by the IDA from PMID:12853476.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10811660" target="_blank" class="term-link">
                                         PMID:10811660
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the tail is necessary for optimum active chaperoning of the progesterone receptor, as well as the passive chaperoning activity of p23 in assays measuring inhibition of heat-induced protein aggregation</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10543959" target="_blank" class="term-link">
                                         PMID:10543959
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">p23 binds to Hsp90 in its ATP-bound state and, on its own, interacts specifically with non-native proteins</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -946,77 +946,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation of PTGES3 to protein-folding chaperone binding (GO:0051087) is phylogenetically inferred. PTGES3/p23 directly binds HSP90, a protein-folding chaperone, in an ATP-dependent manner (PMID:10543959, PMID:9817749). This interaction is one of the most well-characterized aspects of PTGES3 function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PTGES3 binding to HSP90 (a protein-folding chaperone) is extensively documented. The protein binds specifically to the ATP-bound state of HSP90 and stabilizes the closed conformation (PMID:10543959, PMID:21183720). This is a core function appropriately captured at this level of specificity by IBA.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10543959" target="_blank" class="term-link">
                                         PMID:10543959
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">p23 binds to Hsp90 in its ATP-bound state</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21183720" target="_blank" class="term-link">
                                         PMID:21183720
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">it is Hsp90&#39;s nucleotide-binding domain that triggers the formation of the Hsp90(2)p23(2) complex</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051131" target="_blank" class="term-link">
                                     GO:0051131
                                 </a>
                             </span>
                             <span class="term-label">chaperone-mediated protein complex assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1028,77 +1028,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for chaperone-mediated protein complex assembly is phylogenetically inferred. PTGES3/p23, as part of the HSP90 chaperone system, facilitates the assembly of multiprotein complexes including steroid receptor complexes (PMID:8114727, PMID:10811660) and telomerase holoenzyme (PMID:10197982).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PTGES3 participates in HSP90-mediated assembly of steroid receptor complexes and telomerase holoenzyme. The IMP evidence from PMID:10811660 directly demonstrates this for the progesterone receptor complex. This is a core function of the HSP90 co-chaperone activity of PTGES3.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10811660" target="_blank" class="term-link">
                                         PMID:10811660
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the tail is necessary for optimum active chaperoning of the progesterone receptor</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10197982" target="_blank" class="term-link">
                                         PMID:10197982
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We have identified the molecular chaperones p23 and Hsp90 as proteins that bind to the catalytic subunit of telomerase. Blockade of this interaction inhibits assembly of active telomerase in vitro.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051879" target="_blank" class="term-link">
                                     GO:0051879
                                 </a>
                             </span>
                             <span class="term-label">Hsp90 protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1110,77 +1110,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for Hsp90 protein binding is phylogenetically inferred. PTGES3/p23 is among the best-characterized HSP90 co-chaperones, binding directly to the N-terminal domain of HSP90 in its ATP-bound state (PMID:10543959, PMID:21183720).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Hsp90 protein binding is a core molecular function of PTGES3. The interaction is extensively documented by crystal structures, NMR, and biochemical studies (PMID:10811660, PMID:10543959, PMID:21183720). Multiple IPI annotations from independent groups confirm this.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21183720" target="_blank" class="term-link">
                                         PMID:21183720
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">it is Hsp90&#39;s nucleotide-binding domain that triggers the formation of the Hsp90(2)p23(2) complex</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10543959" target="_blank" class="term-link">
                                         PMID:10543959
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">p23 binds to Hsp90 in its ATP-bound state</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001516" target="_blank" class="term-link">
                                     GO:0001516
                                 </a>
                             </span>
                             <span class="term-label">prostaglandin biosynthetic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1192,64 +1192,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for prostaglandin biosynthetic process is phylogenetically inferred. PTGES3/p23 was identified as cytosolic prostaglandin E2 synthase (cPGES) that catalyzes conversion of PGH2 to PGE2, functionally coupled with COX-1 (PMID:10922363).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Prostaglandin biosynthesis is a core function of PTGES3. The protein was molecularly identified as cPGES with demonstrated PGE synthase enzymatic activity (Km=14 uM for PGH2, Vmax=190 nmol/min/mg) (PMID:10922363). This is also supported by IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10922363" target="_blank" class="term-link">
                                         PMID:10922363
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Recombinant p23 expressed in Escherichia coli and 293 cells exhibited all the features of PGES activity detected in rat brain cytosol</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1261,64 +1261,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for cytosol is phylogenetically inferred. PTGES3/p23 was originally identified as a cytosolic component of progesterone receptor complexes (PMID:8114727) and was later identified as a cytosolic PGE synthase (PMID:10922363). UniProt annotates it to cytoplasm.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosolic localization is one of the primary sites for PTGES3 function, both for its co-chaperone role in steroid receptor maturation and for its prostaglandin synthase activity. This is well established and concordant with the IBA inference.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10922363" target="_blank" class="term-link">
                                         PMID:10922363
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Here we report the molecular identification of cytosolic glutathione (GSH)-dependent prostaglandin (PG) E(2) synthase (cPGES)</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050220" target="_blank" class="term-link">
                                     GO:0050220
                                 </a>
                             </span>
                             <span class="term-label">prostaglandin-E synthase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1330,202 +1330,213 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for prostaglandin-E synthase activity is phylogenetically inferred. This enzymatic activity was directly demonstrated by Tanioka et al. (PMID:10922363) who identified p23 as cytosolic PGES. This is a core molecular function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Prostaglandin-E synthase activity is a core molecular function of PTGES3, demonstrated by direct enzymatic assay with purified recombinant protein (PMID:10922363). The IBA annotation is concordant with multiple IDA and EXP annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10922363" target="_blank" class="term-link">
                                         PMID:10922363
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Recombinant p23 expressed in Escherichia coli and 293 cells exhibited all the features of PGES activity detected in rat brain cytosol</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PTGES3/PTGES3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PTGES3/cPGES catalyzes the glutathione-dependent isomerization of PGH2 to PGE2 and is functionally coupled with COX-1-derived PGH2 in current pathway models.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007004" target="_blank" class="term-link">
                                     GO:0007004
                                 </a>
                             </span>
                             <span class="term-label">telomere maintenance via telomerase</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q15185" data-a="GO:0007004" data-r="GO_REF:0000033" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q15185" data-a="GO:0007004" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for telomere maintenance via telomerase is phylogenetically inferred. PTGES3/p23 and HSP90 were shown to be required for assembly and activity of telomerase (PMID:10197982). Inhibition of p23-HSP90 interaction blocks telomerase assembly.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> PTGES3 participates in telomere maintenance via telomerase through its role in assembling and stabilizing the telomerase holoenzyme complex with HSP90 (PMID:10197982, PMID:12135483). This is an established secondary function of PTGES3 and the IBA annotation is appropriate.
+                            <strong>Reason:</strong> PTGES3 participates in telomere maintenance via telomerase through its role in assembling and stabilizing the telomerase holoenzyme complex with HSP90 (PMID:10197982, PMID:12135483). This is an established client-specific consequence of the p23/HSP90 co-chaperone role, not a core PTGES3 function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10197982" target="_blank" class="term-link">
                                         PMID:10197982
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We have identified the molecular chaperones p23 and Hsp90 as proteins that bind to the catalytic subunit of telomerase. Blockade of this interaction inhibits assembly of active telomerase in vitro.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905323" target="_blank" class="term-link">
                                     GO:1905323
                                 </a>
                             </span>
                             <span class="term-label">telomerase holoenzyme complex assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q15185" data-a="GO:1905323" data-r="GO_REF:0000033" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q15185" data-a="GO:1905323" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for telomerase holoenzyme complex assembly. PTGES3/p23 together with HSP90 is required for in vitro assembly of active telomerase from its components (PMID:10197982). The IDA from PMID:10197982 directly supports this.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Telomerase holoenzyme complex assembly is a well-documented function of PTGES3 in concert with HSP90. Holt et al. (PMID:10197982) showed that p23 and HSP90 bind hTERT and are required for assembly of active telomerase. This is concordant with the IBA.
+                            <strong>Reason:</strong> Telomerase holoenzyme complex assembly is a well-documented function of PTGES3 in concert with HSP90. Holt et al. (PMID:10197982) showed that p23 and HSP90 bind hTERT and are required for assembly of active telomerase. This should be kept as a non-core HSP90-client assembly consequence rather than elevated to a core function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10197982" target="_blank" class="term-link">
                                         PMID:10197982
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">assembly of active telomerase from in vitro-synthesized components requires the contribution of proteins present in reticulocyte extracts. We have identified the molecular chaperones p23 and Hsp90 as proteins that bind to the catalytic subunit of telomerase.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001516" target="_blank" class="term-link">
                                     GO:0001516
                                 </a>
                             </span>
                             <span class="term-label">prostaglandin biosynthetic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1537,46 +1548,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for prostaglandin biosynthetic process from combined automated methods. This is consistent with the core prostaglandin synthase function of PTGES3 (PMID:10922363).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This IEA annotation is consistent with the well-established prostaglandin E synthase activity of PTGES3 and is concordant with the IBA and IDA annotations for the same term.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1588,46 +1599,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for cytoplasm from UniProt subcellular location mapping. PTGES3 is annotated to cytoplasm in UniProt based on sequence similarity evidence. The protein is primarily cytosolic.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization is well established for PTGES3. While cytosol (GO:0005829) is more specific and also annotated, the broader cytoplasm term from an IEA pipeline is not incorrect. It is simply less specific than the IBA and TAS annotations to cytosol.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006629" target="_blank" class="term-link">
                                     GO:0006629
                                 </a>
                             </span>
                             <span class="term-label">lipid metabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1639,46 +1650,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for lipid metabolic process from UniProt keyword mapping. PTGES3 catalyzes conversion of PGH2 to PGE2, which is a lipid metabolic process.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> This is a broad but not incorrect annotation. PTGES3 participates in prostaglandin biosynthesis, which is a form of lipid metabolism. The more specific annotations to prostaglandin biosynthetic process (GO:0001516) and fatty acid biosynthetic process (GO:0006633) provide better granularity, but this IEA annotation is acceptable as a parent term.
+                            <strong>Reason:</strong> This is a broad but not incorrect annotation. PTGES3 participates in prostaglandin biosynthesis, which is a form of lipid metabolism. The more specific annotations to prostaglandin biosynthetic and metabolic process annotations provide better granularity. The separate fatty acid biosynthetic process annotation overstates this terminal prostanoid-synthesis step.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006631" target="_blank" class="term-link">
                                     GO:0006631
                                 </a>
                             </span>
                             <span class="term-label">fatty acid metabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1690,97 +1701,108 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for fatty acid metabolic process from UniProt keyword mapping. Prostaglandins are derived from arachidonic acid, a fatty acid. PTGES3 catalyzes the terminal step converting PGH2 to PGE2.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Prostaglandins are eicosanoids derived from arachidonic acid (a fatty acid), so this broad IEA mapping is not incorrect. The more specific prostaglandin biosynthetic process annotation provides better specificity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006633" target="_blank" class="term-link">
                                     GO:0006633
                                 </a>
                             </span>
                             <span class="term-label">fatty acid biosynthetic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q15185" data-a="GO:0006633" data-r="GO_REF:0000043" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q15185" data-a="GO:0006633" data-r="GO_REF:0000043" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for fatty acid biosynthetic process from UniProt keyword mapping. PTGES3 catalyzes the isomerization of PGH2 to PGE2 in the prostaglandin biosynthetic pathway, which is derived from arachidonic acid metabolism.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> This IEA mapping from UniProt keywords is broadly acceptable since prostaglandins are fatty acid derivatives. However, prostaglandin biosynthesis is more accurately described as eicosanoid/prostanoid biosynthesis than as fatty acid biosynthesis per se. This is a tolerable IEA-level annotation given the more specific annotations exist.
+                            <strong>Reason:</strong> PTGES3 catalyzes the terminal isomerization of PGH2 to PGE2 in prostaglandin biosynthesis; it does not synthesize fatty acids. This keyword-derived IEA annotation is therefore too broad and biologically misleading compared with the existing prostaglandin biosynthetic process annotation.
                         </div>
-                        
-                        
-                        
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001516" target="_blank" class="term-link">
+                                    prostaglandin biosynthetic process
+                                </a>
+                            </span>
+
+                        </div>
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006693" target="_blank" class="term-link">
                                     GO:0006693
                                 </a>
                             </span>
                             <span class="term-label">prostaglandin metabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1792,46 +1814,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for prostaglandin metabolic process from UniProt keyword mapping. PTGES3 is a prostaglandin E synthase that converts PGH2 to PGE2 (PMID:10922363).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is a correct but broader annotation than the more specific prostaglandin biosynthetic process (GO:0001516) that is also annotated. Acceptable for an IEA-level annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016853" target="_blank" class="term-link">
                                     GO:0016853
                                 </a>
                             </span>
                             <span class="term-label">isomerase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1843,46 +1865,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for isomerase activity from UniProt keyword mapping. The UniProt EC number for PTGES3 is 5.3.99.3 (prostaglandin-E synthase), which is classified as an isomerase. The conversion of PGH2 to PGE2 is an isomerization reaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PTGES3 catalyzes the isomerization of PGH2 to PGE2 (EC 5.3.99.3), making isomerase activity a correct broad annotation. The more specific prostaglandin-E synthase activity (GO:0050220) is also annotated. This IEA annotation is acceptable as a parent MF term.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050220" target="_blank" class="term-link">
                                     GO:0050220
                                 </a>
                             </span>
                             <span class="term-label">prostaglandin-E synthase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1894,46 +1916,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for prostaglandin-E synthase activity from combined automated methods. This is concordant with the experimentally demonstrated enzymatic activity (PMID:10922363).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This IEA annotation is concordant with the directly demonstrated prostaglandin-E synthase activity of PTGES3 (PMID:10922363), which is also captured by IDA and EXP annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051879" target="_blank" class="term-link">
                                     GO:0051879
                                 </a>
                             </span>
                             <span class="term-label">Hsp90 protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1945,57 +1967,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for Hsp90 protein binding from InterPro mapping. PTGES3 contains a CS domain (InterPro IPR007052) that mediates HSP90 binding.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Hsp90 protein binding is a core function of PTGES3 well documented by multiple experimental studies (PMID:10543959, PMID:10811660, PMID:21183720). The IEA annotation from InterPro is concordant with IBA and IPI annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17353931" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17353931
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Large-scale mapping of human protein-protein interactions by...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2007,57 +2029,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from large-scale mass spectrometry mapping of human protein-protein interactions. This is a high-throughput study without specific binding partner information in the GO annotation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding (GO:0005515) is uninformative for PTGES3, which has well-characterized specific binding interactions (Hsp90 protein binding, GO:0051879). The high-throughput nature of the study (large-scale mapping by mass spectrometry) and the vague term make this annotation of limited value. The specific binding functions of PTGES3 are better captured by GO:0051879 and GO:0051087.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19875381" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19875381
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A proteomic investigation of ligand-dependent HSP90 complexe...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2069,57 +2091,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from a proteomic study of ligand-dependent HSP90 complexes (PMID:19875381). PTGES3 was identified as a component of HSP90 complexes in this study.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While PTGES3 was correctly identified in HSP90 complexes in this study, the annotation to the generic protein binding term is uninformative. The interaction with HSP90 is already well captured by GO:0051879 (Hsp90 protein binding). The generic protein binding annotation adds no value.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21183720" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21183720
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     N-terminal domain of human Hsp90 triggers binding to the coc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2131,75 +2153,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from Karagoz et al. (PMID:21183720) which characterized the p23-HSP90 interaction by NMR. This study specifically showed that Hsp90&#39;s N-terminal domain triggers binding to p23.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PMID:21183720 demonstrated specific binding of p23 to HSP90&#39;s N-terminal domain, which is better captured by GO:0051879 (Hsp90 protein binding) than the generic protein binding term. The generic annotation is redundant and uninformative.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21183720" target="_blank" class="term-link">
                                         PMID:21183720
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">it is Hsp90&#39;s nucleotide-binding domain that triggers the formation of the Hsp90(2)p23(2) complex</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21988832" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21988832
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Toward an understanding of the protein interaction network o...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2211,57 +2233,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from a large-scale study of human liver protein interaction network.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Generic protein binding annotation from a high-throughput interaction study. The specific molecular function binding terms (GO:0051879 Hsp90 protein binding, GO:0051087 protein-folding chaperone binding) are far more informative.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23741051" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23741051
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Hsp90 cochaperones p23 and FKBP4 physically interact with hA...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2273,75 +2295,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from Pare et al. (PMID:23741051), which showed that p23 and FKBP4 physically interact with hAgo2 and activate RNA interference. The specific interaction with hAgo2 in the context of the HSP90 chaperone cycle is noteworthy.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While PMID:23741051 demonstrates a biologically interesting interaction (p23 with hAgo2 in RISC loading), the generic protein binding annotation does not capture this specificity. The interaction with hAgo2 occurs as part of PTGES3&#39;s HSP90 co-chaperone function, which is already well annotated.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23741051" target="_blank" class="term-link">
                                         PMID:23741051
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Two of these cochaperones (FKBP4 and p23) form stable complexes with Hsp90 and hAgo2, and our data suggest that this interaction occurs before binding small RNAs</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24981860" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24981860
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human-chromatin-related protein interactions identify a deme...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2353,57 +2375,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from a study of human chromatin-related protein interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Generic protein binding annotation from a high-throughput interaction study. Uninformative given the well-characterized specific binding functions of PTGES3.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25036637
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A quantitative chaperone interaction network reveals the arc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2415,57 +2437,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from a quantitative chaperone interaction network study. This study mapped chaperone-client relationships.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While this study provides useful information about PTGES3 in the chaperone network, the generic protein binding annotation is uninformative. PTGES3&#39;s chaperone binding is better captured by GO:0051879 and GO:0051087.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2477,57 +2499,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from a dual proteome-scale network study of the human interactome.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Generic protein binding from a high-throughput interactome study. The specific binding functions of PTGES3 are better captured by more informative terms already annotated.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:35271311
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     OpenCell: Endogenous tagging for the cartography of human ce...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2539,57 +2561,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from the OpenCell endogenous tagging study.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Generic protein binding from a large-scale cellular organization study. Uninformative for PTGES3 which has well-characterized specific binding partners.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/35914814" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:35914814
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Chr21 protein-protein interactions: enrichment in proteins i...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2601,57 +2623,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from a study of Chr21 protein-protein interactions related to intellectual disability and Alzheimer&#39;s disease.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Generic protein binding from a focused interaction study. Uninformative for PTGES3 given existing specific binding annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9817749" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9817749
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     In vivo function of Hsp90 is dependent on ATP binding and AT...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2663,64 +2685,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from Obermann et al. (PMID:9817749), which demonstrated that p23 binding to HSP90 is ATP-dependent and that mutant HSP90 proteins defective in ATP binding/hydrolysis are defective in p23 cycling.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PMID:9817749 specifically demonstrates the ATP-dependent interaction between p23 and HSP90, which is better captured by GO:0051879 (Hsp90 protein binding). The generic protein binding annotation is redundant.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9817749" target="_blank" class="term-link">
                                         PMID:9817749
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The mutant Hsp90 proteins tested are defective in the binding and ATP hydrolysis-dependent cycling of the co-chaperone p23</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046457" target="_blank" class="term-link">
                                     GO:0046457
                                 </a>
                             </span>
                             <span class="term-label">prostanoid biosynthetic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-2162123
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2732,57 +2754,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for prostanoid biosynthetic process from Reactome pathway R-HSA-2162123 (Synthesis of Prostaglandins and Thromboxanes). PTGES3 catalyzes the conversion of PGH2 to PGE2 as part of this pathway.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Prostanoid biosynthetic process is a correct and appropriate annotation for PTGES3. PGE2 is a prostanoid, and PTGES3 catalyzes the terminal step in its biosynthesis (PMID:10922363). This is concordant with the prostaglandin biosynthetic process annotation and represents the same core enzymatic function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050220" target="_blank" class="term-link">
                                     GO:0050220
                                 </a>
                             </span>
                             <span class="term-label">prostaglandin-E synthase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">EXP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10922363" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10922363
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular identification of cytosolic prostaglandin E2 synth...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2794,395 +2816,395 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> EXP annotation for prostaglandin-E synthase activity based on the landmark paper by Tanioka et al. (PMID:10922363) that molecularly identified p23 as cytosolic PGES. Recombinant p23 demonstrated all features of PGES activity with Km=14 uM and Vmax=190 nmol/min/mg.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is a core enzymatic function of PTGES3 demonstrated by direct biochemical assay with purified recombinant protein (PMID:10922363). The enzyme was shown to catalyze GSH-dependent isomerization of PGH2 to PGE2 and to be functionally coupled with COX-1.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10922363" target="_blank" class="term-link">
                                         PMID:10922363
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Recombinant p23 expressed in Escherichia coli and 293 cells exhibited all the features of PGES activity detected in rat brain cytosol</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032212" target="_blank" class="term-link">
                                     GO:0032212
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of telomere maintenance via telomerase</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19740745" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19740745
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A truncated form of p23 down-regulates telomerase activity v...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q15185" data-a="GO:0032212" data-r="PMID:19740745" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q15185" data-a="GO:0032212" data-r="PMID:19740745" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for positive regulation of telomere maintenance via telomerase based on Woo et al. (PMID:19740745). This study showed that overexpression of truncated p23 (Delta p23) down-regulated telomerase activity and decreased hTERT levels, implying that full-length p23 positively regulates telomerase maintenance.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> The study demonstrates that PTGES3 positively regulates telomerase activity through its HSP90 co-chaperone function. Truncation of p23 disrupts HSP90 function, leading to reduced telomerase activity, decreased hTERT stability, and inhibited cell growth (PMID:19740745). This is consistent with the broader literature on PTGES3&#39;s role in telomerase assembly.
+                            <strong>Reason:</strong> The study demonstrates that PTGES3 positively regulates telomerase activity through its HSP90 co-chaperone function. Truncation of p23 disrupts HSP90 function, leading to reduced telomerase activity, decreased hTERT stability, and inhibited cell growth (PMID:19740745). This is a non-core client-specific effect of the p23/HSP90 system.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19740745" target="_blank" class="term-link">
                                         PMID:19740745
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">overexpression of Delta p23 resulted in a decrease in hTERT levels, and a down-regulation in telomerase activity</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007004" target="_blank" class="term-link">
                                     GO:0007004
                                 </a>
                             </span>
                             <span class="term-label">telomere maintenance via telomerase</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10197982" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10197982
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional requirement of p23 and Hsp90 in telomerase comple...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q15185" data-a="GO:0007004" data-r="PMID:10197982" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q15185" data-a="GO:0007004" data-r="PMID:10197982" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for telomere maintenance via telomerase from the seminal Holt et al. study (PMID:10197982) that demonstrated p23 and HSP90 are required for telomerase assembly and that a significant fraction of cellular telomerase is associated with p23 and HSP90.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> This is well-supported experimental evidence. Holt et al. showed that p23 and HSP90 bind hTERT, that blockade of their interaction inhibits telomerase assembly, and that active telomerase in cell extracts is associated with p23 and HSP90 (PMID:10197982). This represents a core secondary function of PTGES3.
+                            <strong>Reason:</strong> This is well-supported experimental evidence. Holt et al. showed that p23 and HSP90 bind hTERT, that blockade of their interaction inhibits telomerase assembly, and that active telomerase in cell extracts is associated with p23 and HSP90 (PMID:10197982). This represents a non-core HSP90-client consequence of PTGES3/p23.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10197982" target="_blank" class="term-link">
                                         PMID:10197982
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">a significant fraction of active telomerase from cell extracts is associated with p23 and Hsp90. Consistent with in vitro results, inhibition of Hsp90 function in cells blocks assembly of active telomerase.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070182" target="_blank" class="term-link">
                                     GO:0070182
                                 </a>
                             </span>
                             <span class="term-label">DNA polymerase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10197982" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10197982
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional requirement of p23 and Hsp90 in telomerase comple...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q15185" data-a="GO:0070182" data-r="PMID:10197982" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q15185" data-a="GO:0070182" data-r="PMID:10197982" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for DNA polymerase binding based on PMID:10197982 (Holt et al., 1999). The study showed that p23 binds to hTERT, the reverse transcriptase catalytic subunit of telomerase. hTERT is a specialized reverse transcriptase (RNA-dependent DNA polymerase). The annotation captures p23&#39;s direct binding to this polymerase.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> PTGES3/p23 directly binds hTERT, the telomerase reverse transcriptase, which is a specialized DNA polymerase. This was demonstrated by co-immunoprecipitation in PMID:10197982. While hTERT is specifically a reverse transcriptase, the GO:0070182 (DNA polymerase binding) captures the binding to this enzyme class. The annotation is technically correct.
+                            <strong>Reason:</strong> PTGES3/p23 directly binds hTERT, the telomerase reverse transcriptase, which is a specialized DNA polymerase. This was demonstrated by co-immunoprecipitation in PMID:10197982. While hTERT is specifically a reverse transcriptase, the GO:0070182 (DNA polymerase binding) captures the binding to this enzyme class. The annotation is technically supported but non-core and should not be represented as a separate PTGES3 core function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10197982" target="_blank" class="term-link">
                                         PMID:10197982
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We have identified the molecular chaperones p23 and Hsp90 as proteins that bind to the catalytic subunit of telomerase</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905323" target="_blank" class="term-link">
                                     GO:1905323
                                 </a>
                             </span>
                             <span class="term-label">telomerase holoenzyme complex assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10197982" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10197982
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional requirement of p23 and Hsp90 in telomerase comple...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q15185" data-a="GO:1905323" data-r="PMID:10197982" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q15185" data-a="GO:1905323" data-r="PMID:10197982" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for telomerase holoenzyme complex assembly based on Holt et al. (PMID:10197982). The study demonstrated that p23 and HSP90 are required for in vitro assembly of active telomerase from purified components.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> This is directly demonstrated experimental evidence. Assembly of active telomerase from in vitro-synthesized components required p23 and HSP90 present in reticulocyte extracts. Blockade of the p23-HSP90 interaction inhibited telomerase assembly (PMID:10197982).
+                            <strong>Reason:</strong> This is directly demonstrated experimental evidence. Assembly of active telomerase from in vitro-synthesized components required p23 and HSP90 present in reticulocyte extracts. Blockade of the p23-HSP90 interaction inhibited telomerase assembly (PMID:10197982). Keep as a non-core client-specific outcome of the HSP90 co-chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10197982" target="_blank" class="term-link">
                                         PMID:10197982
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">assembly of active telomerase from in vitro-synthesized components requires the contribution of proteins present in reticulocyte extracts. We have identified the molecular chaperones p23 and Hsp90</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0101031" target="_blank" class="term-link">
                                     GO:0101031
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/29127155" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:29127155
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tumor suppressor Tsc1 is a new Hsp90 co-chaperone that facil...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3194,75 +3216,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for protein folding chaperone complex based on Woodford et al. (PMID:29127155). This study identified PTGES3 as part of a complex containing HSP90, HSP70, STIP1, CDC37, PPP5C, TSC1, and TSC2. The complex facilitates folding of kinase and non-kinase clients.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PTGES3 is an established component of the HSP90 chaperone complex. The study (PMID:29127155) identified PTGES3 in a multi-protein chaperone complex with HSP90 and other co-chaperones. This is consistent with the well-known role of PTGES3 as an HSP90 co-chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/29127155" target="_blank" class="term-link">
                                         PMID:29127155
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Here, we show that Tsc1 is a new co-chaperone for Hsp90 that inhibits its ATPase activity</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000781" target="_blank" class="term-link">
                                     GO:0000781
                                 </a>
                             </span>
                             <span class="term-label">chromosome, telomeric region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IC</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12135483" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12135483
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Differential regulation of telomerase activity by six telome...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3274,75 +3296,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IC annotation for chromosome, telomeric region based on Chang et al. (PMID:12135483), inferred from the role of p23 as a telomerase subunit. Since PTGES3 is part of the telomerase holoenzyme and telomerase acts at telomeres, localization to the telomeric region is a reasonable inference.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is an inferred localization based on PTGES3&#39;s role as a component of the telomerase holoenzyme complex (PMID:12135483, PMID:10197982). While the inference is reasonable, the primary localization sites of PTGES3 are the cytosol and nucleoplasm. Telomeric localization is secondary to its main co-chaperone and enzymatic functions.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12135483" target="_blank" class="term-link">
                                         PMID:12135483
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Six subunits composing the telomerase complex have been cloned: hTR (human telomerase RNA), TEP1 (telomerase-associated protein 1), hTERT (human telomerase reverse transcriptase), hsp90 (heat shock protein 90), p23, and dyskerin</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
                                     GO:0032991
                                 </a>
                             </span>
                             <span class="term-label">protein-containing complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10543959" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10543959
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An unstructured C-terminal region of the Hsp90 co-chaperone ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3354,57 +3376,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IMP annotation for protein-containing complex from Weikl et al. (PMID:10543959), which demonstrated that p23 forms complexes with HSP90 and that the C-terminal truncation affects complex formation with non-native proteins but not with HSP90.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PTGES3 is demonstrated to exist in multiple protein complexes including HSP90 chaperone complexes (PMID:10543959) and the telomerase holoenzyme. While the term protein-containing complex is very broad, the annotation is correct and reflects experimental evidence. The more specific protein folding chaperone complex (GO:0101031) annotation provides better granularity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
                                     GO:0032991
                                 </a>
                             </span>
                             <span class="term-label">protein-containing complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10811660" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10811660
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Crystal structure and activity of human p23, a heat shock pr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3416,57 +3438,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IMP annotation for protein-containing complex from Weaver et al. (PMID:10811660), which determined the crystal structure of p23 and showed it exists in complexes with HSP90 and progesterone receptor.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PTGES3 is a well-established component of HSP90-containing multi-protein complexes. Weaver et al. showed that p23 binds to HSP90 and to progesterone receptor complexes (PMID:10811660). This duplicates the annotation from PMID:10543959 but with independent evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                     GO:0050821
                                 </a>
                             </span>
                             <span class="term-label">protein stabilization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10543959" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10543959
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An unstructured C-terminal region of the Hsp90 co-chaperone ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3478,75 +3500,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IMP annotation for protein stabilization from Weikl et al. (PMID:10543959). p23 was shown to prevent non-specific aggregation of non-native proteins, acting as a holdase-type chaperone that stabilizes protein substrates.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PTGES3 contributes to protein stabilization through two mechanisms: (1) as an HSP90 co-chaperone it stabilizes the HSP90-client complex in the mature conformation, and (2) independently it prevents aggregation of non-native proteins (PMID:10543959). This is a core aspect of its chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10543959" target="_blank" class="term-link">
                                         PMID:10543959
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">truncation of the C-terminal 30 amino acid residues of p23 affects the ability of p23 to bind non-native proteins and to prevent their non-specific aggregation</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                     GO:0050821
                                 </a>
                             </span>
                             <span class="term-label">protein stabilization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10811660" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10811660
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Crystal structure and activity of human p23, a heat shock pr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3558,75 +3580,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IMP annotation for protein stabilization from Weaver et al. (PMID:10811660), which showed that the C-terminal tail of p23 is required for passive chaperoning activity in assays measuring inhibition of heat-induced protein aggregation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Independent evidence from PMID:10811660 confirming the protein stabilization function of PTGES3. The C-terminal tail is needed for both active chaperoning of progesterone receptor and passive chaperoning preventing protein aggregation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10811660" target="_blank" class="term-link">
                                         PMID:10811660
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the tail is necessary for optimum active chaperoning of the progesterone receptor, as well as the passive chaperoning activity of p23 in assays measuring inhibition of heat-induced protein aggregation</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051131" target="_blank" class="term-link">
                                     GO:0051131
                                 </a>
                             </span>
                             <span class="term-label">chaperone-mediated protein complex assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10811660" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10811660
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Crystal structure and activity of human p23, a heat shock pr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3638,75 +3660,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IMP annotation for chaperone-mediated protein complex assembly from Weaver et al. (PMID:10811660). The study showed that p23 participates in the active chaperoning of the progesterone receptor, with the C-terminal tail required for optimum activity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PTGES3 participates in HSP90-mediated assembly of steroid receptor complexes. Weaver et al. demonstrated that p23&#39;s C-terminal tail is necessary for optimum active chaperoning of the progesterone receptor complex (PMID:10811660). This is a core function of PTGES3.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10811660" target="_blank" class="term-link">
                                         PMID:10811660
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the tail is necessary for optimum active chaperoning of the progesterone receptor</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051879" target="_blank" class="term-link">
                                     GO:0051879
                                 </a>
                             </span>
                             <span class="term-label">Hsp90 protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10543959" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10543959
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An unstructured C-terminal region of the Hsp90 co-chaperone ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3718,88 +3740,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for Hsp90 protein binding from Weikl et al. (PMID:10543959), which demonstrated that p23 binds HSP90 in its ATP-bound state and that the HSP90 binding site is contained in the folded N-terminal domain of p23.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is direct experimental evidence for a core molecular function of PTGES3. The study clearly demonstrated ATP-dependent binding of p23 to HSP90 and mapped the binding determinants (PMID:10543959).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10543959" target="_blank" class="term-link">
                                         PMID:10543959
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">p23 binds to Hsp90 in its ATP-bound state</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10543959" target="_blank" class="term-link">
                                         PMID:10543959
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the binding site for Hsp90 is contained in the folded domain of p23</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051879" target="_blank" class="term-link">
                                     GO:0051879
                                 </a>
                             </span>
                             <span class="term-label">Hsp90 protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10811660" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10811660
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Crystal structure and activity of human p23, a heat shock pr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3811,168 +3833,168 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for Hsp90 protein binding from Weaver et al. (PMID:10811660), which determined the crystal structure of p23 and confirmed its binding to HSP90. The C-terminal tail is not needed for HSP90 binding.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Independent structural and biochemical evidence confirming Hsp90 protein binding as a core function of PTGES3. The crystal structure identified a conserved surface region on p23 for HSP90 interaction (PMID:10811660).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10811660" target="_blank" class="term-link">
                                         PMID:10811660
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Conserved residues are clustered on one face of the monomer and define a putative surface region and binding pocket for interaction(s) with hsp90 or protein substrates</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10811660" target="_blank" class="term-link">
                                         PMID:10811660
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">This tail is not needed for the binding of p23 to hsp90 or to complexes with the progesterone receptor</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070182" target="_blank" class="term-link">
                                     GO:0070182
                                 </a>
                             </span>
                             <span class="term-label">DNA polymerase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19751963" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19751963
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Curcumin inhibits nuclear localization of telomerase by diss...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q15185" data-a="GO:0070182" data-r="PMID:19751963" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q15185" data-a="GO:0070182" data-r="PMID:19751963" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for DNA polymerase binding from Lee &amp; Chung (PMID:19751963), which demonstrated that p23 binds hTERT (telomerase reverse transcriptase) and that curcumin treatment dissociates p23 from hTERT.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> PTGES3/p23 directly binds hTERT, the reverse transcriptase subunit of telomerase. PMID:19751963 showed that curcumin treatment resulted in decreased association of p23 with hTERT. This is consistent with the earlier finding from PMID:10197982. hTERT is a DNA polymerase (reverse transcriptase) so the GO term is appropriate.
+                            <strong>Reason:</strong> PTGES3/p23 directly binds hTERT, the reverse transcriptase subunit of telomerase. PMID:19751963 showed that curcumin treatment resulted in decreased association of p23 with hTERT. This is consistent with the earlier finding from PMID:10197982. hTERT is a DNA polymerase (reverse transcriptase), so the term is technically supported but should be kept non-core as a client-specific HSP90/p23 interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19751963" target="_blank" class="term-link">
                                         PMID:19751963
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">curcumin treatment results in a substantial decrease in association of p23 and hTERT but does not affect the Hsp90 binding to hTERT</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051879" target="_blank" class="term-link">
                                     GO:0051879
                                 </a>
                             </span>
                             <span class="term-label">Hsp90 protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19740745" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19740745
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A truncated form of p23 down-regulates telomerase activity v...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3984,75 +4006,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for Hsp90 protein binding from Woo et al. (PMID:19740745). The study examined the effects of truncated p23 on HSP90 function and telomerase activity, demonstrating that the p23-HSP90 interaction is critical for telomerase regulation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Further experimental evidence for PTGES3 binding to HSP90, demonstrated in the context of telomerase regulation. The truncated form of p23 disrupts normal HSP90 function, confirming the functional importance of the p23-HSP90 interaction (PMID:19740745).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19740745" target="_blank" class="term-link">
                                         PMID:19740745
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The Hsp90-associated protein p23 modulates Hsp90 activity during the final stages of the chaperone pathway to facilitate maturation of client proteins</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27353360" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27353360
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The FNIP co-chaperones decelerate the Hsp90 chaperone cycle ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -4064,75 +4086,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from Woodford et al. (PMID:27353360), which demonstrated that PTGES3 interacts with HSP90AA1, FLCN, FNIP1, and FNIP2 in the context of the HSP90 chaperone cycle.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PMID:27353360 demonstrates specific interactions of PTGES3 with HSP90AA1, FLCN, FNIP1, and FNIP2. These are biologically meaningful interactions in the context of the HSP90 chaperone cycle, but the generic protein binding annotation is uninformative. The HSP90 interaction is already captured by GO:0051879.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/27353360" target="_blank" class="term-link">
                                         PMID:27353360
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">tumour suppressor FLCN is an Hsp90 client protein and its binding partners FNIP1/FNIP2 function as co-chaperones</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21630459
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomic characterization of the human sperm nucleus.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4144,46 +4166,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HDA annotation for nucleus from de Mateo et al. (PMID:21630459), a proteomic characterization of the human sperm nucleus that identified PTGES3 among 403 nuclear proteins by mass spectrometry.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear localization of PTGES3 is supported by this high-throughput proteomics study (PMID:21630459) and is consistent with its known function in translocating to the nucleus as part of HSP90-steroid receptor complexes (PMID:12077419) and its role in transcriptional complex disassembly.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5082409
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4195,46 +4217,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for nucleoplasm from Reactome pathway R-HSA-5082409 (Dissociation of HSF1:HSP90 complex in the nucleus). PTGES3 is part of the HSP90 complex that dissociates from HSF1 in the nucleus.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PTGES3 is documented in multiple Reactome nuclear events as part of HSP90 chaperone complexes. This and the following nucleoplasm TAS annotations all reflect PTGES3&#39;s participation in HSP90-dependent processes in the nucleus. Accepting the first instance as representative.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5324617
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4246,46 +4268,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for nucleoplasm from Reactome R-HSA-5324617 (HSP90:FKBP4:PTGES3 binds HSF1 trimer).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Duplicate nucleoplasm annotation from a different Reactome event. Consistent with PTGES3&#39;s nuclear function as part of HSP90 complexes.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5618080
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4297,46 +4319,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for nucleoplasm from Reactome R-HSA-5618080 (HSP90:ATP:p23:FKBP52:SHR:SH translocates to the nucleus).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent nucleoplasm annotation reflecting PTGES3&#39;s role in nuclear translocation of steroid hormone receptor complexes.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5618093
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4348,46 +4370,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for nucleoplasm from Reactome R-HSA-5618093 (ATP hydrolysis by HSP90).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent nucleoplasm annotation from Reactome pathway events.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8937169
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4399,46 +4421,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for nucleoplasm from Reactome R-HSA-8937169 (AHR:TCDD:2xHSP90AB1:AIP:PTGES3 translocates from cytosol to nucleoplasm). PTGES3 is part of the aryl hydrocarbon receptor complex that translocates to the nucleus.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent nucleoplasm annotation. PTGES3 translocates to the nucleus as part of the AHR signaling complex.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8937191
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4450,46 +4472,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for nucleoplasm from Reactome R-HSA-8937191 (AHR:TCDD:2xHSP90AB1:AIP:PTGES3 dissociates).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent nucleoplasm annotation from AHR signaling pathway.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8939203
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4501,46 +4523,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for nucleoplasm from Reactome R-HSA-8939203 (HSP90-dependent ATP hydrolysis promotes release of ESR:ESTG from chaperone complex).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent nucleoplasm annotation from estrogen receptor signaling pathway.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8939204
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4552,46 +4574,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for nucleoplasm from Reactome R-HSA-8939204 (ESTG binds ESR1:chaperone complex).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent nucleoplasm annotation from estrogen receptor signaling pathway.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9032751
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4603,46 +4625,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for nucleoplasm from Reactome R-HSA-9032751 (Estrogen-independent phosphorylation of ESR1 S118 by MAPK1 and MAPK3).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent nucleoplasm annotation from ESR-mediated signaling pathway.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9038161
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4654,46 +4676,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for nucleoplasm from Reactome R-HSA-9038161 (Progesterone stimulation promotes PGR:P4 binding to ESR1:ESTG).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent nucleoplasm annotation from estrogen-dependent gene expression pathway.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9709547
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4705,46 +4727,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for nucleoplasm from Reactome R-HSA-9709547 (ESTG binds ESR2:chaperone complex).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent nucleoplasm annotation from ESR2 signaling pathway.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9716913
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4756,46 +4778,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for nucleoplasm from Reactome R-HSA-9716913 (ESR1 binds ESR1 antagonists).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent nucleoplasm annotation from ESR1 signaling pathway.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9716947
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4807,46 +4829,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for nucleoplasm from Reactome R-HSA-9716947 (ESR1 binds ESR1 agonists).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent nucleoplasm annotation from ESR1 signaling pathway.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-265295
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4858,46 +4880,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for cytosol from Reactome R-HSA-265295 (Prostaglandin E synthase isomerizes PGH2 to PGE2). PTGES3 catalyzes PGE2 synthesis in the cytosol.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosolic localization of PTGES3 for its prostaglandin synthase activity is well established (PMID:10922363). Accepting as representative of the many cytosol TAS annotations from Reactome.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371586
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4909,46 +4931,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for cytosol from Reactome R-HSA-3371586 (Dissociation of cytosolic HSF1:HSP90 complex).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent cytosol annotation from HSF1 activation pathway.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5324632
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4960,46 +4982,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for cytosol from Reactome R-HSA-5324632 (Dissociation of cytosolic HSF1:HSP90:HDAC6:PTGES3 upon sensing protein aggregates).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent cytosol annotation from heat stress response pathway.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5618073
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5011,46 +5033,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for cytosol from Reactome R-HSA-5618073 (FKBP4 replaces FKBP5 within HSP90:ATP:FKBP5:unfolded protein).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent cytosol annotation from HSP90 chaperone cycle for steroid receptors.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5618080
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5062,46 +5084,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for cytosol from Reactome R-HSA-5618080 (HSP90:ATP:p23:FKBP52:SHR:SH translocates to the nucleus).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent cytosol annotation. PTGES3 starts in the cytosol before translocation to the nucleus with the steroid receptor complex.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5618098
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5113,46 +5135,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for cytosol from Reactome R-HSA-5618098 (p23 (PTGES3) binds HSP90:ATP:FKBP5:nascent protein). PTGES3 binds to the HSP90 complex in the cytosol.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent cytosol annotation. PTGES3 binds to HSP90 in the cytosol during steroid receptor maturation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5618099
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5164,46 +5186,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for cytosol from Reactome R-HSA-5618099 (NR3C2 ligands bind NR3C2 in the HSP90 chaperone complex).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent cytosol annotation from mineralocorticoid receptor signaling.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5618110
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5215,46 +5237,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for cytosol from Reactome R-HSA-5618110 (p23 (PTGES3) binds HSP90:ATP:FKBP4:nascent protein).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent cytosol annotation from HSP90 chaperone cycle.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8936849
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5266,46 +5288,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for cytosol from Reactome R-HSA-8936849 (AHR:2xHSP90:AIP:PTGES3 binds TCDD).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent cytosol annotation. PTGES3 is part of the cytosolic AHR complex before ligand-induced nuclear translocation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8937169
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5317,46 +5339,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for cytosol from Reactome R-HSA-8937169 (AHR:TCDD:2xHSP90AB1:AIP:PTGES3 translocates from cytosol to nucleoplasm).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent cytosol annotation for AHR complex translocation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9678925
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5368,46 +5390,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for cytosol from Reactome R-HSA-9678925 (NR3C1 binds NR3C1 agonists).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent cytosol annotation from glucocorticoid receptor signaling.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9690534
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5419,46 +5441,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for cytosol from Reactome R-HSA-9690534 (NR3C1 ligands bind NR3C1 in the HSP90 chaperone complex).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent cytosol annotation from glucocorticoid receptor signaling.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9705925
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5470,46 +5492,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for cytosol from Reactome R-HSA-9705925 (Androgens bind AR in the HSP90 chaperone complex).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent cytosol annotation from androgen receptor signaling.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9705926
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5521,46 +5543,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for cytosol from Reactome R-HSA-9705926 (AR binds AR agonists).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent cytosol annotation from androgen receptor signaling.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9706837
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5572,46 +5594,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for cytosol from Reactome R-HSA-9706837 (AR binds AR antagonists).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent cytosol annotation from androgen receptor signaling.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9725855
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5623,46 +5645,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for cytosol from Reactome R-HSA-9725855 (NR3C2 binds NR3C2 antagonists).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent cytosol annotation from mineralocorticoid receptor signaling.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9725885
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5674,46 +5696,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for cytosol from Reactome R-HSA-9725885 (P4 binds PGR in the HSP90 chaperone complex).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent cytosol annotation from progesterone receptor signaling.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9726509
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5725,46 +5747,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for cytosol from Reactome R-HSA-9726509 (NR3C2 binds fludrocortisone).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent cytosol annotation from mineralocorticoid receptor signaling.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9726580
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5776,46 +5798,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for cytosol from Reactome R-HSA-9726580 (PGR binds PGR agonists).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent cytosol annotation from progesterone receptor signaling.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9726621
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5827,57 +5849,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for cytosol from Reactome R-HSA-9726621 (PGR binds PGR antagonists).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent cytosol annotation from progesterone receptor signaling.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12853476" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12853476
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Cofactor Tpr2 combines two TPR domains and a J domain to reg...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5889,75 +5911,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for protein folding from Brychzy et al. (PMID:12853476). This study examined the co-chaperone Tpr2 and its regulation of the Hsp70/Hsp90 chaperone system. PTGES3/p23 was part of the HSP90-dependent folding system studied. The paper examined glucocorticoid receptor folding in the context of the multi-chaperone machinery including p23.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein folding is a core function of PTGES3 as an HSP90 co-chaperone. While this paper focuses on Tpr2, it demonstrates p23&#39;s involvement in HSP90-dependent protein folding of glucocorticoid receptor (PMID:12853476). This is consistent with multiple other lines of evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12853476" target="_blank" class="term-link">
                                         PMID:12853476
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Excess Tpr2 inhibits the Hsp90-dependent folding of GR in cell lysates</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12077419" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12077419
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Disassembly of transcriptional regulatory complexes by molec...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -5969,205 +5991,205 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is annotated to PTGES3 based on PMID:12077419 (Freeman &amp; Yamamoto, 2002), which demonstrated that p23 acts as a molecular chaperone that localizes to genomic response elements and promotes disassembly of transcriptional regulatory complexes. However, this paper does not directly demonstrate binding to unfolded proteins. The paper shows that p23 disrupts receptor-mediated transcriptional activation by promoting disassembly of multicomponent regulatory complexes, functioning as an HSP90 co-chaperone rather than independently binding unfolded substrates. Separate evidence from PMID:10543959 (Weikl et al., 1999) does demonstrate that p23 has independent chaperone activity, showing that it &#34;interacts specifically with non-native proteins&#34; and prevents &#34;non-specific aggregation.&#34; PMID:10811660 (Weaver et al., 2000) also confirmed the &#34;passive chaperoning activity of p23 in assays measuring inhibition of heat-induced protein aggregation.&#34; However, this holdase-type activity is secondary to p23&#39;s primary role as an HSP90 co-chaperone, and the cited reference PMID:12077419 does not support &#34;unfolded protein binding&#34; as such. Furthermore, GO:0051082 is being obsoleted (go-ontology issue 30962) in favor of more specific terms such as GO:0044183 &#34;protein folding chaperone.&#34; Given that PTGES3 already has annotations for Hsp90 protein binding (GO:0051879), protein folding (GO:0006457), protein-folding chaperone binding (GO:0051087), and membership in a protein folding chaperone complex (GO:0101031), the core chaperone functions are well-captured by existing annotations. The independent holdase activity demonstrated in PMID:10543959 and PMID:10811660 could be better represented by GO:0044183 &#34;protein folding chaperone&#34; if needed, but the current annotation to GO:0051082 based on PMID:12077419 is a misattribution of the cited evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The GO:0051082 &#34;unfolded protein binding&#34; annotation should be marked as over-annotated for three reasons. First, the cited reference PMID:12077419 does not demonstrate unfolded protein binding; it shows p23 promotes disassembly of transcriptional regulatory complexes as part of the HSP90 chaperone system. Second, while p23 does have a modest independent holdase-type chaperone activity preventing aggregation of non-native proteins (demonstrated in PMID:10543959 and PMID:10811660), this is secondary to its primary role as an HSP90 co-chaperone and is not the activity described in the cited reference. Third, GO:0051082 is being obsoleted (go-ontology issue 30962) because it conflates binding with chaperone activity. The core chaperone functions of PTGES3 are already well-represented by existing annotations to GO:0051879 (Hsp90 protein binding), GO:0006457 (protein folding), GO:0051087 (protein-folding chaperone binding), and GO:0101031 (protein folding chaperone complex). If the independent holdase activity needs representation, GO:0044183 &#34;protein folding chaperone&#34; would be more appropriate than the soon-to-be-obsoleted GO:0051082.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12077419" target="_blank" class="term-link">
                                         PMID:12077419
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the p23 molecular chaperone localizes in vivo to genomic response elements in a hormone-dependent manner, disrupting receptor-mediated transcriptional activation in vivo and in vitro; Hsp90 weakly displayed similar activities</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10543959" target="_blank" class="term-link">
                                         PMID:10543959
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">p23 binds to Hsp90 in its ATP-bound state and, on its own, interacts specifically with non-native proteins</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10543959" target="_blank" class="term-link">
                                         PMID:10543959
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">truncation of the C-terminal 30 amino acid residues of p23 affects the ability of p23 to bind non-native proteins and to prevent their non-specific aggregation</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10811660" target="_blank" class="term-link">
                                         PMID:10811660
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the tail is necessary for optimum active chaperoning of the progesterone receptor, as well as the passive chaperoning activity of p23 in assays measuring inhibition of heat-induced protein aggregation</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000723" target="_blank" class="term-link">
                                     GO:0000723
                                 </a>
                             </span>
                             <span class="term-label">telomere maintenance</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12135483" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12135483
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Differential regulation of telomerase activity by six telome...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q15185" data-a="GO:0000723" data-r="PMID:12135483" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q15185" data-a="GO:0000723" data-r="PMID:12135483" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for telomere maintenance from Chang et al. (PMID:12135483), which examined the role of six telomerase subunits (hTR, TEP1, hTERT, hsp90, p23, dyskerin) in telomerase regulation. The study confirmed that p23 participates in full enzyme activity even though hTERT is the rate-limiting subunit.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Telomere maintenance is well supported for PTGES3. The study showed that antisense treatment against p23 decreased telomerase activity (PMID:12135483). This is broader than but consistent with the more specific annotation to telomere maintenance via telomerase (GO:0007004).
+                            <strong>Reason:</strong> Telomere maintenance is well supported for PTGES3. The study showed that antisense treatment against p23 decreased telomerase activity (PMID:12135483). This is broader than but consistent with the more specific annotation to telomere maintenance via telomerase (GO:0007004), and should be treated as non-core because it reflects one HSP90-client system rather than PTGES3&#39;s primary molecular function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12135483" target="_blank" class="term-link">
                                         PMID:12135483
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the other telomerase subunits (hTR, TEP1, hsp90, p23, dyskerin) participated in full enzyme activity</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003720" target="_blank" class="term-link">
                                     GO:0003720
                                 </a>
                             </span>
                             <span class="term-label">telomerase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12135483" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12135483
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Differential regulation of telomerase activity by six telome...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -6179,198 +6201,198 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for telomerase activity from Chang et al. (PMID:12135483). The study identified p23 as one of six telomerase subunits and showed that antisense treatment against p23 abolished telomerase activity. However, PTGES3 does not itself have telomerase catalytic activity; hTERT is the catalytic reverse transcriptase subunit. PTGES3 is a non-catalytic component of the holoenzyme complex.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0003720 (telomerase activity) implies catalytic reverse transcriptase activity, which is performed by hTERT, not by PTGES3/p23. PTGES3 is a structural/regulatory component of the telomerase holoenzyme, required for its assembly and activity, but does not contribute the catalytic function itself. The role of PTGES3 is better described by the existing annotations to telomerase holoenzyme complex assembly (GO:1905323) and telomerase holoenzyme complex (GO:0005697). Annotating PTGES3 to telomerase activity is an over-attribution of catalytic function to a non-catalytic subunit.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905323" target="_blank" class="term-link">
                                     telomerase holoenzyme complex assembly
                                 </a>
                             </span>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005697" target="_blank" class="term-link">
                                     telomerase holoenzyme complex
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12135483" target="_blank" class="term-link">
                                         PMID:12135483
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Telomerase activity was decreased or abolished by antisense treatment</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10197982" target="_blank" class="term-link">
                                         PMID:10197982
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We have identified the molecular chaperones p23 and Hsp90 as proteins that bind to the catalytic subunit of telomerase</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005697" target="_blank" class="term-link">
                                     GO:0005697
                                 </a>
                             </span>
                             <span class="term-label">telomerase holoenzyme complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12135483" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12135483
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Differential regulation of telomerase activity by six telome...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q15185" data-a="GO:0005697" data-r="PMID:12135483" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q15185" data-a="GO:0005697" data-r="PMID:12135483" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for telomerase holoenzyme complex from Chang et al. (PMID:12135483), which identified p23 as one of the six subunits of the telomerase complex. Earlier work (PMID:10197982) showed that a significant fraction of active telomerase is associated with p23 and HSP90.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> PTGES3/p23 is a confirmed component of the telomerase holoenzyme complex. Multiple studies demonstrate its presence in active telomerase complexes (PMID:10197982, PMID:12135483). This localization annotation appropriately captures PTGES3&#39;s role in the telomerase complex.
+                            <strong>Reason:</strong> PTGES3/p23 is a confirmed component of the telomerase holoenzyme complex. Multiple studies demonstrate its presence in active telomerase complexes (PMID:10197982, PMID:12135483). This localization annotation appropriately captures PTGES3&#39;s role in the telomerase complex, but the role is client-specific and non-core.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12135483" target="_blank" class="term-link">
                                         PMID:12135483
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Six subunits composing the telomerase complex have been cloned: hTR (human telomerase RNA), TEP1 (telomerase-associated protein 1), hTERT (human telomerase reverse transcriptase), hsp90 (heat shock protein 90), p23, and dyskerin</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10197982" target="_blank" class="term-link">
                                         PMID:10197982
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">a significant fraction of active telomerase from cell extracts is associated with p23 and Hsp90</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001516" target="_blank" class="term-link">
                                     GO:0001516
                                 </a>
                             </span>
                             <span class="term-label">prostaglandin biosynthetic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10922363" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10922363
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular identification of cytosolic prostaglandin E2 synth...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6382,88 +6404,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for prostaglandin biosynthetic process from the landmark study by Tanioka et al. (PMID:10922363) that identified p23 as cytosolic PGE2 synthase. The study demonstrated that recombinant p23 catalyzes GSH-dependent PGE2 synthesis and is functionally coupled with COX-1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is direct experimental evidence for a core enzymatic function of PTGES3. The study demonstrated that p23 is the cytosolic PGES, with all features of PGES activity including GSH-dependence, COX-1 coupling, and kinetic parameters (PMID:10922363).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10922363" target="_blank" class="term-link">
                                         PMID:10922363
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Recombinant p23 expressed in Escherichia coli and 293 cells exhibited all the features of PGES activity detected in rat brain cytosol</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10922363" target="_blank" class="term-link">
                                         PMID:10922363
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">cPGES/p23 was functionally linked with COX-1 in marked preference to COX-2 to produce PGE(2) from exogenous and endogenous arachidonic acid</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050220" target="_blank" class="term-link">
                                     GO:0050220
                                 </a>
                             </span>
                             <span class="term-label">prostaglandin-E synthase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10922363" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10922363
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular identification of cytosolic prostaglandin E2 synth...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6475,75 +6497,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for prostaglandin-E synthase activity from Tanioka et al. (PMID:10922363). Same landmark study demonstrating enzymatic activity of PTGES3 with Km=14 uM for PGH2 and Vmax=190 nmol/min/mg.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core enzymatic function directly demonstrated with purified recombinant protein. The catalytic parameters were determined and the enzyme was shown to be GSH-dependent and functionally coupled with COX-1 (PMID:10922363).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10922363" target="_blank" class="term-link">
                                         PMID:10922363
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Here we report the molecular identification of cytosolic glutathione (GSH)-dependent prostaglandin (PG) E(2) synthase (cPGES)</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007165" target="_blank" class="term-link">
                                     GO:0007165
                                 </a>
                             </span>
                             <span class="term-label">signal transduction</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/8114727" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:8114727
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Characterization of a novel 23-kilodalton protein of unactiv...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -6555,50 +6577,50 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation for signal transduction from Johnson et al. (PMID:8114727), the original characterization of p23 as a component of unactive progesterone receptor complexes. The annotation reflects PTGES3&#39;s role in steroid hormone signaling through its association with steroid receptor complexes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PTGES3 participates in signal transduction indirectly through its role as an HSP90 co-chaperone in steroid receptor maturation. However, signal transduction is very broad and PTGES3 is not a signaling molecule itself; it is a chaperone/enzyme. The annotation is not wrong but represents a downstream biological consequence rather than a core function. The specific chaperone functions (protein folding, chaperone-mediated protein complex assembly) better capture its role.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8114727" target="_blank" class="term-link">
                                         PMID:8114727
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Immunoprecipitation of unactivated avian progesterone receptor results in the copurification of hsp90, hsp70, and three additional proteins, p54, p50, and p23</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>PTGES3 (cPGES/p23) catalyzes the GSH-dependent isomerization of PGH2 to PGE2 in the cytosol. It is functionally coupled with COX-1 (not COX-2) for immediate prostaglandin E2 biosynthesis with Km=14 uM for PGH2 and Vmax=190 nmol/min/mg.</h3>
                 <span class="vote-buttons" data-g="Q15185" data-a="FUNCTION: PTGES3 (cPGES/p23) catalyzes the GSH-dependent iso..." data-r="" data-act="CORE_FUNCTION">
@@ -6606,10 +6628,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -6618,81 +6640,81 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001516" target="_blank" class="term-link">
                                 prostaglandin biosynthetic process
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10922363" target="_blank" class="term-link">
                                 PMID:10922363
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">Recombinant p23 expressed in Escherichia coli and 293 cells exhibited all the features of PGES activity detected in rat brain cytosol.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10922363" target="_blank" class="term-link">
                                 PMID:10922363
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">cPGES/p23 was functionally linked with COX-1 in marked preference to COX-2 to produce PGE(2) from exogenous and endogenous arachidonic acid.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>PTGES3/p23 binds to the N-terminal domain of HSP90 in its ATP-bound conformation, stabilizing the &#34;closed 2&#34; HSP90 dimer state and inhibiting/reducing HSP90 ATPase activity, thereby regulating progression of the HSP90 chaperone cycle and shaping client maturation/release (DOI:10.1038/nrm.2017.20, DOI:10.3389/fimmu.2024.1436973). This co-chaperone activity is essential for maturation of steroid hormone receptors, hTERT, and other HSP90 client proteins. The CS domain in the N-terminal region of p23 mediates HSP90 binding, while the unstructured acidic C-terminal tail is important for its independent passive chaperoning activity preventing protein aggregation. Beyond the cytosol, nuclear p23 can function as an HSP90-independent transcription factor for COX-2 (PTGS2) in lung adenocarcinoma, driven by succinate-induced succinylation at K7/K33/K79 (DOI:10.1126/sciadv.ade0387).</h3>
                 <span class="vote-buttons" data-g="Q15185" data-a="FUNCTION: PTGES3/p23 binds to the N-terminal domain of HSP90..." data-r="" data-act="CORE_FUNCTION">
@@ -6700,10 +6722,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -6712,57 +6734,57 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                 protein folding
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051131" target="_blank" class="term-link">
                                 chaperone-mediated protein complex assembly
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                 protein stabilization
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                 nucleoplasm
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">In Complex:</div>
                     <span class="badge">
@@ -6771,1200 +6793,1114 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10543959" target="_blank" class="term-link">
                                 PMID:10543959
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">p23 binds to Hsp90 in its ATP-bound state and, on its own, interacts specifically with non-native proteins.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10811660" target="_blank" class="term-link">
                                 PMID:10811660
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">the tail is necessary for optimum active chaperoning of the progesterone receptor, as well as the passive chaperoning activity of p23 in assays measuring inhibition of heat-induced protein aggregation.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21183720" target="_blank" class="term-link">
                                 PMID:21183720
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">it is Hsp90&#39;s nucleotide-binding domain that triggers the formation of the Hsp90(2)p23(2) complex.</div>
-                        
+
                     </li>
-                    
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PTGES3/PTGES3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">PTGES3/p23 binds HSP90 in the ATP-bound closed conformation and inhibits or slows the HSP90 ATPase cycle, shaping client maturation and release.</div>
+
+                    </li>
+
                 </ul>
             </div>
-            
+
         </div>
-        
-        <div class="core-function-card">
-            
-            <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>PTGES3/p23 directly binds hTERT, the telomerase reverse transcriptase catalytic subunit, as part of the HSP90-dependent telomerase holoenzyme assembly pathway. Together with HSP90, p23 is required for assembly of active telomerase from its components and a significant fraction of cellular telomerase is associated with p23 and HSP90.</h3>
-                <span class="vote-buttons" data-g="Q15185" data-a="FUNCTION: PTGES3/p23 directly binds hTERT, the telomerase re..." data-r="" data-act="CORE_FUNCTION">
-                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
-                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
-                </span>
-            </div>
-            
 
-            <div class="core-function-terms">
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">Molecular Function:</div>
-                    <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070182" target="_blank" class="term-link">
-                            DNA polymerase binding
-                        </a>
-                    </span>
-                </div>
-                
-
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">Directly Involved In:</div>
-                    <div class="function-annotations">
-                        
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007004" target="_blank" class="term-link">
-                                telomere maintenance via telomerase
-                            </a>
-                        </span>
-                        
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905323" target="_blank" class="term-link">
-                                telomerase holoenzyme complex assembly
-                            </a>
-                        </span>
-                        
-                    </div>
-                </div>
-                
-
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">Cellular Locations:</div>
-                    <div class="function-annotations">
-                        
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
-                                nucleoplasm
-                            </a>
-                        </span>
-                        
-                    </div>
-                </div>
-                
-
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">In Complex:</div>
-                    <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005697" target="_blank" class="term-link">
-                            telomerase holoenzyme complex
-                        </a>
-                    </span>
-                </div>
-                
-
-                
-            </div>
-
-            
-            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
-                <strong>Supporting Evidence:</strong>
-                <ul class="findings-list">
-                    
-                    <li class="finding-item">
-                        <span class="reference-id">
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/10197982" target="_blank" class="term-link">
-                                PMID:10197982
-                            </a>
-                            
-                        </span>
-                        
-                        <div class="finding-text">We have identified the molecular chaperones p23 and Hsp90 as proteins that bind to the catalytic subunit of telomerase. Blockade of this interaction inhibits assembly of active telomerase in vitro.</div>
-                        
-                    </li>
-                    
-                    <li class="finding-item">
-                        <span class="reference-id">
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/10197982" target="_blank" class="term-link">
-                                PMID:10197982
-                            </a>
-                            
-                        </span>
-                        
-                        <div class="finding-text">a significant fraction of active telomerase from cell extracts is associated with p23 and Hsp90.</div>
-                        
-                    </li>
-                    
-                    <li class="finding-item">
-                        <span class="reference-id">
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/19751963" target="_blank" class="term-link">
-                                PMID:19751963
-                            </a>
-                            
-                        </span>
-                        
-                        <div class="finding-text">curcumin treatment results in a substantial decrease in association of p23 and hTERT but does not affect the Hsp90 binding to hTERT.</div>
-                        
-                    </li>
-                    
-                </ul>
-            </div>
-            
-        </div>
-        
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/PTGES3/PTGES3-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research synthesis for PTGES3</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">PTGES3 is bifunctional: a cytosolic glutathione-dependent prostaglandin E synthase and the p23 HSP90 co-chaperone that stabilizes ATP-bound HSP90 closed states.</div>
+
+                        <div class="finding-text">"PTGES3/cPGES is annotated to catalyze the isomerization/conversion of prostaglandin H2 (PGH2) to prostaglandin E2 (PGE2), and PTGES3 is explicitly identified as the co-chaperone p23 in authoritative HSP90 machinery literature."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10197982" target="_blank" class="term-link">
                             PMID:10197982
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Functional requirement of p23 and Hsp90 in telomerase complexes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10543959" target="_blank" class="term-link">
                             PMID:10543959
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An unstructured C-terminal region of the Hsp90 co-chaperone p23 is important for its chaperone function.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10811660" target="_blank" class="term-link">
                             PMID:10811660
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Crystal structure and activity of human p23, a heat shock protein 90 co-chaperone.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10922363" target="_blank" class="term-link">
                             PMID:10922363
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Molecular identification of cytosolic prostaglandin E2 synthase that is functionally coupled with cyclooxygenase-1 in immediate prostaglandin E2 biosynthesis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12077419" target="_blank" class="term-link">
                             PMID:12077419
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Disassembly of transcriptional regulatory complexes by molecular chaperones.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12135483" target="_blank" class="term-link">
                             PMID:12135483
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Differential regulation of telomerase activity by six telomerase subunits.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12853476" target="_blank" class="term-link">
                             PMID:12853476
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Cofactor Tpr2 combines two TPR domains and a J domain to regulate the Hsp70/Hsp90 chaperone system.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17353931" target="_blank" class="term-link">
                             PMID:17353931
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Large-scale mapping of human protein-protein interactions by mass spectrometry.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19740745" target="_blank" class="term-link">
                             PMID:19740745
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A truncated form of p23 down-regulates telomerase activity via disruption of Hsp90 function.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19751963" target="_blank" class="term-link">
                             PMID:19751963
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Curcumin inhibits nuclear localization of telomerase by dissociating the Hsp90 co-chaperone p23 from hTERT.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19875381" target="_blank" class="term-link">
                             PMID:19875381
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A proteomic investigation of ligand-dependent HSP90 complexes reveals CHORDC1 as a novel ADP-dependent HSP90-interacting protein.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21183720" target="_blank" class="term-link">
                             PMID:21183720
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">N-terminal domain of human Hsp90 triggers binding to the cochaperone p23.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link">
                             PMID:21630459
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteomic characterization of the human sperm nucleus.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21988832" target="_blank" class="term-link">
                             PMID:21988832
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Toward an understanding of the protein interaction network of the human liver.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23741051" target="_blank" class="term-link">
                             PMID:23741051
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Hsp90 cochaperones p23 and FKBP4 physically interact with hAgo2 and activate RNA interference-mediated silencing in mammalian cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24981860" target="_blank" class="term-link">
                             PMID:24981860
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Human-chromatin-related protein interactions identify a demethylase complex required for chromosome segregation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link">
                             PMID:25036637
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A quantitative chaperone interaction network reveals the architecture of cellular protein homeostasis pathways.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27353360" target="_blank" class="term-link">
                             PMID:27353360
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The FNIP co-chaperones decelerate the Hsp90 chaperone cycle and enhance drug binding.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/29127155" target="_blank" class="term-link">
                             PMID:29127155
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Tumor suppressor Tsc1 is a new Hsp90 co-chaperone that facilitates folding of kinase and non-kinase clients.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link">
                             PMID:35271311
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">OpenCell: Endogenous tagging for the cartography of human cellular organization.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/35914814" target="_blank" class="term-link">
                             PMID:35914814
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Chr21 protein-protein interactions: enrichment in proteins involved in intellectual disability, autism, and late-onset Alzheimer&#39;s disease.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/8114727" target="_blank" class="term-link">
                             PMID:8114727
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Characterization of a novel 23-kilodalton protein of unactive progesterone receptor complexes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9817749" target="_blank" class="term-link">
                             PMID:9817749
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">In vivo function of Hsp90 is dependent on ATP binding and ATP hydrolysis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-2162123
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Synthesis of Prostaglandins (PG) and Thromboxanes (TX)</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-265295
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Prostaglandin E synthase isomerizes PGH2 to PGE2</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371586
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dissociation of cytosolic HSF1:HSP90 complex</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5082409
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dissociation of HSF1:HSP90 complex in the nucleus</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5324617
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP90:FKBP4:PTGES3 binds HSF1 trimer</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5324632
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dissociation of cytosolic HSF1:HSP90:HDAC6:PTGES3 upon sensing protein aggregates</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5618073
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">FKBP4 replaces FKBP5 within HSP90:ATP:FKBP5:unfolded protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5618080
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP90:ATP:p23:FKBP52:SHR:SH translocates to the nucleus</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5618093
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ATP hydrolysis by HSP90</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5618098
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">p23 (PTGES3) binds HSP90:ATP:FKBP5:nascent protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5618099
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NR3C2 ligands bind NR3C2 (in the HSP90 chaperone complex)</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5618110
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">p23 (PTGES3) binds HSP90:ATP:FKBP4:nascent protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8936849
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">AHR:2xHSP90:AIP:PTGES3 binds TCDD</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8937169
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">AHR:TCDD:2xHSP90AB1:AIP:PTGES3 translocates from cytosol to nucleoplasm</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8937191
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">AHR:TCDD:2xHSP90AB1:AIP:PTGES3 dissociates</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8939203
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP90-dependent ATP hydrolysis promotes release of ESR:ESTG from chaperone complex</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8939204
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ESTG binds ESR1:chaperone complex</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9032751
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Estrogen-independent phosphorylation of ESR1 S118 by MAPK1 and MAPK3</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9038161
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Progesterone stimulation promotes PGR:P4 binding to ESR1:ESTG</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9678925
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NR3C1 binds NR3C1 agonists</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9690534
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NR3C1 ligands bind NR3C1 (in the HSP90 chaperone complex)</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9705925
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Androgens binds AR (in the HSP90 chaperone complex)</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9705926
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">AR binds AR agonists</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9706837
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">AR binds AR antagonists</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9709547
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ESTG binds ESR2:chaperone complex</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9716913
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ESR1 binds ESR1 antagonists</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9716947
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ESR1 binds ESR1 agonists</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9725855
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NR3C2 binds NR3C2 antagonists</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9725885
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">P4 bind PGR (in the HSP90 chaperone complex)</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9726509
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NR3C2 binds fludrocortisone</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9726580
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">PGR binds PGR agonists</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9726621
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">PGR binds PGR antagonists</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1038/nrm.2017.20
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The HSP90 chaperone machinery.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">p23/PTGES3 stabilizes the HSP90 closed 2 conformational state and inhibits/reduces HSP90 ATPase activity, functioning as a late-stage co-chaperone regulator of the HSP90 cycle</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1126/sciadv.ade0387
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The p23 co-chaperone is a succinate-activated COX-2 transcription factor in lung adenocarcinoma tumorigenesis.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Nuclear p23/PTGES3 functions as an HSP90-independent transcription factor for COX-2 (PTGS2), driven by succinate-dependent lysine succinylation at K7, K33, and K79 that promotes nuclear translocation</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Nuclear p23 expression was detected in &gt;90% of lung adenocarcinoma tumor tissues versus ~5% of adjacent normal tissues</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Small-molecule inhibitor M16 inhibits p23 succinylation and nuclear translocation, suppressing tumor growth in a p23-dependent manner</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.3389/fimmu.2024.1436973
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSP90 multi-functionality in cancer.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">2024 review reiterating PTGES3/p23 mechanistic role in slowing HSP90 ATPase cycle by stabilizing the closed ATP-committed conformation</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -8271,9 +8207,9 @@ Similarly, although nuclear transcription-factor function is well-supported in a
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -8285,7 +8221,7 @@ Similarly, although nuclear transcription-factor function is well-supported in a
                 <pre><code>id: Q15185
 gene_symbol: PTGES3
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -8512,6 +8448,11 @@ existing_annotations:
       supporting_text: &gt;-
         Recombinant p23 expressed in Escherichia coli and 293 cells exhibited all the
         features of PGES activity detected in rat brain cytosol
+    - reference_id: file:human/PTGES3/PTGES3-deep-research-falcon.md
+      supporting_text: &gt;-
+        PTGES3/cPGES catalyzes the glutathione-dependent isomerization of PGH2
+        to PGE2 and is functionally coupled with COX-1-derived PGH2 in current
+        pathway models.
 - term:
     id: GO:0007004
     label: telomere maintenance via telomerase
@@ -8522,12 +8463,12 @@ existing_annotations:
       IBA annotation for telomere maintenance via telomerase is phylogenetically inferred.
       PTGES3/p23 and HSP90 were shown to be required for assembly and activity of telomerase
       (PMID:10197982). Inhibition of p23-HSP90 interaction blocks telomerase assembly.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
       PTGES3 participates in telomere maintenance via telomerase through its role in
       assembling and stabilizing the telomerase holoenzyme complex with HSP90 (PMID:10197982,
-      PMID:12135483). This is an established secondary function of PTGES3 and the IBA
-      annotation is appropriate.
+      PMID:12135483). This is an established client-specific consequence of the p23/HSP90
+      co-chaperone role, not a core PTGES3 function.
     supported_by:
     - reference_id: PMID:10197982
       supporting_text: &gt;-
@@ -8544,11 +8485,12 @@ existing_annotations:
       IBA annotation for telomerase holoenzyme complex assembly. PTGES3/p23 together with
       HSP90 is required for in vitro assembly of active telomerase from its components
       (PMID:10197982). The IDA from PMID:10197982 directly supports this.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
       Telomerase holoenzyme complex assembly is a well-documented function of PTGES3 in
       concert with HSP90. Holt et al. (PMID:10197982) showed that p23 and HSP90 bind hTERT
-      and are required for assembly of active telomerase. This is concordant with the IBA.
+      and are required for assembly of active telomerase. This should be kept as a
+      non-core HSP90-client assembly consequence rather than elevated to a core function.
     supported_by:
     - reference_id: PMID:10197982
       supporting_text: &gt;-
@@ -8599,9 +8541,9 @@ existing_annotations:
     reason: &gt;-
       This is a broad but not incorrect annotation. PTGES3 participates in prostaglandin
       biosynthesis, which is a form of lipid metabolism. The more specific annotations to
-      prostaglandin biosynthetic process (GO:0001516) and fatty acid biosynthetic process
-      (GO:0006633) provide better granularity, but this IEA annotation is acceptable as
-      a parent term.
+      prostaglandin biosynthetic and metabolic process annotations provide
+      better granularity. The separate fatty acid biosynthetic process
+      annotation overstates this terminal prostanoid-synthesis step.
 - term:
     id: GO:0006631
     label: fatty acid metabolic process
@@ -8627,12 +8569,16 @@ existing_annotations:
       IEA annotation for fatty acid biosynthetic process from UniProt keyword mapping.
       PTGES3 catalyzes the isomerization of PGH2 to PGE2 in the prostaglandin biosynthetic
       pathway, which is derived from arachidonic acid metabolism.
-    action: ACCEPT
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      This IEA mapping from UniProt keywords is broadly acceptable since prostaglandins are
-      fatty acid derivatives. However, prostaglandin biosynthesis is more accurately described
-      as eicosanoid/prostanoid biosynthesis than as fatty acid biosynthesis per se. This is a
-      tolerable IEA-level annotation given the more specific annotations exist.
+      PTGES3 catalyzes the terminal isomerization of PGH2 to PGE2 in
+      prostaglandin biosynthesis; it does not synthesize fatty acids. This
+      keyword-derived IEA annotation is therefore too broad and biologically
+      misleading compared with the existing prostaglandin biosynthetic process
+      annotation.
+    proposed_replacement_terms:
+    - id: GO:0001516
+      label: prostaglandin biosynthetic process
 - term:
     id: GO:0006693
     label: prostaglandin metabolic process
@@ -8912,13 +8858,12 @@ existing_annotations:
       on Woo et al. (PMID:19740745). This study showed that overexpression of truncated p23
       (Delta p23) down-regulated telomerase activity and decreased hTERT levels, implying
       that full-length p23 positively regulates telomerase maintenance.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
       The study demonstrates that PTGES3 positively regulates telomerase activity through
       its HSP90 co-chaperone function. Truncation of p23 disrupts HSP90 function, leading
       to reduced telomerase activity, decreased hTERT stability, and inhibited cell growth
-      (PMID:19740745). This is consistent with the broader literature on PTGES3&#39;s role in
-      telomerase assembly.
+      (PMID:19740745). This is a non-core client-specific effect of the p23/HSP90 system.
     supported_by:
     - reference_id: PMID:19740745
       supporting_text: &gt;-
@@ -8935,12 +8880,12 @@ existing_annotations:
       study (PMID:10197982) that demonstrated p23 and HSP90 are required for telomerase
       assembly and that a significant fraction of cellular telomerase is associated with
       p23 and HSP90.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
       This is well-supported experimental evidence. Holt et al. showed that p23 and HSP90
       bind hTERT, that blockade of their interaction inhibits telomerase assembly, and
       that active telomerase in cell extracts is associated with p23 and HSP90
-      (PMID:10197982). This represents a core secondary function of PTGES3.
+      (PMID:10197982). This represents a non-core HSP90-client consequence of PTGES3/p23.
     supported_by:
     - reference_id: PMID:10197982
       supporting_text: &gt;-
@@ -8958,13 +8903,14 @@ existing_annotations:
       The study showed that p23 binds to hTERT, the reverse transcriptase catalytic subunit
       of telomerase. hTERT is a specialized reverse transcriptase (RNA-dependent DNA
       polymerase). The annotation captures p23&#39;s direct binding to this polymerase.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
       PTGES3/p23 directly binds hTERT, the telomerase reverse transcriptase, which is a
       specialized DNA polymerase. This was demonstrated by co-immunoprecipitation in
       PMID:10197982. While hTERT is specifically a reverse transcriptase, the GO:0070182
       (DNA polymerase binding) captures the binding to this enzyme class. The annotation
-      is technically correct.
+      is technically supported but non-core and should not be represented as a separate
+      PTGES3 core function.
     supported_by:
     - reference_id: PMID:10197982
       supporting_text: &gt;-
@@ -8980,12 +8926,13 @@ existing_annotations:
       IDA annotation for telomerase holoenzyme complex assembly based on Holt et al.
       (PMID:10197982). The study demonstrated that p23 and HSP90 are required for in vitro
       assembly of active telomerase from purified components.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
       This is directly demonstrated experimental evidence. Assembly of active telomerase
       from in vitro-synthesized components required p23 and HSP90 present in reticulocyte
       extracts. Blockade of the p23-HSP90 interaction inhibited telomerase assembly
-      (PMID:10197982).
+      (PMID:10197982). Keep as a non-core client-specific outcome of the HSP90
+      co-chaperone function.
     supported_by:
     - reference_id: PMID:10197982
       supporting_text: &gt;-
@@ -9189,12 +9136,13 @@ existing_annotations:
       IPI annotation for DNA polymerase binding from Lee &amp; Chung (PMID:19751963), which
       demonstrated that p23 binds hTERT (telomerase reverse transcriptase) and that
       curcumin treatment dissociates p23 from hTERT.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
       PTGES3/p23 directly binds hTERT, the reverse transcriptase subunit of telomerase.
       PMID:19751963 showed that curcumin treatment resulted in decreased association of
       p23 with hTERT. This is consistent with the earlier finding from PMID:10197982.
-      hTERT is a DNA polymerase (reverse transcriptase) so the GO term is appropriate.
+      hTERT is a DNA polymerase (reverse transcriptase), so the term is technically
+      supported but should be kept non-core as a client-specific HSP90/p23 interaction.
     supported_by:
     - reference_id: PMID:19751963
       supporting_text: &gt;-
@@ -9765,12 +9713,13 @@ existing_annotations:
       examined the role of six telomerase subunits (hTR, TEP1, hTERT, hsp90, p23, dyskerin)
       in telomerase regulation. The study confirmed that p23 participates in full enzyme
       activity even though hTERT is the rate-limiting subunit.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
       Telomere maintenance is well supported for PTGES3. The study showed that antisense
       treatment against p23 decreased telomerase activity (PMID:12135483). This is broader
       than but consistent with the more specific annotation to telomere maintenance via
-      telomerase (GO:0007004).
+      telomerase (GO:0007004), and should be treated as non-core because it reflects one
+      HSP90-client system rather than PTGES3&#39;s primary molecular function.
     supported_by:
     - reference_id: PMID:12135483
       supporting_text: &gt;-
@@ -9822,12 +9771,12 @@ existing_annotations:
       which identified p23 as one of the six subunits of the telomerase complex. Earlier
       work (PMID:10197982) showed that a significant fraction of active telomerase is
       associated with p23 and HSP90.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
       PTGES3/p23 is a confirmed component of the telomerase holoenzyme complex. Multiple
       studies demonstrate its presence in active telomerase complexes (PMID:10197982,
       PMID:12135483). This localization annotation appropriately captures PTGES3&#39;s role
-      in the telomerase complex.
+      in the telomerase complex, but the role is client-specific and non-core.
     supported_by:
     - reference_id: PMID:12135483
       supporting_text: &gt;-
@@ -9976,39 +9925,11 @@ core_functions:
       supporting_text: &gt;-
         it is Hsp90&#39;s nucleotide-binding domain that triggers the formation of the
         Hsp90(2)p23(2) complex.
-- molecular_function:
-    id: GO:0070182
-    label: DNA polymerase binding
-  description: &gt;-
-    PTGES3/p23 directly binds hTERT, the telomerase reverse transcriptase catalytic subunit,
-    as part of the HSP90-dependent telomerase holoenzyme assembly pathway. Together with
-    HSP90, p23 is required for assembly of active telomerase from its components and a
-    significant fraction of cellular telomerase is associated with p23 and HSP90.
-  directly_involved_in:
-    - id: GO:0007004
-      label: telomere maintenance via telomerase
-    - id: GO:1905323
-      label: telomerase holoenzyme complex assembly
-  locations:
-    - id: GO:0005654
-      label: nucleoplasm
-  in_complex:
-    id: GO:0005697
-    label: telomerase holoenzyme complex
-  supported_by:
-    - reference_id: PMID:10197982
+    - reference_id: file:human/PTGES3/PTGES3-deep-research-falcon.md
       supporting_text: &gt;-
-        We have identified the molecular chaperones p23 and Hsp90 as proteins that bind to
-        the catalytic subunit of telomerase. Blockade of this interaction inhibits assembly
-        of active telomerase in vitro.
-    - reference_id: PMID:10197982
-      supporting_text: &gt;-
-        a significant fraction of active telomerase from cell extracts is associated with
-        p23 and Hsp90.
-    - reference_id: PMID:19751963
-      supporting_text: &gt;-
-        curcumin treatment results in a substantial decrease in association of p23 and
-        hTERT but does not affect the Hsp90 binding to hTERT.
+        PTGES3/p23 binds HSP90 in the ATP-bound closed conformation and
+        inhibits or slows the HSP90 ATPase cycle, shaping client maturation and
+        release.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
@@ -10028,6 +9949,18 @@ references:
 - id: GO_REF:0000120
   title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
+- id: file:human/PTGES3/PTGES3-deep-research-falcon.md
+  title: Falcon deep research synthesis for PTGES3
+  findings:
+  - statement: &gt;-
+      PTGES3 is bifunctional: a cytosolic glutathione-dependent prostaglandin E
+      synthase and the p23 HSP90 co-chaperone that stabilizes ATP-bound HSP90
+      closed states.
+    supporting_text: &gt;-
+      PTGES3/cPGES is annotated to catalyze the isomerization/conversion of
+      prostaglandin H2 (PGH2) to prostaglandin E2 (PGE2), and PTGES3 is
+      explicitly identified as the co-chaperone p23 in authoritative HSP90
+      machinery literature.
 - id: PMID:10197982
   title: Functional requirement of p23 and Hsp90 in telomerase complexes.
   findings: []
@@ -10244,7 +10177,7 @@ references:
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/PTGES3/PTGES3-ai-review.yaml
+++ b/genes/human/PTGES3/PTGES3-ai-review.yaml
@@ -1,7 +1,7 @@
 id: Q15185
 gene_symbol: PTGES3
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -228,6 +228,11 @@ existing_annotations:
       supporting_text: >-
         Recombinant p23 expressed in Escherichia coli and 293 cells exhibited all the
         features of PGES activity detected in rat brain cytosol
+    - reference_id: file:human/PTGES3/PTGES3-deep-research-falcon.md
+      supporting_text: >-
+        PTGES3/cPGES catalyzes the glutathione-dependent isomerization of PGH2
+        to PGE2 and is functionally coupled with COX-1-derived PGH2 in current
+        pathway models.
 - term:
     id: GO:0007004
     label: telomere maintenance via telomerase
@@ -238,12 +243,12 @@ existing_annotations:
       IBA annotation for telomere maintenance via telomerase is phylogenetically inferred.
       PTGES3/p23 and HSP90 were shown to be required for assembly and activity of telomerase
       (PMID:10197982). Inhibition of p23-HSP90 interaction blocks telomerase assembly.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
       PTGES3 participates in telomere maintenance via telomerase through its role in
       assembling and stabilizing the telomerase holoenzyme complex with HSP90 (PMID:10197982,
-      PMID:12135483). This is an established secondary function of PTGES3 and the IBA
-      annotation is appropriate.
+      PMID:12135483). This is an established client-specific consequence of the p23/HSP90
+      co-chaperone role, not a core PTGES3 function.
     supported_by:
     - reference_id: PMID:10197982
       supporting_text: >-
@@ -260,11 +265,12 @@ existing_annotations:
       IBA annotation for telomerase holoenzyme complex assembly. PTGES3/p23 together with
       HSP90 is required for in vitro assembly of active telomerase from its components
       (PMID:10197982). The IDA from PMID:10197982 directly supports this.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
       Telomerase holoenzyme complex assembly is a well-documented function of PTGES3 in
       concert with HSP90. Holt et al. (PMID:10197982) showed that p23 and HSP90 bind hTERT
-      and are required for assembly of active telomerase. This is concordant with the IBA.
+      and are required for assembly of active telomerase. This should be kept as a
+      non-core HSP90-client assembly consequence rather than elevated to a core function.
     supported_by:
     - reference_id: PMID:10197982
       supporting_text: >-
@@ -315,9 +321,9 @@ existing_annotations:
     reason: >-
       This is a broad but not incorrect annotation. PTGES3 participates in prostaglandin
       biosynthesis, which is a form of lipid metabolism. The more specific annotations to
-      prostaglandin biosynthetic process (GO:0001516) and fatty acid biosynthetic process
-      (GO:0006633) provide better granularity, but this IEA annotation is acceptable as
-      a parent term.
+      prostaglandin biosynthetic and metabolic process annotations provide
+      better granularity. The separate fatty acid biosynthetic process
+      annotation overstates this terminal prostanoid-synthesis step.
 - term:
     id: GO:0006631
     label: fatty acid metabolic process
@@ -343,12 +349,16 @@ existing_annotations:
       IEA annotation for fatty acid biosynthetic process from UniProt keyword mapping.
       PTGES3 catalyzes the isomerization of PGH2 to PGE2 in the prostaglandin biosynthetic
       pathway, which is derived from arachidonic acid metabolism.
-    action: ACCEPT
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      This IEA mapping from UniProt keywords is broadly acceptable since prostaglandins are
-      fatty acid derivatives. However, prostaglandin biosynthesis is more accurately described
-      as eicosanoid/prostanoid biosynthesis than as fatty acid biosynthesis per se. This is a
-      tolerable IEA-level annotation given the more specific annotations exist.
+      PTGES3 catalyzes the terminal isomerization of PGH2 to PGE2 in
+      prostaglandin biosynthesis; it does not synthesize fatty acids. This
+      keyword-derived IEA annotation is therefore too broad and biologically
+      misleading compared with the existing prostaglandin biosynthetic process
+      annotation.
+    proposed_replacement_terms:
+    - id: GO:0001516
+      label: prostaglandin biosynthetic process
 - term:
     id: GO:0006693
     label: prostaglandin metabolic process
@@ -628,13 +638,12 @@ existing_annotations:
       on Woo et al. (PMID:19740745). This study showed that overexpression of truncated p23
       (Delta p23) down-regulated telomerase activity and decreased hTERT levels, implying
       that full-length p23 positively regulates telomerase maintenance.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
       The study demonstrates that PTGES3 positively regulates telomerase activity through
       its HSP90 co-chaperone function. Truncation of p23 disrupts HSP90 function, leading
       to reduced telomerase activity, decreased hTERT stability, and inhibited cell growth
-      (PMID:19740745). This is consistent with the broader literature on PTGES3's role in
-      telomerase assembly.
+      (PMID:19740745). This is a non-core client-specific effect of the p23/HSP90 system.
     supported_by:
     - reference_id: PMID:19740745
       supporting_text: >-
@@ -651,12 +660,12 @@ existing_annotations:
       study (PMID:10197982) that demonstrated p23 and HSP90 are required for telomerase
       assembly and that a significant fraction of cellular telomerase is associated with
       p23 and HSP90.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
       This is well-supported experimental evidence. Holt et al. showed that p23 and HSP90
       bind hTERT, that blockade of their interaction inhibits telomerase assembly, and
       that active telomerase in cell extracts is associated with p23 and HSP90
-      (PMID:10197982). This represents a core secondary function of PTGES3.
+      (PMID:10197982). This represents a non-core HSP90-client consequence of PTGES3/p23.
     supported_by:
     - reference_id: PMID:10197982
       supporting_text: >-
@@ -674,13 +683,14 @@ existing_annotations:
       The study showed that p23 binds to hTERT, the reverse transcriptase catalytic subunit
       of telomerase. hTERT is a specialized reverse transcriptase (RNA-dependent DNA
       polymerase). The annotation captures p23's direct binding to this polymerase.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
       PTGES3/p23 directly binds hTERT, the telomerase reverse transcriptase, which is a
       specialized DNA polymerase. This was demonstrated by co-immunoprecipitation in
       PMID:10197982. While hTERT is specifically a reverse transcriptase, the GO:0070182
       (DNA polymerase binding) captures the binding to this enzyme class. The annotation
-      is technically correct.
+      is technically supported but non-core and should not be represented as a separate
+      PTGES3 core function.
     supported_by:
     - reference_id: PMID:10197982
       supporting_text: >-
@@ -696,12 +706,13 @@ existing_annotations:
       IDA annotation for telomerase holoenzyme complex assembly based on Holt et al.
       (PMID:10197982). The study demonstrated that p23 and HSP90 are required for in vitro
       assembly of active telomerase from purified components.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
       This is directly demonstrated experimental evidence. Assembly of active telomerase
       from in vitro-synthesized components required p23 and HSP90 present in reticulocyte
       extracts. Blockade of the p23-HSP90 interaction inhibited telomerase assembly
-      (PMID:10197982).
+      (PMID:10197982). Keep as a non-core client-specific outcome of the HSP90
+      co-chaperone function.
     supported_by:
     - reference_id: PMID:10197982
       supporting_text: >-
@@ -905,12 +916,13 @@ existing_annotations:
       IPI annotation for DNA polymerase binding from Lee & Chung (PMID:19751963), which
       demonstrated that p23 binds hTERT (telomerase reverse transcriptase) and that
       curcumin treatment dissociates p23 from hTERT.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
       PTGES3/p23 directly binds hTERT, the reverse transcriptase subunit of telomerase.
       PMID:19751963 showed that curcumin treatment resulted in decreased association of
       p23 with hTERT. This is consistent with the earlier finding from PMID:10197982.
-      hTERT is a DNA polymerase (reverse transcriptase) so the GO term is appropriate.
+      hTERT is a DNA polymerase (reverse transcriptase), so the term is technically
+      supported but should be kept non-core as a client-specific HSP90/p23 interaction.
     supported_by:
     - reference_id: PMID:19751963
       supporting_text: >-
@@ -1481,12 +1493,13 @@ existing_annotations:
       examined the role of six telomerase subunits (hTR, TEP1, hTERT, hsp90, p23, dyskerin)
       in telomerase regulation. The study confirmed that p23 participates in full enzyme
       activity even though hTERT is the rate-limiting subunit.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
       Telomere maintenance is well supported for PTGES3. The study showed that antisense
       treatment against p23 decreased telomerase activity (PMID:12135483). This is broader
       than but consistent with the more specific annotation to telomere maintenance via
-      telomerase (GO:0007004).
+      telomerase (GO:0007004), and should be treated as non-core because it reflects one
+      HSP90-client system rather than PTGES3's primary molecular function.
     supported_by:
     - reference_id: PMID:12135483
       supporting_text: >-
@@ -1538,12 +1551,12 @@ existing_annotations:
       which identified p23 as one of the six subunits of the telomerase complex. Earlier
       work (PMID:10197982) showed that a significant fraction of active telomerase is
       associated with p23 and HSP90.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
       PTGES3/p23 is a confirmed component of the telomerase holoenzyme complex. Multiple
       studies demonstrate its presence in active telomerase complexes (PMID:10197982,
       PMID:12135483). This localization annotation appropriately captures PTGES3's role
-      in the telomerase complex.
+      in the telomerase complex, but the role is client-specific and non-core.
     supported_by:
     - reference_id: PMID:12135483
       supporting_text: >-
@@ -1692,39 +1705,11 @@ core_functions:
       supporting_text: >-
         it is Hsp90's nucleotide-binding domain that triggers the formation of the
         Hsp90(2)p23(2) complex.
-- molecular_function:
-    id: GO:0070182
-    label: DNA polymerase binding
-  description: >-
-    PTGES3/p23 directly binds hTERT, the telomerase reverse transcriptase catalytic subunit,
-    as part of the HSP90-dependent telomerase holoenzyme assembly pathway. Together with
-    HSP90, p23 is required for assembly of active telomerase from its components and a
-    significant fraction of cellular telomerase is associated with p23 and HSP90.
-  directly_involved_in:
-    - id: GO:0007004
-      label: telomere maintenance via telomerase
-    - id: GO:1905323
-      label: telomerase holoenzyme complex assembly
-  locations:
-    - id: GO:0005654
-      label: nucleoplasm
-  in_complex:
-    id: GO:0005697
-    label: telomerase holoenzyme complex
-  supported_by:
-    - reference_id: PMID:10197982
+    - reference_id: file:human/PTGES3/PTGES3-deep-research-falcon.md
       supporting_text: >-
-        We have identified the molecular chaperones p23 and Hsp90 as proteins that bind to
-        the catalytic subunit of telomerase. Blockade of this interaction inhibits assembly
-        of active telomerase in vitro.
-    - reference_id: PMID:10197982
-      supporting_text: >-
-        a significant fraction of active telomerase from cell extracts is associated with
-        p23 and Hsp90.
-    - reference_id: PMID:19751963
-      supporting_text: >-
-        curcumin treatment results in a substantial decrease in association of p23 and
-        hTERT but does not affect the Hsp90 binding to hTERT.
+        PTGES3/p23 binds HSP90 in the ATP-bound closed conformation and
+        inhibits or slows the HSP90 ATPase cycle, shaping client maturation and
+        release.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
@@ -1744,6 +1729,18 @@ references:
 - id: GO_REF:0000120
   title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
+- id: file:human/PTGES3/PTGES3-deep-research-falcon.md
+  title: Falcon deep research synthesis for PTGES3
+  findings:
+  - statement: >-
+      PTGES3 is bifunctional: a cytosolic glutathione-dependent prostaglandin E
+      synthase and the p23 HSP90 co-chaperone that stabilizes ATP-bound HSP90
+      closed states.
+    supporting_text: >-
+      PTGES3/cPGES is annotated to catalyze the isomerization/conversion of
+      prostaglandin H2 (PGH2) to prostaglandin E2 (PGE2), and PTGES3 is
+      explicitly identified as the co-chaperone p23 in authoritative HSP90
+      machinery literature.
 - id: PMID:10197982
   title: Functional requirement of p23 and Hsp90 in telomerase complexes.
   findings: []

--- a/genes/human/PTGES3/PTGES3-ai-review.yaml
+++ b/genes/human/PTGES3/PTGES3-ai-review.yaml
@@ -334,11 +334,12 @@ existing_annotations:
       IEA annotation for fatty acid metabolic process from UniProt keyword mapping.
       Prostaglandins are derived from arachidonic acid, a fatty acid. PTGES3 catalyzes the
       terminal step converting PGH2 to PGE2.
-    action: ACCEPT
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      Prostaglandins are eicosanoids derived from arachidonic acid (a fatty acid), so
-      this broad IEA mapping is not incorrect. The more specific prostaglandin biosynthetic
-      process annotation provides better specificity.
+      PTGES3/cPGES converts PGH2 to PGE2 in prostanoid metabolism; it does not broadly
+      participate in fatty acid metabolism. This parent term is therefore too broad for
+      the terminal prostaglandin synthase activity, and the existing prostaglandin
+      biosynthetic and metabolic process annotations provide better specificity.
 - term:
     id: GO:0006633
     label: fatty acid biosynthetic process

--- a/publications/DOI_10.1152_ajplung.00235.2007.md
+++ b/publications/DOI_10.1152_ajplung.00235.2007.md
@@ -1,0 +1,28 @@
+---
+reference_id: DOI:10.1152/ajplung.00235.2007
+title: "The small heat shock-related protein, HSP20, is a cAMP-dependent protein kinase substrate that is involved in airway smooth muscle relaxation"
+authors:
+- Padmini Komalavilas
+- Raymond B. Penn
+- Charles R. Flynn
+- Jeffrey Thresher
+- Luciana B. Lopes
+- Elizabeth J. Furnish
+- Manhong Guo
+- Manuel A. Pallero
+- Joanne E. Murphy-Ullrich
+- Colleen M. Brophy
+journal: American Journal of Physiology-Lung Cellular and Molecular Physiology
+year: '2008'
+doi: 10.1152/ajplung.00235.2007
+content_type: abstract_only
+---
+
+# The small heat shock-related protein, HSP20, is a cAMP-dependent protein kinase substrate that is involved in airway smooth muscle relaxation
+**Authors:** Padmini Komalavilas, Raymond B. Penn, Charles R. Flynn, Jeffrey Thresher, Luciana B. Lopes, Elizabeth J. Furnish, Manhong Guo, Manuel A. Pallero, Joanne E. Murphy-Ullrich, Colleen M. Brophy
+**Journal:** American Journal of Physiology-Lung Cellular and Molecular Physiology (2008)
+**DOI:** [10.1152/ajplung.00235.2007](https://doi.org/10.1152/ajplung.00235.2007)
+
+## Content
+
+Activation of the cAMP/cAMP-dependent PKA pathway leads to relaxation of airway smooth muscle (ASM). The purpose of this study was to examine the role of the small heat shock-related protein HSP20 in mediating PKA-dependent ASM relaxation. Human ASM cells were engineered to constitutively express a green fluorescent protein-PKA inhibitory fusion protein (PKI-GFP) or GFP alone. Activation of the cAMP-dependent signaling pathways by isoproterenol (ISO) or forskolin led to increases in the phosphorylation of HSP20 in GFP but not PKI-GFP cells. Forskolin treatment in GFP but not PKI-GFP cells led to a loss of central actin stress fibers and decreases in the number of focal adhesion complexes. This loss of stress fibers was associated with dephosphorylation of the actin-depolymerizing protein cofilin in GFP but not PKI-GFP cells. To confirm that phosphorylated HSP20 plays a role in PKA-induced ASM relaxation, intact strips of bovine ASM were precontracted with serotonin followed by ISO. Activation of the PKA pathway led to relaxation of bovine ASM, which was associated with phosphorylation of HSP20 and dephosphorylation of cofilin. Finally, treatment with phosphopeptide mimetics of HSP20 possessing a protein transduction domain partially relaxed precontracted bovine ASM strips. In summary, ISO-induced phosphorylation of HSP20 or synthetic phosphopeptide analogs of HSP20 decreases phosphorylation of cofilin and disrupts actin in ASM, suggesting that one possible mechanism by which HSP20 mediates ASM relaxation is via regulation of actin filament dynamics.


### PR DESCRIPTION
## Summary

Adds completed human gene reviews for batch 08:

- HSPA2
- HSPB6
- AHSA1
- PTGES3
- DNAJB8

Each review is marked `status: COMPLETE`, integrates Falcon deep research, and includes regenerated HTML. This also adds the DOI publication cache entry needed for the HSPB6 smooth-muscle relaxation evidence.

## Review QA

Each gene was reviewed by a separate subagent before publication. Requested subagent fixes were applied for HSPA2, HSPB6, and PTGES3; AHSA1 and DNAJB8 were approved without required changes.

## Validation

- `just validate human HSPA2`
- `just validate human HSPB6`
- `just validate human AHSA1`
- `just validate human PTGES3`
- `just validate human DNAJB8`
- `uv run mypy src tests --exclude "src/ai_gene_review/(datamodel|tools|export)/"`
- `just pytest`
- `git diff --check`