### PR TITLE
[codex] Review human chaperone batch 09

### DIFF
--- a/cache/go/terms.csv
+++ b/cache/go/terms.csv
@@ -6792,7 +6792,7 @@ GO:0140288,GBAF complex,2026-03-22T22:38:14.237952
 GO:0140296,general transcription initiation factor binding,2026-03-22T22:38:14.237952
 GO:0140297,DNA-binding transcription factor binding,2026-03-22T22:38:14.237952
 GO:0140303,intramembrane lipid transporter activity,2026-03-22T22:38:14.237952
-GO:0140309,unfolded protein carrier activity,2026-03-22T22:38:14.237952
+GO:0140309,unfolded protein holdase activity,2026-03-22T22:38:14.237952
 GO:0140311,protein sequestering activity,2026-03-22T22:38:14.237952
 GO:0140313,molecular sequestering activity,2026-03-22T22:38:14.237952
 GO:0140315,iron ion sequestering activity,2026-03-22T22:38:14.237952

--- a/cache/ontologies/go.tsv
+++ b/cache/ontologies/go.tsv
@@ -6692,7 +6692,7 @@ GO:0140288	GBAF complex	False	2026-03-21T13:03:26.965807
 GO:0140296	general transcription initiation factor binding	False	2026-03-21T13:03:26.965881
 GO:0140297	DNA-binding transcription factor binding	False	2026-03-21T13:03:26.965954
 GO:0140303	intramembrane lipid transporter activity	False	2026-03-21T13:03:26.966026
-GO:0140309	unfolded protein carrier activity	False	2026-03-21T13:03:26.966107
+GO:0140309	unfolded protein holdase activity	False	2026-03-21T13:03:26.966107
 GO:0140311	protein sequestering activity	False	2026-03-21T13:03:26.966179
 GO:0140313	molecular sequestering activity	False	2026-03-21T13:03:26.966253
 GO:0140315	iron ion sequestering activity	False	2026-03-21T13:03:26.966325

--- a/genes/human/AIP/AIP-ai-review.html
+++ b/genes/human/AIP/AIP-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>AIP</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/O00170" target="_blank" class="term-link">
                         O00170
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>AIP (AH receptor-interacting protein, also known as XAP2/ARA9) is a ~37 kDa, 330-amino acid FKBP-type immunophilin homolog that functions as a co-chaperone/scaffold in the HSP90-AHR (aryl hydrocarbon receptor) cytosolic complex and as a cytosolic factor mediating mitochondrial preprotein import via interaction with the import receptor TOMM20. It contains an N-terminal FKBP-type PPIase-like domain that is catalytically inactive (lacking PPIase enzymatic activity and FK506/rapamycin binding) and C-terminal TPR repeats (three TPR motifs plus a terminal alpha-7 helix) that mediate interactions with HSP90 and TOMM20. Cryo-EM structural analysis of the human agonist-bound AHR cytosolic complex (DOI:10.1038/s41467-022-34773-w) reveals AIP/XAP2 acting as a structural brace associated with the HSP90 dimer and the AHR client, with the HSP90 C-terminal MEEVD motif docked into the TPR domain of AIP. AIP exhibits chaperone-like (holdase) activity, suppressing thermal aggregation of substrate proteins. Beyond the AHR complex, AIP also interacts with phosphodiesterases PDE4A5 and PDE2A3, linking it to localized cAMP regulation and modulation of AHR nuclear translocation. Proteomic studies show AIP co-localizes with HSPA9 in the mitochondrial chaperone network, consistent with broader chaperone-network functions beyond the AHR complex (DOI:10.18632/oncotarget.24183). Germline loss-of-function AIP variants predispose to pituitary neuroendocrine tumors (PitNETs) with incomplete penetrance (~12-30%), behaving as a tumor suppressor with a two-hit model (loss of heterozygosity in tumors). AIP mutations account for ~29% of childhood-onset GH-secreting pituitary tumors presenting as gigantism and ~9% of macroprolactinomas presenting before age 20 (DOI:10.1038/s41574-023-00948-8).</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045893" target="_blank" class="term-link">
                                     GO:0045893
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of DNA-templated transcription</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000108
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -795,64 +795,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation was inferred by logical inference from AIP having transcription coactivator activity (GO:0003713). AIP/XAP2 was shown by Meyer et al. (PMID:9447995) to enhance AhR-driven transcription from a dioxin-responsive element by about twofold. This is an indirect consequence of AIP stabilizing the AHR-HSP90 complex in the cytosol, not a direct transcriptional activation function. The annotation is logically consistent with the coactivator annotation but represents a secondary downstream effect rather than a core function of AIP.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> AIP does enhance AhR-driven transcription, but this is an indirect effect of its co-chaperone function in stabilizing the AHR-HSP90 complex, not a direct transcriptional regulatory activity. The annotation is technically correct as an inference from the coactivator annotation, but represents a downstream biological consequence rather than core function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9447995" target="_blank" class="term-link">
                                         PMID:9447995
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">XAP2 enhanced the ability of endogenous murine and human AhR complexes to activate a dioxin-responsive element-luciferase reporter twofold, following transient expression of XAP2 in Hepa 1c1c7 and HeLa cells.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003755" target="_blank" class="term-link">
                                     GO:0003755
                                 </a>
                             </span>
                             <span class="term-label">peptidyl-prolyl cis-trans isomerase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -864,64 +864,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation was automatically assigned based on InterPro domain IPR001179 (FKBP-type PPIase domain). While AIP does contain an FKBP-type PPIase-like domain, multiple studies have shown this domain is catalytically inactive. Laenger et al. (PMID:19375531) explicitly demonstrated that the PPIase-like region of XAP2 is enzymatically inactive. The domain has diverged from catalytically active FKBP family members and lacks key residues for PPIase catalysis.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> AIP contains an FKBP-type PPIase-like domain that is catalytically inactive (PMID:19375531). The InterPro domain match is structurally correct but the functional annotation of PPIase activity is incorrect for this protein. This is a well-documented case of a domain homolog that has lost enzymatic activity.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19375531" target="_blank" class="term-link">
                                         PMID:19375531
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The PPIase-like region turned out to be enzymatically inactive. Thus, PPIase activity is not essential for the action of XAP2 on GR, similarly to FKBP51 and FKBP52.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -933,64 +933,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation is based on UniProtKB/Swiss-Prot Subcellular Location mapping. AIP is well-established as a cytoplasmic protein. Kuzhandaivelu et al. (PMID:8972861) showed by immunofluorescence that XAP2 is a cytoplasmic protein. UniProt CC line states Subcellular location as Cytoplasm. This is consistent with AIP functioning as a cytosolic co-chaperone in the AHR-HSP90 complex and as a cytosolic factor in mitochondrial preprotein import.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> AIP is well-established as a cytoplasmic protein across multiple studies. This is consistent with its function as a cytosolic co-chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8972861" target="_blank" class="term-link">
                                         PMID:8972861
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Antiserum raised against XAP2 recognizes a cytoplasmic protein with an apparent molecular mass of 36 kDa.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1002,86 +1002,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation of GO:0051082 (unfolded protein binding) was assigned by ARBA machine learning models. GO:0051082 is being obsoleted (go-ontology issue 30962). While AIP does have experimentally demonstrated chaperone-like activity that prevents thermal aggregation of substrate proteins (PMID:14557246), the appropriate replacement term is GO:0044183 (protein folding chaperone), which better captures the holdase/chaperone function rather than implying simple binding to unfolded proteins. The IEA annotation here is redundant with the IDA annotation from the same gene also annotated to GO:0051082 based on PMID:14557246.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. The experimental data from PMID:14557246 demonstrates genuine chaperone-like (holdase) activity for AIP, including suppression of thermal aggregation of rhodanese and citrate synthase in vitro. The replacement term GO:0044183 (protein folding chaperone) accurately captures this function. Additionally, this IEA annotation is redundant with the experimentally supported IDA annotation from PMID:14557246 on the same gene.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link">
                                         PMID:14557246
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">An aggregation suppression assay indicated that AIP has a chaperone-like activity to prevent substrate proteins from aggregation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17329248" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17329248
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphodiesterase 2A forms a complex with the co-chaperone X...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1093,75 +1093,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IPI annotation records the interaction between AIP (XAP2) and PDE2A (UniProtKB:O00408). De Oliveira et al. (PMID:17329248) identified XAP2 as a major PDE2A-interacting protein via yeast two-hybrid screening and mapped the binding site to the GAF-B domain of PDE2A. This is a functionally significant interaction as PDE2A binding to XAP2 inhibits TCDD- and cAMP-induced nuclear translocation of AhR in hepatocytes. The interaction is relevant to AIP function in cAMP signaling regulation. However, protein binding is uninformative; the more specific annotation GO:0036004 (GAF domain binding) already captures this interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The interaction between AIP and PDE2A is well-documented by yeast two-hybrid and co-immunoprecipitation (PMID:17329248). While protein binding is a generic term, the IPI evidence with specific interactor is standard practice and the more specific GAF domain binding annotation is also present. Duplicates with different evidence lines are acceptable.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17329248" target="_blank" class="term-link">
                                         PMID:17329248
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">In a yeast two-hybrid screening we identified XAP2, a crucial component of the aryl hydrocarbon receptor (AhR) complex, as a major PDE2A-interacting protein. We mapped the XAP2 binding site to the GAF-B domain of PDE2A.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19375531" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19375531
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     XAP2 inhibits glucocorticoid receptor activity in mammalian ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1173,137 +1173,137 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IPI annotation records the interaction between AIP (XAP2) and HSP90AB1 (UniProtKB:P08238). Laenger et al. (PMID:19375531) showed that XAP2 interacts with Hsp90 through its TPR motif and that this interaction is required for XAP2 to inhibit glucocorticoid receptor activity. The AIP-HSP90 interaction is one of the most well-characterized interactions for this protein, mediated by the TPR domain binding to the MEEVD motif at the C-terminus of HSP90. This is a core interaction of AIP.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The AIP-HSP90 interaction is a core functional interaction, extensively validated. This IPI evidence from PMID:19375531 provides additional confirmation that the TPR domain mediates the HSP90 binding. Multiple independent studies confirm this interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19375531" target="_blank" class="term-link">
                                         PMID:19375531
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The effect of XAP2 on GR requires its interaction with Hsp90 through the TPR motif.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20029029" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20029029
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Regulation of epidermal growth factor receptor trafficking b...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="O00170" data-a="GO:0005515" data-r="PMID:20029029" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="O00170" data-a="GO:0005515" data-r="PMID:20029029" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IPI annotation records the interaction between AIP and EGFR (UniProtKB:P00533) from a study on HDAC6 regulation of EGFR trafficking (PMID:20029029). AIP was not the focus of this study. The interaction between AIP and EGFR is likely detected in a high-throughput context and may represent an indirect interaction mediated through the HSP90 chaperone machinery, since EGFR is a known HSP90 client. Without more specific evidence for a direct, functional AIP-EGFR interaction, this should be considered with caution.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> The interaction was detected by physical interaction evidence (IPI) and is plausible given that AIP is part of the HSP90 co-chaperone system and EGFR is an HSP90 client. While likely indirect, the IPI evidence is valid as recorded.
+                            <strong>Reason:</strong> The cached publication describes an EGFR interactome screen but does not provide enough accessible detail here to verify the specific AIP-EGFR pair or its directness. This should not be treated as a core AIP function; retain for expert review of the underlying IntAct evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21170051" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21170051
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Mixed Hsp90-cochaperone complexes are important for the prog...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1315,181 +1315,181 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IPI annotation records the interaction between AIP and HSP90AB1 (UniProtKB:P08238) from a study on mixed Hsp90-cochaperone complexes (PMID:21170051). This study demonstrates that AIP forms part of mixed HSP90 co-chaperone complexes important for the chaperone reaction cycle. This is consistent with AIP being a bona fide HSP90 co-chaperone via its TPR domain.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This confirms the well-established AIP-HSP90 co-chaperone interaction in the context of functional chaperone cycle complexes.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21903422" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21903422
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Mapping a dynamic innate immunity protein interaction networ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="O00170" data-a="GO:0005515" data-r="PMID:21903422" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="O00170" data-a="GO:0005515" data-r="PMID:21903422" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IPI annotation records the interaction between AIP and IRF7 (UniProtKB:Q92985) from a study mapping innate immunity protein interaction networks (PMID:21903422). AIP was detected interacting with IRF7 in a high-throughput innate immunity interaction mapping study. AIP is not known to have a role in interferon signaling. This interaction may be indirect (mediated through HSP90 which is known to interact with various signaling proteins) or may represent a non-physiological interaction from the high-throughput screen.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> The interaction was detected by IPI evidence in a systematic study. While the biological relevance to AIP function is unclear, the physical evidence is valid as recorded. It may reflect AIP participating in HSP90-mediated regulation of signaling proteins.
+                            <strong>Reason:</strong> The cached paper describes a systematic innate-immunity interactome, but the accessible text does not verify the specific AIP-IRF7 interaction or establish relevance to AIP function. This generic protein-binding call should not be accepted as core AIP biology.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22113938" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22113938
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A bead-based approach for large-scale identification of in v...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="O00170" data-a="GO:0005515" data-r="PMID:22113938" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="O00170" data-a="GO:0005515" data-r="PMID:22113938" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IPI annotation records the interaction between AIP and CSNK2A1/CK2alpha (UniProtKB:P68400) from a large-scale kinase substrate identification study (PMID:22113938). The interaction is from a high-throughput bead-based screen. CK2 is a ubiquitous kinase and the interaction may or may not be physiologically significant for AIP function. AIP has a phosphoserine at position 43 (ECO:0007744|PubMed:23186163), which could be a CK2 substrate site.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> The interaction was detected by IPI evidence and is plausible given that AIP is known to be phosphorylated. The evidence stands as a valid physical interaction record.
+                            <strong>Reason:</strong> The interaction comes from a large-scale kinase substrate screen, but the cached text does not provide enough specific support for an AIP-CK2alpha interaction or its functional relevance. This should remain a non-core item for expert review, not an accepted core annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25036637
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A quantitative chaperone interaction network reveals the arc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1501,119 +1501,119 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IPI annotation records the interaction between AIP and HSP90AB1 (UniProtKB:P08238) from a quantitative chaperone interaction network study (PMID:25036637). This study systematically mapped the chaperone-cochaperone interaction network and places AIP firmly within the HSP90 co-chaperone system. This is one of the core interactions of AIP.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This further validates the well-established AIP-HSP90 co-chaperone interaction in a comprehensive chaperone interactome study.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28514442
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Architecture of the human interactome defines protein commun...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="O00170" data-a="GO:0005515" data-r="PMID:28514442" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="O00170" data-a="GO:0005515" data-r="PMID:28514442" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IPI annotation records the interaction between AIP and PRAMEF10 (UniProtKB:O60809) from a large-scale interactome mapping study (PMID:28514442). PRAMEF10 is a PRAME family member. This is from a high-throughput study and the biological significance of AIP interacting with PRAMEF10 is unclear. PRAMEF10 is poorly characterized.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> The interaction was detected by IPI evidence in a systematic interactome study. The biological relevance is uncertain, but the physical interaction evidence is valid as recorded.
+                            <strong>Reason:</strong> This derives from a proteome-scale interactome study, and the cached text does not verify the specific AIP-PRAMEF10 interaction. PRAMEF10 is not part of the established AIP-HSP90/AHR tumor-suppressor mechanism, so the generic binding annotation should not be accepted as core.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28634279" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28634279
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     In-frame seven amino-acid duplication in AIP arose over the ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1625,263 +1625,263 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IPI annotation records the interaction between AIP and HSP90AB1 (UniProtKB:P08238) from Salvatori et al. (PMID:28634279), which studied the c.805_825dup AIP mutation. The study demonstrated by co-immunoprecipitation that wild-type AIP interacts with HSP90, and that the p.F269_H275dup mutation in TPR3 disrupts this interaction. This provides important functional validation that the AIP-HSP90 interaction is mediated through the TPR domain and is disrupted by disease-causing mutations.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This co-immunoprecipitation study confirms the AIP-HSP90 interaction and demonstrates its functional importance, as disease-causing AIP mutations disrupt the HSP90 binding. This is directly relevant to the tumor suppressor function of AIP.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/28634279" target="_blank" class="term-link">
                                         PMID:28634279
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The results of a co-immunoprecipitation experiment with mutant AIP and HSP90 were consistent with lack of interaction between the two proteins (Fig</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/28634279" target="_blank" class="term-link">
                                         PMID:28634279
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The mutation results in the duplication of seven amino-acids in third TPR domain of AIP, leading to the disruption of protein-protein interactions and markedly reduced protein stability.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31980649" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31980649
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Extensive rewiring of the EGFR network in colorectal cancer ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="O00170" data-a="GO:0005515" data-r="PMID:31980649" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="O00170" data-a="GO:0005515" data-r="PMID:31980649" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IPI annotation records the interaction between AIP and EGFR (UniProtKB:P00533) from a study on EGFR network rewiring in KRAS-mutant colorectal cancer cells (PMID:31980649). AIP was not the focus of this study. The interaction with EGFR is likely indirect, mediated through the HSP90 chaperone machinery.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> The interaction was detected by IPI evidence. While likely reflecting indirect interaction through the HSP90 system, the physical evidence is valid as recorded.
+                            <strong>Reason:</strong> The cached publication describes EGFR network remodeling, but it does not provide enough accessible detail to verify the specific AIP-EGFR pair or distinguish direct binding from indirect HSP90-system association. This is not a core AIP function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="O00170" data-a="GO:0005515" data-r="PMID:33961781" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="O00170" data-a="GO:0005515" data-r="PMID:33961781" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IPI annotation records interactions between AIP and PRAMEF10 (UniProtKB:O60809) and/or SYCN (UniProtKB:Q0VAF6) from a dual proteome-scale network study (PMID:33961781). These are from a high-throughput interactome study. The biological significance of these interactions for AIP function is unclear.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> The interactions were detected by IPI evidence in a systematic proteome-scale interactome study. While biological relevance to AIP function is uncertain, the physical evidence is valid as recorded.
+                            <strong>Reason:</strong> The interaction comes from a systematic proteome-scale network study, but the cached text does not verify the specific AIP-PRAMEF10/SYCN pair(s). Their relevance to AIP function is unclear, so this generic binding annotation should not be accepted as core.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:35271311
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     OpenCell: Endogenous tagging for the cartography of human ce...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="O00170" data-a="GO:0005515" data-r="PMID:35271311" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="O00170" data-a="GO:0005515" data-r="PMID:35271311" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IPI annotation records the interaction between AIP and CSNK2A1/CK2alpha (UniProtKB:P68400) from the OpenCell study (PMID:35271311), a large-scale endogenous tagging and imaging study. This is a second independent confirmation of the AIP-CK2alpha interaction after PMID:22113938.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> The interaction was detected by IPI evidence in an independent large-scale study, providing a second line of evidence for the AIP-CK2alpha interaction.
+                            <strong>Reason:</strong> The OpenCell paper is a large-scale localization and interaction resource, but the cached text does not provide specific support for the AIP-CK2alpha pair. Treat this as an unresolved, non-core protein-binding record rather than accepted AIP biology.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003712" target="_blank" class="term-link">
                                     GO:0003712
                                 </a>
                             </span>
                             <span class="term-label">transcription coregulator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1893,64 +1893,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation was transferred from the mouse ortholog via Ensembl Compara. AIP/XAP2 was shown to enhance AhR-mediated transcription (PMID:9447995), which is the basis for the mouse ortholog annotation. The term GO:0003712 (transcription coregulator activity) is broader than the TAS annotation GO:0003713 (transcription coactivator activity) also present for this gene. AIP enhances AhR transcription indirectly by stabilizing the cytosolic AHR-HSP90 complex, not by acting as a direct transcriptional coregulator in the nucleus. This is a secondary consequence of its co-chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> AIP does enhance AhR-dependent transcription, but this is an indirect effect of its co-chaperone role in stabilizing the AHR complex. The broader IEA term is acceptable as a non-core annotation consistent with the TAS coactivator annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9447995" target="_blank" class="term-link">
                                         PMID:9447995
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">XAP2 enhanced the ability of endogenous murine and human AhR complexes to activate a dioxin-responsive element-luciferase reporter twofold, following transient expression of XAP2 in Hepa 1c1c7 and HeLa cells.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1962,46 +1962,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation was transferred from the mouse ortholog via Ensembl Compara. AIP is established as a cytosolic protein by multiple lines of evidence including IDA annotations based on immunofluorescence (GO_REF:0000052) and direct experimental evidence (PMID:17329248). This IEA is consistent with and redundant with the experimental evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosolic localization of AIP is well-established by multiple experimental methods. This IEA is consistent with experimental evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
                                     GO:0016020
                                 </a>
                             </span>
                             <span class="term-label">membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2013,46 +2013,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation was transferred from the mouse ortholog via Ensembl Compara. AIP is primarily a cytosolic protein. The membrane annotation may reflect AIP association with the outer mitochondrial membrane via its interaction with TOMM20 (PMID:14557246), or its reported colocalization with the plasma membrane via PDE2A interaction (PMID:17329248). AIP itself is not a membrane protein and does not have a transmembrane domain. The term GO:0016020 (membrane) is very broad and not very informative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> AIP is not an integral membrane protein. While it may associate with membranes through protein-protein interactions (TOMM20 at the mitochondrial outer membrane, or PDE2A at the plasma membrane), the broad term &#34;membrane&#34; is uninformative and potentially misleading for a primarily cytosolic co-chaperone protein. More specific localization terms (cytosol, plasma membrane colocalization) are already captured by other annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0017162" target="_blank" class="term-link">
                                     GO:0017162
                                 </a>
                             </span>
                             <span class="term-label">aryl hydrocarbon receptor binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2064,64 +2064,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation was transferred from the mouse ortholog via Ensembl Compara. AIP/XAP2 was originally identified as a component of the AhR core complex (PMID:9447995). Meyer et al. showed that XAP2 coprecipitates with FLAG-tagged AhR and is present in the unliganded AhR 9S complex. AIP binding to AhR is well-established as a core function of this protein and is the basis for its name.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> AIP binding to the aryl hydrocarbon receptor is one of its best-characterized functions. This was demonstrated by coprecipitation and is the basis for the protein name. The IEA transfer from mouse ortholog is appropriate.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9447995" target="_blank" class="term-link">
                                         PMID:9447995
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Here we report the purification of an approximately 38-kDa protein (p38) from COS-1 cell cytosol that is a member of this complex by coprecipitation with a FLAG-tagged AhR.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/AIP/AIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">AIP participates in a cytosolic multiprotein complex with AHR and HSP90 (and p23), regulating AHR stability/cytosolic retention and nuclear translocation following ligand activation.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034751" target="_blank" class="term-link">
                                     GO:0034751
                                 </a>
                             </span>
                             <span class="term-label">aryl hydrocarbon receptor complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2133,64 +2144,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IEA annotation was transferred from the mouse ortholog via Ensembl Compara. AIP/XAP2 is an established subunit of the unliganded AhR core complex (PMID:9447995). Meyer et al. demonstrated that XAP2 is part of the heterotetrameric 9S AhR complex consisting of AhR, two HSP90 molecules, and XAP2. Reactome entries (R-HSA-8936849, R-HSA-8937169) also model AIP as part of the AHR:2xHSP90:AIP:PTGES3 complex. This is a core localization for AIP.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> AIP is a bona fide subunit of the aryl hydrocarbon receptor complex. This is one of the defining characteristics of this protein and is supported by multiple independent studies and Reactome pathway models.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9447995" target="_blank" class="term-link">
                                         PMID:9447995
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prior to ligand activation, the unactivated aryl hydrocarbon receptor (AhR) exists in a heterotetrameric 9S core complex consisting of the AhR ligand-binding subunit, a dimer of hsp90, and an unknown subunit.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2202,57 +2213,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IDA annotation is based on curation of immunofluorescence data (HPA). Cytosolic localization of AIP is well-established and consistent with its function as a cytosolic co-chaperone. Multiple studies confirm AIP is primarily cytosolic (PMID:8972861, PMID:14557246, PMID:17329248).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Immunofluorescence-based evidence for cytosolic localization of AIP is consistent with extensive other evidence for cytosolic localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003755" target="_blank" class="term-link">
                                     GO:0003755
                                 </a>
                             </span>
                             <span class="term-label">peptidyl-prolyl cis-trans isomerase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14557246
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     AIP is a mitochondrial import mediator that binds to both im...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -2264,88 +2275,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IDA annotation citing PMID:14557246 (Yano et al. 2003) claims PPIase activity for AIP. However, Yano et al. 2003 does NOT demonstrate PPIase enzymatic activity for AIP. The paper focuses on AIP as a mitochondrial import mediator with chaperone-like holdase activity. AIP belongs to the FKBP PPIase family structurally but its PPIase domain is catalytically inactive. Laenger et al. (PMID:19375531) explicitly showed the PPIase-like region is enzymatically inactive. This IDA annotation appears to be an error in the original curation, conflating structural homology to PPIases with actual catalytic activity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> AIP does not have PPIase catalytic activity. PMID:14557246 does not demonstrate PPIase activity; it describes chaperone-like holdase activity and mitochondrial import function. PMID:19375531 explicitly demonstrated that the PPIase-like region of AIP is enzymatically inactive. The IDA annotation based on PMID:14557246 for PPIase activity is an error.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19375531" target="_blank" class="term-link">
                                         PMID:19375531
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The PPIase-like region turned out to be enzymatically inactive.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link">
                                         PMID:14557246
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">AIP belongs to a family of peptidyl-prolyl cis/trans isomerases (PPIases) that are ubiquitous in prokaryotes and eukaryotes (Galat and Metcalfe, 1995).</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051604" target="_blank" class="term-link">
                                     GO:0051604
                                 </a>
                             </span>
                             <span class="term-label">protein maturation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14557246
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     AIP is a mitochondrial import mediator that binds to both im...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2357,77 +2368,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IDA annotation to GO:0051604 (protein maturation) cites Yano et al. (PMID:14557246). The paper demonstrates that AIP functions as a cytosolic factor mediating mitochondrial preprotein import. AIP maintains preproteins in an import-competent conformation and facilitates their import into mitochondria via interaction with TOMM20. Overexpression of AIP enhanced mature OTC production (processing of pOTC to mature OTC by mitochondrial import and cleavage), and depletion reduced it. While the end result is maturation of mitochondrial preproteins (signal peptide cleavage), AIP does not directly participate in the proteolytic processing. A more accurate annotation would be GO:0070585 (protein localization to mitochondrion), which is already annotated.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> AIP facilitates mitochondrial import but does not directly participate in protein maturation (proteolytic processing). The observed effect on pOTC maturation is an indirect consequence of enhanced mitochondrial import. The more appropriate annotation GO:0070585 (protein localization to mitochondrion) is already present for this gene and this reference. GO:0051604 is too broad and somewhat misleading for what AIP actually does.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link">
                                         PMID:14557246
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">AIP can enhance the mitochondrial import of pOTC.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link">
                                         PMID:14557246
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">All these results suggest strongly that AIP stabilizes pOTC in the cytosol and facilitates its import into mitochondria.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8937169
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2439,46 +2450,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This TAS annotation is based on Reactome pathway R-HSA-8937169 (AHR:TCDD:2xHSP90AB1:AIP:PTGES3 translocates from cytosol to nucleoplasm). In the Reactome model, the entire AHR complex including AIP translocates to the nucleus upon ligand binding. AIP is primarily cytosolic and its presence in the nucleoplasm is transient as part of the ligand-bound AHR complex before the complex dissociates. This is a non-core localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> AIP transiently enters the nucleoplasm as part of the ligand-activated AHR-HSP90 complex, but this is not its primary localization. The Reactome pathway model is accurate for the transient translocation event.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8937191
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2490,46 +2501,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This TAS annotation is based on Reactome pathway R-HSA-8937191 (AHR:TCDD:2xHSP90AB1:AIP:PTGES3 dissociates). This represents the dissociation of the AHR complex in the nucleoplasm after translocation. AIP is released from the complex in the nucleus. This is consistent with the transient nuclear localization of AIP during AHR signaling.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This represents transient nuclear localization of AIP during AHR signaling, consistent with the Reactome pathway model. Not the primary localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8936849
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2541,46 +2552,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This TAS annotation is based on Reactome pathway R-HSA-8936849 (AHR:2xHSP90:AIP:PTGES3 binds TCDD). AIP is part of the cytosolic AHR complex that binds the TCDD ligand. Cytosolic localization of AIP is well-established.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosolic localization of AIP as part of the AHR complex is well-supported by multiple lines of evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8937169
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2592,46 +2603,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This TAS annotation is based on Reactome pathway R-HSA-8937169 (AHR:TCDD:2xHSP90AB1:AIP:PTGES3 translocates from cytosol to nucleoplasm). AIP starts in the cytosol as part of the AHR complex. Cytosol is the primary localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosolic localization is the primary and well-established localization for AIP.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8950201
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2643,57 +2654,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This TAS annotation is based on Reactome pathway R-HSA-8950201 (Expression of Aryl Hydrocarbon receptor-interacting protein). AIP is expressed and localized in the cytosol. This is consistent with all other evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosolic localization of AIP is the primary and well-established localization, supported by all available evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036004" target="_blank" class="term-link">
                                     GO:0036004
                                 </a>
                             </span>
                             <span class="term-label">GAF domain binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17329248" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17329248
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphodiesterase 2A forms a complex with the co-chaperone X...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2705,75 +2716,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IDA annotation to GO:0036004 (GAF domain binding) is based on de Oliveira et al. (PMID:17329248), which showed that XAP2 binds to the GAF-B domain of PDE2A. The binding was identified by yeast two-hybrid and confirmed by immunoprecipitation. The GAF-B domain was specifically mapped as the XAP2 binding site. This is a well-characterized, specific molecular interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The interaction between AIP/XAP2 and the GAF-B domain of PDE2A was specifically mapped and validated by multiple methods (yeast two-hybrid and co-immunoprecipitation). This is a specific and informative MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17329248" target="_blank" class="term-link">
                                         PMID:17329248
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We mapped the XAP2 binding site to the GAF-B domain of PDE2A.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17329248" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17329248
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphodiesterase 2A forms a complex with the co-chaperone X...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2785,57 +2796,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IDA annotation for cytosol localization is based on de Oliveira et al. (PMID:17329248), which performed immunofluorescence showing XAP2 in the cytosol. The study also showed that PDE2A colocalizes with XAP2 in the cytosol and at the plasma membrane.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosolic localization demonstrated by immunofluorescence is consistent with all other evidence for AIP being primarily a cytosolic protein.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17329248" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17329248
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphodiesterase 2A forms a complex with the co-chaperone X...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2847,57 +2858,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IDA annotation with qualifier colocalizes_with records that AIP/XAP2 colocalizes with the plasma membrane, based on de Oliveira et al. (PMID:17329248). The study showed XAP2 and PDE2A colocalize at the plasma membrane in addition to the cytosol. This likely reflects AIP being recruited to the plasma membrane through its interaction with PDE2A, which has membrane association. This is a secondary, non-core localization dependent on the PDE2A interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Plasma membrane colocalization is a secondary localization dependent on the interaction with PDE2A. AIP is primarily a cytosolic protein and does not have intrinsic membrane targeting. The colocalizes_with qualifier appropriately indicates indirect association.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14557246
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     AIP is a mitochondrial import mediator that binds to both im...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2909,88 +2920,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IPI annotation records AIP interactions with Hsc70 (UniProtKB:P11142), TOMM20 (UniProtKB:Q15388), and/or TOMM20L (UniProtKB:Q9NS69) from Yano et al. (PMID:14557246). The paper demonstrated by two-hybrid and in vitro binding that AIP interacts with TOMM20 via its TPR domain and with Hsc70. AIP forms a ternary complex with preproteins and TOMM20. These are core, functionally important interactions for AIP&#39;s role in mitochondrial preprotein import.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The interactions of AIP with TOMM20 and Hsc70 demonstrated in PMID:14557246 are core to its mitochondrial import mediator function. The binding was validated by multiple methods including two-hybrid, in vitro binding, and co-precipitation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link">
                                         PMID:14557246
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Using two-hybrid screening, we identified arylhydrocarbon receptor-interacting protein (AIP), an FK506-binding protein homologue, interacting with Tom20.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link">
                                         PMID:14557246
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Hsc70 was also found to bind to AIP.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14557246
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     AIP is a mitochondrial import mediator that binds to both im...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3002,75 +3013,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This TAS annotation for cytosol localization cites Yano et al. (PMID:14557246). The paper demonstrates AIP functions as a cytosolic factor mediating preprotein import into mitochondria. AIP was detected in cytosolic fractions of HeLa, HepG2, COS-7, and Hepa1c1c7 cells by immunoblot.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosolic localization of AIP is well-documented by immunoblot analysis in multiple cell lines in this paper and is consistent with all other evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link">
                                         PMID:14557246
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">When immunoblot analysis was done using anti-human AIP, AIP polypeptides were readily detected in the lysates of HeLa (human), HepG2 (human), COS-7 (monkey), and Hepa1c1c7 (mouse) cells.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14557246
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     AIP is a mitochondrial import mediator that binds to both im...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -3082,112 +3093,112 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IDA annotation to GO:0051082 (unfolded protein binding) is based on Yano et al. 2003 (PMID:14557246), which demonstrated that AIP has genuine chaperone-like (holdase) activity. The key evidence is from thermal aggregation suppression assays (Figure 6 of the paper). AIP suppressed thermal aggregation of rhodanese at 55C and citrate synthase at 43C in a dose-dependent manner. At equimolar concentrations, GST-AIP suppressed rhodanese aggregation at early time points, and completely suppressed citrate synthase aggregation. This activity was additive or synergistic with Hsc70. The paper also showed AIP binds specifically to mitochondrial preproteins via their presequences, maintaining them in an import-competent (unfolded) conformation. The chaperone activity is mechanistically linked to AIP&#39;s role in mitochondrial import, keeping preproteins unfolded for translocation through the TOM complex. GO:0051082 is being obsoleted (go-ontology issue 30962), and the activity described is better captured by GO:0044183 (protein folding chaperone), which describes binding to proteins to assist the folding process, encompassing holdase activity that prevents aggregation of unfolded substrates.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. The experimental evidence from PMID:14557246 clearly demonstrates a chaperone-like holdase activity for AIP, not merely passive binding to unfolded proteins. AIP actively prevents thermal aggregation of model substrates (rhodanese and citrate synthase) and maintains mitochondrial preproteins in import-competent conformations. The replacement term GO:0044183 (protein folding chaperone) is the appropriate successor, capturing the active nature of this chaperone function. The evidence is robust -- the aggregation suppression assays used purified GST-AIP protein with proper GST-only controls, showed dose-dependent effects, and the physiological relevance was confirmed by in vivo import assays showing AIP maintains preprotein import competency.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link">
                                         PMID:14557246
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">AIP exhibited a chaperone-like activity to suppress the aggregation of substrate proteins.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link">
                                         PMID:14557246
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">When GST-AIP was added instead of GST, the aggregation of rhodanese was partially suppressed, and that of citrate synthase was completely suppressed. These results reconfirmed that AIP has chaperone-like activity.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link">
                                         PMID:14557246
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">AIP was found to function as a chaperone to suppress thermal aggregation of rhodanese and citrate synthase (Fig. 6). AIP may function as a chaperone to maintain mitochondria-targeted preproteins unfolded and to suppress their aggregation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070585" target="_blank" class="term-link">
                                     GO:0070585
                                 </a>
                             </span>
                             <span class="term-label">protein localization to mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14557246
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     AIP is a mitochondrial import mediator that binds to both im...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3199,101 +3210,101 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IDA annotation to GO:0070585 (protein localization to mitochondrion) is based on Yano et al. (PMID:14557246), which provides extensive evidence that AIP mediates mitochondrial preprotein import. Key evidence includes in vitro import assays showing AIP maintains pOTC import competency, cell-based assays showing AIP overexpression enhances pOTC import by ~3-fold, siRNA depletion of AIP impairing pOTC import to ~40% of control, AIP binding specifically to mitochondrial preproteins via their presequences, AIP forming ternary complexes with preproteins and TOMM20, and AIP having chaperone-like activity to prevent preprotein aggregation. This is a well-supported core function of AIP.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The evidence for AIP mediating protein localization to mitochondria is extensive and robust, including in vitro import assays, overexpression and depletion experiments in cells, specific binding to preproteins and TOMM20, and ternary complex formation. This represents a core function of AIP alongside its role in the AHR-HSP90 complex.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link">
                                         PMID:14557246
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">These results suggest that AIP functions as a cytosolic factor that mediates preprotein import into mitochondria.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link">
                                         PMID:14557246
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Thus, depletion of AIP reduced the mitochondrial import of pOTC, which means that endogenous AIP facilitates pOTC import into mitochondria.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link">
                                         PMID:14557246
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Formation of a ternary complex of Tom20, AIP, and preprotein was observed.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003713" target="_blank" class="term-link">
                                     GO:0003713
                                 </a>
                             </span>
                             <span class="term-label">transcription coactivator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9447995" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9447995
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Hepatitis B virus X-associated protein 2 is a subunit of the...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -3305,88 +3316,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This TAS annotation to GO:0003713 (transcription coactivator activity) is based on Meyer et al. (PMID:9447995), which showed that XAP2 enhanced AhR-driven transcription of a dioxin-responsive element reporter by about twofold when transiently expressed in Hepa 1c1c7 and HeLa cells. However, AIP does not function as a classical transcription coactivator. AIP enhances AhR signaling indirectly by stabilizing the cytosolic AHR-HSP90 complex, improving AhR receptivity for ligand and/or nuclear targeting. AIP does not directly contact DNA or recruit transcriptional machinery. The term &#34;transcription coactivator activity&#34; implies direct participation in transcriptional activation, which overstates AIP&#39;s role. A more accurate description would be that AIP modulates AhR signaling through its co-chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> AIP enhances AhR-driven transcription indirectly through its co-chaperone function in the AHR-HSP90 complex, not by acting as a direct transcription coactivator. The twofold enhancement of reporter activity (PMID:9447995) reflects improved AhR complex stability and signaling, not direct transcriptional coactivation. Calling AIP a transcription coactivator overstates its molecular role and is misleading about its mechanism of action.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9447995" target="_blank" class="term-link">
                                         PMID:9447995
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">XAP2 enhanced the ability of endogenous murine and human AhR complexes to activate a dioxin-responsive element-luciferase reporter twofold, following transient expression of XAP2 in Hepa 1c1c7 and HeLa cells.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9447995" target="_blank" class="term-link">
                                         PMID:9447995
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">It was not required for the assembly of an AhR-hsp90 complex in vitro. Additionally, XAP2 did not directly associate with hsp90 upon in vitro translation, but was present in a 9S form when cotranslated in vitro with murine AhR.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/8972861" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:8972861
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     XAP2, a novel hepatitis B virus X-associated protein that in...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3398,75 +3409,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This TAS annotation for cytoplasm is based on Kuzhandaivelu et al. (PMID:8972861), the original paper identifying XAP2 as a hepatitis B virus X-associated protein. The paper showed by immunostaining with anti-XAP2 antiserum that XAP2 is a cytoplasmic protein with apparent molecular mass of 36 kDa.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization of AIP/XAP2 was directly demonstrated by immunostaining in the original characterization paper and is consistent with all subsequent evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8972861" target="_blank" class="term-link">
                                         PMID:8972861
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Antiserum raised against XAP2 recognizes a cytoplasmic protein with an apparent molecular mass of 36 kDa.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051879" target="_blank" class="term-link">
                                     GO:0051879
                                 </a>
                             </span>
                             <span class="term-label">Hsp90 protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19375531" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19375531
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     XAP2 inhibits glucocorticoid receptor activity in mammalian ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-new">
@@ -3478,63 +3489,63 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> AIP/XAP2 binds HSP90 through its TPR motif, as demonstrated in multiple studies. Laenger et al. (PMID:19375531) showed that XAP2 inhibits GR through its interaction with Hsp90 via the TPR motif. The crystal structure of the AIP TPR domain bound to the HSP90 MEEVD peptide (PDB:4APO, PMID:23300914) confirms this interaction at atomic resolution. Salvatori et al. (PMID:28634279) showed disease-causing TPR mutations disrupt HSP90 binding. This is a core molecular function of AIP not currently captured by a specific GO annotation in the existing set.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> AIP binding to HSP90 via its TPR domain is the most well-characterized core molecular function of AIP. While multiple IPI protein binding annotations record AIP-HSP90 interactions, the specific term GO:0051879 (Hsp90 protein binding) would more accurately capture this core function. This is supported by extensive experimental evidence including co-immunoprecipitation, structural data, and functional studies.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19375531" target="_blank" class="term-link">
                                         PMID:19375531
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The effect of XAP2 on GR requires its interaction with Hsp90 through the TPR motif.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/28634279" target="_blank" class="term-link">
                                         PMID:28634279
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The mutation results in the duplication of seven amino-acids in third TPR domain of AIP, leading to the disruption of protein-protein interactions and markedly reduced protein stability.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>AIP/XAP2 binds HSP90 via its C-terminal TPR domain (three TPR motifs plus a terminal alpha-7 helix), serving as a co-chaperone/scaffold in the AHR-HSP90 complex. The TPR domain engages the MEEVD motif at the HSP90 C-terminus (PDB:4APO). Cryo-EM structure of the human agonist-bound HSP90-XAP2-AHR cytosolic complex (DOI:10.1038/s41467-022-34773-w) reveals AIP acting as a structural brace associated with the HSP90 dimer and the AHR client, with the MEEVD motif docked into the TPR domain of AIP, consistent with canonical TPR-mediated recruitment of HSP90 co-chaperones. Disease-causing mutations in the TPR domain disrupt HSP90 binding and are associated with pituitary neuroendocrine tumor predisposition (PitNET/PITA1), consistent with a two-hit tumor suppressor model (loss of heterozygosity in tumors).</h3>
                 <span class="vote-buttons" data-g="O00170" data-a="FUNCTION: AIP/XAP2 binds HSP90 via its C-terminal TPR domain..." data-r="" data-act="CORE_FUNCTION">
@@ -3542,10 +3553,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -3554,39 +3565,26 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">Directly Involved In:</div>
-                    <div class="function-annotations">
-                        
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
-                                protein folding
-                            </a>
-                        </span>
-                        
-                    </div>
-                </div>
-                
 
-                
+
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">In Complex:</div>
                     <span class="badge">
@@ -3595,49 +3593,49 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19375531" target="_blank" class="term-link">
                                 PMID:19375531
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">The effect of XAP2 on GR requires its interaction with Hsp90 through the TPR motif.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28634279" target="_blank" class="term-link">
                                 PMID:28634279
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">The mutation results in the duplication of seven amino-acids in third TPR domain of AIP, leading to the disruption of protein-protein interactions and markedly reduced protein stability.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>AIP exhibits chaperone-like holdase activity, suppressing thermal aggregation of model substrates (rhodanese, citrate synthase) in vitro. This chaperone activity is linked to its role in maintaining mitochondrial preproteins in an import-competent conformation for translocation through the TOM complex.</h3>
                 <span class="vote-buttons" data-g="O00170" data-a="FUNCTION: AIP exhibits chaperone-like holdase activity, supp..." data-r="" data-act="CORE_FUNCTION">
@@ -3645,10 +3643,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -3657,81 +3655,81 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070585" target="_blank" class="term-link">
                                 protein localization to mitochondrion
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link">
                                 PMID:14557246
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">AIP exhibited a chaperone-like activity to suppress the aggregation of substrate proteins.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link">
                                 PMID:14557246
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">AIP may function as a chaperone to maintain mitochondria-targeted preproteins unfolded and to suppress their aggregation.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>AIP/XAP2 is a stoichiometric component of the unliganded AHR 9S core complex (AHR:2xHSP90:AIP:PTGES3), binding directly to the aryl hydrocarbon receptor. It stabilizes the cytosolic AHR-HSP90 complex, enhancing AhR receptivity for ligand and subsequent transcriptional activation. Cryo-EM structural analysis (DOI:10.1038/s41467-022-34773-w) confirms the architectural arrangement of AIP as a brace spanning the HSP90 dimer and AHR client within this complex.</h3>
                 <span class="vote-buttons" data-g="O00170" data-a="FUNCTION: AIP/XAP2 is a stoichiometric component of the unli..." data-r="" data-act="CORE_FUNCTION">
@@ -3739,10 +3737,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -3751,39 +3749,26 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">Directly Involved In:</div>
-                    <div class="function-annotations">
-                        
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045893" target="_blank" class="term-link">
-                                positive regulation of DNA-templated transcription
-                            </a>
-                        </span>
-                        
-                    </div>
-                </div>
-                
 
-                
+
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">In Complex:</div>
                     <span class="badge">
@@ -3792,36 +3777,36 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9447995" target="_blank" class="term-link">
                                 PMID:9447995
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">Here we report the purification of an approximately 38-kDa protein (p38) from COS-1 cell cytosol that is a member of this complex by coprecipitation with a FLAG-tagged AhR.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>AIP binds to the GAF-B domain of phosphodiesterase 2A (PDE2A), an interaction that inhibits TCDD- and cAMP-induced nuclear translocation of AhR in hepatocytes, providing a regulatory link between cAMP signaling and the AhR pathway. AIP also interacts with PDE4A5, further linking it to localized cAMP regulation (DOI:10.1586/eem.10.42). These phosphodiesterase interactions suggest AIP may modulate pituitary tumor biology through cAMP pathway effects.</h3>
                 <span class="vote-buttons" data-g="O00170" data-a="FUNCTION: AIP binds to the GAF-B domain of phosphodiesterase..." data-r="" data-act="CORE_FUNCTION">
@@ -3829,10 +3814,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -3841,626 +3826,649 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
 
-                
+
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17329248" target="_blank" class="term-link">
                                 PMID:17329248
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">We mapped the XAP2 binding site to the GAF-B domain of PDE2A.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
                             GO_REF:0000052
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
                             GO_REF:0000107
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000108.md" target="_blank" class="term-link">
                             GO_REF:0000108
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Automatic assignment of GO terms using logical inference, based on on inter-ontology links</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link">
                             PMID:14557246
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">AIP is a mitochondrial import mediator that binds to both import receptor Tom20 and preproteins.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17329248" target="_blank" class="term-link">
                             PMID:17329248
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Phosphodiesterase 2A forms a complex with the co-chaperone XAP2 and regulates nuclear translocation of the aryl hydrocarbon receptor.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19375531" target="_blank" class="term-link">
                             PMID:19375531
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">XAP2 inhibits glucocorticoid receptor activity in mammalian cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20029029" target="_blank" class="term-link">
                             PMID:20029029
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Regulation of epidermal growth factor receptor trafficking by lysine deacetylase HDAC6.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21170051" target="_blank" class="term-link">
                             PMID:21170051
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Mixed Hsp90-cochaperone complexes are important for the progression of the reaction cycle.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21903422" target="_blank" class="term-link">
                             PMID:21903422
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Mapping a dynamic innate immunity protein interaction network regulating type I interferon production.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22113938" target="_blank" class="term-link">
                             PMID:22113938
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A bead-based approach for large-scale identification of in vitro kinase substrates.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23300914" target="_blank" class="term-link">
                             PMID:23300914
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Structure of the TPR domain of AIP: lack of client protein interaction with the C-terminal α-7 helix of the TPR domain of AIP is sufficient for pituitary adenoma predisposition.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25036637" target="_blank" class="term-link">
                             PMID:25036637
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A quantitative chaperone interaction network reveals the architecture of cellular protein homeostasis pathways.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
                             PMID:28514442
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28634279" target="_blank" class="term-link">
                             PMID:28634279
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">In-frame seven amino-acid duplication in AIP arose over the last 3000 years, disrupts protein interaction and stability and is associated with gigantism.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/31980649" target="_blank" class="term-link">
                             PMID:31980649
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Extensive rewiring of the EGFR network in colorectal cancer cells expressing transforming levels of KRAS(G13D).</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link">
                             PMID:35271311
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">OpenCell: Endogenous tagging for the cartography of human cellular organization.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/8972861" target="_blank" class="term-link">
                             PMID:8972861
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">XAP2, a novel hepatitis B virus X-associated protein that inhibits X transactivation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9447995" target="_blank" class="term-link">
                             PMID:9447995
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Hepatitis B virus X-associated protein 2 is a subunit of the unliganded aryl hydrocarbon receptor core complex and exhibits transcriptional enhancer activity.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8936849
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">AHR:2xHSP90:AIP:PTGES3 binds TCDD</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8937169
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">AHR:TCDD:2xHSP90AB1:AIP:PTGES3 translocates from cytosol to nucleoplasm</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8937191
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">AHR:TCDD:2xHSP90AB1:AIP:PTGES3 dissociates</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8950201
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Expression of Aryl Hydrocarbon receptor-interacting protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1038/s41467-022-34773-w
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Cryo-EM structure of the agonist-bound Hsp90-XAP2-AHR cytosolic complex</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">High-resolution cryo-EM structure of the human agonist-bound AHR cytosolic complex with Hsp90 and XAP2/AIP reveals AIP acting as a structural brace associated with the Hsp90 dimer and the AHR client; the Hsp90 C-terminal MEEVD motif docks into the TPR domain of AIP, consistent with canonical TPR-mediated recruitment of HSP90 co-chaperones.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.18632/oncotarget.24183
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Multi-chaperone function modulation and association with cytoskeletal proteins are key features of the function of AIP in the pituitary gland</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Proteomic analysis shows AIP co-localizes with HSPA9 in the mitochondrial chaperone network, consistent with broader chaperone-network associations beyond the AHR complex.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1586/eem.10.42
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Role of the aryl hydrocarbon receptor-interacting protein in familial isolated pituitary adenoma</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">AIP interacts with phosphodiesterases PDE4A5 and PDE2A3, linking it to localized cAMP regulation and potentially to modulation of AHR nuclear translocation and pituitary tumor biology.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1038/s41574-023-00948-8
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Consensus guideline for the diagnosis and management of pituitary adenomas in childhood and adolescence</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Among childhood-onset GH-secreting pituitary tumours presenting as gigantism, AIP mutations account for approximately 29% of cases; for macroprolactinomas presenting before age 20, the genetic aetiology includes approximately 9% AIP and 5% MEN1.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1093/ejendo/lvad148
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Genetic testing in prolactinomas - a cohort study</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">In sporadic isolated macroprolactinomas diagnosed at age 30 or younger, the germline pathogenic/likely pathogenic variant prevalence was 4.3% overall, with 1.9% AIP; sporadic macroprolactinoma diagnosed before age 18 had approximately 9-fold higher odds of carrying a germline mutation than diagnosis at 18-30.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.3389/fendo.2023.1098367
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">AIP gene germline variants in adult Polish patients with apparently sporadic pituitary macroadenomas</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Penetrance among AIP variant carriers is incomplete and variable, with reported estimates ranging from approximately 12-30%, and some variants/families as low as approximately 6%.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/AIP/AIP-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research for human AIP</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Falcon synthesis supports AIP as a cytosolic HSP90/AHR co-chaperone and scaffold that stabilizes client-protein complexes and lacks PPIase catalytic activity.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -4757,9 +4765,9 @@ this with annotations you find in gene/protein databases, but these can be outda
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -4771,7 +4779,7 @@ this with annotations you find in gene/protein databases, but these can be outda
                 <pre><code>id: O00170
 gene_symbol: AIP
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -4954,10 +4962,12 @@ existing_annotations:
       indirect interaction mediated through the HSP90 chaperone machinery, since EGFR
       is a known HSP90 client. Without more specific evidence for a direct, functional
       AIP-EGFR interaction, this should be considered with caution.
-    action: ACCEPT
-    reason: The interaction was detected by physical interaction evidence (IPI) and is
-      plausible given that AIP is part of the HSP90 co-chaperone system and EGFR is an
-      HSP90 client. While likely indirect, the IPI evidence is valid as recorded.
+    action: UNDECIDED
+    reason: &gt;-
+      The cached publication describes an EGFR interactome screen but does not provide
+      enough accessible detail here to verify the specific AIP-EGFR pair or its directness.
+      This should not be treated as a core AIP function; retain for expert review of the
+      underlying IntAct evidence.
 - term:
     id: GO:0005515
     label: protein binding
@@ -4985,11 +4995,12 @@ existing_annotations:
       interferon signaling. This interaction may be indirect (mediated through HSP90
       which is known to interact with various signaling proteins) or may represent a
       non-physiological interaction from the high-throughput screen.
-    action: ACCEPT
-    reason: The interaction was detected by IPI evidence in a systematic study. While
-      the biological relevance to AIP function is unclear, the physical evidence is
-      valid as recorded. It may reflect AIP participating in HSP90-mediated regulation
-      of signaling proteins.
+    action: UNDECIDED
+    reason: &gt;-
+      The cached paper describes a systematic innate-immunity interactome, but the
+      accessible text does not verify the specific AIP-IRF7 interaction or establish
+      relevance to AIP function. This generic protein-binding call should not be
+      accepted as core AIP biology.
 - term:
     id: GO:0005515
     label: protein binding
@@ -5002,10 +5013,12 @@ existing_annotations:
       is a ubiquitous kinase and the interaction may or may not be physiologically
       significant for AIP function. AIP has a phosphoserine at position 43
       (ECO:0007744|PubMed:23186163), which could be a CK2 substrate site.
-    action: ACCEPT
-    reason: The interaction was detected by IPI evidence and is plausible given that
-      AIP is known to be phosphorylated. The evidence stands as a valid physical
-      interaction record.
+    action: UNDECIDED
+    reason: &gt;-
+      The interaction comes from a large-scale kinase substrate screen, but the cached
+      text does not provide enough specific support for an AIP-CK2alpha interaction or
+      its functional relevance. This should remain a non-core item for expert review,
+      not an accepted core annotation.
 - term:
     id: GO:0005515
     label: protein binding
@@ -5031,10 +5044,12 @@ existing_annotations:
       PRAMEF10 is a PRAME family member. This is from a high-throughput study and the
       biological significance of AIP interacting with PRAMEF10 is unclear. PRAMEF10
       is poorly characterized.
-    action: ACCEPT
-    reason: The interaction was detected by IPI evidence in a systematic interactome
-      study. The biological relevance is uncertain, but the physical interaction evidence
-      is valid as recorded.
+    action: UNDECIDED
+    reason: &gt;-
+      This derives from a proteome-scale interactome study, and the cached text does
+      not verify the specific AIP-PRAMEF10 interaction. PRAMEF10 is not part of the
+      established AIP-HSP90/AHR tumor-suppressor mechanism, so the generic binding
+      annotation should not be accepted as core.
 - term:
     id: GO:0005515
     label: protein binding
@@ -5072,10 +5087,12 @@ existing_annotations:
       (UniProtKB:P00533) from a study on EGFR network rewiring in KRAS-mutant colorectal
       cancer cells (PMID:31980649). AIP was not the focus of this study. The interaction
       with EGFR is likely indirect, mediated through the HSP90 chaperone machinery.
-    action: ACCEPT
-    reason: The interaction was detected by IPI evidence. While likely reflecting
-      indirect interaction through the HSP90 system, the physical evidence is valid
-      as recorded.
+    action: UNDECIDED
+    reason: &gt;-
+      The cached publication describes EGFR network remodeling, but it does not provide
+      enough accessible detail to verify the specific AIP-EGFR pair or distinguish
+      direct binding from indirect HSP90-system association. This is not a core AIP
+      function.
 - term:
     id: GO:0005515
     label: protein binding
@@ -5087,10 +5104,12 @@ existing_annotations:
       network study (PMID:33961781). These are from a high-throughput interactome
       study. The biological significance of these interactions for AIP function is
       unclear.
-    action: ACCEPT
-    reason: The interactions were detected by IPI evidence in a systematic
-      proteome-scale interactome study. While biological relevance to AIP function is
-      uncertain, the physical evidence is valid as recorded.
+    action: UNDECIDED
+    reason: &gt;-
+      The interaction comes from a systematic proteome-scale network study, but the
+      cached text does not verify the specific AIP-PRAMEF10/SYCN pair(s). Their
+      relevance to AIP function is unclear, so this generic binding annotation should
+      not be accepted as core.
 - term:
     id: GO:0005515
     label: protein binding
@@ -5101,9 +5120,12 @@ existing_annotations:
       (UniProtKB:P68400) from the OpenCell study (PMID:35271311), a large-scale
       endogenous tagging and imaging study. This is a second independent confirmation
       of the AIP-CK2alpha interaction after PMID:22113938.
-    action: ACCEPT
-    reason: The interaction was detected by IPI evidence in an independent large-scale
-      study, providing a second line of evidence for the AIP-CK2alpha interaction.
+    action: UNDECIDED
+    reason: &gt;-
+      The OpenCell paper is a large-scale localization and interaction resource, but
+      the cached text does not provide specific support for the AIP-CK2alpha pair.
+      Treat this as an unresolved, non-core protein-binding record rather than accepted
+      AIP biology.
 - term:
     id: GO:0003712
     label: transcription coregulator activity
@@ -5183,6 +5205,11 @@ existing_annotations:
       supporting_text: Here we report the purification of an approximately 38-kDa protein
         (p38) from COS-1 cell cytosol that is a member of this complex by
         coprecipitation with a FLAG-tagged AhR.
+    - reference_id: file:human/AIP/AIP-deep-research-falcon.md
+      supporting_text: &gt;-
+        AIP participates in a cytosolic multiprotein complex with AHR and HSP90
+        (and p23), regulating AHR stability/cytosolic retention and nuclear
+        translocation following ligand activation.
 - term:
     id: GO:0034751
     label: aryl hydrocarbon receptor complex
@@ -5606,9 +5633,6 @@ core_functions:
     the TPR domain disrupt HSP90 binding and are associated with pituitary
     neuroendocrine tumor predisposition (PitNET/PITA1), consistent with a two-hit
     tumor suppressor model (loss of heterozygosity in tumors).
-  directly_involved_in:
-    - id: GO:0006457
-      label: protein folding
   locations:
     - id: GO:0005829
       label: cytosol
@@ -5658,9 +5682,6 @@ core_functions:
     ligand and subsequent transcriptional activation. Cryo-EM structural analysis
     (DOI:10.1038/s41467-022-34773-w) confirms the architectural arrangement of AIP
     as a brace spanning the HSP90 dimer and AHR client within this complex.
-  directly_involved_in:
-    - id: GO:0045893
-      label: positive regulation of DNA-templated transcription
   locations:
     - id: GO:0005829
       label: cytosol
@@ -5838,13 +5859,20 @@ references:
         Penetrance among AIP variant carriers is incomplete and variable, with
         reported estimates ranging from approximately 12-30%, and some
         variants/families as low as approximately 6%.
+- id: file:human/AIP/AIP-deep-research-falcon.md
+  title: Falcon deep research for human AIP
+  findings:
+    - statement: &gt;-
+        Falcon synthesis supports AIP as a cytosolic HSP90/AHR co-chaperone and
+        scaffold that stabilizes client-protein complexes and lacks PPIase
+        catalytic activity.
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/AIP/AIP-ai-review.yaml
+++ b/genes/human/AIP/AIP-ai-review.yaml
@@ -1,7 +1,7 @@
 id: O00170
 gene_symbol: AIP
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -184,10 +184,12 @@ existing_annotations:
       indirect interaction mediated through the HSP90 chaperone machinery, since EGFR
       is a known HSP90 client. Without more specific evidence for a direct, functional
       AIP-EGFR interaction, this should be considered with caution.
-    action: ACCEPT
-    reason: The interaction was detected by physical interaction evidence (IPI) and is
-      plausible given that AIP is part of the HSP90 co-chaperone system and EGFR is an
-      HSP90 client. While likely indirect, the IPI evidence is valid as recorded.
+    action: UNDECIDED
+    reason: >-
+      The cached publication describes an EGFR interactome screen but does not provide
+      enough accessible detail here to verify the specific AIP-EGFR pair or its directness.
+      This should not be treated as a core AIP function; retain for expert review of the
+      underlying IntAct evidence.
 - term:
     id: GO:0005515
     label: protein binding
@@ -215,11 +217,12 @@ existing_annotations:
       interferon signaling. This interaction may be indirect (mediated through HSP90
       which is known to interact with various signaling proteins) or may represent a
       non-physiological interaction from the high-throughput screen.
-    action: ACCEPT
-    reason: The interaction was detected by IPI evidence in a systematic study. While
-      the biological relevance to AIP function is unclear, the physical evidence is
-      valid as recorded. It may reflect AIP participating in HSP90-mediated regulation
-      of signaling proteins.
+    action: UNDECIDED
+    reason: >-
+      The cached paper describes a systematic innate-immunity interactome, but the
+      accessible text does not verify the specific AIP-IRF7 interaction or establish
+      relevance to AIP function. This generic protein-binding call should not be
+      accepted as core AIP biology.
 - term:
     id: GO:0005515
     label: protein binding
@@ -232,10 +235,12 @@ existing_annotations:
       is a ubiquitous kinase and the interaction may or may not be physiologically
       significant for AIP function. AIP has a phosphoserine at position 43
       (ECO:0007744|PubMed:23186163), which could be a CK2 substrate site.
-    action: ACCEPT
-    reason: The interaction was detected by IPI evidence and is plausible given that
-      AIP is known to be phosphorylated. The evidence stands as a valid physical
-      interaction record.
+    action: UNDECIDED
+    reason: >-
+      The interaction comes from a large-scale kinase substrate screen, but the cached
+      text does not provide enough specific support for an AIP-CK2alpha interaction or
+      its functional relevance. This should remain a non-core item for expert review,
+      not an accepted core annotation.
 - term:
     id: GO:0005515
     label: protein binding
@@ -261,10 +266,12 @@ existing_annotations:
       PRAMEF10 is a PRAME family member. This is from a high-throughput study and the
       biological significance of AIP interacting with PRAMEF10 is unclear. PRAMEF10
       is poorly characterized.
-    action: ACCEPT
-    reason: The interaction was detected by IPI evidence in a systematic interactome
-      study. The biological relevance is uncertain, but the physical interaction evidence
-      is valid as recorded.
+    action: UNDECIDED
+    reason: >-
+      This derives from a proteome-scale interactome study, and the cached text does
+      not verify the specific AIP-PRAMEF10 interaction. PRAMEF10 is not part of the
+      established AIP-HSP90/AHR tumor-suppressor mechanism, so the generic binding
+      annotation should not be accepted as core.
 - term:
     id: GO:0005515
     label: protein binding
@@ -302,10 +309,12 @@ existing_annotations:
       (UniProtKB:P00533) from a study on EGFR network rewiring in KRAS-mutant colorectal
       cancer cells (PMID:31980649). AIP was not the focus of this study. The interaction
       with EGFR is likely indirect, mediated through the HSP90 chaperone machinery.
-    action: ACCEPT
-    reason: The interaction was detected by IPI evidence. While likely reflecting
-      indirect interaction through the HSP90 system, the physical evidence is valid
-      as recorded.
+    action: UNDECIDED
+    reason: >-
+      The cached publication describes EGFR network remodeling, but it does not provide
+      enough accessible detail to verify the specific AIP-EGFR pair or distinguish
+      direct binding from indirect HSP90-system association. This is not a core AIP
+      function.
 - term:
     id: GO:0005515
     label: protein binding
@@ -317,10 +326,12 @@ existing_annotations:
       network study (PMID:33961781). These are from a high-throughput interactome
       study. The biological significance of these interactions for AIP function is
       unclear.
-    action: ACCEPT
-    reason: The interactions were detected by IPI evidence in a systematic
-      proteome-scale interactome study. While biological relevance to AIP function is
-      uncertain, the physical evidence is valid as recorded.
+    action: UNDECIDED
+    reason: >-
+      The interaction comes from a systematic proteome-scale network study, but the
+      cached text does not verify the specific AIP-PRAMEF10/SYCN pair(s). Their
+      relevance to AIP function is unclear, so this generic binding annotation should
+      not be accepted as core.
 - term:
     id: GO:0005515
     label: protein binding
@@ -331,9 +342,12 @@ existing_annotations:
       (UniProtKB:P68400) from the OpenCell study (PMID:35271311), a large-scale
       endogenous tagging and imaging study. This is a second independent confirmation
       of the AIP-CK2alpha interaction after PMID:22113938.
-    action: ACCEPT
-    reason: The interaction was detected by IPI evidence in an independent large-scale
-      study, providing a second line of evidence for the AIP-CK2alpha interaction.
+    action: UNDECIDED
+    reason: >-
+      The OpenCell paper is a large-scale localization and interaction resource, but
+      the cached text does not provide specific support for the AIP-CK2alpha pair.
+      Treat this as an unresolved, non-core protein-binding record rather than accepted
+      AIP biology.
 - term:
     id: GO:0003712
     label: transcription coregulator activity
@@ -413,6 +427,11 @@ existing_annotations:
       supporting_text: Here we report the purification of an approximately 38-kDa protein
         (p38) from COS-1 cell cytosol that is a member of this complex by
         coprecipitation with a FLAG-tagged AhR.
+    - reference_id: file:human/AIP/AIP-deep-research-falcon.md
+      supporting_text: >-
+        AIP participates in a cytosolic multiprotein complex with AHR and HSP90
+        (and p23), regulating AHR stability/cytosolic retention and nuclear
+        translocation following ligand activation.
 - term:
     id: GO:0034751
     label: aryl hydrocarbon receptor complex
@@ -836,9 +855,6 @@ core_functions:
     the TPR domain disrupt HSP90 binding and are associated with pituitary
     neuroendocrine tumor predisposition (PitNET/PITA1), consistent with a two-hit
     tumor suppressor model (loss of heterozygosity in tumors).
-  directly_involved_in:
-    - id: GO:0006457
-      label: protein folding
   locations:
     - id: GO:0005829
       label: cytosol
@@ -888,9 +904,6 @@ core_functions:
     ligand and subsequent transcriptional activation. Cryo-EM structural analysis
     (DOI:10.1038/s41467-022-34773-w) confirms the architectural arrangement of AIP
     as a brace spanning the HSP90 dimer and AHR client within this complex.
-  directly_involved_in:
-    - id: GO:0045893
-      label: positive regulation of DNA-templated transcription
   locations:
     - id: GO:0005829
       label: cytosol
@@ -1068,3 +1081,10 @@ references:
         Penetrance among AIP variant carriers is incomplete and variable, with
         reported estimates ranging from approximately 12-30%, and some
         variants/families as low as approximately 6%.
+- id: file:human/AIP/AIP-deep-research-falcon.md
+  title: Falcon deep research for human AIP
+  findings:
+    - statement: >-
+        Falcon synthesis supports AIP as a cytosolic HSP90/AHR co-chaperone and
+        scaffold that stabilizes client-protein complexes and lacks PPIase
+        catalytic activity.

--- a/genes/human/CRYAA/CRYAA-ai-review.html
+++ b/genes/human/CRYAA/CRYAA-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>CRYAA</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P02489" target="_blank" class="term-link">
                         P02489
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>Alpha-crystallin A chain (CRYAA/HSPB4) is a member of the small heat shock protein (sHSP) family that serves dual roles as a major structural component of the ocular lens and as a molecular chaperone with holdase activity. CRYAA forms large oligomeric complexes (approximately 540 kDa) that suppress nonspecific aggregation of destabilized proteins under stress conditions including heat, UV irradiation, and chemical modification (PMID:8943244). Critically, CRYAA acts as a holdase rather than a foldase -- it prevents aggregation of partially unfolded proteins but does NOT actively refold them (as documented by the NOT annotation to GO:0042026 protein refolding, ISS from bovine ortholog). CRYAA hetero-oligomerizes with CRYAB (HSPB5) and contributes to lens transparency and refractive index. Post-translational modifications including phosphorylation at T148 (mediated by mTORC2) regulate chaperone capacity. Mutations in CRYAA (e.g., R116H, R116C) cause autosomal dominant congenital cataracts through loss of chaperone activity and increased protein aggregation (PMID:18407550). CRYAA also has anti-apoptotic activity, binding and sequestering pro-apoptotic Bax and Bcl-X(S) proteins (PMID:14752512).</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043066" target="_blank" class="term-link">
                                     GO:0043066
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of apoptotic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -795,90 +795,90 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for negative regulation of apoptotic process. CRYAA has well-documented anti-apoptotic activity. PMID:14752512 demonstrated that alphaA- and alphaB-crystallins bind to pro-apoptotic Bax and Bcl-X(S) proteins via GST pulldown and coimmunoprecipitation, preventing their translocation from cytosol to mitochondria during staurosporine-induced apoptosis. The R116C cataract mutant shows much weaker affinity to Bax and Bcl-X(S) (PMID:14752512). PMID:14512969 showed that the R49C mutant failed to protect lens epithelial cells from staurosporine-induced apoptosis. The IBA annotation is phylogenetically appropriate for sHSP family members with anti-apoptotic activity. This is a secondary/non-core function for CRYAA beyond its primary structural and chaperone roles.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Anti-apoptotic activity is well-supported by direct experimental evidence from PMID:14752512 and PMID:14512969, and the IBA annotation is phylogenetically sound. However, this is a secondary function compared to the core structural and chaperone holdase roles in the lens.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link">
                                         PMID:14752512
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">alphaA- and alphaB-crystallins prevent staurosporine-induced apoptosis through interactions with members of the Bcl-2 family</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link">
                                         PMID:14752512
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">alpha-crystallins bind to Bax and Bcl-X(S) both in vitro and in vivo</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14512969" target="_blank" class="term-link">
                                         PMID:14512969
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">unlike wild-type CRYAA, the R49C mutant protein was abnormally localized to the nucleus and failed to protect from staurosporine-induced apoptotic cell death</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -890,77 +890,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for cytoplasm localization. CRYAA is abundantly expressed in the cytoplasm of lens fiber cells. Multiple IDA-level studies confirm cytoplasmic localization including PMID:19464326, PMID:14752512, PMID:29259299, PMID:19503744, PMID:26004348, and PMID:30340470. UniProt also lists cytoplasm as a confirmed subcellular location. The IBA annotation is consistent with direct experimental evidence and is phylogenetically appropriate.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization is the primary location of CRYAA, confirmed by multiple independent IDA studies using fluorescence microscopy in lens epithelial cells and other cell types. The IBA annotation is well supported.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/29259299" target="_blank" class="term-link">
                                         PMID:29259299
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Wild-type alphaA-crystallin was also equally distributed in the cytoplasm</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link">
                                         PMID:14752512
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">alpha-crystallins prevent the translocation of Bax and Bcl-X(S) from cytosol into mitochondria during staurosporine-induced apoptosis</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -972,64 +972,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IBA annotation for nucleus localization. PMID:19464326 showed that CRYAA (HSPB4) translocates to sub-nuclear structures (SC35 speckles) during heat shock. UniProt notes that CRYAA translocates to the nucleus during heat shock and resides in SC35 splicing speckles. This is a stress-induced secondary localization rather than the primary constitutive location. The IBA annotation is phylogenetically appropriate for sHSP family members that show nuclear translocation under stress.
+                            <strong>Summary:</strong> IBA annotation for nucleus localization. UniProt notes that CRYAA (HSPB4) translocates to the nucleus during heat shock and resides in SC35 splicing speckles. This is a stress-induced secondary localization rather than the primary constitutive location. The IBA annotation is phylogenetically appropriate for sHSP family members that show nuclear translocation under stress.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Nuclear localization is real but conditional (stress-induced). CRYAA translocates to SC35 splicing speckles during heat shock (PMID:19464326). This is not the primary constitutive localization of CRYAA, which is cytoplasmic. Keeping as non-core reflects that this is a secondary, stress-dependent localization.
+                            <strong>Reason:</strong> Nuclear localization is real but conditional (stress-induced). UniProt records CRYAA translocation to SC35 splicing speckles during heat shock. This is not the primary constitutive localization of CRYAA, which is cytoplasmic. Keeping as non-core reflects that this is a secondary, stress-dependent localization.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
-                                        PMID:19464326
-                                    </a>
-                                    
+
+                                    UniProtKB:P02489
+
                                 </span>
-                                
-                                <div class="support-text">HSPB7 constitutively localized to SC35 splicing speckles</div>
-                                
+
+                                <div class="support-text">Nucleus. Note=Translocates to the nucleus during heat shock and resides in sub-nuclear structures known as SC35 speckles or nuclear splicing speckles.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009408" target="_blank" class="term-link">
                                     GO:0009408
                                 </a>
                             </span>
                             <span class="term-label">response to heat</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1041,64 +1039,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for response to heat. CRYAA is a member of the small heat shock protein (sHSP) family and its chaperone-like activity was explicitly demonstrated using heat-induced aggregation assays (PMID:8943244). The protein suppresses heat-induced aggregation of aldose reductase and other lens proteins. CRYAA also translocates to nuclear SC35 speckles during heat shock (PMID:19464326). The IBA annotation is phylogenetically appropriate for the sHSP family whose hallmark is response to heat stress.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Response to heat is a core function of sHSP family members. CRYAA suppresses heat-induced protein aggregation (PMID:8943244) and shows heat-shock-dependent nuclear translocation (PMID:19464326). The IBA annotation is well justified for the sHSP family.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8943244" target="_blank" class="term-link">
                                         PMID:8943244
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">both WT and W9F subunits completely suppressed the heat-induced aggregation of aldose reductase</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CRYAA/CRYAA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">As a chaperone, HSPB4 binds partially unfolded proteins to prevent misfolding and aggregation, thereby maintaining lens proteostasis and cell survival</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1110,77 +1119,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for protein refolding. This is problematic for CRYAA. While some sHSP family members can assist in protein refolding (e.g., HSPB1/Hsp27 cooperates with Hsp70 to refold substrates), CRYAA specifically acts as a holdase that prevents aggregation but does NOT refold proteins. This is documented by the NOT annotation to GO:0042026 (ISS from bovine ortholog, GO_REF:0000024). The IBA propagation from the broader sHSP family is overly broad for CRYAA, which lacks foldase activity. PMID:19464326 showed that HSPB1 and HSPB5 kept heat-unfolded substrates folding-competent, but HSPB7 did not support refolding, highlighting functional divergence within the family. CRYAA has holdase but not foldase activity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CRYAA is a holdase, not a foldase. It prevents aggregation of denatured proteins but does not refold them. The NOT annotation to GO:0042026 (ISS, GO_REF:0000024) explicitly documents this. The IBA propagation from the broader sHSP family is incorrect for CRYAA because not all sHSP members have refolding activity. There is functional divergence within the family (PMID:19464326).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8943244" target="_blank" class="term-link">
                                         PMID:8943244
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">alpha-crystallin subunits associate to form large oligomeric aggregates that express chaperone-like activity, as defined by the ability to suppress nonspecific aggregation of proteins destabilized by treatment with a variety of denaturants</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
                                         PMID:19464326
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Unlike HSPB1 and HSPB5, that chaperoned heat unfolded substrates and kept them folding competent, HSPB7 did not support refolding</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1192,88 +1201,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). CRYAA/HSPB4 does interact with partially unfolded/destabilized proteins, but the term &#34;unfolded protein binding&#34; is problematic because it implies a simple binding function rather than the active chaperone holdase activity that CRYAA performs. CRYAA suppresses nonspecific aggregation of destabilized proteins (PMID:8943244) but does NOT refold them -- it is a holdase, not a foldase. The IBA annotation is phylogenetically propagated from sHSP family members across Drosophila, zebrafish, and mammals, which is appropriate for the family-level chaperone function. However, the term itself needs replacement. GO:0044183 &#34;protein folding chaperone&#34; is the closest available MF term, defined as &#34;Binding to a protein or a protein-containing complex to assist the protein folding process.&#34; This is an imperfect replacement because CRYAA specifically does NOT assist in protein folding -- it prevents aggregation (holdase activity). A dedicated holdase-specific GO term is needed. As a biological process annotation, GO:0050821 &#34;protein stabilization&#34; (defined as &#34;Any process involved in maintaining the structure and integrity of a protein and preventing it from degradation or aggregation&#34;) is also relevant and is already annotated for CRYAA via PMID:12235146.
+                            <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). CRYAA/HSPB4 does interact with partially unfolded/destabilized proteins, but the term &#34;unfolded protein binding&#34; is problematic because it implies a simple binding function rather than the active chaperone holdase activity that CRYAA performs. CRYAA suppresses nonspecific aggregation of destabilized proteins (PMID:8943244) but does NOT refold them -- it is a holdase, not a foldase. The IBA annotation is phylogenetically propagated from sHSP family members across Drosophila, zebrafish, and mammals, which is appropriate for the family-level chaperone function. However, the term itself needs replacement. GO:0140309 &#34;unfolded protein holdase activity&#34; is the appropriate MF term for ATP-independent binding to unfolded proteins to prevent their aggregation without active refolding. As a biological process annotation, GO:0050821 &#34;protein stabilization&#34; (defined as &#34;Any process involved in maintaining the structure and integrity of a protein and preventing it from degradation or aggregation&#34;) is also relevant and is already annotated for CRYAA via PMID:12235146.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> GO:0051082 is being obsoleted. CRYAA has well-documented chaperone-like holdase activity: it suppresses aggregation of heat-denatured aldose reductase and singlet-oxygen-damaged gamma-crystallin (PMID:8943244). However, it does NOT refold proteins (NOT annotation to GO:0042026 protein refolding, ISS). The best available interim MF replacement is GO:0044183 &#34;protein folding chaperone,&#34; though this term is not ideal because its definition references &#34;protein folding process&#34; which is not what CRYAA does. A new holdase-specific term should be requested. GO:0050821 &#34;protein stabilization&#34; is appropriate as a BP term.
+                            <strong>Reason:</strong> GO:0051082 is being obsoleted. CRYAA has well-documented chaperone-like holdase activity: it suppresses aggregation of heat-denatured aldose reductase and singlet-oxygen-damaged gamma-crystallin (PMID:8943244). However, it does NOT refold proteins (NOT annotation to GO:0042026 protein refolding, ISS). The appropriate MF replacement is GO:0140309 &#34;unfolded protein holdase activity.&#34; GO:0050821 &#34;protein stabilization&#34; is appropriate as a BP term.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140309" target="_blank" class="term-link">
+                                    unfolded protein holdase activity
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8943244" target="_blank" class="term-link">
                                         PMID:8943244
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">alpha-crystallin subunits associate to form large oligomeric aggregates that express chaperone-like activity, as defined by the ability to suppress nonspecific aggregation of proteins destabilized by treatment with a variety of denaturants including heat, UV irradiation, and chemical modification</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8943244" target="_blank" class="term-link">
                                         PMID:8943244
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">both WT and W9F subunits completely suppressed the heat-induced aggregation of aldose reductase</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0002088" target="_blank" class="term-link">
                                     GO:0002088
                                 </a>
                             </span>
                             <span class="term-label">lens development in camera-type eye</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1285,77 +1294,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for lens development in camera-type eye. CRYAA is the most abundantly expressed protein in the ocular lens and is essential for normal lens development and transparency. UniProt states it is expressed in the eye lens (PubMed:12356833, PubMed:23255486). Knockout studies in zebrafish show abnormal differentiation of lens fiber cells when alpha-crystallins are absent (cited in PMID:29259299). Numerous CRYAA mutations cause congenital cataracts (PMID:9467006, PMID:14512969, PMID:18407550), demonstrating the essential role in lens development. The IBA annotation is appropriate for crystallin family members involved in lens development.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CRYAA is a core lens protein essential for normal lens development. Mutations consistently cause congenital cataracts (PMID:9467006, PMID:14512969, PMID:18407550). The IBA annotation appropriately captures this conserved developmental role.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14512969" target="_blank" class="term-link">
                                         PMID:14512969
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The alphaA-crystallin (CRYAA) gene (CRYAA) encodes a member of the small-heat-shock protein (sHSP) family of molecular chaperones and is primarily and abundantly expressed in the ocular lens</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9467006" target="_blank" class="term-link">
                                         PMID:9467006
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we found that a missense mutation, R116C, is associated with ADCC in this family</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005198" target="_blank" class="term-link">
                                     GO:0005198
                                 </a>
                             </span>
                             <span class="term-label">structural molecule activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1367,57 +1376,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for structural molecule activity. CRYAA is a major structural protein of the eye lens contributing to transparency and refractive index (UniProt FUNCTION section). While correct, the more specific child term GO:0005212 &#34;structural constituent of eye lens&#34; is also annotated and is more informative. This broader IEA term is acceptable as a parent term but less informative than the specific one.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While structural molecule activity is correct for CRYAA as a major structural lens protein, the more specific child term GO:0005212 &#34;structural constituent of eye lens&#34; is already annotated and is more informative. Modifying to the specific term for consistency with the IDA annotation review of the same GO term.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005212" target="_blank" class="term-link">
                                     structural constituent of eye lens
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005212" target="_blank" class="term-link">
                                     GO:0005212
                                 </a>
                             </span>
                             <span class="term-label">structural constituent of eye lens</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1429,46 +1438,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for structural constituent of eye lens. This is one of the most appropriate terms for CRYAA. As alphaA-crystallin, it is the most abundant soluble protein in the lens, contributing to transparency and refractive index (UniProt FUNCTION: &#34;Contributes to the transparency and refractive index of the lens&#34;). The IEA mapping is accurate and captures a core function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CRYAA is the defining structural constituent of the eye lens. This is a core function annotation. UniProt documents that CRYAA contributes to transparency and refractive index of the lens, confirmed by the fact that mutations cause cataracts (PMID:9467006, PMID:18407550).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1480,46 +1489,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for nucleus based on UniProt subcellular location mapping. UniProt lists nucleus as a confirmed subcellular location, noting that CRYAA translocates to the nucleus during heat shock and resides in SC35 speckles (PMID:19464326). The IEA mapping is correct and consistent with the IBA and IDA annotations for the same term. However, nuclear localization is stress-induced and secondary, not constitutive.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The IEA mapping from UniProt subcellular location is accurate. Nuclear localization is supported by PMID:19464326 showing heat-shock-induced translocation to SC35 speckles. However, this is a stress-dependent secondary localization, not the primary constitutive location of CRYAA. Marked as KEEP_AS_NON_CORE for consistency with the IBA and IDA annotations for the same GO term.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1531,46 +1540,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for cytoplasm. Cytoplasmic localization is the primary constitutive location of CRYAA, confirmed by multiple IDA-level studies (PMID:19464326, PMID:29259299, PMID:19503744, PMID:14752512, etc.) and UniProt subcellular location annotation. The IEA mapping is correct.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasm is the primary constitutive localization of CRYAA, well supported by multiple independent studies. The IEA is consistent with IBA and IDA annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007601" target="_blank" class="term-link">
                                     GO:0007601
                                 </a>
                             </span>
                             <span class="term-label">visual perception</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1582,46 +1591,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for visual perception based on UniProt keyword mapping. CRYAA is essential for lens transparency, and mutations cause cataracts that impair vision (PMID:9467006, PMID:14512969). However, CRYAA does not directly participate in the visual perception signaling pathway (phototransduction). Rather, it maintains the structural integrity of the lens through which light passes. This term is somewhat over-annotated as it implies a role in visual signaling rather than lens maintenance.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While CRYAA is essential for lens transparency and mutations cause cataracts that impair vision, the term &#34;visual perception&#34; implies involvement in the phototransduction/visual signaling pathway. CRYAA contributes to vision indirectly by maintaining lens structure, not by participating in the perception process itself. GO:0002088 &#34;lens development in camera-type eye&#34; and GO:0005212 &#34;structural constituent of eye lens&#34; better capture the actual role.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
                                     GO:0046872
                                 </a>
                             </span>
                             <span class="term-label">metal ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1633,250 +1642,228 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for metal ion binding from UniProt keyword mapping. UniProt documents that CRYAA binds zinc ions, with the zinc-binding motif created from residues of 3 different molecules (His-100, Glu-102 from one molecule; His-107 and His-154 from additional molecules) to create tetrahedral coordination geometry (PMID:22890888). Inter-subunit bridging via zinc ions enhances oligomer stability. This is a legitimate but generic annotation; a more specific term like &#34;zinc ion binding&#34; (GO:0008270) would be more informative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Metal ion binding is too generic. The specific metal bound is zinc, which is important for oligomer stability (PMID:22890888 via UniProt). GO:0008270 &#34;zinc ion binding&#34; would be more informative.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
                                     zinc ion binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11700327" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11700327
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Detection of protein-protein interactions among lens crystal...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P02489" data-a="GO:0005515" data-r="PMID:11700327" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="P02489" data-a="GO:0005515" data-r="PMID:11700327" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from PMID:11700327. This study used a mammalian two-hybrid system to detect interactions between alphaA-crystallin and other lens crystallins (alphaB-, betaB2-, and gammaC-crystallin) and Hsp27 in HeLa cells. The interactions between alpha- crystallins and beta/gamma-crystallins were about one-third the intensity of alphaA-alphaB interactions. While the interactions are real and functionally relevant (crystallin-crystallin interactions maintain lens transparency), &#34;protein binding&#34; is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> &#34;Protein binding&#34; is too vague. The actual interactions detected are crystallin-crystallin interactions relevant to the chaperone holdase function. GO:0044183 &#34;protein folding chaperone&#34; better captures the molecular function, as CRYAA interacts with destabilized crystallins to prevent their aggregation.
+                            <strong>Reason:</strong> &#34;Protein binding&#34; is too vague. The actual interactions detected are crystallin-crystallin interactions, not direct evidence for a specific molecular-function replacement. CRYAA holdase activity is supported by aggregation-suppression assays elsewhere; this two-hybrid interaction record should not be used to infer a chaperone term.
                         </div>
-                        
-                        
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-                            
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
-                                </a>
-                            </span>
-                            
-                        </div>
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11700327" target="_blank" class="term-link">
                                         PMID:11700327
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">there were interactions between alphaA- (or alphaB-) and betaB2- or gammaC-crystallins but with an intensity of one-third that of alphaA-alphaB interactions</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12601044" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12601044
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Alteration of protein-protein interactions of congenital cat...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P02489" data-a="GO:0005515" data-r="PMID:12601044" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="P02489" data-a="GO:0005515" data-r="PMID:12601044" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from PMID:12601044. This study used the mammalian two-hybrid system to show that cataract-causing R116C alphaA-crystallin mutant has altered protein-protein interactions with crystallins. The wild-type CRYAA interactions with betaB2- and gammaC-crystallin decreased in the R116C mutant, while interactions with alphaB-crystallin and Hsp27 increased. &#34;Protein binding&#34; is uninformative for the functional context.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> &#34;Protein binding&#34; is too generic. The crystallin-crystallin interactions documented are functionally relevant to chaperone holdase activity and lens structural integrity. The identical protein binding annotation (GO:0042802) from the same paper better captures the self-interaction aspect.
+                            <strong>Reason:</strong> &#34;Protein binding&#34; is too generic. The crystallin-crystallin interactions documented are functionally relevant to lens protein organization, but altered two-hybrid interactions in a cataract mutant are not direct evidence for a chaperone molecular-function replacement. Keep the mechanistic context without treating generic protein binding as a core function.
                         </div>
-                        
-                        
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-                            
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
-                                </a>
-                            </span>
-                            
-                        </div>
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12601044" target="_blank" class="term-link">
                                         PMID:12601044
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">for the R116C alphaA-crystallin, the interactions with betaB2- and gammaC-crystallin decreased and those with alphaB-crystallin and heat-shock protein (Hsp)27 increased</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19651604" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19651604
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The eye lens chaperone alpha-crystallin forms defined globul...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1888,86 +1875,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from PMID:19651604. This study analyzed quaternary structures of alpha-crystallins and showed that alphaA-crystallin forms defined oligomers of 24 subunits as well as smaller oligomers and large clusters. The protein-protein interactions documented here are oligomerization (homo- and hetero-oligomerization with CRYAB), which is intrinsic to the structural and chaperone function. &#34;Protein binding&#34; is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is too vague. The interactions are homo-oligomerization and hetero- oligomerization relevant to CRYAA structural and chaperone function. GO:0042802 &#34;identical protein binding&#34; is already annotated from this reference, which is more specific.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     identical protein binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19651604" target="_blank" class="term-link">
                                         PMID:19651604
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">alphaA-Crystallin forms, in addition to complexes of 24 subunits, also smaller oligomers and large clusters consisting of individual oligomers</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22085609" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22085609
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Temperature-dependent structural and functional properties o...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1979,287 +1966,254 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from PMID:22085609, which studied the F71L mutant of alphaA-crystallin. This study examined structural and functional properties of the cataract- causing mutant. The interactions documented are likely crystallin oligomerization relevant to the chaperone function. &#34;Protein binding&#34; is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is too generic. The interactions documented in this paper are crystallin self-interactions (oligomerization) relevant to chaperone function. GO:0042802 &#34;identical protein binding&#34; is already annotated from this reference.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     identical protein binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22153508" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22153508
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The polydispersity of αB-crystallin is rationalized by an in...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P02489" data-a="GO:0005515" data-r="PMID:22153508" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="P02489" data-a="GO:0005515" data-r="PMID:22153508" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from PMID:22153508, which studied the polyhedral architecture of alphaB-crystallin. While primarily focused on CRYAB, interactions with CRYAA may have been detected in this study. &#34;Protein binding&#34; is uninformative and should be replaced with more specific terms for the alpha-crystallin hetero-oligomerization.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> &#34;Protein binding&#34; is too vague. The context is alpha-crystallin oligomerization. A more specific term describing hetero-oligomerization or structural complex formation would be more informative.
+                            <strong>Reason:</strong> &#34;Protein binding&#34; is too vague. The context is alpha-crystallin oligomerization. A more specific term describing hetero-oligomerization or structural complex formation would be more informative, but GO:0042802 should not be used here because this row is not specific to CRYAA self-interaction.
                         </div>
-                        
-                        
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-                            
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
-                                    identical protein binding
-                                </a>
-                            </span>
-                            
-                        </div>
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23188086" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23188086
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Binding determinants of the small heat shock protein, αB-cry...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P02489" data-a="GO:0005515" data-r="PMID:23188086" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="P02489" data-a="GO:0005515" data-r="PMID:23188086" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from PMID:23188086. This study investigated binding determinants of alphaB-crystallin, specifically recognition of the IxI motif. The IxI motif is important for sHSP oligomerization and substrate interaction. Interactions with CRYAA would be in the context of hetero-oligomerization. &#34;Protein binding&#34; is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> &#34;Protein binding&#34; is too vague. The context is sHSP subunit interactions via the IxI motif, relevant to hetero-oligomerization with CRYAB.
+                            <strong>Reason:</strong> &#34;Protein binding&#34; is too vague. The context is sHSP subunit interactions via the IxI motif, relevant to hetero-oligomerization with CRYAB rather than identical CRYAA self-binding.
                         </div>
-                        
-                        
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-                            
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
-                                    identical protein binding
-                                </a>
-                            </span>
-                            
-                        </div>
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25416956
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A proteome-scale map of the human interactome network.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P02489" data-a="GO:0005515" data-r="PMID:25416956" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="P02489" data-a="GO:0005515" data-r="PMID:25416956" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from PMID:25416956 (proteome-scale interactome map). This is a high-throughput study. &#34;Protein binding&#34; from high-throughput interactome studies is uninformative and lacks the context of specific functional interactions.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> &#34;Protein binding&#34; from high-throughput interactome mapping is too generic. CRYAA is known to form homo- and hetero-oligomers; GO:0042802 &#34;identical protein binding&#34; is already annotated from this reference. The generic protein binding annotation adds no information.
+                            <strong>Reason:</strong> &#34;Protein binding&#34; from high-throughput interactome mapping is too generic. CRYAA is known to form homo- and hetero-oligomers, but this broad interactome row is not specific enough to justify replacing the annotation with identical protein binding.
                         </div>
-                        
-                        
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-                            
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
-                                    identical protein binding
-                                </a>
-                            </span>
-                            
-                        </div>
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25910212
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Widespread macromolecular interaction perturbations in human...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2271,57 +2225,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from PMID:25910212 (macromolecular interaction perturbations in human genetic disorders). This is a high-throughput study examining how disease-associated mutations perturb protein interactions. &#34;Protein binding&#34; from such studies is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; from a high-throughput interaction perturbation study does not tell us anything specific about CRYAA function. The actual molecular functions (chaperone holdase, structural lens protein, oligomerization) are better captured by other annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/29892012" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:29892012
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An interactome perturbation framework prioritizes damaging m...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2333,57 +2287,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from PMID:29892012 (interactome perturbation framework for developmental disorders). This is a high-throughput study. &#34;Protein binding&#34; is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; from a high-throughput interactome perturbation study is too generic to be informative about CRYAA function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31515488
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Extensive disruption of protein interactions by genetic vari...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2395,130 +2349,119 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from PMID:31515488 (disruption of protein interactions by genetic variants). This is a high-throughput study examining interaction perturbations. &#34;Protein binding&#34; is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; from high-throughput variant effect mapping is too generic.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32296183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A reference map of the human binary protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P02489" data-a="GO:0005515" data-r="PMID:32296183" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="P02489" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from PMID:32296183 (reference map of human binary protein interactome). This is a high-throughput interactome mapping study. &#34;Protein binding&#34; is uninformative. GO:0042802 is already annotated from this same reference.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> &#34;Protein binding&#34; is too vague. GO:0042802 &#34;identical protein binding&#34; is already annotated from this same reference and is more informative for CRYAA self-interactions.
+                            <strong>Reason:</strong> &#34;Protein binding&#34; is too vague. Although GO:0042802 &#34;identical protein binding&#34; is annotated separately from this reference, this broad interactome protein-binding row should not itself be converted to a self-interaction assertion.
                         </div>
-                        
-                        
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-                            
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
-                                    identical protein binding
-                                </a>
-                            </span>
-                            
-                        </div>
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32814053
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interactome Mapping Provides a Network of Neurodegenerative ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2530,57 +2473,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from PMID:32814053 (interactome mapping of neurodegenerative disease proteins). This is a high-throughput study. &#34;Protein binding&#34; is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; from a high-throughput neurodegenerative disease interactome study is too generic. The finding that CRYAA interacts with disease-associated proteins could be relevant to its chaperone holdase function but &#34;protein binding&#34; does not capture this.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2592,57 +2535,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from PMID:33961781 (dual proteome-scale networks for cell-specific interactome). This is a high-throughput study. &#34;Protein binding&#34; is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; from a high-throughput proteome-scale interactome study is too generic.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12601044" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12601044
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Alteration of protein-protein interactions of congenital cat...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2654,75 +2597,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for identical protein binding from PMID:12601044. This study demonstrated alphaA-crystallin self-interaction using a mammalian two-hybrid system, showing that the R116C cataract mutant had altered self-interaction. Self-interaction (homo-oligomerization) is a core property of CRYAA -- it forms homodimers and homotetramers as building blocks of larger homo-oligomers (UniProt). This annotation appropriately captures the self-interaction property.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CRYAA homo-oligomerization is a core structural property essential for both its lens structural role and chaperone function. The R116C cataract mutation alters this self- interaction (PMID:12601044), confirming functional importance.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12601044" target="_blank" class="term-link">
                                         PMID:12601044
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">for the R116C alphaA-crystallin, the interactions with betaB2- and gammaC-crystallin decreased and those with alphaB-crystallin and heat-shock protein (Hsp)27 increased</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19651604" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19651604
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The eye lens chaperone alpha-crystallin forms defined globul...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2734,75 +2677,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for identical protein binding from PMID:19651604. This study demonstrated that alphaA-crystallin forms defined oligomers of 24 subunits as well as smaller oligomers and large clusters using biophysical methods and electron microscopy. The self-interaction (homo-oligomerization) is directly demonstrated.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CRYAA homo-oligomerization is directly demonstrated by biophysical analysis showing 24-subunit oligomers (PMID:19651604). This is a core property of the protein.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19651604" target="_blank" class="term-link">
                                         PMID:19651604
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">alphaA-Crystallin forms, in addition to complexes of 24 subunits, also smaller oligomers and large clusters consisting of individual oligomers</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22085609" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22085609
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Temperature-dependent structural and functional properties o...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2814,57 +2757,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for identical protein binding from PMID:22085609. The F71L cataract-causing mutant study examined structural and functional properties including oligomerization. Self-interaction of CRYAA is documented.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Self-interaction (homo-oligomerization) is a core property of CRYAA confirmed by multiple studies. The F71L mutant study provides additional evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25416956
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A proteome-scale map of the human interactome network.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2876,57 +2819,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for identical protein binding from PMID:25416956 (proteome-scale interactome map). CRYAA-CRYAA self-interaction is documented in this high-throughput study. UniProt lists 12 experiments supporting CRYAA self-interaction (IntAct). While from a high- throughput study, the self-interaction is well validated by targeted studies.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CRYAA homo-oligomerization is well documented. The high-throughput detection confirms targeted studies. UniProt lists 12 experiments for CRYAA-CRYAA interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32296183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A reference map of the human binary protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2938,46 +2881,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for identical protein binding from PMID:32296183 (reference map of human binary protein interactome). CRYAA self-interaction detected in this systematic study. Consistent with extensive prior evidence for homo-oligomerization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CRYAA homo-oligomerization is a well-established core property, and this high-throughput study provides consistent confirmatory evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2989,46 +2932,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for nucleoplasm based on curation of immunofluorescence data (GO_REF:0000052). PMID:19464326 showed that CRYAA (HSPB4) translocates to the nucleus during heat shock and resides in SC35 speckles, which are nuclear sub-structures within the nucleoplasm. The nucleoplasm localization is consistent with this stress-dependent translocation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization is supported by evidence of heat-shock-induced translocation to SC35 speckles (PMID:19464326). However, this is a stress-dependent secondary localization, not the primary constitutive location.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3040,57 +2983,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for cytosol based on curation of immunofluorescence data (GO_REF:0000052). CRYAA is a soluble cytoplasmic protein that exists free in the cytosol as oligomeric complexes. Multiple studies show uniform cytoplasmic distribution (PMID:29259299, PMID:19503744). Cytosol is a more specific sub-compartment of cytoplasm and is consistent with the known biology.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol is the primary constitutive location of CRYAA, where it exists as soluble oligomeric complexes. Consistent with multiple IDA studies showing cytoplasmic distribution.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/29259299" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:29259299
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Two novel mutations identified in ADCC families impair cryst...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3102,75 +3045,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for cytoplasm from PMID:29259299. This study used fluorescence microscopy of GFP-tagged wild-type alphaA-crystallin in human lens epithelial cells and showed that wild-type CRYAA was equally distributed in the cytoplasm. The mutant (p.116_118del) accumulated at the nuclear peripheral membrane.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct fluorescence microscopy evidence showing wild-type CRYAA is uniformly distributed in the cytoplasm of human lens epithelial cells (PMID:29259299).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/29259299" target="_blank" class="term-link">
                                         PMID:29259299
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Wild-type alphaA-crystallin was also equally distributed in the cytoplasm</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26004348" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26004348
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Mutation analysis of two families with inherited congenital ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3182,57 +3125,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for cytoplasm from PMID:26004348. This study on congenital cataract families included subcellular localization analysis. UniProt lists this as a supporting reference for cytoplasmic localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization supported by localization data from PMID:26004348, consistent with the primary constitutive location of CRYAA.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19503744" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19503744
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An alphaA-crystallin gene mutation, Arg12Cys, causing inheri...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3244,57 +3187,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for cytoplasm from PMID:19503744. This study on the R12C alphaA-crystallin mutation characterized subcellular localization. UniProt lists this as supporting evidence for cytoplasmic localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization is documented as the primary location in this study of the R12C mutant, consistent with multiple other studies.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30340470" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30340470
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A novel mutation in the CRYAA gene associated with congenita...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3306,57 +3249,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for cytoplasm from PMID:30340470. This study on a novel CRYAA mutation (congenital cataract and microphthalmia) included subcellular localization analysis. UniProt lists this as supporting evidence for cytoplasmic localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization confirmed by this cataract mutation study, consistent with the known primary location of CRYAA.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005198" target="_blank" class="term-link">
                                     GO:0005198
                                 </a>
                             </span>
                             <span class="term-label">structural molecule activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16303126
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Lenticular chaperones suppress the aggregation of the catara...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -3368,99 +3311,99 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for structural molecule activity from PMID:16303126. This study showed that alpha-crystallins (alphaA- and alphaB-) suppress aggregation of the cataract-causing T5P gammaC-crystallin mutant both in vitro and in transfected cells. The study demonstrated a dual role: increasing solubility and reducing aggregate size. However, &#34;structural molecule activity&#34; is not the best descriptor for this chaperone function. The paper is really about chaperone holdase activity, not structural function per se. The more specific term GO:0005212 &#34;structural constituent of eye lens&#34; better captures the structural role.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> The evidence in PMID:16303126 is about chaperone holdase activity (suppressing aggregation of T5P gammaC-crystallin), not structural molecule activity per se. GO:0044183 &#34;protein folding chaperone&#34; better captures the molecular function demonstrated. For the true structural role, GO:0005212 is already annotated.
+                            <strong>Reason:</strong> The evidence in PMID:16303126 is about chaperone holdase activity (suppressing aggregation of T5P gammaC-crystallin), not structural molecule activity per se. GO:0140309 &#34;unfolded protein holdase activity&#34; better captures the molecular function demonstrated. For the true structural role, GO:0005212 is already annotated.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140309" target="_blank" class="term-link">
+                                    unfolded protein holdase activity
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link">
                                         PMID:16303126
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the major lenticular protein chaperones, alpha A- and alpha B-crystallin, increased the solubility of the T5P gamma C-crystallin both in vitro and in transfected cells</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link">
                                         PMID:16303126
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the size of the T5P gamma C-crystallin aggregates were also significantly reduced in the presence of the lenticular chaperones</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
                                     GO:0032991
                                 </a>
                             </span>
                             <span class="term-label">protein-containing complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16303126
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Lenticular chaperones suppress the aggregation of the catara...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3472,88 +3415,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for protein-containing complex from PMID:16303126. CRYAA forms large oligomeric complexes of approximately 540 kDa (PMID:8943244). UniProt documents that CRYAA forms heteropolymers (3 CRYAA : 1 CRYAB), homodimers, homotetramers, and larger homo-oligomers. It is also part of a complex with BFSP1 and BFSP2 for lens intermediate filament formation. The protein-containing complex annotation is correct but very generic.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CRYAA forms large homo- and hetero-oligomeric complexes as a core feature of its biology. The annotation is correct, though generic. The oligomeric complex is essential for both structural and chaperone functions.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8943244" target="_blank" class="term-link">
                                         PMID:8943244
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">aggregates of approximately 540 kDa were formed from a tryptophan-free alphaA mutant (W9F)</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link">
                                         PMID:16303126
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the major lenticular protein chaperones, alpha A- and alpha B-crystallin, increased the solubility of the T5P gamma C-crystallin both in vitro and in transfected cells</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16303126
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Lenticular chaperones suppress the aggregation of the catara...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3565,57 +3508,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for identical protein binding from PMID:16303126. This study used both in vitro sedimentation assays and cell transfection to demonstrate that alpha-crystallins form complexes. CRYAA homo-oligomerization is well established and essential for function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CRYAA homo-oligomerization is a core property demonstrated in this study and many others. The self-interaction is essential for forming the large oligomeric complexes required for both structural and chaperone functions.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12235146" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12235146
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Role of the C-terminal extensions of alpha-crystallins. Swap...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -3627,86 +3570,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from PMID:12235146. This study investigated the role of C-terminal extensions of alphaA- and alphaB-crystallins by domain swapping, demonstrating that the C-terminal extension plays a crucial role in structure and chaperone activity. The protein-protein interactions are alphaA-alphaB hetero-oligomerization. &#34;Protein binding&#34; is too generic.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. The interactions documented are alpha-crystallin subunit interactions (hetero-oligomerization) relevant to chaperone function. GO:0044183 &#34;protein folding chaperone&#34; better captures the molecular function demonstrated by the chaperone activity assays used.
+                            <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. The interactions documented are alpha-crystallin subunit interactions (hetero-oligomerization) relevant to chaperone function. GO:0140309 &#34;unfolded protein holdase activity&#34; better captures the molecular function demonstrated by the chaperone activity assays used.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140309" target="_blank" class="term-link">
+                                    unfolded protein holdase activity
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12235146" target="_blank" class="term-link">
                                         PMID:12235146
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Our study demonstrates that the unstructured C-terminal extensions play a crucial role in the structure and chaperone activity, in addition to generally believed electrostatic &#34;solubilizer&#34; function</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                     GO:0050821
                                 </a>
                             </span>
                             <span class="term-label">protein stabilization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12235146" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12235146
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Role of the C-terminal extensions of alpha-crystallins. Swap...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3718,88 +3661,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IMP annotation for protein stabilization from PMID:12235146. This study showed that domain-swapped chimeras of alphaA and alphaB crystallins have dramatically altered chaperone-like activity -- the chimeric alphaB with CRYAA C-terminal extension showed enhanced chaperone activity while the chimeric alphaA with CRYAB C-terminal extension almost lost activity. This demonstrates that CRYAA contributes to protein stabilization (preventing aggregation of destabilized proteins). GO:0050821 &#34;protein stabilization&#34; is defined as &#34;any process involved in maintaining the structure and integrity of a protein and preventing it from degradation or aggregation.&#34; This is an excellent fit for CRYAA holdase activity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0050821 &#34;protein stabilization&#34; accurately describes the core holdase function of CRYAA -- preventing aggregation and maintaining protein integrity. The evidence from PMID:12235146 demonstrates that the C-terminal extension of CRYAA is crucial for this function. This is one of the most appropriate BP terms for the CRYAA holdase chaperone activity.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12235146" target="_blank" class="term-link">
                                         PMID:12235146
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the chimeric alphaB with the C-terminal extension of alphaA-crystallin, alphaBAc, exhibits dramatically enhanced chaperone-like activity</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12235146" target="_blank" class="term-link">
                                         PMID:12235146
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the unstructured C-terminal extensions play a crucial role in the structure and chaperone activity</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19464326
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HSPB7 is a SC35 speckle resident small heat shock protein.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3811,75 +3754,73 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IDA annotation for nucleus from PMID:19464326. This study directly demonstrated by confocal microscopy that CRYAA (HSPB4) translocates to the nucleus during heat shock and resides in SC35 splicing speckles. While not the primary constitutive localization, the stress- induced nuclear translocation is experimentally well documented.
+                            <strong>Summary:</strong> IDA annotation for nucleus from PMID:19464326. The cached abstract excerpt available here is about HSPB7, so explicit text support is taken from the UniProt CRYAA subcellular-location statement, which records heat-shock-induced nuclear translocation to SC35 splicing speckles. While not the primary constitutive localization, the stress-induced nuclear translocation is experimentally documented in the UniProt record.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Nuclear localization is directly demonstrated by confocal microscopy (PMID:19464326) but is stress-induced (heat shock) rather than constitutive. CRYAA resides in SC35 speckles under stress conditions. This is a secondary localization.
+                            <strong>Reason:</strong> Nuclear localization is stress-induced (heat shock) rather than constitutive. CRYAA resides in SC35 speckles under stress conditions. This is a secondary localization.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
-                                        PMID:19464326
-                                    </a>
-                                    
+
+                                    UniProtKB:P02489
+
                                 </span>
-                                
-                                <div class="support-text">HSPB7 constitutively localized to SC35 splicing speckles</div>
-                                
+
+                                <div class="support-text">Nucleus. Note=Translocates to the nucleus during heat shock and resides in sub-nuclear structures known as SC35 speckles or nuclear splicing speckles.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19464326
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HSPB7 is a SC35 speckle resident small heat shock protein.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3891,232 +3832,221 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for cytoplasm from PMID:19464326. This study used confocal microscopy to characterize subcellular localization of HSPB family members and showed CRYAA (HSPB4) in the cytoplasm under basal conditions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization is directly demonstrated by confocal microscopy in PMID:19464326, consistent with the primary constitutive location of CRYAA.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14752512
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human alphaA- and alphaB-crystallins bind to Bax and Bcl-X(S...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P02489" data-a="GO:0005515" data-r="PMID:14752512" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="P02489" data-a="GO:0005515" data-r="PMID:14752512" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from PMID:14752512. This study demonstrated by GST pulldown and coimmunoprecipitation that alphaA-crystallin binds to pro-apoptotic Bax and Bcl-X(S) proteins both in vitro and in vivo, preventing their translocation to mitochondria during staurosporine-induced apoptosis. The R116C cataract mutant showed much weaker affinity. &#34;Protein binding&#34; is uninformative for this specific anti-apoptotic binding activity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is too generic. The specific interaction is binding to pro-apoptotic Bax and Bcl-X(S) to sequester them and prevent apoptosis. This is better captured by the negative regulation of apoptotic process annotation (GO:0043066) already present. No single MF term perfectly captures anti-apoptotic binding, but the IPI evidence supports the GO:0043066 BP annotation.
                         </div>
-                        
-                        
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-                            
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
-                                </a>
-                            </span>
-                            
-                        </div>
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link">
                                         PMID:14752512
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Using GST pulldown assays and coimmunoprecipitations, we demonstrated that alpha-crystallins bind to Bax and Bcl-X(S) both in vitro and in vivo</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link">
                                         PMID:14752512
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Through the interaction, alpha-crystallins prevent the translocation of Bax and Bcl-X(S) from cytosol into mitochondria during staurosporine-induced apoptosis</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
+
                         <span class="not-badge" title="This is a NOT annotation - gene does NOT have this function">NOT</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P02489" data-a="GO:0042026" data-r="GO_REF:0000024" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="P02489" data-a="GO:0042026" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> NOT annotation for protein refolding (ISS from bovine ortholog via GO_REF:0000024). This is a critical annotation that explicitly states CRYAA does NOT perform protein refolding. CRYAA is a holdase chaperone that prevents aggregation of denatured proteins but does not actively refold them. This is consistent with all experimental evidence: PMID:8943244 describes the chaperone-like activity as &#34;the ability to suppress nonspecific aggregation&#34; with no mention of refolding capability. PMID:19464326 showed functional divergence among sHSP family members -- HSPB1 and HSPB5 kept substrates folding-competent but HSPB7 did not support refolding. CRYAA (HSPB4), like HSPB7, is a holdase without foldase activity. Both this NOT annotation and the positive IBA annotation for GO:0042026 should be removed: the IBA positive assertion is incorrect for CRYAA, and the NOT annotation becomes redundant once the incorrect positive assertion is removed.
+                            <strong>Summary:</strong> NOT annotation for protein refolding (ISS from bovine ortholog via GO_REF:0000024). This is a critical annotation that explicitly states CRYAA does NOT perform protein refolding. CRYAA is a holdase chaperone that prevents aggregation of denatured proteins but does not actively refold them. This is consistent with all experimental evidence: PMID:8943244 describes the chaperone-like activity as &#34;the ability to suppress nonspecific aggregation&#34; with no mention of refolding capability. The negated GOA assertion is therefore consistent with CRYAA being a holdase without foldase activity. This NOT annotation should be retained because it records the biologically important distinction between CRYAA holdase activity and active protein refolding.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> While the NOT annotation correctly states that CRYAA does not perform protein refolding, both the positive IBA and this negated ISS annotation for GO:0042026 should be removed together. The IBA positive assertion is incorrect (CRYAA is a holdase, not a foldase), and once the incorrect positive assertion is removed, the NOT annotation is no longer needed. The holdase vs foldase distinction is better captured by GO:0050821 &#34;protein stabilization&#34; (already annotated) and the proposed GO:0044183 &#34;protein folding chaperone&#34; replacement annotations.
+                            <strong>Reason:</strong> The negated annotation correctly states that CRYAA does not perform active protein refolding. Retaining this NOT assertion is useful because it prevents propagation of a foldase interpretation and supports the replacement of unfolded protein binding with GO:0140309 &#34;unfolded protein holdase activity.&#34;
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8943244" target="_blank" class="term-link">
                                         PMID:8943244
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">alpha-crystallin subunits associate to form large oligomeric aggregates that express chaperone-like activity, as defined by the ability to suppress nonspecific aggregation of proteins destabilized by treatment with a variety of denaturants</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/8943244" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:8943244
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Cloning, expression, and chaperone-like activity of human al...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -4128,112 +4058,112 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). This IPI annotation is based on PMID:8943244, which demonstrated that recombinant human alphaA-crystallin (CRYAA) suppresses heat-induced aggregation of aldose reductase (UniProtKB:P07320, the WITH/FROM interactor) and singlet-oxygen-induced aggregation of gamma-crystallin in stoichiometric amounts. The paper explicitly defines this as &#34;chaperone-like activity&#34; meaning the ability to suppress nonspecific aggregation of destabilized proteins. The C-terminal truncation mutant (R157STOP) showed markedly reduced chaperone-like activity despite preserved secondary structure, confirming that the C-terminal region is essential for the holdase function. The experimental evidence clearly supports that CRYAA binds partially denatured proteins and prevents their aggregation, which is holdase (not foldase) activity. The term GO:0044183 &#34;protein folding chaperone&#34; is the best available interim replacement MF term, though imperfect because CRYAA does not assist in protein folding per se -- it prevents aggregation. A holdase-specific GO term is needed.
+                            <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). This IPI annotation is based on PMID:8943244, which demonstrated that recombinant human alphaA-crystallin (CRYAA) suppresses heat-induced aggregation of aldose reductase (UniProtKB:P07320, the WITH/FROM interactor) and singlet-oxygen-induced aggregation of gamma-crystallin in stoichiometric amounts. The paper explicitly defines this as &#34;chaperone-like activity&#34; meaning the ability to suppress nonspecific aggregation of destabilized proteins. The C-terminal truncation mutant (R157STOP) showed markedly reduced chaperone-like activity despite preserved secondary structure, confirming that the C-terminal region is essential for the holdase function. The experimental evidence clearly supports that CRYAA binds partially denatured proteins and prevents their aggregation, which is holdase (not foldase) activity. The term GO:0140309 &#34;unfolded protein holdase activity&#34; is the appropriate MF replacement because CRYAA prevents aggregation without active refolding.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> GO:0051082 is being obsoleted. The experimental evidence from PMID:8943244 clearly demonstrates holdase chaperone activity -- CRYAA suppresses aggregation of heat-denatured aldose reductase and singlet-oxygen-damaged gamma-crystallin. This is not &#34;unfolded protein binding&#34; in a passive sense; it is active suppression of aggregation. The IPI evidence (with aldose reductase UniProtKB:P07320 as interactor) is strong. GO:0044183 &#34;protein folding chaperone&#34; is the closest current MF term, but a holdase-specific term is needed since CRYAA does NOT refold proteins. GO:0050821 &#34;protein stabilization&#34; is also relevant as a BP term.
+                            <strong>Reason:</strong> GO:0051082 is being obsoleted. The experimental evidence from PMID:8943244 clearly demonstrates holdase chaperone activity -- CRYAA suppresses aggregation of heat-denatured aldose reductase and singlet-oxygen-damaged gamma-crystallin. This is not &#34;unfolded protein binding&#34; in a passive sense; it is active suppression of aggregation. The IPI evidence (with aldose reductase UniProtKB:P07320 as interactor) is strong. GO:0140309 &#34;unfolded protein holdase activity&#34; is the correct current MF term since CRYAA does NOT refold proteins. GO:0050821 &#34;protein stabilization&#34; is also relevant as a BP term.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140309" target="_blank" class="term-link">
+                                    unfolded protein holdase activity
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8943244" target="_blank" class="term-link">
                                         PMID:8943244
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">alpha-crystallin subunits associate to form large oligomeric aggregates that express chaperone-like activity, as defined by the ability to suppress nonspecific aggregation of proteins destabilized by treatment with a variety of denaturants including heat, UV irradiation, and chemical modification</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8943244" target="_blank" class="term-link">
                                         PMID:8943244
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">When added in stoichiometric amounts, both WT and W9F subunits completely suppressed the heat-induced aggregation of aldose reductase</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8943244" target="_blank" class="term-link">
                                         PMID:8943244
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">subunits encoded by a truncation mutant in which the C-terminal 17 residues were deleted (R157STOP), despite having spectroscopic properties similar to WT, formed much larger aggregates with a marked reduction in chaperone-like activity</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007601" target="_blank" class="term-link">
                                     GO:0007601
                                 </a>
                             </span>
                             <span class="term-label">visual perception</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9467006" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9467006
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Autosomal dominant congenital cataract associated with a mis...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -4245,75 +4175,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IMP annotation for visual perception from PMID:9467006. This study identified the R116C missense mutation in CRYAA as causing autosomal dominant congenital cataract (ADCC) in a family. The logic is that mutation in CRYAA causes cataract, which impairs visual perception. However, CRYAA does not directly participate in phototransduction or visual signaling. It maintains lens transparency, which is a prerequisite for vision but not part of the perception pathway itself. The IMP evidence connects CRYAA to visual impairment through lens opacity, not through a direct role in visual perception.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While CRYAA mutations cause cataracts that impair vision (PMID:9467006), CRYAA does not participate in the visual perception signaling pathway. It maintains lens structural integrity. GO:0002088 &#34;lens development in camera-type eye&#34; and GO:0005212 &#34;structural constituent of eye lens&#34; better capture the role. Marking as over-annotated because the connection to visual perception is indirect.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9467006" target="_blank" class="term-link">
                                         PMID:9467006
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we found that a missense mutation, R116C, is associated with ADCC in this family</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043066" target="_blank" class="term-link">
                                     GO:0043066
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of apoptotic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14512969" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14512969
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Cell death triggered by a novel mutation in the alphaA-cryst...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4325,75 +4255,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IMP annotation for negative regulation of apoptotic process from PMID:14512969. This study identified the R49C mutation in CRYAA and showed that the R49C mutant protein failed to protect lens epithelial cells from staurosporine-induced apoptotic cell death, whereas wild-type CRYAA did protect. The IMP logic is that loss-of-function mutation leads to failure to suppress apoptosis, implicating wild-type CRYAA in negative regulation of apoptosis. This is well-supported anti-apoptotic activity, consistent with the IBA and IDA annotations to the same term.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Anti-apoptotic function is well demonstrated by mutant phenotype: the R49C mutant fails to protect from staurosporine-induced apoptosis (PMID:14512969). This is a secondary function compared to the core structural and chaperone holdase roles.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14512969" target="_blank" class="term-link">
                                         PMID:14512969
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">unlike wild-type CRYAA, the R49C mutant protein was abnormally localized to the nucleus and failed to protect from staurosporine-induced apoptotic cell death</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18407550" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18407550
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A novel mutation in AlphaA-crystallin (CRYAA) caused autosom...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -4405,112 +4335,112 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). This IMP annotation is based on PMID:18407550, which identified the R116H (c.346G&gt;A) mutation in CRYAA as the cause of autosomal dominant congenital cataract in a large Chinese family. The mutant phenotype evidence is that the R116H mutant protein showed loss of chaperone activity in the DTT-induced insulin aggregation assay, increased hydrophobicity, and increased binding affinity to lysozyme. The logic is: mutation in CRYAA causes loss of chaperone (holdase) activity, leading to cataract, therefore wild-type CRYAA enables this chaperone function. This is valid IMP evidence for chaperone holdase activity. However, the term &#34;unfolded protein binding&#34; does not accurately capture the functional consequence measured, which is suppression of protein aggregation (holdase activity). GO:0044183 &#34;protein folding chaperone&#34; is the best available interim replacement, though imperfect. A holdase-specific term is needed.
+                            <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). This IMP annotation is based on PMID:18407550, which identified the R116H (c.346G&gt;A) mutation in CRYAA as the cause of autosomal dominant congenital cataract in a large Chinese family. The mutant phenotype evidence is that the R116H mutant protein showed loss of chaperone activity in the DTT-induced insulin aggregation assay, increased hydrophobicity, and increased binding affinity to lysozyme. The logic is: mutation in CRYAA causes loss of chaperone (holdase) activity, leading to cataract, therefore wild-type CRYAA enables this chaperone function. This is valid IMP evidence for chaperone holdase activity. However, the term &#34;unfolded protein binding&#34; does not accurately capture the functional consequence measured, which is suppression of protein aggregation (holdase activity). GO:0140309 &#34;unfolded protein holdase activity&#34; is the appropriate replacement.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> GO:0051082 is being obsoleted. The IMP evidence from PMID:18407550 is based on the R116H cataract-causing mutation showing loss of chaperone activity in DTT-induced insulin aggregation assay. This demonstrates the functional importance of CRYAA holdase activity but the term &#34;unfolded protein binding&#34; mischaracterizes the function. GO:0044183 &#34;protein folding chaperone&#34; is the closest current replacement, though a holdase-specific term is needed since the evidence shows CRYAA prevents aggregation rather than assisting folding.
+                            <strong>Reason:</strong> GO:0051082 is being obsoleted. The IMP evidence from PMID:18407550 is based on the R116H cataract-causing mutation showing loss of chaperone activity in DTT-induced insulin aggregation assay. This demonstrates the functional importance of CRYAA holdase activity but the term &#34;unfolded protein binding&#34; mischaracterizes the function. GO:0140309 &#34;unfolded protein holdase activity&#34; is the correct replacement because the evidence shows CRYAA prevents aggregation rather than assisting folding.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140309" target="_blank" class="term-link">
+                                    unfolded protein holdase activity
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/18407550" target="_blank" class="term-link">
                                         PMID:18407550
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">loss of chaperone activity of the mutant was seen in DTT (DL-dithiothreitol)-induced insulin aggregation assay</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/18407550" target="_blank" class="term-link">
                                         PMID:18407550
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Gain of activated lysozyme binding, elevation of hydrophobicity and loss of chaperone activity of the mutant protein may be some of the molecular mechanisms underlying cataract in this large family</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/18407550" target="_blank" class="term-link">
                                         PMID:18407550
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Sequencing of CRYAA revealed a novel heterozygous G&gt;A transition (c.346G&gt;A) in exon 3 that cosegregated with the disease phenotype and results in a conservative substitution of Arg to His at codon 116 (p.R116H)</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14752512
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human alphaA- and alphaB-crystallins bind to Bax and Bcl-X(S...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4522,75 +4452,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for cytoplasm from PMID:14752512. This study demonstrated that alphaA- and alphaB-crystallins reside in the cytosol and prevent the translocation of pro-apoptotic Bax and Bcl-X(S) from cytosol to mitochondria during staurosporine-induced apoptosis. The abstract states that &#34;alpha-crystallins prevent the translocation of Bax and Bcl-X(S) from cytosol into mitochondria during staurosporine-induced apoptosis&#34; (PMID:14752512), implying CRYAA co-localizes with these targets in the cytoplasm. This is consistent with multiple other IDA studies confirming cytoplasmic localization (PMID:29259299, PMID:19464326, PMID:19503744, PMID:26004348, PMID:30340470).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization is the primary constitutive location of CRYAA. PMID:14752512 demonstrates CRYAA in the cytosol where it interacts with and sequesters Bax and Bcl-X(S). This is consistent with all other localization studies and represents a core annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link">
                                         PMID:14752512
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">alpha-crystallins prevent the translocation of Bax and Bcl-X(S) from cytosol into mitochondria during staurosporine-induced apoptosis</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032387" target="_blank" class="term-link">
                                     GO:0032387
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of intracellular transport</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14752512
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human alphaA- and alphaB-crystallins bind to Bax and Bcl-X(S...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4602,88 +4532,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for negative regulation of intracellular transport from PMID:14752512. This study demonstrated using GST pulldown assays and coimmunoprecipitation that alphaA- and alphaB-crystallins bind to pro-apoptotic Bax and Bcl-X(S) both in vitro and in vivo, and &#34;prevent the translocation of Bax and Bcl-X(S) from cytosol into mitochondria during staurosporine-induced apoptosis&#34; (PMID:14752512). This is a specific form of negative regulation of intracellular transport -- CRYAA sequesters these proteins in the cytosol, preventing their mitochondrial translocation. The cataract-causing R116C mutant shows &#34;much weaker affinity to Bax and Bcl-X(S)&#34; (PMID:14752512), further supporting that wild-type CRYAA actively prevents this transport. This is a secondary, non-core function tied to the anti-apoptotic role rather than the primary structural or chaperone holdase functions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The annotation is well supported by direct experimental evidence from PMID:14752512 showing that CRYAA prevents translocation of Bax and Bcl-X(S) from cytosol to mitochondria. However, this is a secondary function tied to the anti-apoptotic role, not the core structural or chaperone holdase activity of CRYAA. Marked as non-core for consistency with the anti-apoptotic annotations (GO:0043066).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link">
                                         PMID:14752512
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Through the interaction, alpha-crystallins prevent the translocation of Bax and Bcl-X(S) from cytosol into mitochondria during staurosporine-induced apoptosis</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link">
                                         PMID:14752512
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Two prominent mutants, R116C in alphaA-crystallin and R120G, in alphaB-crystallin display much weaker affinity to Bax and Bcl-X(S)</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043066" target="_blank" class="term-link">
                                     GO:0043066
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of apoptotic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14752512
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human alphaA- and alphaB-crystallins bind to Bax and Bcl-X(S...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4695,101 +4625,101 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for negative regulation of apoptotic process from PMID:14752512. This study directly demonstrated that &#34;Human alphaA- and alphaB-crystallins prevent staurosporine-induced apoptosis through interactions with members of the Bcl-2 family&#34; (PMID:14752512). Using GST pulldown and coimmunoprecipitation, the authors showed that alpha-crystallins bind to pro-apoptotic Bax and Bcl-X(S) both in vitro and in vivo, sequestering them in the cytosol and preventing their translocation to mitochondria. As a result, &#34;alpha-crystallins preserve the integrity of mitochondria, restrict release of cytochrome c, repress activation of caspase-3 and block degradation of PARP&#34; (PMID:14752512). The anti-apoptotic function was confirmed in human lens epithelial cells, ARPE-19 cells, and H9c2 cells under staurosporine, etoposide, or sorbitol treatment. The R116C cataract mutant showed much weaker affinity to Bax and Bcl-X(S), consistent with loss of anti-apoptotic activity contributing to cataract pathology. This is a well- documented secondary function of CRYAA beyond its primary structural and chaperone roles.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Anti-apoptotic activity of CRYAA is directly demonstrated by IDA evidence in PMID:14752512 using multiple experimental approaches (GST pulldown, coimmunoprecipitation, functional apoptosis assays in multiple cell types). However, this is a secondary function compared to the core structural lens protein and chaperone holdase roles. Marked as non-core for consistency with the IBA and IMP annotations for the same GO term.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link">
                                         PMID:14752512
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Human alphaA- and alphaB-crystallins prevent staurosporine-induced apoptosis through interactions with members of the Bcl-2 family</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link">
                                         PMID:14752512
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Using GST pulldown assays and coimmunoprecipitations, we demonstrated that alpha-crystallins bind to Bax and Bcl-X(S) both in vitro and in vivo</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link">
                                         PMID:14752512
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">alpha-crystallins preserve the integrity of mitochondria, restrict release of cytochrome c, repress activation of caspase-3 and block degradation of PARP</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007601" target="_blank" class="term-link">
                                     GO:0007601
                                 </a>
                             </span>
                             <span class="term-label">visual perception</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14512969" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14512969
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Cell death triggered by a novel mutation in the alphaA-cryst...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -4801,63 +4731,63 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IMP annotation for visual perception from PMID:14512969. This study identified the R49C missense mutation in CRYAA as causing autosomal dominant &#34;nuclear&#34; cataract in a four- generation family. The mutant protein &#34;was abnormally localized to the nucleus and failed to protect from staurosporine-induced apoptotic cell death&#34; (PMID:14512969). The logic connecting CRYAA to visual perception is that the R49C mutation causes cataract (lens opacity), which impairs vision. However, CRYAA does not directly participate in the visual perception signaling pathway (phototransduction). It maintains lens structural integrity and transparency, which is a prerequisite for light transmission but not part of the perception process itself. GO:0002088 &#34;lens development in camera-type eye&#34; and GO:0005212 &#34;structural constituent of eye lens&#34; more accurately capture the actual role. This is the same over-annotation issue identified for the IEA (GO_REF:0000043) and IMP (PMID:9467006) visual perception annotations already reviewed.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While the R49C CRYAA mutation causes autosomal dominant cataract that impairs vision (PMID:14512969), CRYAA does not participate in the visual perception signaling pathway. It maintains lens transparency through its structural and chaperone roles. The connection to visual perception is indirect -- through lens opacity rather than involvement in phototransduction. GO:0002088 &#34;lens development in camera-type eye&#34; and GO:0005212 &#34;structural constituent of eye lens&#34; better capture the actual function. Consistent with the assessment of the other visual perception annotations for CRYAA.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14512969" target="_blank" class="term-link">
                                         PMID:14512969
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">unlike wild-type CRYAA, the R49C mutant protein was abnormally localized to the nucleus and failed to protect from staurosporine-induced apoptotic cell death</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14512969" target="_blank" class="term-link">
                                         PMID:14512969
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Hereditary cataract is a clinically and genetically heterogeneous lens disease that accounts for a significant proportion of visual impairment and blindness in childhood</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>CRYAA (HSPB4) is a small heat shock protein that functions as an ATP-independent holdase chaperone. It forms large homo-oligomeric complexes (~540 kDa, ~24 subunits) that suppress nonspecific aggregation of proteins destabilized by heat, UV irradiation, and chemical modification. CRYAA does NOT actively refold substrates (documented by NOT annotation to GO:0042026 protein refolding). It maintains denatured proteins in a soluble, non-aggregated state. The C-terminal extension is essential for chaperone activity, and the T148 phosphorylation site (mediated by mTORC2) regulates chaperone capacity. Disease-causing mutations (R116C, R116H, R49C, F71L) impair chaperone holdase activity and cause congenital cataracts.</h3>
                 <span class="vote-buttons" data-g="P02489" data-a="FUNCTION: CRYAA (HSPB4) is a small heat shock protein that f..." data-r="" data-act="CORE_FUNCTION">
@@ -4865,112 +4795,112 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                            protein folding chaperone
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140309" target="_blank" class="term-link">
+                            unfolded protein holdase activity
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                 protein stabilization
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009408" target="_blank" class="term-link">
                                 response to heat
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/8943244" target="_blank" class="term-link">
                                 PMID:8943244
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">alpha-crystallin subunits associate to form large oligomeric aggregates that express chaperone-like activity, as defined by the ability to suppress nonspecific aggregation of proteins destabilized by treatment with a variety of denaturants including heat, UV irradiation, and chemical modification.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12235146" target="_blank" class="term-link">
                                 PMID:12235146
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">the chimeric alphaB with the C-terminal extension of alphaA-crystallin exhibits dramatically enhanced chaperone-like activity.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18407550" target="_blank" class="term-link">
                                 PMID:18407550
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">loss of chaperone activity of the mutant was seen in DTT-induced insulin aggregation assay.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>CRYAA is the most abundantly expressed protein in the ocular lens, contributing to lens transparency and refractive index. It serves a dual role as a structural protein providing the high-concentration protein matrix required for lens transparency, and as a chaperone preventing aggregation of damaged crystallins that would cause light-scattering opacification. CRYAA hetero-oligomerizes with CRYAB (HSPB5) in a 3:1 ratio. Mutations in CRYAA consistently cause autosomal dominant congenital cataracts (ADCC), confirming its essential structural role.</h3>
                 <span class="vote-buttons" data-g="P02489" data-a="FUNCTION: CRYAA is the most abundantly expressed protein in ..." data-r="" data-act="CORE_FUNCTION">
@@ -4978,10 +4908,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -4990,631 +4920,679 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0002088" target="_blank" class="term-link">
                                 lens development in camera-type eye
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14512969" target="_blank" class="term-link">
                                 PMID:14512969
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">The alphaA-crystallin (CRYAA) gene (CRYAA) encodes a member of the small-heat-shock protein (sHSP) family of molecular chaperones and is primarily and abundantly expressed in the ocular lens</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9467006" target="_blank" class="term-link">
                                 PMID:9467006
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">we found that a missense mutation, R116C, is associated with ADCC in this family.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link">
                                 PMID:16303126
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">the major lenticular protein chaperones, alpha A- and alpha B-crystallin, increased the solubility of the T5P gamma C-crystallin both in vitro and in transfected cells.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        UniProtKB:P02489
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry for human CRYAA (Alpha-crystallin A chain)</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">UniProt records CRYAA as cytoplasmic and stress-induced nuclear, with heat-shock-dependent residence in SC35/nuclear splicing speckles.</div>
+
+                        <div class="finding-text">"Nucleus. Note=Translocates to the nucleus during heat shock and resides in sub-nuclear structures known as SC35 speckles or nuclear splicing speckles."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
                             GO_REF:0000024
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
                             GO_REF:0000052
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11700327" target="_blank" class="term-link">
                             PMID:11700327
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Detection of protein-protein interactions among lens crystallins in a mammalian two-hybrid system assay.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12235146" target="_blank" class="term-link">
                             PMID:12235146
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Role of the C-terminal extensions of alpha-crystallins. Swapping the C-terminal extension of alpha-crystallin to alphaB-crystallin results in enhanced chaperone activity.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12601044" target="_blank" class="term-link">
                             PMID:12601044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Alteration of protein-protein interactions of congenital cataract crystallin mutants.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14512969" target="_blank" class="term-link">
                             PMID:14512969
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Cell death triggered by a novel mutation in the alphaA-crystallin gene underlies autosomal dominant cataract linked to chromosome 21q.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link">
                             PMID:14752512
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Human alphaA- and alphaB-crystallins bind to Bax and Bcl-X(S) to sequester their translocation during staurosporine-induced apoptosis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link">
                             PMID:16303126
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Lenticular chaperones suppress the aggregation of the cataract-causing mutant T5P gamma C-crystallin.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18407550" target="_blank" class="term-link">
                             PMID:18407550
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A novel mutation in AlphaA-crystallin (CRYAA) caused autosomal dominant congenital cataract in a large Chinese family.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
                             PMID:19464326
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSPB7 is a SC35 speckle resident small heat shock protein.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19503744" target="_blank" class="term-link">
                             PMID:19503744
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An alphaA-crystallin gene mutation, Arg12Cys, causing inherited cataract-microcornea exhibits an altered heat-shock response.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19651604" target="_blank" class="term-link">
                             PMID:19651604
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The eye lens chaperone alpha-crystallin forms defined globular assemblies.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22085609" target="_blank" class="term-link">
                             PMID:22085609
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Temperature-dependent structural and functional properties of a mutant (F71L) αA-crystallin: molecular basis for early onset of age-related cataract.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22153508" target="_blank" class="term-link">
                             PMID:22153508
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The polydispersity of αB-crystallin is rationalized by an interconverting polyhedral architecture.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23188086" target="_blank" class="term-link">
                             PMID:23188086
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Binding determinants of the small heat shock protein, αB-crystallin: recognition of the &#39;IxI&#39; motif.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
                             PMID:25416956
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A proteome-scale map of the human interactome network.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link">
                             PMID:25910212
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Widespread macromolecular interaction perturbations in human genetic disorders.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26004348" target="_blank" class="term-link">
                             PMID:26004348
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Mutation analysis of two families with inherited congenital cataracts.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/29259299" target="_blank" class="term-link">
                             PMID:29259299
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Two novel mutations identified in ADCC families impair crystallin protein distribution and induce apoptosis in human lens epithelial cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/29892012" target="_blank" class="term-link">
                             PMID:29892012
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An interactome perturbation framework prioritizes damaging missense mutations for developmental disorders.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/30340470" target="_blank" class="term-link">
                             PMID:30340470
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A novel mutation in the CRYAA gene associated with congenital cataract and microphthalmia in a Chinese family.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link">
                             PMID:31515488
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Extensive disruption of protein interactions by genetic variants across the allele frequency spectrum in human populations.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                             PMID:32296183
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A reference map of the human binary protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
                             PMID:32814053
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/8943244" target="_blank" class="term-link">
                             PMID:8943244
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Cloning, expression, and chaperone-like activity of human alphaA-crystallin.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9467006" target="_blank" class="term-link">
                             PMID:9467006
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Autosomal dominant congenital cataract associated with a missense mutation in the human alpha crystallin gene CRYAA.</div>
-                
-                
+
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/CRYAA/CRYAA-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research for human CRYAA</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Falcon synthesis supports CRYAA/HSPB4 as an alpha-crystallin small heat shock protein with ATP-independent holdase chaperone activity central to lens proteostasis and cataract biology.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -5847,9 +5825,9 @@ CRYAA (HSPB4) is a canonical sHSP chaperone critical for lens proteostasis, with
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -5861,7 +5839,7 @@ CRYAA (HSPB4) is a canonical sHSP chaperone critical for lens proteostasis, with
                 <pre><code>id: P02489
 gene_symbol: CRYAA
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -5971,30 +5949,27 @@ existing_annotations:
   original_reference_id: GO_REF:0000033
   review:
     summary: &gt;-
-      IBA annotation for nucleus localization. PMID:19464326 showed that CRYAA (HSPB4)
-      translocates
-      to sub-nuclear structures (SC35 speckles) during heat shock. UniProt notes that
-      CRYAA
-      translocates to the nucleus during heat shock and resides in SC35 splicing speckles.
-      This is
-      a stress-induced secondary localization rather than the primary constitutive
-      location. The
+      IBA annotation for nucleus localization. UniProt notes that CRYAA (HSPB4)
+      translocates to the nucleus during heat shock and resides in SC35 splicing
+      speckles. This is a stress-induced secondary localization rather than the
+      primary constitutive location. The
       IBA annotation is phylogenetically appropriate for sHSP family members that
       show nuclear
       translocation under stress.
     action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Nuclear localization is real but conditional (stress-induced). CRYAA translocates
-      to SC35
-      splicing speckles during heat shock (PMID:19464326). This is not the primary
-      constitutive
+      Nuclear localization is real but conditional (stress-induced). UniProt records
+      CRYAA translocation to SC35 splicing speckles during heat shock. This is not
+      the primary constitutive
       localization of CRYAA, which is cytoplasmic. Keeping as non-core reflects that
       this is a
       secondary, stress-dependent localization.
     supported_by:
-    - reference_id: PMID:19464326
+    - reference_id: UniProtKB:P02489
       supporting_text: &gt;-
-        HSPB7 constitutively localized to SC35 splicing speckles
+        Nucleus. Note=Translocates to the nucleus during heat shock and resides
+        in sub-nuclear structures known as SC35 speckles or nuclear splicing
+        speckles.
 - term:
     id: GO:0009408
     label: response to heat
@@ -6025,6 +6000,11 @@ existing_annotations:
         both WT and W9F subunits completely suppressed the heat-induced aggregation
         of aldose
         reductase
+    - reference_id: file:human/CRYAA/CRYAA-deep-research-falcon.md
+      supporting_text: &gt;-
+        As a chaperone, HSPB4 binds partially unfolded proteins to prevent
+        misfolding and aggregation, thereby maintaining lens proteostasis and
+        cell survival
 - term:
     id: GO:0042026
     label: protein refolding
@@ -6091,15 +6071,10 @@ existing_annotations:
       zebrafish,
       and mammals, which is appropriate for the family-level chaperone function. However,
       the term
-      itself needs replacement. GO:0044183 &#34;protein folding chaperone&#34; is the closest
-      available MF term,
-      defined as &#34;Binding to a protein or a protein-containing complex to assist the
-      protein folding
-      process.&#34; This is an imperfect replacement because CRYAA specifically does NOT
-      assist in protein
-      folding -- it prevents aggregation (holdase activity). A dedicated holdase-specific
-      GO term is
-      needed. As a biological process annotation, GO:0050821 &#34;protein stabilization&#34;
+      itself needs replacement. GO:0140309 &#34;unfolded protein holdase activity&#34; is
+      the appropriate MF term for ATP-independent binding to unfolded proteins to
+      prevent their aggregation without active refolding. As a biological process
+      annotation, GO:0050821 &#34;protein stabilization&#34;
       (defined as
       &#34;Any process involved in maintaining the structure and integrity of a protein
       and preventing it
@@ -6113,16 +6088,12 @@ existing_annotations:
       it suppresses aggregation of heat-denatured aldose reductase and singlet-oxygen-damaged
       gamma-crystallin (PMID:8943244). However, it does NOT refold proteins (NOT annotation
       to
-      GO:0042026 protein refolding, ISS). The best available interim MF replacement
-      is GO:0044183
-      &#34;protein folding chaperone,&#34; though this term is not ideal because its definition
-      references
-      &#34;protein folding process&#34; which is not what CRYAA does. A new holdase-specific
-      term should be
-      requested. GO:0050821 &#34;protein stabilization&#34; is appropriate as a BP term.
+      GO:0042026 protein refolding, ISS). The appropriate MF replacement is
+      GO:0140309 &#34;unfolded protein holdase activity.&#34; GO:0050821 &#34;protein
+      stabilization&#34; is appropriate as a BP term.
     proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+    - id: GO:0140309
+      label: unfolded protein holdase activity
     additional_reference_ids:
     - PMID:8943244
     - PMID:18407550
@@ -6350,16 +6321,12 @@ existing_annotations:
       alphaA-alphaB
       interactions. While the interactions are real and functionally relevant (crystallin-crystallin
       interactions maintain lens transparency), &#34;protein binding&#34; is uninformative.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       &#34;Protein binding&#34; is too vague. The actual interactions detected are crystallin-crystallin
-      interactions relevant to the chaperone holdase function. GO:0044183 &#34;protein
-      folding
-      chaperone&#34; better captures the molecular function, as CRYAA interacts with destabilized
-      crystallins to prevent their aggregation.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+      interactions, not direct evidence for a specific molecular-function replacement.
+      CRYAA holdase activity is supported by aggregation-suppression assays elsewhere;
+      this two-hybrid interaction record should not be used to infer a chaperone term.
     supported_by:
     - reference_id: PMID:11700327
       supporting_text: &gt;-
@@ -6380,18 +6347,14 @@ existing_annotations:
       and gammaC-crystallin decreased in the R116C mutant, while interactions with
       alphaB-crystallin
       and Hsp27 increased. &#34;Protein binding&#34; is uninformative for the functional context.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       &#34;Protein binding&#34; is too generic. The crystallin-crystallin interactions documented
       are
-      functionally relevant to chaperone holdase activity and lens structural integrity.
-      The
-      identical protein binding annotation (GO:0042802) from the same paper better
-      captures the
-      self-interaction aspect.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+      functionally relevant to lens protein organization, but altered two-hybrid
+      interactions in a cataract mutant are not direct evidence for a chaperone
+      molecular-function replacement. Keep the mechanistic context without treating
+      generic protein binding as a core function.
     supported_by:
     - reference_id: PMID:12601044
       supporting_text: &gt;-
@@ -6467,16 +6430,14 @@ existing_annotations:
       CRYAA may have been detected in this study. &#34;Protein binding&#34; is uninformative
       and should
       be replaced with more specific terms for the alpha-crystallin hetero-oligomerization.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       &#34;Protein binding&#34; is too vague. The context is alpha-crystallin oligomerization.
       A more
       specific term describing hetero-oligomerization or structural complex formation
       would be
-      more informative.
-    proposed_replacement_terms:
-    - id: GO:0042802
-      label: identical protein binding
+      more informative, but GO:0042802 should not be used here because this row is
+      not specific to CRYAA self-interaction.
 - term:
     id: GO:0005515
     label: protein binding
@@ -6492,14 +6453,12 @@ existing_annotations:
       with
       CRYAA would be in the context of hetero-oligomerization. &#34;Protein binding&#34; is
       uninformative.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       &#34;Protein binding&#34; is too vague. The context is sHSP subunit interactions via
       the IxI
-      motif, relevant to hetero-oligomerization with CRYAB.
-    proposed_replacement_terms:
-    - id: GO:0042802
-      label: identical protein binding
+      motif, relevant to hetero-oligomerization with CRYAB rather than identical
+      CRYAA self-binding.
 - term:
     id: GO:0005515
     label: protein binding
@@ -6511,17 +6470,13 @@ existing_annotations:
       map).
       This is a high-throughput study. &#34;Protein binding&#34; from high-throughput interactome
       studies is uninformative and lacks the context of specific functional interactions.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       &#34;Protein binding&#34; from high-throughput interactome mapping is too generic. CRYAA
       is known
-      to form homo- and hetero-oligomers; GO:0042802 &#34;identical protein binding&#34; is
-      already
-      annotated from this reference. The generic protein binding annotation adds no
-      information.
-    proposed_replacement_terms:
-    - id: GO:0042802
-      label: identical protein binding
+      to form homo- and hetero-oligomers, but this broad interactome row is not
+      specific enough to justify replacing the annotation with identical protein
+      binding.
 - term:
     id: GO:0005515
     label: protein binding
@@ -6585,13 +6540,11 @@ existing_annotations:
       binary
       protein interactome). This is a high-throughput interactome mapping study. &#34;Protein
       binding&#34; is uninformative. GO:0042802 is already annotated from this same reference.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      &#34;Protein binding&#34; is too vague. GO:0042802 &#34;identical protein binding&#34; is already
-      annotated from this same reference and is more informative for CRYAA self-interactions.
-    proposed_replacement_terms:
-    - id: GO:0042802
-      label: identical protein binding
+      &#34;Protein binding&#34; is too vague. Although GO:0042802 &#34;identical protein binding&#34;
+      is annotated separately from this reference, this broad interactome protein-binding
+      row should not itself be converted to a self-interaction assertion.
 - term:
     id: GO:0005515
     label: protein binding
@@ -6864,14 +6817,13 @@ existing_annotations:
     reason: &gt;-
       The evidence in PMID:16303126 is about chaperone holdase activity (suppressing
       aggregation
-      of T5P gammaC-crystallin), not structural molecule activity per se. GO:0044183
-      &#34;protein
-      folding chaperone&#34; better captures the molecular function demonstrated. For
+      of T5P gammaC-crystallin), not structural molecule activity per se. GO:0140309
+      &#34;unfolded protein holdase activity&#34; better captures the molecular function demonstrated. For
       the true
       structural role, GO:0005212 is already annotated.
     proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+    - id: GO:0140309
+      label: unfolded protein holdase activity
     supported_by:
     - reference_id: PMID:16303126
       supporting_text: &gt;-
@@ -6958,13 +6910,11 @@ existing_annotations:
     reason: &gt;-
       &#34;Protein binding&#34; is uninformative. The interactions documented are alpha-crystallin
       subunit interactions (hetero-oligomerization) relevant to chaperone function.
-      GO:0044183
-      &#34;protein folding chaperone&#34; better captures the molecular function demonstrated
-      by
-      the chaperone activity assays used.
+      GO:0140309 &#34;unfolded protein holdase activity&#34; better captures the molecular
+      function demonstrated by the chaperone activity assays used.
     proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+    - id: GO:0140309
+      label: unfolded protein holdase activity
     supported_by:
     - reference_id: PMID:12235146
       supporting_text: &gt;-
@@ -7021,24 +6971,23 @@ existing_annotations:
   original_reference_id: PMID:19464326
   review:
     summary: &gt;-
-      IDA annotation for nucleus from PMID:19464326. This study directly demonstrated
-      by confocal
-      microscopy that CRYAA (HSPB4) translocates to the nucleus during heat shock
-      and resides
-      in SC35 splicing speckles. While not the primary constitutive localization,
-      the stress-
-      induced nuclear translocation is experimentally well documented.
+      IDA annotation for nucleus from PMID:19464326. The cached abstract excerpt
+      available here is about HSPB7, so explicit text support is taken from the
+      UniProt CRYAA subcellular-location statement, which records heat-shock-induced
+      nuclear translocation to SC35 splicing speckles. While not the primary
+      constitutive localization, the stress-induced nuclear translocation is
+      experimentally documented in the UniProt record.
     action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Nuclear localization is directly demonstrated by confocal microscopy (PMID:19464326)
-      but
-      is stress-induced (heat shock) rather than constitutive. CRYAA resides in SC35
-      speckles
-      under stress conditions. This is a secondary localization.
+      Nuclear localization is stress-induced (heat shock) rather than constitutive.
+      CRYAA resides in SC35 speckles under stress conditions. This is a secondary
+      localization.
     supported_by:
-    - reference_id: PMID:19464326
+    - reference_id: UniProtKB:P02489
       supporting_text: &gt;-
-        HSPB7 constitutively localized to SC35 splicing speckles
+        Nucleus. Note=Translocates to the nucleus during heat shock and resides
+        in sub-nuclear structures known as SC35 speckles or nuclear splicing
+        speckles.
 - term:
     id: GO:0005737
     label: cytoplasm
@@ -7074,7 +7023,7 @@ existing_annotations:
       affinity. &#34;Protein binding&#34; is uninformative for this specific anti-apoptotic
       binding
       activity.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       &#34;Protein binding&#34; is too generic. The specific interaction is binding to pro-apoptotic
       Bax and Bcl-X(S) to sequester them and prevent apoptosis. This is better captured
@@ -7083,9 +7032,6 @@ existing_annotations:
       present.
       No single MF term perfectly captures anti-apoptotic binding, but the IPI evidence
       supports the GO:0043066 BP annotation.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
     supported_by:
     - reference_id: PMID:14752512
       supporting_text: &gt;-
@@ -7113,32 +7059,17 @@ existing_annotations:
       actively refold them. This is consistent with all experimental evidence: PMID:8943244
       describes the chaperone-like activity as &#34;the ability to suppress nonspecific
       aggregation&#34;
-      with no mention of refolding capability. PMID:19464326 showed functional divergence
-      among
-      sHSP family members -- HSPB1 and HSPB5 kept substrates folding-competent but
-      HSPB7 did
-      not support refolding. CRYAA (HSPB4), like HSPB7, is a holdase without foldase
-      activity.
-      Both this NOT annotation and the positive IBA annotation for GO:0042026 should
-      be removed:
-      the IBA positive assertion is incorrect for CRYAA, and the NOT annotation becomes
-      redundant
-      once the incorrect positive assertion is removed.
-    action: REMOVE
+      with no mention of refolding capability. The negated GOA assertion is
+      therefore consistent with CRYAA being a holdase without foldase activity.
+      This NOT annotation should be retained because it records the biologically
+      important distinction between CRYAA holdase activity and active protein
+      refolding.
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      While the NOT annotation correctly states that CRYAA does not perform protein
-      refolding,
-      both the positive IBA and this negated ISS annotation for GO:0042026 should
-      be removed
-      together. The IBA positive assertion is incorrect (CRYAA is a holdase, not a
-      foldase),
-      and once the incorrect positive assertion is removed, the NOT annotation is
-      no longer
-      needed. The holdase vs foldase distinction is better captured by GO:0050821
-      &#34;protein
-      stabilization&#34; (already annotated) and the proposed GO:0044183 &#34;protein folding
-      chaperone&#34;
-      replacement annotations.
+      The negated annotation correctly states that CRYAA does not perform active
+      protein refolding. Retaining this NOT assertion is useful because it prevents
+      propagation of a foldase interpretation and supports the replacement of
+      unfolded protein binding with GO:0140309 &#34;unfolded protein holdase activity.&#34;
     supported_by:
     - reference_id: PMID:8943244
       supporting_text: &gt;-
@@ -7172,12 +7103,9 @@ existing_annotations:
       evidence
       clearly supports that CRYAA binds partially denatured proteins and prevents
       their aggregation,
-      which is holdase (not foldase) activity. The term GO:0044183 &#34;protein folding
-      chaperone&#34; is the
-      best available interim replacement MF term, though imperfect because CRYAA does
-      not assist in
-      protein folding per se -- it prevents aggregation. A holdase-specific GO term
-      is needed.
+      which is holdase (not foldase) activity. The term GO:0140309 &#34;unfolded protein
+      holdase activity&#34; is the appropriate MF replacement because CRYAA prevents
+      aggregation without active refolding.
     action: MODIFY
     reason: &gt;-
       GO:0051082 is being obsoleted. The experimental evidence from PMID:8943244 clearly
@@ -7188,14 +7116,12 @@ existing_annotations:
       in a passive
       sense; it is active suppression of aggregation. The IPI evidence (with aldose
       reductase
-      UniProtKB:P07320 as interactor) is strong. GO:0044183 &#34;protein folding chaperone&#34;
-      is the
-      closest current MF term, but a holdase-specific term is needed since CRYAA does
-      NOT refold
+      UniProtKB:P07320 as interactor) is strong. GO:0140309 &#34;unfolded protein
+      holdase activity&#34; is the correct current MF term since CRYAA does NOT refold
       proteins. GO:0050821 &#34;protein stabilization&#34; is also relevant as a BP term.
     proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+    - id: GO:0140309
+      label: unfolded protein holdase activity
     additional_reference_ids:
     - PMID:18407550
     supported_by:
@@ -7311,9 +7237,8 @@ existing_annotations:
       not accurately
       capture the functional consequence measured, which is suppression of protein
       aggregation (holdase
-      activity). GO:0044183 &#34;protein folding chaperone&#34; is the best available interim
-      replacement,
-      though imperfect. A holdase-specific term is needed.
+      activity). GO:0140309 &#34;unfolded protein holdase activity&#34; is the appropriate
+      replacement.
     action: MODIFY
     reason: &gt;-
       GO:0051082 is being obsoleted. The IMP evidence from PMID:18407550 is based
@@ -7322,14 +7247,12 @@ existing_annotations:
       insulin aggregation
       assay. This demonstrates the functional importance of CRYAA holdase activity
       but the term
-      &#34;unfolded protein binding&#34; mischaracterizes the function. GO:0044183 &#34;protein
-      folding chaperone&#34;
-      is the closest current replacement, though a holdase-specific term is needed
-      since the evidence
-      shows CRYAA prevents aggregation rather than assisting folding.
+      &#34;unfolded protein binding&#34; mischaracterizes the function. GO:0140309
+      &#34;unfolded protein holdase activity&#34; is the correct replacement because the
+      evidence shows CRYAA prevents aggregation rather than assisting folding.
     proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+    - id: GO:0140309
+      label: unfolded protein holdase activity
     additional_reference_ids:
     - PMID:8943244
     supported_by:
@@ -7538,8 +7461,8 @@ existing_annotations:
         childhood
 core_functions:
 - molecular_function:
-    id: GO:0044183
-    label: protein folding chaperone
+    id: GO:0140309
+    label: unfolded protein holdase activity
   description: &gt;-
     CRYAA (HSPB4) is a small heat shock protein that functions as an ATP-independent
     holdase chaperone. It forms large homo-oligomeric complexes (~540 kDa, ~24 subunits)
@@ -7613,6 +7536,16 @@ core_functions:
       increased the solubility of the T5P gamma C-crystallin both in vitro and in
       transfected cells.
 references:
+- id: UniProtKB:P02489
+  title: UniProtKB entry for human CRYAA (Alpha-crystallin A chain)
+  findings:
+    - statement: &gt;-
+        UniProt records CRYAA as cytoplasmic and stress-induced nuclear, with
+        heat-shock-dependent residence in SC35/nuclear splicing speckles.
+      supporting_text: &gt;-
+        Nucleus. Note=Translocates to the nucleus during heat shock and resides
+        in sub-nuclear structures known as SC35 speckles or nuclear splicing
+        speckles.
 - id: GO_REF:0000024
   title: Manual transfer of experimentally-verified manual GO annotation data to
     orthologs by curator judgment of sequence similarity
@@ -7624,7 +7557,7 @@ references:
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular 
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular
     Location vocabulary mapping, accompanied by conservative changes to GO terms
     applied by UniProt
   findings: []
@@ -7632,35 +7565,35 @@ references:
   title: Gene Ontology annotation based on curation of immunofluorescence data
   findings: []
 - id: GO_REF:0000117
-  title: Electronic Gene Ontology annotations created by ARBA machine learning 
+  title: Electronic Gene Ontology annotations created by ARBA machine learning
     models
   findings: []
 - id: GO_REF:0000120
   title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
 - id: PMID:11700327
-  title: Detection of protein-protein interactions among lens crystallins in a 
+  title: Detection of protein-protein interactions among lens crystallins in a
     mammalian two-hybrid system assay.
   findings: []
 - id: PMID:12235146
-  title: Role of the C-terminal extensions of alpha-crystallins. Swapping the 
-    C-terminal extension of alpha-crystallin to alphaB-crystallin results in 
+  title: Role of the C-terminal extensions of alpha-crystallins. Swapping the
+    C-terminal extension of alpha-crystallin to alphaB-crystallin results in
     enhanced chaperone activity.
   findings: []
 - id: PMID:12601044
-  title: Alteration of protein-protein interactions of congenital cataract 
+  title: Alteration of protein-protein interactions of congenital cataract
     crystallin mutants.
   findings: []
 - id: PMID:14512969
-  title: Cell death triggered by a novel mutation in the alphaA-crystallin gene 
+  title: Cell death triggered by a novel mutation in the alphaA-crystallin gene
     underlies autosomal dominant cataract linked to chromosome 21q.
   findings: []
 - id: PMID:14752512
-  title: Human alphaA- and alphaB-crystallins bind to Bax and Bcl-X(S) to 
+  title: Human alphaA- and alphaB-crystallins bind to Bax and Bcl-X(S) to
     sequester their translocation during staurosporine-induced apoptosis.
   findings: []
 - id: PMID:16303126
-  title: Lenticular chaperones suppress the aggregation of the cataract-causing 
+  title: Lenticular chaperones suppress the aggregation of the cataract-causing
     mutant T5P gamma C-crystallin.
   findings: []
 - id: PMID:18407550
@@ -7671,11 +7604,11 @@ references:
   title: HSPB7 is a SC35 speckle resident small heat shock protein.
   findings: []
 - id: PMID:19503744
-  title: An alphaA-crystallin gene mutation, Arg12Cys, causing inherited 
+  title: An alphaA-crystallin gene mutation, Arg12Cys, causing inherited
     cataract-microcornea exhibits an altered heat-shock response.
   findings: []
 - id: PMID:19651604
-  title: The eye lens chaperone alpha-crystallin forms defined globular 
+  title: The eye lens chaperone alpha-crystallin forms defined globular
     assemblies.
   findings: []
 - id: PMID:22085609
@@ -7683,7 +7616,7 @@ references:
     αA-crystallin: molecular basis for early onset of age-related cataract.&#39;
   findings: []
 - id: PMID:22153508
-  title: The polydispersity of αB-crystallin is rationalized by an 
+  title: The polydispersity of αB-crystallin is rationalized by an
     interconverting polyhedral architecture.
   findings: []
 - id: PMID:23188086
@@ -7694,22 +7627,22 @@ references:
   title: A proteome-scale map of the human interactome network.
   findings: []
 - id: PMID:25910212
-  title: Widespread macromolecular interaction perturbations in human genetic 
+  title: Widespread macromolecular interaction perturbations in human genetic
     disorders.
   findings: []
 - id: PMID:26004348
   title: Mutation analysis of two families with inherited congenital cataracts.
   findings: []
 - id: PMID:29259299
-  title: Two novel mutations identified in ADCC families impair crystallin 
+  title: Two novel mutations identified in ADCC families impair crystallin
     protein distribution and induce apoptosis in human lens epithelial cells.
   findings: []
 - id: PMID:29892012
-  title: An interactome perturbation framework prioritizes damaging missense 
+  title: An interactome perturbation framework prioritizes damaging missense
     mutations for developmental disorders.
   findings: []
 - id: PMID:30340470
-  title: A novel mutation in the CRYAA gene associated with congenital cataract 
+  title: A novel mutation in the CRYAA gene associated with congenital cataract
     and microphthalmia in a Chinese family.
   findings: []
 - id: PMID:31515488
@@ -7720,28 +7653,35 @@ references:
   title: A reference map of the human binary protein interactome.
   findings: []
 - id: PMID:32814053
-  title: Interactome Mapping Provides a Network of Neurodegenerative Disease 
+  title: Interactome Mapping Provides a Network of Neurodegenerative Disease
     Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.
   findings: []
 - id: PMID:33961781
-  title: Dual proteome-scale networks reveal cell-specific remodeling of the 
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the
     human interactome.
   findings: []
 - id: PMID:8943244
-  title: Cloning, expression, and chaperone-like activity of human 
+  title: Cloning, expression, and chaperone-like activity of human
     alphaA-crystallin.
   findings: []
 - id: PMID:9467006
-  title: Autosomal dominant congenital cataract associated with a missense 
+  title: Autosomal dominant congenital cataract associated with a missense
     mutation in the human alpha crystallin gene CRYAA.
   findings: []
+- id: file:human/CRYAA/CRYAA-deep-research-falcon.md
+  title: Falcon deep research for human CRYAA
+  findings:
+    - statement: &gt;-
+        Falcon synthesis supports CRYAA/HSPB4 as an alpha-crystallin small heat
+        shock protein with ATP-independent holdase chaperone activity central to
+        lens proteostasis and cataract biology.
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/CRYAA/CRYAA-ai-review.yaml
+++ b/genes/human/CRYAA/CRYAA-ai-review.yaml
@@ -1,7 +1,7 @@
 id: P02489
 gene_symbol: CRYAA
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -111,30 +111,27 @@ existing_annotations:
   original_reference_id: GO_REF:0000033
   review:
     summary: >-
-      IBA annotation for nucleus localization. PMID:19464326 showed that CRYAA (HSPB4)
-      translocates
-      to sub-nuclear structures (SC35 speckles) during heat shock. UniProt notes that
-      CRYAA
-      translocates to the nucleus during heat shock and resides in SC35 splicing speckles.
-      This is
-      a stress-induced secondary localization rather than the primary constitutive
-      location. The
+      IBA annotation for nucleus localization. UniProt notes that CRYAA (HSPB4)
+      translocates to the nucleus during heat shock and resides in SC35 splicing
+      speckles. This is a stress-induced secondary localization rather than the
+      primary constitutive location. The
       IBA annotation is phylogenetically appropriate for sHSP family members that
       show nuclear
       translocation under stress.
     action: KEEP_AS_NON_CORE
     reason: >-
-      Nuclear localization is real but conditional (stress-induced). CRYAA translocates
-      to SC35
-      splicing speckles during heat shock (PMID:19464326). This is not the primary
-      constitutive
+      Nuclear localization is real but conditional (stress-induced). UniProt records
+      CRYAA translocation to SC35 splicing speckles during heat shock. This is not
+      the primary constitutive
       localization of CRYAA, which is cytoplasmic. Keeping as non-core reflects that
       this is a
       secondary, stress-dependent localization.
     supported_by:
-    - reference_id: PMID:19464326
+    - reference_id: UniProtKB:P02489
       supporting_text: >-
-        HSPB7 constitutively localized to SC35 splicing speckles
+        Nucleus. Note=Translocates to the nucleus during heat shock and resides
+        in sub-nuclear structures known as SC35 speckles or nuclear splicing
+        speckles.
 - term:
     id: GO:0009408
     label: response to heat
@@ -165,6 +162,11 @@ existing_annotations:
         both WT and W9F subunits completely suppressed the heat-induced aggregation
         of aldose
         reductase
+    - reference_id: file:human/CRYAA/CRYAA-deep-research-falcon.md
+      supporting_text: >-
+        As a chaperone, HSPB4 binds partially unfolded proteins to prevent
+        misfolding and aggregation, thereby maintaining lens proteostasis and
+        cell survival
 - term:
     id: GO:0042026
     label: protein refolding
@@ -231,15 +233,10 @@ existing_annotations:
       zebrafish,
       and mammals, which is appropriate for the family-level chaperone function. However,
       the term
-      itself needs replacement. GO:0044183 "protein folding chaperone" is the closest
-      available MF term,
-      defined as "Binding to a protein or a protein-containing complex to assist the
-      protein folding
-      process." This is an imperfect replacement because CRYAA specifically does NOT
-      assist in protein
-      folding -- it prevents aggregation (holdase activity). A dedicated holdase-specific
-      GO term is
-      needed. As a biological process annotation, GO:0050821 "protein stabilization"
+      itself needs replacement. GO:0140309 "unfolded protein holdase activity" is
+      the appropriate MF term for ATP-independent binding to unfolded proteins to
+      prevent their aggregation without active refolding. As a biological process
+      annotation, GO:0050821 "protein stabilization"
       (defined as
       "Any process involved in maintaining the structure and integrity of a protein
       and preventing it
@@ -253,16 +250,12 @@ existing_annotations:
       it suppresses aggregation of heat-denatured aldose reductase and singlet-oxygen-damaged
       gamma-crystallin (PMID:8943244). However, it does NOT refold proteins (NOT annotation
       to
-      GO:0042026 protein refolding, ISS). The best available interim MF replacement
-      is GO:0044183
-      "protein folding chaperone," though this term is not ideal because its definition
-      references
-      "protein folding process" which is not what CRYAA does. A new holdase-specific
-      term should be
-      requested. GO:0050821 "protein stabilization" is appropriate as a BP term.
+      GO:0042026 protein refolding, ISS). The appropriate MF replacement is
+      GO:0140309 "unfolded protein holdase activity." GO:0050821 "protein
+      stabilization" is appropriate as a BP term.
     proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+    - id: GO:0140309
+      label: unfolded protein holdase activity
     additional_reference_ids:
     - PMID:8943244
     - PMID:18407550
@@ -490,16 +483,12 @@ existing_annotations:
       alphaA-alphaB
       interactions. While the interactions are real and functionally relevant (crystallin-crystallin
       interactions maintain lens transparency), "protein binding" is uninformative.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
       "Protein binding" is too vague. The actual interactions detected are crystallin-crystallin
-      interactions relevant to the chaperone holdase function. GO:0044183 "protein
-      folding
-      chaperone" better captures the molecular function, as CRYAA interacts with destabilized
-      crystallins to prevent their aggregation.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+      interactions, not direct evidence for a specific molecular-function replacement.
+      CRYAA holdase activity is supported by aggregation-suppression assays elsewhere;
+      this two-hybrid interaction record should not be used to infer a chaperone term.
     supported_by:
     - reference_id: PMID:11700327
       supporting_text: >-
@@ -520,18 +509,14 @@ existing_annotations:
       and gammaC-crystallin decreased in the R116C mutant, while interactions with
       alphaB-crystallin
       and Hsp27 increased. "Protein binding" is uninformative for the functional context.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
       "Protein binding" is too generic. The crystallin-crystallin interactions documented
       are
-      functionally relevant to chaperone holdase activity and lens structural integrity.
-      The
-      identical protein binding annotation (GO:0042802) from the same paper better
-      captures the
-      self-interaction aspect.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+      functionally relevant to lens protein organization, but altered two-hybrid
+      interactions in a cataract mutant are not direct evidence for a chaperone
+      molecular-function replacement. Keep the mechanistic context without treating
+      generic protein binding as a core function.
     supported_by:
     - reference_id: PMID:12601044
       supporting_text: >-
@@ -607,16 +592,14 @@ existing_annotations:
       CRYAA may have been detected in this study. "Protein binding" is uninformative
       and should
       be replaced with more specific terms for the alpha-crystallin hetero-oligomerization.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
       "Protein binding" is too vague. The context is alpha-crystallin oligomerization.
       A more
       specific term describing hetero-oligomerization or structural complex formation
       would be
-      more informative.
-    proposed_replacement_terms:
-    - id: GO:0042802
-      label: identical protein binding
+      more informative, but GO:0042802 should not be used here because this row is
+      not specific to CRYAA self-interaction.
 - term:
     id: GO:0005515
     label: protein binding
@@ -632,14 +615,12 @@ existing_annotations:
       with
       CRYAA would be in the context of hetero-oligomerization. "Protein binding" is
       uninformative.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
       "Protein binding" is too vague. The context is sHSP subunit interactions via
       the IxI
-      motif, relevant to hetero-oligomerization with CRYAB.
-    proposed_replacement_terms:
-    - id: GO:0042802
-      label: identical protein binding
+      motif, relevant to hetero-oligomerization with CRYAB rather than identical
+      CRYAA self-binding.
 - term:
     id: GO:0005515
     label: protein binding
@@ -651,17 +632,13 @@ existing_annotations:
       map).
       This is a high-throughput study. "Protein binding" from high-throughput interactome
       studies is uninformative and lacks the context of specific functional interactions.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
       "Protein binding" from high-throughput interactome mapping is too generic. CRYAA
       is known
-      to form homo- and hetero-oligomers; GO:0042802 "identical protein binding" is
-      already
-      annotated from this reference. The generic protein binding annotation adds no
-      information.
-    proposed_replacement_terms:
-    - id: GO:0042802
-      label: identical protein binding
+      to form homo- and hetero-oligomers, but this broad interactome row is not
+      specific enough to justify replacing the annotation with identical protein
+      binding.
 - term:
     id: GO:0005515
     label: protein binding
@@ -725,13 +702,11 @@ existing_annotations:
       binary
       protein interactome). This is a high-throughput interactome mapping study. "Protein
       binding" is uninformative. GO:0042802 is already annotated from this same reference.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      "Protein binding" is too vague. GO:0042802 "identical protein binding" is already
-      annotated from this same reference and is more informative for CRYAA self-interactions.
-    proposed_replacement_terms:
-    - id: GO:0042802
-      label: identical protein binding
+      "Protein binding" is too vague. Although GO:0042802 "identical protein binding"
+      is annotated separately from this reference, this broad interactome protein-binding
+      row should not itself be converted to a self-interaction assertion.
 - term:
     id: GO:0005515
     label: protein binding
@@ -1004,14 +979,13 @@ existing_annotations:
     reason: >-
       The evidence in PMID:16303126 is about chaperone holdase activity (suppressing
       aggregation
-      of T5P gammaC-crystallin), not structural molecule activity per se. GO:0044183
-      "protein
-      folding chaperone" better captures the molecular function demonstrated. For
+      of T5P gammaC-crystallin), not structural molecule activity per se. GO:0140309
+      "unfolded protein holdase activity" better captures the molecular function demonstrated. For
       the true
       structural role, GO:0005212 is already annotated.
     proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+    - id: GO:0140309
+      label: unfolded protein holdase activity
     supported_by:
     - reference_id: PMID:16303126
       supporting_text: >-
@@ -1098,13 +1072,11 @@ existing_annotations:
     reason: >-
       "Protein binding" is uninformative. The interactions documented are alpha-crystallin
       subunit interactions (hetero-oligomerization) relevant to chaperone function.
-      GO:0044183
-      "protein folding chaperone" better captures the molecular function demonstrated
-      by
-      the chaperone activity assays used.
+      GO:0140309 "unfolded protein holdase activity" better captures the molecular
+      function demonstrated by the chaperone activity assays used.
     proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+    - id: GO:0140309
+      label: unfolded protein holdase activity
     supported_by:
     - reference_id: PMID:12235146
       supporting_text: >-
@@ -1161,24 +1133,23 @@ existing_annotations:
   original_reference_id: PMID:19464326
   review:
     summary: >-
-      IDA annotation for nucleus from PMID:19464326. This study directly demonstrated
-      by confocal
-      microscopy that CRYAA (HSPB4) translocates to the nucleus during heat shock
-      and resides
-      in SC35 splicing speckles. While not the primary constitutive localization,
-      the stress-
-      induced nuclear translocation is experimentally well documented.
+      IDA annotation for nucleus from PMID:19464326. The cached abstract excerpt
+      available here is about HSPB7, so explicit text support is taken from the
+      UniProt CRYAA subcellular-location statement, which records heat-shock-induced
+      nuclear translocation to SC35 splicing speckles. While not the primary
+      constitutive localization, the stress-induced nuclear translocation is
+      experimentally documented in the UniProt record.
     action: KEEP_AS_NON_CORE
     reason: >-
-      Nuclear localization is directly demonstrated by confocal microscopy (PMID:19464326)
-      but
-      is stress-induced (heat shock) rather than constitutive. CRYAA resides in SC35
-      speckles
-      under stress conditions. This is a secondary localization.
+      Nuclear localization is stress-induced (heat shock) rather than constitutive.
+      CRYAA resides in SC35 speckles under stress conditions. This is a secondary
+      localization.
     supported_by:
-    - reference_id: PMID:19464326
+    - reference_id: UniProtKB:P02489
       supporting_text: >-
-        HSPB7 constitutively localized to SC35 splicing speckles
+        Nucleus. Note=Translocates to the nucleus during heat shock and resides
+        in sub-nuclear structures known as SC35 speckles or nuclear splicing
+        speckles.
 - term:
     id: GO:0005737
     label: cytoplasm
@@ -1214,7 +1185,7 @@ existing_annotations:
       affinity. "Protein binding" is uninformative for this specific anti-apoptotic
       binding
       activity.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
       "Protein binding" is too generic. The specific interaction is binding to pro-apoptotic
       Bax and Bcl-X(S) to sequester them and prevent apoptosis. This is better captured
@@ -1223,9 +1194,6 @@ existing_annotations:
       present.
       No single MF term perfectly captures anti-apoptotic binding, but the IPI evidence
       supports the GO:0043066 BP annotation.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
     supported_by:
     - reference_id: PMID:14752512
       supporting_text: >-
@@ -1253,32 +1221,17 @@ existing_annotations:
       actively refold them. This is consistent with all experimental evidence: PMID:8943244
       describes the chaperone-like activity as "the ability to suppress nonspecific
       aggregation"
-      with no mention of refolding capability. PMID:19464326 showed functional divergence
-      among
-      sHSP family members -- HSPB1 and HSPB5 kept substrates folding-competent but
-      HSPB7 did
-      not support refolding. CRYAA (HSPB4), like HSPB7, is a holdase without foldase
-      activity.
-      Both this NOT annotation and the positive IBA annotation for GO:0042026 should
-      be removed:
-      the IBA positive assertion is incorrect for CRYAA, and the NOT annotation becomes
-      redundant
-      once the incorrect positive assertion is removed.
-    action: REMOVE
+      with no mention of refolding capability. The negated GOA assertion is
+      therefore consistent with CRYAA being a holdase without foldase activity.
+      This NOT annotation should be retained because it records the biologically
+      important distinction between CRYAA holdase activity and active protein
+      refolding.
+    action: KEEP_AS_NON_CORE
     reason: >-
-      While the NOT annotation correctly states that CRYAA does not perform protein
-      refolding,
-      both the positive IBA and this negated ISS annotation for GO:0042026 should
-      be removed
-      together. The IBA positive assertion is incorrect (CRYAA is a holdase, not a
-      foldase),
-      and once the incorrect positive assertion is removed, the NOT annotation is
-      no longer
-      needed. The holdase vs foldase distinction is better captured by GO:0050821
-      "protein
-      stabilization" (already annotated) and the proposed GO:0044183 "protein folding
-      chaperone"
-      replacement annotations.
+      The negated annotation correctly states that CRYAA does not perform active
+      protein refolding. Retaining this NOT assertion is useful because it prevents
+      propagation of a foldase interpretation and supports the replacement of
+      unfolded protein binding with GO:0140309 "unfolded protein holdase activity."
     supported_by:
     - reference_id: PMID:8943244
       supporting_text: >-
@@ -1312,12 +1265,9 @@ existing_annotations:
       evidence
       clearly supports that CRYAA binds partially denatured proteins and prevents
       their aggregation,
-      which is holdase (not foldase) activity. The term GO:0044183 "protein folding
-      chaperone" is the
-      best available interim replacement MF term, though imperfect because CRYAA does
-      not assist in
-      protein folding per se -- it prevents aggregation. A holdase-specific GO term
-      is needed.
+      which is holdase (not foldase) activity. The term GO:0140309 "unfolded protein
+      holdase activity" is the appropriate MF replacement because CRYAA prevents
+      aggregation without active refolding.
     action: MODIFY
     reason: >-
       GO:0051082 is being obsoleted. The experimental evidence from PMID:8943244 clearly
@@ -1328,14 +1278,12 @@ existing_annotations:
       in a passive
       sense; it is active suppression of aggregation. The IPI evidence (with aldose
       reductase
-      UniProtKB:P07320 as interactor) is strong. GO:0044183 "protein folding chaperone"
-      is the
-      closest current MF term, but a holdase-specific term is needed since CRYAA does
-      NOT refold
+      UniProtKB:P07320 as interactor) is strong. GO:0140309 "unfolded protein
+      holdase activity" is the correct current MF term since CRYAA does NOT refold
       proteins. GO:0050821 "protein stabilization" is also relevant as a BP term.
     proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+    - id: GO:0140309
+      label: unfolded protein holdase activity
     additional_reference_ids:
     - PMID:18407550
     supported_by:
@@ -1451,9 +1399,8 @@ existing_annotations:
       not accurately
       capture the functional consequence measured, which is suppression of protein
       aggregation (holdase
-      activity). GO:0044183 "protein folding chaperone" is the best available interim
-      replacement,
-      though imperfect. A holdase-specific term is needed.
+      activity). GO:0140309 "unfolded protein holdase activity" is the appropriate
+      replacement.
     action: MODIFY
     reason: >-
       GO:0051082 is being obsoleted. The IMP evidence from PMID:18407550 is based
@@ -1462,14 +1409,12 @@ existing_annotations:
       insulin aggregation
       assay. This demonstrates the functional importance of CRYAA holdase activity
       but the term
-      "unfolded protein binding" mischaracterizes the function. GO:0044183 "protein
-      folding chaperone"
-      is the closest current replacement, though a holdase-specific term is needed
-      since the evidence
-      shows CRYAA prevents aggregation rather than assisting folding.
+      "unfolded protein binding" mischaracterizes the function. GO:0140309
+      "unfolded protein holdase activity" is the correct replacement because the
+      evidence shows CRYAA prevents aggregation rather than assisting folding.
     proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+    - id: GO:0140309
+      label: unfolded protein holdase activity
     additional_reference_ids:
     - PMID:8943244
     supported_by:
@@ -1678,8 +1623,8 @@ existing_annotations:
         childhood
 core_functions:
 - molecular_function:
-    id: GO:0044183
-    label: protein folding chaperone
+    id: GO:0140309
+    label: unfolded protein holdase activity
   description: >-
     CRYAA (HSPB4) is a small heat shock protein that functions as an ATP-independent
     holdase chaperone. It forms large homo-oligomeric complexes (~540 kDa, ~24 subunits)
@@ -1753,6 +1698,16 @@ core_functions:
       increased the solubility of the T5P gamma C-crystallin both in vitro and in
       transfected cells.
 references:
+- id: UniProtKB:P02489
+  title: UniProtKB entry for human CRYAA (Alpha-crystallin A chain)
+  findings:
+    - statement: >-
+        UniProt records CRYAA as cytoplasmic and stress-induced nuclear, with
+        heat-shock-dependent residence in SC35/nuclear splicing speckles.
+      supporting_text: >-
+        Nucleus. Note=Translocates to the nucleus during heat shock and resides
+        in sub-nuclear structures known as SC35 speckles or nuclear splicing
+        speckles.
 - id: GO_REF:0000024
   title: Manual transfer of experimentally-verified manual GO annotation data to
     orthologs by curator judgment of sequence similarity
@@ -1875,3 +1830,10 @@ references:
   title: Autosomal dominant congenital cataract associated with a missense 
     mutation in the human alpha crystallin gene CRYAA.
   findings: []
+- id: file:human/CRYAA/CRYAA-deep-research-falcon.md
+  title: Falcon deep research for human CRYAA
+  findings:
+    - statement: >-
+        Falcon synthesis supports CRYAA/HSPB4 as an alpha-crystallin small heat
+        shock protein with ATP-independent holdase chaperone activity central to
+        lens proteostasis and cataract biology.

--- a/genes/human/CRYAB/CRYAB-ai-review.html
+++ b/genes/human/CRYAB/CRYAB-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>CRYAB</h1>
         <div class="gene-info">
-
+            
             <div class="info-item">
-
+                
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P02511" target="_blank" class="term-link">
                         P02511
                     </a>
                 </span>
-
+                
             </div>
-
-
+            
+            
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-
-
+            
+            
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
                 <span class="status-badge status-complete">
                     COMPLETE
                 </span>
             </div>
-
-
+            
+            
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-
+    
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>CRYAB (alpha-crystallin B chain, also known as HSPB5) is a small heat shock protein that functions as a molecular chaperone with holdase activity. It binds partially denatured or destabilized proteins in an ATP-independent manner to prevent their aggregation, but unlike HSP70-family foldase chaperones, it does NOT actively refold substrates. CRYAB forms large polydisperse oligomeric complexes, typically of 10-40 subunits, and can hetero-oligomerize with CRYAA (HSPB4). The canonical sHSP architecture comprises a central alpha-crystallin domain (ACD) flanked by a variable N-terminal domain (NTD) and a short C-terminal domain (CTD); chaperone activity is tightly coupled to oligomeric assembly and dynamic subunit exchange (DOI:10.1038/s41467-024-54647-7). A conserved N-terminal IXI-like motif (NT-IXI) engages the ACD hydrophobic groove, and perturbation of this motif transforms native assemblies into reversible elongated helical fibrils, as resolved by cryo-EM (DOI:10.1038/s41467-024-54647-7). Stress-activated phosphorylation at Ser19/Ser45/Ser59 by p38 MAPK modulates oligomeric state; the p38-CRYAB(pS59) cascade is a stress-response module that can shift CRYAB condensates toward less dynamic, aggregate-prone states under pathological conditions (DOI:10.1016/j.isci.2024.109510, DOI:10.1172/jci163730). In the eye lens, CRYAB serves dual roles as a structural protein contributing to transparency and refractive index, and as a chaperone preventing aggregation of damaged crystallins. Outside the lens, it is highly expressed in cardiac and skeletal muscle where it associates with cytoskeletal elements including desmin intermediate filaments and titin at Z-bands and intercalated disks. CRYAB also functions as a mitochondrial chaperone and anti-apoptotic protein, binding pro-apoptotic factors Bax, Bcl-X(S), cytochrome c, and VDAC; the E105K mutation causing hereditary optic atrophy reduces these interactions and impairs mitochondrial OXPHOS assembly (DOI:10.1172/jci.insight.182209). CRYAB is secreted via extracellular vesicles and exerts paracrine effects including promotion of angiogenesis in cardiac contexts (DOI:10.1186/s13287-023-03468-4, DOI:10.1038/s42003-022-04402-9). Mutations in CRYAB cause myofibrillar myopathy, cataracts, dilated cardiomyopathy, restrictive cardiomyopathy, and hereditary optic atrophy.</p>
     </div>
+    
 
+    
 
+    
 
-
-
-
-
+    
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043066" target="_blank" class="term-link">
                                     GO:0043066
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of apoptotic process</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000033
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,64 +795,64 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for negative regulation of apoptotic process, phylogenetically propagated across small heat shock protein family members (CRYAA, CRYAB, HSPB1). CRYAB has well-documented anti-apoptotic activity. It binds pro-apoptotic Bax and Bcl-X(S) to prevent their translocation from cytosol to mitochondria during staurosporine-induced apoptosis (PMID:14752512). This preserves mitochondrial integrity and blocks caspase-3 activation and PARP degradation.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> CRYAB is a bona fide anti-apoptotic protein. PMID:14752512 demonstrates that alpha-crystallins bind Bax and Bcl-X(S) both in vitro and in vivo, preventing their translocation to mitochondria. The IBA annotation is phylogenetically appropriate and reflects a well-established function of CRYAB beyond its lens chaperone role. This is a core function of CRYAB, particularly in cardiac and muscle contexts.
                         </div>
-
-
-
+                        
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link">
                                         PMID:14752512
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">alphaA- and alphaB-crystallins prevent staurosporine-induced apoptosis through interactions with members of the Bcl-2 family. Using GST pulldown assays and coimmunoprecipitations, we demonstrated that alpha-crystallins bind to Bax and Bcl-X(S) both in vitro and in vivo.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000033
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -864,64 +864,64 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for cytoplasm localization, phylogenetically propagated across sHSP family. CRYAB is a predominantly cytoplasmic protein. Multiple IDA annotations from different studies (PMID:19464326, PMID:20587334, PMID:14752512) confirm cytoplasmic localization. UniProt lists cytoplasm as a primary subcellular location.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Cytoplasm is the primary localization of CRYAB. This is confirmed by multiple independent IDA studies (PMID:19464326, PMID:20587334, PMID:14752512) and is consistent with its role as a cytoplasmic holdase chaperone. The IBA annotation is appropriate and well-supported.
                         </div>
-
-
-
+                        
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
                                         PMID:19464326
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">Online databases did not accurately predict the sub-cellular distribution of all the HSPB members.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000033
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -933,64 +933,64 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for nuclear localization. CRYAB has been shown to translocate to the nucleus during heat shock, where it resides in SC35 speckles (nuclear splicing speckles) (PMID:19464326). It can also accumulate in the nucleus when co-expressed with LBH (PMID:20587334). Multiple IDA annotations support this.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Nuclear localization is confirmed by IDA evidence from PMID:19464326 and PMID:20587334. CRYAB translocates to the nucleus during heat stress and resides in SC35 speckles. This is a conditional/stress-dependent localization but is well-documented. The IBA annotation is appropriate.
                         </div>
-
-
-
+                        
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
                                         PMID:19464326
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">Some members also show a dynamic, stress-induced translocation to SC35 splicing speckles.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009408" target="_blank" class="term-link">
                                     GO:0009408
                                 </a>
                             </span>
                             <span class="term-label">response to heat</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000033
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1002,64 +1002,64 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for response to heat. CRYAB is a small heat shock protein (HSPB5) that is upregulated during heat stress and translocates to the nucleus (PMID:19464326). Its chaperone activity in preventing protein aggregation is central to its role in the heat shock response. The IBA is propagated from multiple Drosophila and C. elegans HSP orthologs.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Response to heat is a core function of CRYAB as a member of the small heat shock protein family. It is upregulated during heat stress and shows stress-induced nuclear translocation (PMID:19464326). The IBA annotation is phylogenetically appropriate and reflects the conserved heat stress response function of sHSPs.
                         </div>
-
-
-
+                        
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
                                         PMID:19464326
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">Unlike HSPB1 and HSPB5, that chaperoned heat unfolded substrates and kept them folding competent, HSPB7 did not support refolding.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000033
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1071,88 +1071,88 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for protein refolding, propagated from Drosophila sHSP orthologs. This is problematic for CRYAB specifically. While some sHSPs in other organisms may participate in protein refolding pathways (by passing substrates to foldase chaperones like HSP70), CRYAB itself is a holdase -- it prevents aggregation of denatured proteins but does NOT actively refold them. PMID:19464326 explicitly tested refolding activity: HSPB1 and HSPB5 chaperoned heat unfolded substrates and kept them folding competent, but the refolding itself depends on downstream HSP70/HSP40 machinery. The term protein refolding implies direct refolding activity which CRYAB does not have.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> CRYAB is a holdase chaperone that prevents aggregation but does NOT perform protein refolding. The IBA may be appropriate at the broader sHSP family level where some members participate in refolding pathways, but for CRYAB specifically, protein refolding is misleading. CRYAB keeps substrates in a folding-competent state for downstream foldases (PMID:19464326), which is better captured by GO:0050821 protein stabilization (already annotated via IMP from PMID:12235146). The annotation should be modified to better reflect holdase/protein stabilization activity rather than direct refolding.
                         </div>
-
-
+                        
+                        
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-
+                            
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                     protein stabilization
                                 </a>
                             </span>
-
+                            
                         </div>
-
-
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
                                         PMID:19464326
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">HSPB1 and HSPB5, that chaperoned heat unfolded substrates and kept them folding competent, HSPB7 did not support refolding.</div>
-
+                                
                             </div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link">
                                         PMID:16303126
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">the major lenticular protein chaperones, alpha A- and alpha B-crystallin, increased the solubility of the T5P gamma C-crystallin both in vitro and in transfected cells.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000033
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1164,86 +1164,86 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). CRYAB/HSPB5 does bind partially denatured or destabilized proteins, but the term &#34;unfolded protein binding&#34; is problematic because it implies a simple binding function rather than the chaperone holdase activity that CRYAB performs. CRYAB acts as a molecular chaperone that suppresses aggregation of destabilized proteins in an ATP-independent manner (PMID:16303126), but unlike HSP70-family foldase chaperones, it does NOT actively refold substrates. The IBA annotation is phylogenetically propagated from sHSP family members, which is appropriate at the family level since small heat shock proteins share this holdase chaperone function. However, the term itself needs replacement. GO:0044183 &#34;protein folding chaperone&#34; (defined as &#34;Binding to a protein or a protein-containing complex to assist the protein folding process&#34;) is the closest available MF term. This is an imperfect replacement because CRYAB specifically does NOT assist in protein folding -- it prevents aggregation (holdase activity). A dedicated holdase-specific GO term does not yet exist and should be requested. UniProt describes CRYAB as having &#34;chaperone-like activity, preventing aggregation of various proteins under a wide range of stress conditions.&#34;
+                            <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). CRYAB/HSPB5 does bind partially denatured or destabilized proteins, but the term &#34;unfolded protein binding&#34; is problematic because it implies a simple binding function rather than the chaperone holdase activity that CRYAB performs. CRYAB acts as a molecular chaperone that suppresses aggregation of destabilized proteins in an ATP-independent manner (PMID:16303126), but unlike HSP70-family foldase chaperones, it does NOT actively refold substrates. The IBA annotation is phylogenetically propagated from sHSP family members, which is appropriate at the family level since small heat shock proteins share this holdase chaperone function. However, the term itself needs replacement. GO:0140309 &#34;unfolded protein holdase activity&#34; is the appropriate MF term for ATP-independent binding to unfolded or destabilized proteins to prevent their aggregation without active refolding. UniProt describes CRYAB as having &#34;chaperone-like activity, preventing aggregation of various proteins under a wide range of stress conditions.&#34;
                         </div>
-
-
+                        
+                        
                         <div>
-                            <strong>Reason:</strong> GO:0051082 is being obsoleted. CRYAB has well-documented chaperone-like holdase activity: alpha-crystallins (including CRYAB) increase the solubility of destabilized T5P gamma C-crystallin and reduce the size of its aggregates both in vitro and in transfected cells (PMID:16303126). However, CRYAB does NOT refold proteins -- it is a holdase, not a foldase. The best available interim MF replacement is GO:0044183 &#34;protein folding chaperone,&#34; though this term is not ideal because its definition references &#34;protein folding process&#34; which is not what CRYAB does. A new holdase-specific term should be requested. GO:0050821 &#34;protein stabilization&#34; is appropriate as a BP term and is already annotated for CRYAB via PMID:12235146.
+                            <strong>Reason:</strong> GO:0051082 is being obsoleted. CRYAB has well-documented chaperone-like holdase activity: alpha-crystallins (including CRYAB) increase the solubility of destabilized T5P gamma C-crystallin and reduce the size of its aggregates both in vitro and in transfected cells (PMID:16303126). However, CRYAB does NOT refold proteins -- it is a holdase, not a foldase. The appropriate MF replacement is GO:0140309 &#34;unfolded protein holdase activity.&#34; GO:0050821 &#34;protein stabilization&#34; is appropriate as a BP term and is already annotated for CRYAB via PMID:12235146.
                         </div>
-
-
+                        
+                        
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-
+                            
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140309" target="_blank" class="term-link">
+                                    unfolded protein holdase activity
                                 </a>
                             </span>
-
+                            
                         </div>
-
-
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link">
                                         PMID:16303126
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">the major lenticular protein chaperones, alpha A- and alpha B-crystallin, increased the solubility of the T5P gamma C-crystallin both in vitro and in transfected cells. More importantly, the size of the T5P gamma C-crystallin aggregates were also significantly reduced in the presence of the lenticular chaperones.</div>
-
+                                
                             </div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     file:human/CRYAB/CRYAB-deep-research-falcon.md
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">These concepts are consistent with CRYAB being a small HSP chaperone/holdase, not an enzyme/transporter; therefore its “primary function” is ATP-independent chaperoning of destabilized proteins and stress-protective regulation of proteostasis.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005198" target="_blank" class="term-link">
                                     GO:0005198
                                 </a>
                             </span>
                             <span class="term-label">structural molecule activity</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000117
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1255,57 +1255,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from ARBA machine learning for structural molecule activity. CRYAB does indeed serve as a structural protein in the eye lens, contributing to transparency and refractive index. There is also an IDA annotation for this term from PMID:16303126. However, the more specific term GO:0005212 structural constituent of eye lens is also annotated and is more informative. This broader IEA annotation is acceptable as it also reflects the structural role in muscle (association with sarcomeric Z-discs and desmin filaments).
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Structural molecule activity is broader than needed for CRYAB. The lens structural role is captured more precisely by GO:0005212 &#34;structural constituent of eye lens&#34;, while muscle/cytoskeletal contexts are better captured by cytoskeletal protein binding and localization annotations.
                         </div>
-
-
+                        
+                        
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-
+                            
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005212" target="_blank" class="term-link">
                                     structural constituent of eye lens
                                 </a>
                             </span>
-
+                            
                         </div>
-
-
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005212" target="_blank" class="term-link">
                                     GO:0005212
                                 </a>
                             </span>
                             <span class="term-label">structural constituent of eye lens</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000120
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1317,46 +1317,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from combined automated methods for structural constituent of eye lens. CRYAB is one of the major structural proteins of the eye lens. It contributes to lens transparency and refractive index. This is well-established from decades of crystallin research and is supported by the InterPro alpha-crystallin N-terminal domain annotation (IPR003090) and the UniProt eye lens protein keyword.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> CRYAB is a major structural protein of the vertebrate eye lens. This is a core function. The annotation is appropriate and well-supported by the established biology of alpha-crystallins as both structural lens proteins and molecular chaperones.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
                                     GO:0005576
                                 </a>
                             </span>
                             <span class="term-label">extracellular region</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000044
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1368,46 +1368,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from UniProt subcellular location mapping. UniProt annotates CRYAB as Secreted based on PMID:32272059, which showed CRYAB can be secreted via an unconventional TMED10-dependent pathway involving translocation to the ERGIC. Additionally, CRYAB is found in extracellular exosomes (PMID:23533145, PMID:19056867). The extracellular region annotation is therefore justified.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> CRYAB has been shown to be secreted via an unconventional protein secretion pathway involving TMED10 (PMID:32272059) and is found in extracellular exosomes (PMID:23533145). The IEA annotation correctly reflects the UniProt subcellular location annotation for Secreted.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000044
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1419,46 +1419,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from UniProt subcellular location mapping for nucleus. This is a duplicate of the IBA annotation for nucleus, and is also supported by multiple IDA annotations (PMID:19464326, PMID:20587334). Nuclear localization is stress-dependent.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> This IEA annotation is consistent with the IBA and IDA evidence. CRYAB translocates to the nucleus during heat stress (PMID:19464326). The IEA correctly maps the UniProt subcellular location annotation.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000120
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1470,46 +1470,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from combined automated methods for cytoplasm localization. CRYAB is primarily a cytoplasmic protein, confirmed by multiple IDA annotations (PMID:19464326, PMID:20587334, PMID:14752512) and the IBA annotation.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> This is redundant with the IBA and IDA annotations but is a correct broader IEA annotation. Cytoplasm is the primary localization of CRYAB.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005764" target="_blank" class="term-link">
                                     GO:0005764
                                 </a>
                             </span>
                             <span class="term-label">lysosome</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000044
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1521,46 +1521,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from UniProt subcellular location mapping. UniProt annotates CRYAB as localizing to the lysosome based on similarity to the mouse ortholog P23927 (ECO:0000250). This is supported by PMID:31786107, which shows that CRYAB forms a complex with ATP6V1A and mTOR and regulates lysosome activity in lens epithelial cells.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Lysosome localization is annotated by similarity to the mouse ortholog and is supported by the functional interaction between CRYAB, ATP6V1A (a lysosomal V-ATPase subunit) and mTOR (PMID:31786107). The IEA annotation is reasonable.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009892" target="_blank" class="term-link">
                                     GO:0009892
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of metabolic process</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000117
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1572,46 +1572,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from ARBA machine learning for negative regulation of metabolic process. This is an extremely broad BP term. CRYAB does negatively regulate some metabolic processes (e.g., negative regulation of apoptosis, negative regulation of protein aggregation), but this term is too general to be informative. More specific terms are already annotated.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> This is an overly broad term that does not add useful information beyond what is captured by more specific annotations such as GO:0043066 negative regulation of apoptotic process and GO:0031333 negative regulation of protein-containing complex assembly. The ARBA prediction likely derives from the general chaperone/anti-apoptotic activities but is too unspecific.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
                                     GO:0046872
                                 </a>
                             </span>
                             <span class="term-label">metal ion binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000043
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1623,57 +1623,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from UniProt keyword mapping for metal ion binding. CRYAB binds zinc ions through histidine residues (His-83, His-104, His-106, His-111, His-119) as documented in UniProt based on PMID:22890888. Zinc binding enhances oligomer stability.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> CRYAB has documented zinc-binding sites identified by chemical modification and MALDI-TOF mass spectrometry (PMID:22890888). Multiple histidine residues coordinate zinc ions, and this inter-subunit bridging enhances structural stability. The IEA annotation from the UniProt metal-binding keyword is appropriate.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11700327" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11700327
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Detection of protein-protein interactions among lens crystal...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1685,57 +1685,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from PMID:11700327 (Fu &amp; Liang 2002), which used a mammalian two-hybrid system to detect interactions among lens crystallins. The WITH/FROM column in GOA lists interactions with CRYAA (P02489), HSPB1 (P04792), CRYGC (P07315), and CRYBB2 (P43320). These are genuine crystallin-crystallin interactions. However, protein binding is uninformative; the interactions with CRYAA are better captured by identical protein binding or the broader chaperone complex context.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative per GO curation guidelines. The interactions detected in PMID:11700327 (crystallin-crystallin interactions in mammalian two-hybrid assay) are real but are better captured by more specific terms such as identical protein binding (for self-interaction) or the chaperone function annotations. The binding to other crystallins reflects CRYAB&#39;s chaperone/structural role in the lens.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12601044" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12601044
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Alteration of protein-protein interactions of congenital cat...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1747,57 +1747,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:12601044 (Fu &amp; Liang 2003), which characterized altered protein-protein interactions of congenital cataract crystallin mutants using a mammalian two-hybrid system. Interactions detected include CRYAB with CRYAA, HSPB1, CRYGC, and CRYBB2.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. The interactions described reflect crystallin-crystallin interactions relevant to lens function and are better captured by the identical protein binding and chaperone annotations.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16049941" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16049941
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A pilot proteomic study of amyloid precursor interactors in ...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1809,57 +1809,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:16049941, a pilot proteomic study of amyloid precursor protein (APP, P05067) interactors in Alzheimer&#39;s disease. CRYAB was identified as an interactor of APP.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. The interaction with APP is more specifically captured by the amyloid-beta binding annotation (GO:0001540) from PMID:23106396.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17046756" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17046756
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     alphaB-crystallin competes with Alzheimer&#39;s disease beta-amy...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1871,57 +1871,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:17046756 (Narayanan et al. 2006), which showed CRYAB competes for amyloid-beta peptide interactions using NMR spectroscopy. The WITH/FROM is CRYBA1 (P05813). The study demonstrated that CRYAB interactions involve the hydrophobic core residues of Abeta.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. The interaction with amyloid-beta is better captured by GO:0001540 amyloid-beta binding (already annotated from PMID:23106396) and the negative regulation of amyloid fibril formation annotation.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18330356" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18330356
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Construction and characterization of a normalized yeast two-...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1933,57 +1933,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:18330356, a large-scale normalized yeast two-hybrid library screen. The WITH/FROM is HSPB1 (P04792). CRYAB interaction with HSPB1 is well-established.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. CRYAB-HSPB1 interaction is well-documented and reflects sHSP hetero-oligomer formation. This is better captured by the protein-containing complex and identical protein binding annotations.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19651604" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19651604
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The eye lens chaperone alpha-crystallin forms defined globul...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1995,57 +1995,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:19651604 (Peschek et al. 2009), which showed that alpha-crystallin forms defined globular assemblies. The WITH/FROM is CRYAA (P02489), reflecting the CRYAB-CRYAA hetero-oligomerization.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. The CRYAB-CRYAA interaction reflects hetero-oligomer formation and is better captured by the identical protein binding and protein-containing complex annotations.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22085609" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22085609
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Temperature-dependent structural and functional properties o...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2057,57 +2057,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:22085609, which studied the F71L mutant alphaA-crystallin and its effects on hetero-oligomeric complex stability. The WITH/FROM is CRYAA (P02489).
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. This reflects CRYAB-CRYAA hetero-oligomerization. More specific annotations are already present.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22153508" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22153508
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The polydispersity of αB-crystallin is rationalized by an in...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2119,57 +2119,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:22153508 (Baldwin et al. 2011), which elucidated the polyhedral architecture of CRYAB oligomers. The WITH/FROM is CRYAA (P02489).
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. This reflects CRYAB oligomerization dynamics. Better captured by identical protein binding and protein-containing complex annotations.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22158051" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22158051
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tumor suppressor Alpha B-crystallin (CRYAB) associates with ...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2181,57 +2181,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:22158051 (Huang et al. 2012), which showed CRYAB associates with the cadherin/catenin adherens junction. The WITH/FROM is beta-catenin (CTNNB1, P35222). CRYAB interacts with both E-cadherin and beta-catenin via its alpha-crystallin core domain, inhibiting E-cadherin internalization and NPC progression.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. The specific interaction with beta-catenin described in PMID:22158051 reflects CRYAB&#39;s role in cell adhesion regulation in cancer context. This is a secondary/non-core function and the term protein binding does not capture the functional significance.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23188086" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23188086
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Binding determinants of the small heat shock protein, αB-cry...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2243,57 +2243,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:23188086 (Delbecq et al. 2012), which studied the IxI motif binding determinants of CRYAB. The WITH/FROM includes CRYAA (P02489), HSPB1 (P04792), and HSPB2 (Q16082).
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. The IxI motif interactions are critical for sHSP oligomer assembly and are better captured by the identical protein binding and oligomerization-related annotations.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23542032" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23542032
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Protective role of the endoplasmic reticulum protein mitsugu...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2305,57 +2305,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:23542032 (Yamashita et al. 2013), which identified CRYAB as a binding partner of mitsugumin23 (TMEM109/MG23, mouse Q3UBX0). The interaction mediates a protective role against UVC-induced cell death by accumulating CRYAB near the ER.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. The CRYAB-TMEM109 interaction is functionally significant in the DNA damage response, but the protein binding term does not capture this. The functional role is partially captured by the regulation of programmed cell death annotation.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24183572" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24183572
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Preferential and specific binding of human αB-crystallin to ...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2367,57 +2367,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:24183572 (Kingsley et al. 2013), which showed preferential and specific binding of CRYAB to the cataract-related G18V variant of gammaS-crystallin (CRYGS, P22914). CRYAB binds more strongly to the variant via a well-defined interaction surface.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. This interaction reflects CRYAB&#39;s chaperone function in the lens -- it preferentially binds destabilized crystallin variants. This is better captured by the chaperone/holdase MF annotations.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25910212
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Widespread macromolecular interaction perturbations in human...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2429,57 +2429,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:25910212, a large-scale study of macromolecular interaction perturbations in human genetic disorders. The WITH/FROM is CRYAA (P02489).
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. Large-scale interaction studies do not provide functional specificity beyond what is already captured by more specific annotations.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26465331" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26465331
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Characterization of the Cardiac Overexpression of HSPB2 Reve...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2491,57 +2491,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:26465331 (Grose et al. 2015), which characterized the cardiac HSPB2 interactome. The WITH/FROM is HSPB2 (Q16082). CRYAB interacts with HSPB2, consistent with sHSP hetero-oligomerization.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. The CRYAB-HSPB2 interaction is part of the sHSP oligomeric network and is better captured by more specific annotations.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28514442
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Architecture of the human interactome defines protein commun...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2553,57 +2553,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:28514442, a large-scale interactome mapping study. The WITH/FROM is HSPB1 (P04792).
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. Large-scale interactome studies confirm known sHSP interactions but do not add functional specificity.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32296183
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A reference map of the human binary protein interactome.
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2615,57 +2615,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:32296183, a reference map of the human binary protein interactome. The WITH/FROM includes CRYAA (P02489), KRTAP6-1 (Q3LI64), and GORASP2 (Q9H8Y8).
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. Large-scale binary interactome studies do not provide functional specificity.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32814053
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interactome Mapping Provides a Network of Neurodegenerative ...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2677,57 +2677,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:32814053, an interactome mapping study focused on neurodegenerative disease proteins. The WITH/FROM includes multiple proteins (APP/P05067, CTNNB1/P35222, EXOC5/O00471, ANXA4/P09525, PRPS1/P60891, CRMP1/Q14194, CORO6/Q6QEF8, ADAMTSL4/Q6UY14, PRUNE2/Q8WUY3, HSFY2/Q96LI6).
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. This large-scale interactome study identifies many interactors but the term does not capture the functional significance of any of these interactions.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2739,57 +2739,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:33961781, a dual proteome-scale network study. The WITH/FROM is HSPB1 (P04792).
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. Confirms CRYAB-HSPB1 interaction from large-scale proteomics.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:40205054
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Multimodal cell maps as a foundation for structural and func...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2801,57 +2801,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:40205054, multimodal cell maps study. The WITH/FROM is HSPB1 (P04792).
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative per GO curation guidelines.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12601044" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12601044
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Alteration of protein-protein interactions of congenital cat...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2863,75 +2863,75 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for identical protein binding (CRYAB self-interaction) from PMID:12601044 (Fu &amp; Liang 2003). The study used mammalian two-hybrid to show CRYAB-CRYAB interaction, and that the R120G mutation decreases self-interaction. CRYAB forms large homo-oligomeric complexes.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> CRYAB self-association to form large homo-oligomeric complexes (typically 24-32 subunits) is a core feature of its biology. This is confirmed by multiple structural studies. The identical protein binding annotation is appropriate and more informative than generic protein binding.
                         </div>
-
-
-
+                        
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12601044" target="_blank" class="term-link">
                                         PMID:12601044
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">for the R120G alphaB-crystallin, the interactions with alphaA- and alphaB-crystallin decreased, but those with betaB2- and gammaC-crystallin increased slightly.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18330356" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18330356
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Construction and characterization of a normalized yeast two-...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2943,57 +2943,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for identical protein binding from PMID:18330356 (normalized yeast two-hybrid library). Confirms CRYAB self-interaction.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Confirms CRYAB homo-oligomerization by an independent method. Core property of CRYAB.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19651604" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19651604
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The eye lens chaperone alpha-crystallin forms defined globul...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3005,57 +3005,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:19651604 (Peschek et al. 2009), which demonstrated that alpha-crystallin forms defined globular assemblies. CRYAB self-interaction is central to its oligomeric architecture.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> CRYAB homo-oligomerization is a core structural property documented by multiple biophysical approaches.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20802487" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20802487
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Solid-state NMR and SAXS studies provide a structural basis ...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3067,57 +3067,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:20802487, which used solid-state NMR and SAXS to study CRYAB oligomer activation. Self-interaction confirmed by structural methods.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Confirms CRYAB self-association by biophysical methods. Core property.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21464278" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21464278
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     N-terminal domain of alphaB-crystallin provides a conformati...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3129,57 +3129,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:21464278, which showed that the N-terminal domain of CRYAB provides a conformational switch for multimerization and structural heterogeneity.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Confirms CRYAB homo-oligomeric assembly, specifically identifying the N-terminal domain role. Core property.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22143763" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22143763
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Multiple molecular architectures of the eye lens chaperone α...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3191,57 +3191,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:22143763, which elucidated multiple molecular architectures of CRYAB oligomers using a triple hybrid approach.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Confirms CRYAB polydisperse homo-oligomeric assembly by multiple structural methods.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22153508" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22153508
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The polydispersity of αB-crystallin is rationalized by an in...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3253,75 +3253,75 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:22153508 (Baldwin et al. 2011), which demonstrated the interconverting polyhedral architecture of CRYAB oligomers using NMR, mass spectrometry, and electron microscopy.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Provides structural basis for CRYAB polydisperse oligomeric assembly. Core property.
                         </div>
-
-
-
+                        
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22153508" target="_blank" class="term-link">
                                         PMID:22153508
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">We report structural models for the most abundant oligomers populated by the polydisperse molecular chaperone alphaB-crystallin.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23188086" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23188086
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Binding determinants of the small heat shock protein, αB-cry...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3333,75 +3333,75 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:23188086 (Delbecq et al. 2012), which characterized the IxI motif binding to the alpha-crystallin domain groove. This inter-subunit interaction is critical for oligomer formation.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> The IxI motif interaction is a key determinant of sHSP oligomer assembly and client binding. This study provides molecular detail on CRYAB self-interaction. Core property.
                         </div>
-
-
-
+                        
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23188086" target="_blank" class="term-link">
                                         PMID:23188086
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">The most commonly observed inter-subunit interaction involves a highly conserved C-terminal &#39;IxI/V&#39; motif and a groove in the ACD that is also implicated in client binding.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24183572" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24183572
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Preferential and specific binding of human αB-crystallin to ...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3413,57 +3413,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:24183572 (Kingsley et al. 2013). The WITH/FROM is CRYAB itself (P02511), reflecting self-interaction in the context of studying CRYAB binding to gammaS-crystallin variants.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Confirms CRYAB self-interaction. Core property.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26465331" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26465331
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Characterization of the Cardiac Overexpression of HSPB2 Reve...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3475,57 +3475,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:26465331 (Grose et al. 2015), cardiac HSPB2 interactome study. The WITH/FROM is CRYAB itself (P02511).
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Confirms CRYAB self-interaction in cardiac context.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27226619" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27226619
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Human 343delT HSPB5 Chaperone Associated with Early-onse...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3537,46 +3537,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:27226619, which studied the 343delT HSPB5 mutation associated with early-onset skeletal myopathy and its defects in protein solubility. Confirms CRYAB self-interaction.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Confirms CRYAB self-interaction. Disease mutations affect oligomeric assembly, underscoring the functional importance of self-interaction.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000107
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3588,46 +3588,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer, based on mouse CRYAB (P23927). CRYAB has been reported to translocate to mitochondria in some contexts, particularly related to its anti-apoptotic function (sequestering Bax and Bcl-X(S) to prevent mitochondrial translocation, PMID:14752512). The anti-apoptotic mechanism involves preventing Bax translocation TO mitochondria rather than CRYAB being a mitochondrial resident protein.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Mitochondrial localization may occur transiently or in specific contexts (e.g., during apoptosis regulation), but CRYAB is not a constitutive mitochondrial protein. The annotation from Ensembl Compara mouse ortholog transfer is acceptable but represents a non-core, context-dependent localization.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000107
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3639,46 +3639,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for cytosol. CRYAB is primarily a cytosolic protein, supported by IDA evidence from GO_REF:0000052 (HPA immunofluorescence). Cytosol is consistent with the cytoplasm annotations.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Cytosol is the more specific subcellular compartment within cytoplasm where CRYAB resides. Supported by IDA from HPA data and consistent with CRYAB&#39;s known biology as a soluble cytoplasmic chaperone.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000107
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3690,46 +3690,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for plasma membrane. Also supported by IDA from HPA immunofluorescence (GO_REF:0000052). CRYAB has been reported at the plasma membrane in some contexts (e.g., association with cadherin/catenin complexes at the cell membrane, PMID:22158051).
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Plasma membrane localization may occur in specific contexts (e.g., cell adhesion junctions) but is not a core localization of CRYAB. The HPA IDA data and mouse ortholog transfer provide some support, but cytoplasm/cytosol are the primary locations.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000107
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -3741,75 +3741,75 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer (from rat) for protein folding. CRYAB is a holdase chaperone that prevents protein aggregation but does NOT actively fold proteins. It keeps substrates in a folding-competent state that can then be refolded by ATP-dependent foldase chaperones like HSP70. The term protein folding implies direct participation in the folding process, which is misleading for a holdase.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> CRYAB is a holdase chaperone, not a foldase. It prevents aggregation and maintains substrates in a folding-competent state (PMID:19464326, PMID:16303126) but does not perform protein folding per se. GO:0050821 protein stabilization is more appropriate as a BP term. The annotation should be modified to reflect holdase activity rather than folding activity.
                         </div>
-
-
+                        
+                        
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-
+                            
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                     protein stabilization
                                 </a>
                             </span>
-
+                            
                         </div>
-
-
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
                                         PMID:19464326
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">HSPB1 and HSPB5, that chaperoned heat unfolded substrates and kept them folding competent, HSPB7 did not support refolding.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008017" target="_blank" class="term-link">
                                     GO:0008017
                                 </a>
                             </span>
                             <span class="term-label">microtubule binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000107
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3821,46 +3821,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer (from rat CRYAB) for microtubule binding. There is limited direct evidence for CRYAB binding microtubules in human. CRYAB is better known for binding intermediate filaments (desmin) and actin filaments. The rat data may reflect CRYAB&#39;s broader cytoskeletal interactions.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Microtubule binding is plausible given CRYAB&#39;s known interactions with cytoskeletal elements (desmin intermediate filaments, actin), but the primary cytoskeletal interaction is with intermediate filaments (PMID:28470624). The broader cytoskeletal protein binding annotation (GO:0008092) is also present and may be more appropriate. This is a non-core function.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008092" target="_blank" class="term-link">
                                     GO:0008092
                                 </a>
                             </span>
                             <span class="term-label">cytoskeletal protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000107
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3872,64 +3872,64 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for cytoskeletal protein binding. CRYAB interacts with desmin intermediate filaments (PMID:28470624), titin (PMID:14676215), and associates with the sarcomeric cytoskeleton. This is well-supported.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> CRYAB has well-documented interactions with cytoskeletal proteins including desmin (PMID:28470624) and titin (UniProt, PMID:14676215). Mutations in CRYAB cause desmin-related myopathy (PMID:9731540), underscoring the functional importance of this interaction. The IEA annotation is appropriate.
                         </div>
-
-
-
+                        
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/28470624" target="_blank" class="term-link">
                                         PMID:28470624
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">the binding of CRYAB to desmin is subject to its assembly status, to the subunit organization within filaments formed and to the integrity of the C-terminal tail domain of desmin.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009986" target="_blank" class="term-link">
                                     GO:0009986
                                 </a>
                             </span>
                             <span class="term-label">cell surface</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000107
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3941,46 +3941,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for cell surface. CRYAB is primarily an intracellular protein. Some evidence suggests it can be secreted (PMID:32272059) and found in exosomes, but cell surface localization is not well-established for human CRYAB.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Cell surface localization is not well-documented for human CRYAB. It may be transiently present at the cell surface during unconventional secretion. This is a non-core, context-dependent localization transferred from rat ortholog.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030018" target="_blank" class="term-link">
                                     GO:0030018
                                 </a>
                             </span>
                             <span class="term-label">Z disc</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000107
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3992,46 +3992,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for Z disc localization. UniProt notes that CRYAB localizes at Z-bands and the intercalated disk in cardiomyocytes (PMID:28493373). This is consistent with its role in muscle and its interaction with desmin and titin.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Z disc localization is documented for human CRYAB in cardiomyocytes (PMID:28493373) and is consistent with its interaction with sarcomeric proteins desmin and titin. This is a core localization in muscle tissue.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030308" target="_blank" class="term-link">
                                     GO:0030308
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of cell growth</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000107
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4043,46 +4043,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for negative regulation of cell growth. CRYAB has been implicated in tumor suppression in some contexts (PMID:22158051 in NPC) and its overexpression can suppress tumor formation. However, this is not a core function.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Negative regulation of cell growth is a secondary function of CRYAB, observed in certain cancer contexts (PMID:22158051). It is not a core function and likely reflects downstream consequences of its anti-apoptotic and chaperone activities rather than a direct growth regulatory function.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030424" target="_blank" class="term-link">
                                     GO:0030424
                                 </a>
                             </span>
                             <span class="term-label">axon</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000107
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4094,46 +4094,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for axon localization. CRYAB is expressed in the nervous system and accumulates in Alexander&#39;s disease brain. Axonal localization is plausible but represents a tissue-specific localization rather than core biology.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Axon localization is transferred from rat ortholog. CRYAB is expressed in neural tissues and accumulates in neurological disease contexts, but axonal localization is not a core feature. Non-core tissue-specific localization.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031109" target="_blank" class="term-link">
                                     GO:0031109
                                 </a>
                             </span>
                             <span class="term-label">microtubule polymerization or depolymerization</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000107
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -4145,46 +4145,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for microtubule polymerization or depolymerization. There is limited direct evidence for CRYAB regulating microtubule dynamics in human. This may be an over-annotation from the rat ortholog.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> There is insufficient evidence that CRYAB directly regulates microtubule polymerization or depolymerization in human. CRYAB&#39;s primary cytoskeletal interactions are with intermediate filaments (desmin) rather than microtubules. This annotation likely represents an over-annotation from ortholog transfer.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031430" target="_blank" class="term-link">
                                     GO:0031430
                                 </a>
                             </span>
                             <span class="term-label">M band</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000107
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4196,46 +4196,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for M band localization. CRYAB interacts with titin, which spans from Z disc to M band. M band localization is plausible in the context of sarcomeric association.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> M band localization is consistent with CRYAB&#39;s interaction with titin and its sarcomeric association. However, the primary sarcomeric localization documented for human CRYAB is at Z-bands (PMID:28493373). M band is a secondary localization from rat ortholog transfer.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031674" target="_blank" class="term-link">
                                     GO:0031674
                                 </a>
                             </span>
                             <span class="term-label">I band</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000107
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4247,46 +4247,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for I band localization. I band localization is consistent with CRYAB&#39;s association with sarcomeric structures and its interaction with titin (which spans the I band).
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> I band localization is plausible given CRYAB&#39;s interaction with titin and sarcomeric structures, but is transferred from rat ortholog. Non-core but reasonable for muscle tissue context.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032355" target="_blank" class="term-link">
                                     GO:0032355
                                 </a>
                             </span>
                             <span class="term-label">response to estradiol</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000107
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4298,46 +4298,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for response to estradiol. CRYAB expression may be regulated by estradiol in certain tissues, but this is not a core function.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Response to estradiol is a secondary, context-dependent process for CRYAB. Many stress-responsive genes show altered expression in response to various stimuli including hormones. This is not a core function and is transferred from rat ortholog.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032432" target="_blank" class="term-link">
                                     GO:0032432
                                 </a>
                             </span>
                             <span class="term-label">actin filament bundle</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000107
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4349,46 +4349,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for actin filament bundle localization. CRYAB has been reported to associate with actin cytoskeletal structures in addition to its well-known intermediate filament interactions.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Actin filament bundle localization is a secondary cytoskeletal association for CRYAB. Its primary cytoskeletal interaction is with desmin intermediate filaments. Transferred from rat ortholog.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042542" target="_blank" class="term-link">
                                     GO:0042542
                                 </a>
                             </span>
                             <span class="term-label">response to hydrogen peroxide</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000107
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4400,46 +4400,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for response to hydrogen peroxide. As a stress-responsive chaperone, CRYAB is likely upregulated during oxidative stress including H2O2 exposure. UniProt notes susceptibility to oxidation at Met-48, Met-60, and Trp-68.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Response to hydrogen peroxide is consistent with CRYAB&#39;s role as a stress-responsive chaperone. It is a non-core, general stress response function rather than a specific core activity. Transferred from rat ortholog.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043066" target="_blank" class="term-link">
                                     GO:0043066
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of apoptotic process</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000120
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4451,46 +4451,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from combined automated methods for negative regulation of apoptotic process. This duplicates the IBA annotation and is also supported by IDA evidence from PMID:14752512. CRYAB&#39;s anti-apoptotic activity through binding Bax and Bcl-X(S) is well-established.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> This IEA annotation is consistent with the IBA and IDA evidence for CRYAB&#39;s anti-apoptotic function. PMID:14752512 provides direct experimental evidence.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043197" target="_blank" class="term-link">
                                     GO:0043197
                                 </a>
                             </span>
                             <span class="term-label">dendritic spine</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000107
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4502,46 +4502,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for dendritic spine localization. CRYAB is expressed in the nervous system and has been found in neural structures. Dendritic spine localization is plausible but represents a tissue-specific neural localization.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Dendritic spine localization is a neural tissue-specific localization transferred from rat ortholog. CRYAB is expressed in the brain and accumulates in neurological disease contexts. Non-core, tissue-specific.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043204" target="_blank" class="term-link">
                                     GO:0043204
                                 </a>
                             </span>
                             <span class="term-label">perikaryon</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000107
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4553,46 +4553,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for perikaryon (cell body of neuron) localization. CRYAB is expressed in neural tissues.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Perikaryon localization is a neural tissue-specific localization transferred from rat ortholog. Non-core.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043292" target="_blank" class="term-link">
                                     GO:0043292
                                 </a>
                             </span>
                             <span class="term-label">contractile muscle fiber</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000107
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4604,46 +4604,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for contractile muscle fiber localization. CRYAB is highly expressed in cardiac and skeletal muscle (HPA: tissue enhanced in heart muscle, skeletal muscle, tongue) and associates with sarcomeric structures.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> CRYAB is highly expressed in muscle tissue and localizes to sarcomeric structures (Z-bands, intercalated disks) as documented by PMID:28493373. Contractile muscle fiber localization is consistent with CRYAB&#39;s role in muscle and its association with desmin and titin.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051403" target="_blank" class="term-link">
                                     GO:0051403
                                 </a>
                             </span>
                             <span class="term-label">stress-activated MAPK cascade</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000107
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4655,46 +4655,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for stress-activated MAPK cascade. CRYAB has been reported to modulate MAPK signaling in some stress contexts, but this is not a core function.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Stress-activated MAPK cascade involvement is a secondary consequence of CRYAB&#39;s stress-protective functions rather than a direct core activity. Transferred from rat ortholog. Non-core.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097060" target="_blank" class="term-link">
                                     GO:0097060
                                 </a>
                             </span>
                             <span class="term-label">synaptic membrane</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000107
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4706,46 +4706,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for synaptic membrane localization. CRYAB is expressed in neural tissues. Synaptic membrane localization is a tissue-specific neural localization.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Synaptic membrane localization is a neural tissue-specific localization transferred from rat ortholog. Non-core.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097512" target="_blank" class="term-link">
                                     GO:0097512
                                 </a>
                             </span>
                             <span class="term-label">cardiac myofibril</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000107
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4757,46 +4757,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for cardiac myofibril localization. CRYAB is highly expressed in cardiac muscle and localizes to sarcomeric structures including Z-bands and intercalated disks (PMID:28493373).
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Cardiac myofibril localization is well-supported by CRYAB&#39;s high expression in cardiac muscle (HPA, UniProt) and its documented localization at Z-bands and intercalated disks (PMID:28493373). CRYAB mutations cause cardiomyopathies, underscoring its cardiac muscle function.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:2000378" target="_blank" class="term-link">
                                     GO:2000378
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of reactive oxygen species metabolic process</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000107
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4808,46 +4808,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for negative regulation of reactive oxygen species metabolic process. CRYAB has been implicated in oxidative stress protection, but this is a secondary function.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Negative regulation of ROS is a downstream protective effect of CRYAB&#39;s chaperone activity rather than a direct core function. Transferred from rat ortholog. Non-core.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000052
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4859,46 +4859,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from HPA immunofluorescence curation for cytosol localization. CRYAB is a soluble cytoplasmic chaperone that resides in the cytosol under normal conditions.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Cytosol localization is the primary subcellular localization of CRYAB under normal conditions. Supported by HPA immunofluorescence data and consistent with its role as a soluble chaperone.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000052
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4910,57 +4910,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from HPA immunofluorescence curation for plasma membrane. Some plasma membrane signal may be detected by immunofluorescence but CRYAB is primarily cytosolic.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Plasma membrane localization from HPA immunofluorescence is a secondary localization. CRYAB may associate with membrane-proximal structures in some contexts (e.g., cadherin/catenin complexes, PMID:22158051) but is primarily a cytosolic protein. Non-core.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043067" target="_blank" class="term-link">
                                     GO:0043067
                                 </a>
                             </span>
                             <span class="term-label">regulation of programmed cell death</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23542032" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23542032
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Protective role of the endoplasmic reticulum protein mitsugu...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4972,75 +4972,75 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IMP annotation from PMID:23542032 (Yamashita et al. 2013) for regulation of programmed cell death. The study showed that knockdown of CRYAB facilitates death of UVC-exposed cells, and that CRYAB expressed as an ER-anchored form lowered UVC sensitivity. CRYAB binding to MG23/TMEM109 mediates protection against UVC-induced cell death.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> CRYAB&#39;s role in regulating programmed cell death is well-established. This annotation from PMID:23542032 specifically documents the protective role against UVC-induced cell death via interaction with TMEM109. This is consistent with CRYAB&#39;s broader anti-apoptotic function (PMID:14752512). The parent term regulation of programmed cell death is appropriate here since the paper demonstrates both protection and sensitization depending on CRYAB expression levels.
                         </div>
-
-
-
+                        
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23542032" target="_blank" class="term-link">
                                         PMID:23542032
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">The small heat shock protein αB-crystallin (αBC) is identified as a MG23 binding molecule and its knockdown facilitates death of UVC-exposed cells.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005198" target="_blank" class="term-link">
                                     GO:0005198
                                 </a>
                             </span>
                             <span class="term-label">structural molecule activity</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16303126
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Lenticular chaperones suppress the aggregation of the catara...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -5052,86 +5052,86 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for structural molecule activity from PMID:16303126 (Pigaga &amp; Quinlan 2006). This paper primarily demonstrates chaperone-like activity of alpha-crystallins in suppressing aggregation of T5P gamma C-crystallin. The structural molecule activity annotation may reflect CRYAB&#39;s dual role in the lens as both a structural protein and a chaperone.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> PMID:16303126 supports CRYAB/alpha-crystallin suppression of aggregation of the cataract-causing T5P gamma C-crystallin, which is chaperone/holdase activity rather than generic structural molecule activity. The true lens structural role is already captured more precisely by GO:0005212 &#34;structural constituent of eye lens.&#34;
                         </div>
-
-
+                        
+                        
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-
+                            
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140309" target="_blank" class="term-link">
+                                    unfolded protein holdase activity
                                 </a>
                             </span>
-
+                            
                         </div>
-
-
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link">
                                         PMID:16303126
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">These data therefore suggest a dual role for these chaperones in maintaining transparency in the lens.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
                                     GO:0032991
                                 </a>
                             </span>
                             <span class="term-label">protein-containing complex</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16303126
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Lenticular chaperones suppress the aggregation of the catara...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5143,57 +5143,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for protein-containing complex from PMID:16303126. CRYAB forms large oligomeric complexes, typically of 24-32 subunits. This is a fundamental feature of its biology as a small heat shock protein.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> CRYAB forms large polydisperse homo-oligomeric and hetero-oligomeric complexes. This is a core structural feature well-documented by multiple biophysical studies (PMID:16303126, PMID:22153508, PMID:19651604).
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16303126
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Lenticular chaperones suppress the aggregation of the catara...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5205,57 +5205,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for identical protein binding from PMID:16303126, reflecting CRYAB self-association in the context of alpha-crystallin oligomeric complexes.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Confirms CRYAB self-interaction, which is central to its oligomeric assembly. Core property.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031333" target="_blank" class="term-link">
                                     GO:0031333
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of protein-containing complex assembly</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23106396" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23106396
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Amyloid-β oligomers are sequestered by both intracellular an...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5267,75 +5267,75 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from PMID:23106396 (Narayan et al. 2012) for negative regulation of protein-containing complex assembly. The study demonstrated that CRYAB binds to misfolded amyloid-beta oligomeric species, forming long-lived complexes that prevent further growth into fibrils and prevent their dissociation. This is a manifestation of CRYAB&#39;s holdase chaperone activity applied to amyloid aggregation.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> This annotation captures an important aspect of CRYAB&#39;s chaperone function -- it prevents further assembly of amyloid-beta oligomers into fibrils. PMID:23106396 provides direct experimental evidence using single-molecule fluorescence techniques.
                         </div>
-
-
-
+                        
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23106396" target="_blank" class="term-link">
                                         PMID:23106396
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">both chaperones bind to misfolded oligomeric species and form long-lived complexes, thereby preventing both their further growth into fibrils and their dissociation.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20587334" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20587334
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Synergistic efficacy of LBH and alphaB-crystallin through in...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -5347,57 +5347,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:20587334 (Deng et al. 2010), which identified LBH (Q53QV2) as a CRYAB-interacting partner by yeast two-hybrid and confirmed by co-immunoprecipitation and GST pull-down. The interaction leads to synergistic repression of p53 and p21 transcriptional activities.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. The CRYAB-LBH interaction is interesting but the term does not capture the functional significance. The downstream functional consequence is captured by the negative regulation of DNA-templated transcription annotation from the same paper.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20587334" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20587334
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Synergistic efficacy of LBH and alphaB-crystallin through in...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5409,75 +5409,75 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for nucleus localization from PMID:20587334. The study showed that CRYAB, which is normally cytoplasmic, accumulates partially in the nucleus when co-transfected with LBH in COS-7 cells.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Nuclear localization of CRYAB is confirmed by direct observation in PMID:20587334, consistent with other IDA evidence from PMID:19464326. CRYAB translocates to the nucleus under specific conditions.
                         </div>
-
-
-
+                        
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20587334" target="_blank" class="term-link">
                                         PMID:20587334
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">alphaB-crystallin that is cytoplasmic alone, accumulates partialy in the nucleus when co-transfected with LBH.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20587334" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20587334
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Synergistic efficacy of LBH and alphaB-crystallin through in...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5489,57 +5489,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for cytoplasm localization from PMID:20587334. CRYAB is cytoplasmic when expressed alone in COS-7 cells.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Cytoplasm is the primary localization of CRYAB, confirmed by direct observation in PMID:20587334.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
                                     GO:0032991
                                 </a>
                             </span>
                             <span class="term-label">protein-containing complex</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20587334" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20587334
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Synergistic efficacy of LBH and alphaB-crystallin through in...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5551,57 +5551,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for protein-containing complex from PMID:20587334. CRYAB forms a complex with LBH as shown by co-immunoprecipitation and GST pull-down.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> CRYAB forms complexes with multiple partners. The complex with LBH is documented by co-immunoprecipitation in PMID:20587334.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045892" target="_blank" class="term-link">
                                     GO:0045892
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of DNA-templated transcription</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20587334" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20587334
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Synergistic efficacy of LBH and alphaB-crystallin through in...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -5613,75 +5613,75 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from PMID:20587334 for negative regulation of DNA-templated transcription. Overexpression of CRYAB reduced the transcriptional activities of p53 and p21 promoters, and co-expression with LBH resulted in stronger repression. This is a secondary/non-core function of CRYAB.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> While the experimental evidence from PMID:20587334 supports that CRYAB can repress transcription from p53 and p21 promoters, this is likely a secondary consequence of CRYAB&#39;s interaction with LBH and its general protein-binding chaperone activity rather than a core transcriptional regulatory function. CRYAB is not a transcription factor. This function is non-core.
                         </div>
-
-
-
+                        
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20587334" target="_blank" class="term-link">
                                         PMID:20587334
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">Transient transfection assays indicated that overexpression of LBH or alphaB-crystallin reduced the transcriptional activities of p53 and p21, respectively, Overexpression of both alphaB-crystallin and LBH together resulted in a stronger repression of the transcriptional activities of p21 and p53.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001540" target="_blank" class="term-link">
                                     GO:0001540
                                 </a>
                             </span>
                             <span class="term-label">amyloid-beta binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23106396" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23106396
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Amyloid-β oligomers are sequestered by both intracellular an...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5693,88 +5693,88 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:23106396 (Narayan et al. 2012) for amyloid-beta binding. Using single-molecule fluorescence techniques, the study demonstrated that CRYAB binds to amyloid-beta oligomeric species, forming long-lived complexes. The WITH/FROM is APP processed to amyloid-beta (P05067-PRO_0000000093).
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> CRYAB binding to amyloid-beta oligomers is well-documented (PMID:23106396, PMID:17046756). This is a specific manifestation of CRYAB&#39;s holdase chaperone activity -- it sequesters misfolded amyloid-beta species. CRYAB is found co-localized with amyloid-beta in senile plaques of Alzheimer&#39;s disease patients. This is a meaningful specific MF annotation.
                         </div>
-
-
-
+                        
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23106396" target="_blank" class="term-link">
                                         PMID:23106396
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">both chaperones bind to misfolded oligomeric species and form long-lived complexes, thereby preventing both their further growth into fibrils and their dissociation.</div>
-
+                                
                             </div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17046756" target="_blank" class="term-link">
                                         PMID:17046756
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">Interactions between Abeta and alphaB-crystallin involve the hydrophobic core residues 17-21 as well as residues 31-32 of Abeta, and thus the same chemical groups which are important for Abeta aggregation.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044877" target="_blank" class="term-link">
                                     GO:0044877
                                 </a>
                             </span>
                             <span class="term-label">protein-containing complex binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23106396" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23106396
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Amyloid-β oligomers are sequestered by both intracellular an...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5786,57 +5786,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:23106396 for protein-containing complex binding. The WITH/FROM is ComplexPortal:CPX-1180, which refers to the amyloid-beta oligomeric complex. CRYAB binds to these oligomeric complexes as shown by single-molecule fluorescence.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> CRYAB binds to amyloid-beta oligomeric complexes (PMID:23106396). This annotation specifically captures the binding to a protein-containing complex (the amyloid-beta oligomer) as opposed to individual amyloid-beta monomers. This reflects CRYAB&#39;s holdase function of sequestering aggregation-prone complexes.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28470624" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28470624
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     αB-crystallin is a sensor for assembly intermediates and for...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -5848,86 +5848,86 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:28470624 (Sharma et al. 2017), which showed CRYAB is a sensor for assembly intermediates and subunit topology of desmin intermediate filaments. The WITH/FROM is desmin (DES, P17661). CRYAB binds rapidly during early stages of desmin filament assembly.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. The CRYAB-desmin interaction is a functionally significant interaction that reflects CRYAB&#39;s role as a chaperone for cytoskeletal assembly. This should be annotated as cytoskeletal protein binding (GO:0008092) which is already present as an IEA annotation, providing experimental support for that more specific term.
                         </div>
-
-
+                        
+                        
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-
+                            
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008092" target="_blank" class="term-link">
                                     cytoskeletal protein binding
                                 </a>
                             </span>
-
+                            
                         </div>
-
-
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/28470624" target="_blank" class="term-link">
                                         PMID:28470624
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">the binding of CRYAB to desmin is subject to its assembly status, to the subunit organization within filaments formed and to the integrity of the C-terminal tail domain of desmin.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905907" target="_blank" class="term-link">
                                     GO:1905907
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of amyloid fibril formation</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23106396" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23106396
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Amyloid-β oligomers are sequestered by both intracellular an...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5939,75 +5939,75 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from PMID:23106396 for negative regulation of amyloid fibril formation. CRYAB sequesters amyloid-beta oligomers, preventing their further growth into fibrils. This is a specific application of CRYAB&#39;s holdase chaperone function to amyloid aggregation.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> PMID:23106396 directly demonstrates that CRYAB prevents amyloid-beta oligomers from growing into fibrils using single-molecule fluorescence techniques. This is a well-supported annotation that captures a specific biological consequence of CRYAB&#39;s holdase activity.
                         </div>
-
-
-
+                        
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23106396" target="_blank" class="term-link">
                                         PMID:23106396
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">both chaperones bind to misfolded oligomeric species and form long-lived complexes, thereby preventing both their further growth into fibrils and their dissociation.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12235146" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12235146
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Role of the C-terminal extensions of alpha-crystallins. Swap...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -6019,57 +6019,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:12235146 (Pasta et al. 2002), which studied C-terminal extension swapping between alphaA- and alphaB-crystallins. The WITH/FROM includes aldolase (P00883) and rhodanese (P11415), which are substrate proteins used in chaperone activity assays. CRYAB binding to these substrates reflects its holdase chaperone activity.
                         </div>
-
-
+                        
+                        
                         <div>
-                            <strong>Reason:</strong> Protein binding is uninformative. The interactions with aldolase and rhodanese are chaperone-substrate interactions used as in vitro assay substrates. This is better captured by the chaperone function annotations (GO:0044183 or GO:0050821).
+                            <strong>Reason:</strong> Protein binding is uninformative. The interactions with aldolase and rhodanese are chaperone-substrate interactions used as in vitro assay substrates. This is better captured by the chaperone function annotations (GO:0140309 or GO:0050821).
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                     GO:0050821
                                 </a>
                             </span>
                             <span class="term-label">protein stabilization</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12235146" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12235146
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Role of the C-terminal extensions of alpha-crystallins. Swap...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6081,64 +6081,64 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IMP annotation from PMID:12235146 (Pasta et al. 2002) for protein stabilization. The study demonstrated that CRYAB (and chimeric variants) prevent aggregation of various substrate proteins (thermal and non-thermal models), demonstrating chaperone-like activity. The C-terminal extension plays a crucial role in structure and chaperone activity.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Protein stabilization is an excellent BP term for CRYAB&#39;s holdase chaperone activity. CRYAB prevents aggregation of denatured proteins and maintains them in a soluble, folding-competent state. This is a core function of CRYAB. PMID:12235146 provides direct evidence for chaperone-like activity using multiple protein substrates.
                         </div>
-
-
-
+                        
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12235146" target="_blank" class="term-link">
                                         PMID:12235146
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">We have used thermal and non-thermal models of protein aggregation and found that the chimeric alphaB with the C-terminal extension of alphaA-crystallin, alphaBAc, exhibits dramatically enhanced chaperone-like activity.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             Reactome:R-HSA-5082356
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6150,57 +6150,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation from Reactome pathway R-HSA-5082356 (HSF1-mediated gene expression) for nucleoplasm localization. CRYAB translocates to the nucleus during heat stress (PMID:19464326) and specifically resides in SC35 speckles within the nucleoplasm.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization is consistent with CRYAB&#39;s documented nuclear translocation during heat stress (PMID:19464326). SC35 speckles are nucleoplasmic structures. The Reactome annotation for HSF1-mediated gene expression context is appropriate.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
                                     GO:0070062
                                 </a>
                             </span>
                             <span class="term-label">extracellular exosome</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23533145
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     In-depth proteomic analyses of exosomes isolated from expres...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6212,57 +6212,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HDA annotation from PMID:23533145, an in-depth proteomic study of exosomes isolated from expressed prostatic secretions in urine. CRYAB was identified in exosome fractions by mass spectrometry.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> CRYAB has been identified in extracellular exosomes by proteomic studies (PMID:23533145). This is consistent with the unconventional secretion pathway described in PMID:32272059.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
                                     GO:0070062
                                 </a>
                             </span>
                             <span class="term-label">extracellular exosome</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19056867
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Large-scale proteomics and phosphoproteomics of urinary exos...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6274,57 +6274,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HDA annotation from PMID:19056867, a large-scale proteomics and phosphoproteomics study of urinary exosomes. CRYAB was identified in exosome fractions.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Independent confirmation of CRYAB in extracellular exosomes by urinary exosome proteomics.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071480" target="_blank" class="term-link">
                                     GO:0071480
                                 </a>
                             </span>
                             <span class="term-label">cellular response to gamma radiation</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23542032" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23542032
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Protective role of the endoplasmic reticulum protein mitsugu...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -6336,86 +6336,86 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IMP annotation from PMID:23542032 for cellular response to gamma radiation. The paper actually studies UVC-induced cell death, not gamma radiation specifically. It shows CRYAB knockdown facilitates death of UVC-exposed cells. This annotation may reflect broader DNA damage response involvement.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> PMID:23542032 specifically demonstrates CRYAB&#39;s protective role against UVC-induced cell death, not gamma radiation. The correct response term for this evidence is cellular response to UV-C, and CRYAB&#39;s role in DNA damage response is secondary to its core chaperone and anti-apoptotic functions.
                         </div>
-
-
+                        
+                        
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-
+                            
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071494" target="_blank" class="term-link">
                                     cellular response to UV-C
                                 </a>
                             </span>
-
+                            
                         </div>
-
-
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23542032" target="_blank" class="term-link">
                                         PMID:23542032
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">knockdown of the ER protein mitsugumin23 (MG23) enhances cell death induced by ultraviolet C (UVC), which causes DNA damage.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14752512
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human alphaA- and alphaB-crystallins bind to Bax and Bcl-X(S...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -6427,57 +6427,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:14752512 (Mao et al. 2004). The WITH/FROM includes Bax (Q07812) and Bcl-X(S) (Q07817). CRYAB binds pro-apoptotic Bax and Bcl-X(S) to sequester their translocation during apoptosis.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. The functionally significant interaction with Bax and Bcl-X(S) is better captured by the negative regulation of apoptotic process annotations. The specific anti-apoptotic mechanism involves sequestering these pro-apoptotic factors in the cytoplasm.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19464326
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HSPB7 is a SC35 speckle resident small heat shock protein.
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6489,75 +6489,75 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from PMID:19464326 (Vos et al. 2009) for nucleus localization. The study used confocal microscopy to show CRYAB (HSPB5) translocates to the nucleus during heat shock, where it resides in SC35 speckles. This is a well-documented stress-dependent nuclear localization.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Direct microscopy evidence for CRYAB nuclear translocation during heat stress. PMID:19464326 is the key study documenting stress-dependent nuclear localization and SC35 speckle residence for CRYAB.
                         </div>
-
-
-
+                        
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
                                         PMID:19464326
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">Some members also show a dynamic, stress-induced translocation to SC35 splicing speckles.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19464326
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HSPB7 is a SC35 speckle resident small heat shock protein.
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6569,46 +6569,46 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from PMID:19464326 for cytoplasm localization. CRYAB localizes to the cytoplasm under normal (unstressed) conditions.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Direct microscopy evidence for cytoplasmic localization under normal conditions (PMID:19464326).
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             GO_REF:0000054
-
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6620,57 +6620,57 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from GO_REF:0000054, based on curation of intracellular localizations of expressed fusion proteins in living cells (LIFEdb). Confirms cytoplasmic localization.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Independent confirmation of cytoplasmic localization from expressed fusion protein imaging.
                         </div>
-
-
-
+                        
+                        
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042803" target="_blank" class="term-link">
                                     GO:0042803
                                 </a>
                             </span>
                             <span class="term-label">protein homodimerization activity</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19646995" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19646995
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Crystal structures of alpha-crystallin domain dimers of alph...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6682,75 +6682,75 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:19646995 (Bagneris et al. 2009) for protein homodimerization activity. The crystal structure of the alpha-crystallin domain dimer of CRYAB was solved at 2.63 angstroms, showing that the alpha- crystallin domain forms homodimers with a shared groove at the interface. The dimer is the basic building block for higher-order oligomeric assembly.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> The crystal structure of CRYAB alpha-crystallin domain homodimers (PMID:19646995) directly demonstrates protein homodimerization activity. The dimer is the fundamental building block of the CRYAB oligomeric assembly. This is a core structural property.
                         </div>
-
-
-
+                        
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19646995" target="_blank" class="term-link">
                                         PMID:19646995
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">crystal structures of excised alpha-crystallin domain from rat Hsp20 and that from human alphaB-crystallin show that they form homodimers with a shared groove at the interface by extending a beta sheet.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16303126
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Lenticular chaperones suppress the aggregation of the catara...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -6762,99 +6762,99 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). This IPI annotation is based on PMID:16303126, which demonstrated that alpha B-crystallin (CRYAB) suppresses the aggregation of the cataract-causing T5P mutant gamma C-crystallin. In this study, CRYAB increased the solubility of T5P gamma C-crystallin both in vitro (by sedimentation assay and sucrose gradient centrifugation) and in transfected cells, and significantly reduced the size of T5P gamma C-crystallin aggregates. The interacting partner (WITH/FROM) is the destabilized T5P gamma C-crystallin. The paper describes this as &#34;chaperone-like activity&#34; with a &#34;dual role&#34; -- increasing soluble protein fraction and reducing aggregate size. This is classic holdase activity: CRYAB binds partially denatured proteins and prevents their aggregation, but does NOT refold them. The term GO:0044183 &#34;protein folding chaperone&#34; is the best available interim replacement MF term, though it is imperfect because CRYAB does not assist in protein folding per se -- it prevents aggregation. A holdase-specific GO term does not yet exist and should be requested.
+                            <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). This IPI annotation is based on PMID:16303126, which demonstrated that alpha B-crystallin (CRYAB) suppresses the aggregation of the cataract-causing T5P mutant gamma C-crystallin. In this study, CRYAB increased the solubility of T5P gamma C-crystallin both in vitro (by sedimentation assay and sucrose gradient centrifugation) and in transfected cells, and significantly reduced the size of T5P gamma C-crystallin aggregates. The interacting partner (WITH/FROM) is the destabilized T5P gamma C-crystallin. The paper describes this as &#34;chaperone-like activity&#34; with a &#34;dual role&#34; -- increasing soluble protein fraction and reducing aggregate size. This is classic holdase activity: CRYAB binds partially denatured proteins and prevents their aggregation, but does NOT refold them. The term GO:0140309 &#34;unfolded protein holdase activity&#34; is the appropriate MF replacement term because CRYAB prevents aggregation without active refolding.
                         </div>
-
-
+                        
+                        
                         <div>
-                            <strong>Reason:</strong> GO:0051082 is being obsoleted. The experimental evidence from PMID:16303126 clearly demonstrates holdase chaperone activity -- CRYAB suppresses aggregation of the destabilized T5P mutant gamma C-crystallin and increases its solubility. The paper explicitly describes &#34;a dual role for these chaperones in maintaining transparency in the lens&#34;: increasing the proportion of soluble protein and reducing aggregate size. This is not passive &#34;unfolded protein binding&#34; but active suppression of aggregation (holdase function). The IPI evidence with T5P gamma C-crystallin as the interacting partner is strong. GO:0044183 &#34;protein folding chaperone&#34; is the closest current MF term, but a holdase-specific term is needed since CRYAB does NOT refold proteins.
+                            <strong>Reason:</strong> GO:0051082 is being obsoleted. The experimental evidence from PMID:16303126 clearly demonstrates holdase chaperone activity -- CRYAB suppresses aggregation of the destabilized T5P mutant gamma C-crystallin and increases its solubility. The paper explicitly describes &#34;a dual role for these chaperones in maintaining transparency in the lens&#34;: increasing the proportion of soluble protein and reducing aggregate size. This is not passive &#34;unfolded protein binding&#34; but active suppression of aggregation (holdase function). The IPI evidence with T5P gamma C-crystallin as the interacting partner is strong. GO:0140309 &#34;unfolded protein holdase activity&#34; is the correct current MF term since CRYAB prevents aggregation but does NOT refold proteins.
                         </div>
-
-
+                        
+                        
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-
+                            
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140309" target="_blank" class="term-link">
+                                    unfolded protein holdase activity
                                 </a>
                             </span>
-
+                            
                         </div>
-
-
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link">
                                         PMID:16303126
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">the major lenticular protein chaperones, alpha A- and alpha B-crystallin, increased the solubility of the T5P gamma C-crystallin both in vitro and in transfected cells. More importantly, the size of the T5P gamma C-crystallin aggregates were also significantly reduced in the presence of the lenticular chaperones.</div>
-
+                                
                             </div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link">
                                         PMID:16303126
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">These data therefore suggest a dual role for these chaperones in maintaining transparency in the lens. The first is that these protein chaperones increase the proportion of the soluble T5P gamma C-crystallin and the second is that they also reduce light scatter by reducing the aggregate size of T5P gamma C-crystallin.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14752512
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human alphaA- and alphaB-crystallins bind to Bax and Bcl-X(S...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6866,75 +6866,75 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from PMID:14752512 (Mao et al. 2004) for cytoplasm localization. The study demonstrated that CRYAB is cytoplasmic and prevents translocation of Bax and Bcl-X(S) from cytosol into mitochondria.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization confirmed by direct observation in PMID:14752512. The anti-apoptotic mechanism requires CRYAB to be cytoplasmic to sequester pro-apoptotic factors.
                         </div>
-
-
-
+                        
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link">
                                         PMID:14752512
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">alpha-crystallins prevent the translocation of Bax and Bcl-X(S) from cytosol into mitochondria during staurosporine-induced apoptosis.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032387" target="_blank" class="term-link">
                                     GO:0032387
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of intracellular transport</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14752512
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human alphaA- and alphaB-crystallins bind to Bax and Bcl-X(S...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6946,75 +6946,75 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from PMID:14752512 for negative regulation of intracellular transport. CRYAB prevents the translocation of Bax and Bcl-X(S) from the cytosol to mitochondria during staurosporine-induced apoptosis. This sequestration of pro-apoptotic factors is a specific form of negative regulation of intracellular transport.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> PMID:14752512 directly demonstrates that CRYAB prevents the cytosol-to-mitochondria translocation of Bax and Bcl-X(S). This is a specific anti-apoptotic mechanism involving negative regulation of intracellular protein transport. The annotation is well-supported by direct experimental evidence.
                         </div>
-
-
-
+                        
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link">
                                         PMID:14752512
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">Through the interaction, alpha-crystallins prevent the translocation of Bax and Bcl-X(S) from cytosol into mitochondria during staurosporine-induced apoptosis.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043066" target="_blank" class="term-link">
                                     GO:0043066
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of apoptotic process</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14752512
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human alphaA- and alphaB-crystallins bind to Bax and Bcl-X(S...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7026,75 +7026,75 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from PMID:14752512 for negative regulation of apoptotic process. The study demonstrates a clear anti-apoptotic mechanism: CRYAB binds Bax and Bcl-X(S) to prevent their mitochondrial translocation, preserves mitochondrial integrity, restricts cytochrome c release, represses caspase-3 activation, and blocks PARP degradation.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> This is one of the strongest pieces of evidence for CRYAB&#39;s anti-apoptotic function. PMID:14752512 provides a complete mechanistic pathway from initial binding (Bax/Bcl-X(S) sequestration) to downstream consequences (preserved mitochondrial integrity, blocked caspase-3 activation). This is a core function of CRYAB.
                         </div>
-
-
-
+                        
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link">
                                         PMID:14752512
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">alpha-crystallins preserve the integrity of mitochondria, restrict release of cytochrome c, repress activation of caspase-3 and block degradation of PARP. Thus, our results demonstrate a novel antiapoptotic mechanism for alpha-crystallins.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9731540" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9731540
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A missense mutation in the alphaB-crystallin chaperone gene ...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -7106,86 +7106,86 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NAS annotation from PMID:9731540 (Vicart et al. 1998) for protein folding. The paper identified the R120G mutation in CRYAB that causes desmin-related myopathy and describes CRYAB as possessing molecular chaperone activity. However, CRYAB is a holdase, not a foldase. It prevents aggregation but does not actively fold proteins.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> PMID:9731540 describes CRYAB as a molecular chaperone but does not demonstrate protein folding activity. CRYAB prevents protein aggregation (holdase activity) but does not refold denatured proteins. GO:0050821 protein stabilization is more appropriate. The NAS evidence code itself is weak (non-traceable author statement).
                         </div>
-
-
+                        
+                        
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-
+                            
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                     protein stabilization
                                 </a>
                             </span>
-
+                            
                         </div>
-
-
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9731540" target="_blank" class="term-link">
                                         PMID:9731540
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">AlphaB-crystallin is a member of the small heat shock protein (shsp) family and possesses molecular chaperone activity.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
                 <tr>
                     <td>
                         <div class="term-info">
-
+                            
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006936" target="_blank" class="term-link">
                                     GO:0006936
                                 </a>
                             </span>
                             <span class="term-label">muscle contraction</span>
-
+                            
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-
-
-
+                        
+                        
+                        
                         <br>
                         <span style="font-size: 0.75rem;">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9731540" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9731540
                             </a>
-
-
-
+                            
+                                
+                                
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A missense mutation in the alphaB-crystallin chaperone gene ...
                                 </span>
-
-
-
+                                
+                            
+                            
                         </span>
-
+                        
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -7197,50 +7197,50 @@
                         </span>
                     </td>
                     <td>
-
+                        
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation from PMID:9731540 for muscle contraction. The paper identified the CRYAB R120G mutation causing desmin-related myopathy. While CRYAB is important for muscle function (interacting with desmin and titin), it is not a direct participant in the muscle contraction machinery. Rather, it serves as a chaperone for muscle structural proteins.
                         </div>
-
-
+                        
+                        
                         <div>
                             <strong>Reason:</strong> CRYAB is not directly involved in the muscle contraction mechanism. Its role in muscle is as a chaperone for cytoskeletal and sarcomeric proteins (desmin, titin). Loss of CRYAB function leads to myopathy through aggregation of desmin, not through direct contractile defects. The TAS evidence is weak, and the association with muscle contraction is indirect. Non-core.
                         </div>
-
-
-
+                        
+                        
+                        
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-
+                            
                             <div class="support-item">
                                 <span class="support-ref">
-
+                                    
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9731540" target="_blank" class="term-link">
                                         PMID:9731540
                                     </a>
-
+                                    
                                 </span>
-
+                                
                                 <div class="support-text">We identified an R120G missense mutation in CRYAB that co-segregates with the disease phenotype in this family.</div>
-
+                                
                             </div>
-
+                            
                         </div>
-
+                        
                     </td>
                 </tr>
-
+                
             </tbody>
         </table>
     </div>
+    
 
-
-
+    
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-
+        
         <div class="core-function-card">
-
+            
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>CRYAB (HSPB5) is a small heat shock protein that functions as an ATP-independent holdase chaperone. It binds partially denatured or destabilized proteins to prevent their aggregation, maintaining clients in a refolding-competent state for downstream ATP-dependent chaperone systems such as HSP70, but does NOT actively refold substrates itself. CRYAB forms highly polydisperse oligomers (approximately 10-40 subunits) with rapid subunit exchange dynamics that are important for chaperone activity (DOI:10.1038/s41467-024-54647-7). The canonical architecture comprises a central alpha-crystallin domain (ACD) mediating dimerization, flanked by a variable N-terminal domain (NTD) and a short C-terminal domain (CTD). A conserved N-terminal IXI-like motif (NT-IXI) engages the ACD hydrophobic groove to govern assembly; perturbation of this motif transforms native assemblies into reversible elongated helical fibrils as resolved by cryo-EM (DOI:10.1038/s41467-024-54647-7). Stress-activated phosphorylation (notably p38 MAPK targeting Ser59) modulates oligomeric state and can shift CRYAB condensates toward protective or pathological material states (DOI:10.1016/j.isci.2024.109510, DOI:10.1172/jci163730). Substrates bound by CRYAB can subsequently be refolded by HSP70/HSP40 foldase chaperones, or routed to the ubiquitin-proteasome system for degradation.</h3>
                 <span class="vote-buttons" data-g="P02511" data-a="FUNCTION: CRYAB (HSPB5) is a small heat shock protein that f..." data-r="" data-act="CORE_FUNCTION">
@@ -7248,163 +7248,163 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-
+            
 
             <div class="core-function-terms">
-
+                
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                            protein folding chaperone
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140309" target="_blank" class="term-link">
+                            unfolded protein holdase activity
                         </a>
                     </span>
                 </div>
+                
 
-
-
+                
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-
+                        
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                 protein stabilization
                             </a>
                         </span>
-
+                        
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009408" target="_blank" class="term-link">
                                 response to heat
                             </a>
                         </span>
-
+                        
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905907" target="_blank" class="term-link">
                                 negative regulation of amyloid fibril formation
                             </a>
                         </span>
-
+                        
                     </div>
                 </div>
+                
 
-
-
+                
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-
+                        
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-
+                        
                     </div>
                 </div>
+                
 
+                
 
-
-
-
+                
                 <div class="function-term-group">
                     <div class="function-term-label">Substrates:</div>
                     <div class="function-annotations">
-
+                        
                         <span class="badge">
                             <a href="https://www.uniprot.org/uniprotkb/P17661" target="_blank" class="term-link">
                                 desmin
                             </a>
                         </span>
-
+                        
                         <span class="badge">
                             <a href="https://www.uniprot.org/uniprotkb/P05067-PRO_0000000093" target="_blank" class="term-link">
                                 amyloid-beta
                             </a>
                         </span>
-
+                        
                     </div>
                 </div>
-
+                
             </div>
 
-
+            
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-
+                    
                     <li class="finding-item">
                         <span class="reference-id">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link">
                                 PMID:16303126
                             </a>
-
+                            
                         </span>
-
+                        
                         <div class="finding-text">the major lenticular protein chaperones, alpha A- and alpha B-crystallin, increased the solubility of the T5P gamma C-crystallin both in vitro and in transfected cells. More importantly, the size of the T5P gamma C-crystallin aggregates were also significantly reduced in the presence of the lenticular chaperones.</div>
-
+                        
                     </li>
-
+                    
                     <li class="finding-item">
                         <span class="reference-id">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
                                 PMID:19464326
                             </a>
-
+                            
                         </span>
-
+                        
                         <div class="finding-text">HSPB1 and HSPB5, that chaperoned heat unfolded substrates and kept them folding competent.</div>
-
+                        
                     </li>
-
+                    
                     <li class="finding-item">
                         <span class="reference-id">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23106396" target="_blank" class="term-link">
                                 PMID:23106396
                             </a>
-
+                            
                         </span>
-
+                        
                         <div class="finding-text">both chaperones bind to misfolded oligomeric species and form long-lived complexes, thereby preventing both their further growth into fibrils and their dissociation.</div>
-
+                        
                     </li>
-
+                    
                     <li class="finding-item">
                         <span class="reference-id">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17046756" target="_blank" class="term-link">
                                 PMID:17046756
                             </a>
-
+                            
                         </span>
-
+                        
                         <div class="finding-text">alphaB-crystallin competes efficiently for Abeta monomer-monomer interactions. Interactions between Abeta and alphaB-crystallin involve the hydrophobic core residues 17-21 as well as residues 31-32 of Abeta.</div>
-
+                        
                     </li>
-
+                    
                     <li class="finding-item">
                         <span class="reference-id">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12235146" target="_blank" class="term-link">
                                 PMID:12235146
                             </a>
-
+                            
                         </span>
-
+                        
                         <div class="finding-text">We have used thermal and non-thermal models of protein aggregation and found that the chimeric alphaB with the C-terminal extension of alphaA-crystallin, alphaBAc, exhibits dramatically enhanced chaperone-like activity</div>
-
+                        
                     </li>
-
+                    
                 </ul>
             </div>
-
+            
         </div>
-
+        
         <div class="core-function-card">
-
+            
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>CRYAB is one of the major structural proteins of the vertebrate eye lens, contributing to lens transparency and refractive index. In the lens, it serves a dual role as both a structural protein (maintaining lens transparency through high concentration and ordered short-range interactions) and a chaperone (preventing aggregation of damaged crystallins that would cause light-scattering opacification).</h3>
                 <span class="vote-buttons" data-g="P02511" data-a="FUNCTION: CRYAB is one of the major structural proteins of t..." data-r="" data-act="CORE_FUNCTION">
@@ -7412,10 +7412,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-
+            
 
             <div class="core-function-terms">
-
+                
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -7424,55 +7424,55 @@
                         </a>
                     </span>
                 </div>
+                
 
+                
 
-
-
-
+                
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-
+                        
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-
+                        
                     </div>
                 </div>
+                
 
+                
 
-
-
-
+                
             </div>
 
-
+            
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-
+                    
                     <li class="finding-item">
                         <span class="reference-id">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link">
                                 PMID:16303126
                             </a>
-
+                            
                         </span>
-
+                        
                         <div class="finding-text">These data therefore suggest a dual role for these chaperones in maintaining transparency in the lens.</div>
-
+                        
                     </li>
-
+                    
                 </ul>
             </div>
-
+            
         </div>
-
+        
         <div class="core-function-card">
-
+            
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>CRYAB binds desmin intermediate filaments in a manner dependent on desmin assembly status and subunit organization, acting as a sensor for assembly intermediates. In cardiac and skeletal muscle, CRYAB associates with sarcomeric structures including Z-bands and intercalated disks, and interacts with titin. Mutations in CRYAB (e.g., R120G) cause desmin-related myopathy through aggregation of desmin filaments. Recent work shows that phosphorylation at Ser59 can shift CRYAB condensates toward less dynamic, aggregate-prone states that mislocalize cytoskeletal and sarcomeric client proteins, a pathological mechanism termed condensatopathy; the phosphomimetic S59D behaves similarly to the R120G cardiomyopathy mutant (DOI:10.1172/jci163730).</h3>
                 <span class="vote-buttons" data-g="P02511" data-a="FUNCTION: CRYAB binds desmin intermediate filaments in a man..." data-r="" data-act="CORE_FUNCTION">
@@ -7480,10 +7480,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-
+            
 
             <div class="core-function-terms">
-
+                
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -7492,1034 +7492,1034 @@
                         </a>
                     </span>
                 </div>
+                
 
-
-
+                
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-
+                        
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                 protein stabilization
                             </a>
                         </span>
-
+                        
                     </div>
                 </div>
+                
 
-
-
+                
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-
+                        
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030018" target="_blank" class="term-link">
                                 Z disc
                             </a>
                         </span>
-
+                        
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097512" target="_blank" class="term-link">
                                 cardiac myofibril
                             </a>
                         </span>
-
+                        
                     </div>
                 </div>
+                
 
+                
 
-
-
-
+                
                 <div class="function-term-group">
                     <div class="function-term-label">Substrates:</div>
                     <div class="function-annotations">
-
+                        
                         <span class="badge">
                             <a href="https://www.uniprot.org/uniprotkb/P17661" target="_blank" class="term-link">
                                 desmin
                             </a>
                         </span>
-
+                        
                     </div>
                 </div>
-
+                
             </div>
 
-
+            
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-
+                    
                     <li class="finding-item">
                         <span class="reference-id">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28470624" target="_blank" class="term-link">
                                 PMID:28470624
                             </a>
-
+                            
                         </span>
-
+                        
                         <div class="finding-text">the binding of CRYAB to desmin is subject to its assembly status, to the subunit organization within filaments formed and to the integrity of the C-terminal tail domain of desmin.</div>
-
+                        
                     </li>
-
+                    
                     <li class="finding-item">
                         <span class="reference-id">
-
+                            
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9731540" target="_blank" class="term-link">
                                 PMID:9731540
                             </a>
-
+                            
                         </span>
-
+                        
                         <div class="finding-text">A missense mutation in the alphaB-crystallin chaperone gene causes a desmin-related myopathy.</div>
-
+                        
                     </li>
-
+                    
                 </ul>
             </div>
-
+            
         </div>
-
+        
     </div>
+    
 
-
-
+    
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
                             GO_REF:0000052
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000054.md" target="_blank" class="term-link">
                             GO_REF:0000054
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Gene Ontology annotation based on curation of intracellular localizations of expressed fusion proteins in living cells</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
                             GO_REF:0000107
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11700327" target="_blank" class="term-link">
                             PMID:11700327
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Detection of protein-protein interactions among lens crystallins in a mammalian two-hybrid system assay.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12235146" target="_blank" class="term-link">
                             PMID:12235146
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Role of the C-terminal extensions of alpha-crystallins. Swapping the C-terminal extension of alpha-crystallin to alphaB-crystallin results in enhanced chaperone activity.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12601044" target="_blank" class="term-link">
                             PMID:12601044
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Alteration of protein-protein interactions of congenital cataract crystallin mutants.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link">
                             PMID:14752512
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Human alphaA- and alphaB-crystallins bind to Bax and Bcl-X(S) to sequester their translocation during staurosporine-induced apoptosis.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16049941" target="_blank" class="term-link">
                             PMID:16049941
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">A pilot proteomic study of amyloid precursor interactors in Alzheimer&#39;s disease.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link">
                             PMID:16303126
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Lenticular chaperones suppress the aggregation of the cataract-causing mutant T5P gamma C-crystallin.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17046756" target="_blank" class="term-link">
                             PMID:17046756
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">alphaB-crystallin competes with Alzheimer&#39;s disease beta-amyloid peptide for peptide-peptide interactions and induces oxidation of Abeta-Met35.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18330356" target="_blank" class="term-link">
                             PMID:18330356
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Construction and characterization of a normalized yeast two-hybrid library derived from a human protein-coding clone collection.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link">
                             PMID:19056867
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Large-scale proteomics and phosphoproteomics of urinary exosomes.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
                             PMID:19464326
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">HSPB7 is a SC35 speckle resident small heat shock protein.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19646995" target="_blank" class="term-link">
                             PMID:19646995
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Crystal structures of alpha-crystallin domain dimers of alphaB-crystallin and Hsp20.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19651604" target="_blank" class="term-link">
                             PMID:19651604
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">The eye lens chaperone alpha-crystallin forms defined globular assemblies.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20587334" target="_blank" class="term-link">
                             PMID:20587334
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Synergistic efficacy of LBH and alphaB-crystallin through inhibiting transcriptional activities of p53 and p21.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20802487" target="_blank" class="term-link">
                             PMID:20802487
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Solid-state NMR and SAXS studies provide a structural basis for the activation of alphaB-crystallin oligomers.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21464278" target="_blank" class="term-link">
                             PMID:21464278
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">N-terminal domain of alphaB-crystallin provides a conformational switch for multimerization and structural heterogeneity.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22085609" target="_blank" class="term-link">
                             PMID:22085609
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Temperature-dependent structural and functional properties of a mutant (F71L) αA-crystallin: molecular basis for early onset of age-related cataract.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22143763" target="_blank" class="term-link">
                             PMID:22143763
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Multiple molecular architectures of the eye lens chaperone αB-crystallin elucidated by a triple hybrid approach.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22153508" target="_blank" class="term-link">
                             PMID:22153508
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">The polydispersity of αB-crystallin is rationalized by an interconverting polyhedral architecture.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22158051" target="_blank" class="term-link">
                             PMID:22158051
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Tumor suppressor Alpha B-crystallin (CRYAB) associates with the cadherin/catenin adherens junction and impairs NPC progression-associated properties.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23106396" target="_blank" class="term-link">
                             PMID:23106396
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Amyloid-β oligomers are sequestered by both intracellular and extracellular chaperones.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23188086" target="_blank" class="term-link">
                             PMID:23188086
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Binding determinants of the small heat shock protein, αB-crystallin: recognition of the &#39;IxI&#39; motif.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link">
                             PMID:23533145
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">In-depth proteomic analyses of exosomes isolated from expressed prostatic secretions in urine.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23542032" target="_blank" class="term-link">
                             PMID:23542032
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Protective role of the endoplasmic reticulum protein mitsugumin23 against ultraviolet C-induced cell death.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24183572" target="_blank" class="term-link">
                             PMID:24183572
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Preferential and specific binding of human αB-crystallin to a cataract-related variant of γS-crystallin.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link">
                             PMID:25910212
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Widespread macromolecular interaction perturbations in human genetic disorders.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26465331" target="_blank" class="term-link">
                             PMID:26465331
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Characterization of the Cardiac Overexpression of HSPB2 Reveals Mitochondrial and Myogenic Roles Supported by a Cardiac HspB2 Interactome.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27226619" target="_blank" class="term-link">
                             PMID:27226619
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">The Human 343delT HSPB5 Chaperone Associated with Early-onset Skeletal Myopathy Causes Defects in Protein Solubility.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28470624" target="_blank" class="term-link">
                             PMID:28470624
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">αB-crystallin is a sensor for assembly intermediates and for the subunit topology of desmin intermediate filaments.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28493373" target="_blank" class="term-link">
                             PMID:28493373
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">The novel αB-crystallin (CRYAB) mutation p.D109G causes restrictive cardiomyopathy.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
                             PMID:28514442
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32272059" target="_blank" class="term-link">
                             PMID:32272059
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">A Translocation Pathway for Vesicle-Mediated Unconventional Protein Secretion.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                             PMID:32296183
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">A reference map of the human binary protein interactome.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
                             PMID:32814053
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
                             PMID:40205054
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9731540" target="_blank" class="term-link">
                             PMID:9731540
                         </a>
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">A missense mutation in the alphaB-crystallin chaperone gene causes a desmin-related myopathy.</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         Reactome:R-HSA-5082356
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">HSF1-mediated gene expression</div>
-
-
+                
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         DOI:10.1038/s41467-024-54647-7
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Dynamic fibrillar assembly of alphaB-crystallin induced by perturbation of the conserved NT-IXI motif resolved by cryo-EM</div>
-
-
+                
+                
                 <ul class="findings-list">
-
+                    
                     <li class="finding-item">
                         <div class="finding-statement">CRYAB exists in highly polydisperse oligomers (approximately 10-40 subunits) with rapid subunit exchange dynamics important for chaperone activity</div>
-
+                        
                     </li>
-
+                    
                     <li class="finding-item">
                         <div class="finding-statement">The conserved N-terminal IXI-like motif (NT-IXI) engages the ACD hydrophobic groove, governing assembly; perturbation transforms native assemblies into reversible elongated helical fibrils resolved by cryo-EM</div>
-
+                        
                     </li>
-
+                    
                 </ul>
-
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         DOI:10.1172/jci.insight.182209
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Mutation of CRYAB encoding a conserved mitochondrial chaperone and antiapoptotic protein causes hereditary optic atrophy</div>
-
-
+                
+                
                 <ul class="findings-list">
-
+                    
                     <li class="finding-item">
                         <div class="finding-statement">CRYAB E105K (within the ACD) causes autosomal dominant optic atrophy by reducing oligomer formation, chaperone activity, and interactions with cytochrome c and VDAC</div>
-
+                        
                     </li>
-
+                    
                     <li class="finding-item">
                         <div class="finding-statement">CRYAB deficiency/mutation leads to increased apoptosis, mitochondrial dysfunction, and impaired OXPHOS assembly in retinal ganglion cells</div>
-
+                        
                     </li>
-
+                    
                 </ul>
-
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         DOI:10.1016/j.isci.2024.109510
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">The activation of LBH-CRYAB signaling promotes cardiac protection against I/R injury by inhibiting apoptosis and ferroptosis</div>
-
-
+                
+                
                 <ul class="findings-list">
-
+                    
                     <li class="finding-item">
                         <div class="finding-statement">LBH enhances p38 phosphorylation and CRYAB Ser59 phosphorylation; p38 inhibitor abolishes LBH-induced CRYAB pS59</div>
-
+                        
                     </li>
-
+                    
                     <li class="finding-item">
                         <div class="finding-statement">Phosphorylated CRYAB facilitates NRF2 upregulation/nuclear translocation and contributes to ferroptosis resistance via GPX4 in cardiomyocytes</div>
-
+                        
                     </li>
-
+                    
                 </ul>
-
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         DOI:10.1186/s13287-023-03468-4
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Mature human induced pluripotent stem cell-derived cardiomyocytes promote angiogenesis through alpha-B crystallin</div>
-
-
+                
+                
                 <ul class="findings-list">
-
+                    
                     <li class="finding-item">
                         <div class="finding-statement">CRYAB is upregulated in mature hiPSC-derived cardiomyocytes and is secreted via exosomes</div>
-
+                        
                     </li>
-
+                    
                     <li class="finding-item">
                         <div class="finding-statement">CRYAB siRNA knockdown significantly inhibits HUVEC migration and tube formation, demonstrating CRYAB is necessary for pro-angiogenic paracrine effects</div>
-
+                        
                     </li>
-
+                    
                 </ul>
-
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         DOI:10.1038/s42003-022-04402-9
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Single-cell transcriptomics reveal extracellular vesicles secretion with a cardiomyocyte proteostasis signature during pathological remodeling</div>
-
-
+                
+                
                 <ul class="findings-list">
-
+                    
                     <li class="finding-item">
                         <div class="finding-statement">Stressed cardiomyocytes secrete EVs enriched in protein-quality-control factors including CRYAB during pathological remodeling</div>
-
+                        
                     </li>
-
+                    
                     <li class="finding-item">
                         <div class="finding-statement">CRYAB accumulates in recipient cells exposed to stressed cardiomyocyte-derived EVs</div>
-
+                        
                     </li>
-
+                    
                 </ul>
-
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         DOI:10.1172/jci163730
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Phosphorylation of CRYAB induces a condensatopathy to worsen post-myocardial infarction left ventricular remodeling</div>
-
-
+                
+                
                 <ul class="findings-list">
-
+                    
                     <li class="finding-item">
                         <div class="finding-statement">Ser59 phosphorylation shifts CRYAB condensates toward less dynamic, more aggregate-prone states (condensatopathy), mislocalizing cytoskeletal and sarcomeric client proteins</div>
-
+                        
                     </li>
-
+                    
                     <li class="finding-item">
                         <div class="finding-statement">Phosphomimetic S59D behaves similarly to cardiomyopathy mutant R120G in condensate behavior; S59A mitigates aggregate toxicity</div>
-
+                        
                     </li>
-
+                    
                 </ul>
-
+                
             </div>
-
+            
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-
+                        
                         file:human/CRYAB/CRYAB-deep-research-falcon.md
-
+                        
                     </span>
                 </div>
-
+                
                 <div class="reference-title">Falcon deep research for human CRYAB</div>
-
-
+                
+                
                 <ul class="findings-list">
-
+                    
                     <li class="finding-item">
                         <div class="finding-statement">Falcon synthesis supports CRYAB/HSPB5 as an ATP-independent small heat shock protein holdase chaperone whose oligomerization, phosphorylation, cytoskeletal clients, and mitochondrial anti-apoptotic roles define its core and context-specific functions.</div>
-
+                        
                     </li>
-
+                    
                 </ul>
-
+                
             </div>
-
+            
         </div>
     </div>
+    
 
 
+    
 
+    
 
-
-
-
-
+    
 
     <!-- Computational Predictions Section -->
-
+    
 
     <!-- Additional Documentation Sections -->
-
+    
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-
+        
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -8866,9 +8866,9 @@ this with annotations you find in gene/protein databases, but these can be outda
 </ol>
             </div>
         </details>
-
+        
     </div>
-
+    
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -9085,15 +9085,11 @@ existing_annotations:
       since
       small heat shock proteins share this holdase chaperone function. However, the
       term
-      itself needs replacement. GO:0044183 &#34;protein folding chaperone&#34; (defined as
-      &#34;Binding
-      to a protein or a protein-containing complex to assist the protein folding process&#34;)
-      is the closest available MF term. This is an imperfect replacement because CRYAB
-      specifically does NOT assist in protein folding -- it prevents aggregation (holdase
-      activity). A dedicated holdase-specific GO term does not yet exist and should
-      be
-      requested. UniProt describes CRYAB as having &#34;chaperone-like activity, preventing
-      aggregation of various proteins under a wide range of stress conditions.&#34;
+      itself needs replacement. GO:0140309 &#34;unfolded protein holdase activity&#34; is
+      the appropriate MF term for ATP-independent binding to unfolded or destabilized
+      proteins to prevent their aggregation without active refolding. UniProt describes
+      CRYAB as having &#34;chaperone-like activity, preventing aggregation of various proteins
+      under a wide range of stress conditions.&#34;
     action: MODIFY
     reason: &gt;-
       GO:0051082 is being obsoleted. CRYAB has well-documented chaperone-like holdase
@@ -9102,15 +9098,12 @@ existing_annotations:
       in
       transfected cells (PMID:16303126). However, CRYAB does NOT refold proteins --
       it is a
-      holdase, not a foldase. The best available interim MF replacement is GO:0044183
-      &#34;protein folding chaperone,&#34; though this term is not ideal because its definition
-      references &#34;protein folding process&#34; which is not what CRYAB does. A new
-      holdase-specific term should be requested. GO:0050821 &#34;protein stabilization&#34;
-      is
-      appropriate as a BP term and is already annotated for CRYAB via PMID:12235146.
+      holdase, not a foldase. The appropriate MF replacement is GO:0140309 &#34;unfolded
+      protein holdase activity.&#34; GO:0050821 &#34;protein stabilization&#34; is appropriate
+      as a BP term and is already annotated for CRYAB via PMID:12235146.
     proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+    - id: GO:0140309
+      label: unfolded protein holdase activity
     additional_reference_ids:
     - PMID:16303126
     - PMID:12235146
@@ -10219,8 +10212,8 @@ existing_annotations:
       structural role is already captured more precisely by GO:0005212
       &#34;structural constituent of eye lens.&#34;
     proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+    - id: GO:0140309
+      label: unfolded protein holdase activity
     supported_by:
     - reference_id: PMID:16303126
       supporting_text: &gt;-
@@ -10484,7 +10477,7 @@ existing_annotations:
     reason: &gt;-
       Protein binding is uninformative. The interactions with aldolase and rhodanese
       are chaperone-substrate interactions used as in vitro assay substrates. This
-      is better captured by the chaperone function annotations (GO:0044183 or
+      is better captured by the chaperone function annotations (GO:0140309 or
       GO:0050821).
 - term:
     id: GO:0050821
@@ -10691,10 +10684,8 @@ existing_annotations:
       activity&#34; with a &#34;dual role&#34; -- increasing soluble protein fraction and reducing
       aggregate size. This is classic holdase activity: CRYAB binds partially denatured
       proteins and prevents their aggregation, but does NOT refold them. The term
-      GO:0044183 &#34;protein folding chaperone&#34; is the best available interim replacement
-      MF term, though it is imperfect because CRYAB does not assist in protein folding
-      per se -- it prevents aggregation. A holdase-specific GO term does not yet exist
-      and should be requested.
+      GO:0140309 &#34;unfolded protein holdase activity&#34; is the appropriate MF replacement
+      term because CRYAB prevents aggregation without active refolding.
     action: MODIFY
     reason: &gt;-
       GO:0051082 is being obsoleted. The experimental evidence from PMID:16303126
@@ -10704,12 +10695,12 @@ existing_annotations:
       transparency in the lens&#34;: increasing the proportion of soluble protein and
       reducing aggregate size. This is not passive &#34;unfolded protein binding&#34; but
       active suppression of aggregation (holdase function). The IPI evidence with
-      T5P gamma C-crystallin as the interacting partner is strong. GO:0044183 &#34;protein
-      folding chaperone&#34; is the closest current MF term, but a holdase-specific term
-      is needed since CRYAB does NOT refold proteins.
+      T5P gamma C-crystallin as the interacting partner is strong. GO:0140309 &#34;unfolded
+      protein holdase activity&#34; is the correct current MF term since CRYAB prevents
+      aggregation but does NOT refold proteins.
     proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+    - id: GO:0140309
+      label: unfolded protein holdase activity
     additional_reference_ids:
     - PMID:12235146
     supported_by:
@@ -10851,8 +10842,8 @@ existing_annotations:
         with the disease phenotype in this family.
 core_functions:
 - molecular_function:
-    id: GO:0044183
-    label: protein folding chaperone
+    id: GO:0140309
+    label: unfolded protein holdase activity
   description: &gt;-
     CRYAB (HSPB5) is a small heat shock protein that functions as an ATP-independent
     holdase chaperone. It binds partially denatured or destabilized proteins to prevent
@@ -10978,7 +10969,7 @@ references:
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular 
     Location vocabulary mapping, accompanied by conservative changes to GO terms
     applied by UniProt
   findings: []
@@ -10986,7 +10977,7 @@ references:
   title: Gene Ontology annotation based on curation of immunofluorescence data
   findings: []
 - id: GO_REF:0000054
-  title: Gene Ontology annotation based on curation of intracellular
+  title: Gene Ontology annotation based on curation of intracellular 
     localizations of expressed fusion proteins in living cells
   findings: []
 - id: GO_REF:0000107
@@ -10994,27 +10985,27 @@ references:
     to orthologs using Ensembl Compara
   findings: []
 - id: GO_REF:0000117
-  title: Electronic Gene Ontology annotations created by ARBA machine learning
+  title: Electronic Gene Ontology annotations created by ARBA machine learning 
     models
   findings: []
 - id: GO_REF:0000120
   title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
 - id: PMID:11700327
-  title: Detection of protein-protein interactions among lens crystallins in a
+  title: Detection of protein-protein interactions among lens crystallins in a 
     mammalian two-hybrid system assay.
   findings: []
 - id: PMID:12235146
-  title: Role of the C-terminal extensions of alpha-crystallins. Swapping the
-    C-terminal extension of alpha-crystallin to alphaB-crystallin results in
+  title: Role of the C-terminal extensions of alpha-crystallins. Swapping the 
+    C-terminal extension of alpha-crystallin to alphaB-crystallin results in 
     enhanced chaperone activity.
   findings: []
 - id: PMID:12601044
-  title: Alteration of protein-protein interactions of congenital cataract
+  title: Alteration of protein-protein interactions of congenital cataract 
     crystallin mutants.
   findings: []
 - id: PMID:14752512
-  title: Human alphaA- and alphaB-crystallins bind to Bax and Bcl-X(S) to
+  title: Human alphaA- and alphaB-crystallins bind to Bax and Bcl-X(S) to 
     sequester their translocation during staurosporine-induced apoptosis.
   findings: []
 - id: PMID:16049941
@@ -11022,16 +11013,16 @@ references:
     disease.
   findings: []
 - id: PMID:16303126
-  title: Lenticular chaperones suppress the aggregation of the cataract-causing
+  title: Lenticular chaperones suppress the aggregation of the cataract-causing 
     mutant T5P gamma C-crystallin.
   findings: []
 - id: PMID:17046756
-  title: alphaB-crystallin competes with Alzheimer&#39;s disease beta-amyloid
-    peptide for peptide-peptide interactions and induces oxidation of
+  title: alphaB-crystallin competes with Alzheimer&#39;s disease beta-amyloid 
+    peptide for peptide-peptide interactions and induces oxidation of 
     Abeta-Met35.
   findings: []
 - id: PMID:18330356
-  title: Construction and characterization of a normalized yeast two-hybrid
+  title: Construction and characterization of a normalized yeast two-hybrid 
     library derived from a human protein-coding clone collection.
   findings: []
 - id: PMID:19056867
@@ -11041,19 +11032,19 @@ references:
   title: HSPB7 is a SC35 speckle resident small heat shock protein.
   findings: []
 - id: PMID:19646995
-  title: Crystal structures of alpha-crystallin domain dimers of
+  title: Crystal structures of alpha-crystallin domain dimers of 
     alphaB-crystallin and Hsp20.
   findings: []
 - id: PMID:19651604
-  title: The eye lens chaperone alpha-crystallin forms defined globular
+  title: The eye lens chaperone alpha-crystallin forms defined globular 
     assemblies.
   findings: []
 - id: PMID:20587334
-  title: Synergistic efficacy of LBH and alphaB-crystallin through inhibiting
+  title: Synergistic efficacy of LBH and alphaB-crystallin through inhibiting 
     transcriptional activities of p53 and p21.
   findings: []
 - id: PMID:20802487
-  title: Solid-state NMR and SAXS studies provide a structural basis for the
+  title: Solid-state NMR and SAXS studies provide a structural basis for the 
     activation of alphaB-crystallin oligomers.
   findings: []
 - id: PMID:21464278
@@ -11065,7 +11056,7 @@ references:
     αA-crystallin: molecular basis for early onset of age-related cataract.&#39;
   findings: []
 - id: PMID:22143763
-  title: Multiple molecular architectures of the eye lens chaperone
+  title: Multiple molecular architectures of the eye lens chaperone 
     αB-crystallin elucidated by a triple hybrid approach.
   findings: []
 - id: PMID:22153508
@@ -11073,8 +11064,8 @@ references:
     polyhedral architecture.&#39;
   findings: []
 - id: PMID:22158051
-  title: Tumor suppressor Alpha B-crystallin (CRYAB) associates with the
-    cadherin/catenin adherens junction and impairs NPC progression-associated
+  title: Tumor suppressor Alpha B-crystallin (CRYAB) associates with the 
+    cadherin/catenin adherens junction and impairs NPC progression-associated 
     properties.
   findings: []
 - id: PMID:23106396
@@ -11086,11 +11077,11 @@ references:
     of the &#39;IxI&#39; motif.&#34;
   findings: []
 - id: PMID:23533145
-  title: In-depth proteomic analyses of exosomes isolated from expressed
+  title: In-depth proteomic analyses of exosomes isolated from expressed 
     prostatic secretions in urine.
   findings: []
 - id: PMID:23542032
-  title: Protective role of the endoplasmic reticulum protein mitsugumin23
+  title: Protective role of the endoplasmic reticulum protein mitsugumin23 
     against ultraviolet C-induced cell death.
   findings: []
 - id: PMID:24183572
@@ -11098,15 +11089,15 @@ references:
     variant of γS-crystallin.&#39;
   findings: []
 - id: PMID:25910212
-  title: Widespread macromolecular interaction perturbations in human genetic
+  title: Widespread macromolecular interaction perturbations in human genetic 
     disorders.
   findings: []
 - id: PMID:26465331
-  title: Characterization of the Cardiac Overexpression of HSPB2 Reveals
+  title: Characterization of the Cardiac Overexpression of HSPB2 Reveals 
     Mitochondrial and Myogenic Roles Supported by a Cardiac HspB2 Interactome.
   findings: []
 - id: PMID:27226619
-  title: The Human 343delT HSPB5 Chaperone Associated with Early-onset Skeletal
+  title: The Human 343delT HSPB5 Chaperone Associated with Early-onset Skeletal 
     Myopathy Causes Defects in Protein Solubility.
   findings: []
 - id: PMID:28470624
@@ -11117,30 +11108,30 @@ references:
   title: &#39;The novel αB-crystallin (CRYAB) mutation p.D109G causes restrictive cardiomyopathy.&#39;
   findings: []
 - id: PMID:28514442
-  title: Architecture of the human interactome defines protein communities and
+  title: Architecture of the human interactome defines protein communities and 
     disease networks.
   findings: []
 - id: PMID:32272059
-  title: A Translocation Pathway for Vesicle-Mediated Unconventional Protein
+  title: A Translocation Pathway for Vesicle-Mediated Unconventional Protein 
     Secretion.
   findings: []
 - id: PMID:32296183
   title: A reference map of the human binary protein interactome.
   findings: []
 - id: PMID:32814053
-  title: Interactome Mapping Provides a Network of Neurodegenerative Disease
+  title: Interactome Mapping Provides a Network of Neurodegenerative Disease 
     Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.
   findings: []
 - id: PMID:33961781
-  title: Dual proteome-scale networks reveal cell-specific remodeling of the
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the 
     human interactome.
   findings: []
 - id: PMID:40205054
-  title: Multimodal cell maps as a foundation for structural and functional
+  title: Multimodal cell maps as a foundation for structural and functional 
     genomics.
   findings: []
 - id: PMID:9731540
-  title: A missense mutation in the alphaB-crystallin chaperone gene causes a
+  title: A missense mutation in the alphaB-crystallin chaperone gene causes a 
     desmin-related myopathy.
   findings: []
 - id: Reactome:R-HSA-5082356
@@ -11150,57 +11141,57 @@ references:
   title: Dynamic fibrillar assembly of alphaB-crystallin induced by perturbation
     of the conserved NT-IXI motif resolved by cryo-EM
   findings:
-  - statement: CRYAB exists in highly polydisperse oligomers (approximately
-      10-40 subunits) with rapid subunit exchange dynamics important for
+  - statement: CRYAB exists in highly polydisperse oligomers (approximately 
+      10-40 subunits) with rapid subunit exchange dynamics important for 
       chaperone activity
-  - statement: The conserved N-terminal IXI-like motif (NT-IXI) engages the ACD
-      hydrophobic groove, governing assembly; perturbation transforms native
+  - statement: The conserved N-terminal IXI-like motif (NT-IXI) engages the ACD 
+      hydrophobic groove, governing assembly; perturbation transforms native 
       assemblies into reversible elongated helical fibrils resolved by cryo-EM
 - id: DOI:10.1172/jci.insight.182209
-  title: Mutation of CRYAB encoding a conserved mitochondrial chaperone and
+  title: Mutation of CRYAB encoding a conserved mitochondrial chaperone and 
     antiapoptotic protein causes hereditary optic atrophy
   findings:
-  - statement: CRYAB E105K (within the ACD) causes autosomal dominant optic
-      atrophy by reducing oligomer formation, chaperone activity, and
+  - statement: CRYAB E105K (within the ACD) causes autosomal dominant optic 
+      atrophy by reducing oligomer formation, chaperone activity, and 
       interactions with cytochrome c and VDAC
-  - statement: CRYAB deficiency/mutation leads to increased apoptosis,
-      mitochondrial dysfunction, and impaired OXPHOS assembly in retinal
+  - statement: CRYAB deficiency/mutation leads to increased apoptosis, 
+      mitochondrial dysfunction, and impaired OXPHOS assembly in retinal 
       ganglion cells
 - id: DOI:10.1016/j.isci.2024.109510
-  title: The activation of LBH-CRYAB signaling promotes cardiac protection
+  title: The activation of LBH-CRYAB signaling promotes cardiac protection 
     against I/R injury by inhibiting apoptosis and ferroptosis
   findings:
   - statement: LBH enhances p38 phosphorylation and CRYAB Ser59 phosphorylation;
       p38 inhibitor abolishes LBH-induced CRYAB pS59
-  - statement: Phosphorylated CRYAB facilitates NRF2 upregulation/nuclear
-      translocation and contributes to ferroptosis resistance via GPX4 in
+  - statement: Phosphorylated CRYAB facilitates NRF2 upregulation/nuclear 
+      translocation and contributes to ferroptosis resistance via GPX4 in 
       cardiomyocytes
 - id: DOI:10.1186/s13287-023-03468-4
-  title: Mature human induced pluripotent stem cell-derived cardiomyocytes
+  title: Mature human induced pluripotent stem cell-derived cardiomyocytes 
     promote angiogenesis through alpha-B crystallin
   findings:
-  - statement: CRYAB is upregulated in mature hiPSC-derived cardiomyocytes and
+  - statement: CRYAB is upregulated in mature hiPSC-derived cardiomyocytes and 
       is secreted via exosomes
-  - statement: CRYAB siRNA knockdown significantly inhibits HUVEC migration and
-      tube formation, demonstrating CRYAB is necessary for pro-angiogenic
+  - statement: CRYAB siRNA knockdown significantly inhibits HUVEC migration and 
+      tube formation, demonstrating CRYAB is necessary for pro-angiogenic 
       paracrine effects
 - id: DOI:10.1038/s42003-022-04402-9
-  title: Single-cell transcriptomics reveal extracellular vesicles secretion
+  title: Single-cell transcriptomics reveal extracellular vesicles secretion 
     with a cardiomyocyte proteostasis signature during pathological remodeling
   findings:
-  - statement: Stressed cardiomyocytes secrete EVs enriched in
-      protein-quality-control factors including CRYAB during pathological
+  - statement: Stressed cardiomyocytes secrete EVs enriched in 
+      protein-quality-control factors including CRYAB during pathological 
       remodeling
-  - statement: CRYAB accumulates in recipient cells exposed to stressed
+  - statement: CRYAB accumulates in recipient cells exposed to stressed 
       cardiomyocyte-derived EVs
 - id: DOI:10.1172/jci163730
-  title: Phosphorylation of CRYAB induces a condensatopathy to worsen
+  title: Phosphorylation of CRYAB induces a condensatopathy to worsen 
     post-myocardial infarction left ventricular remodeling
   findings:
-  - statement: Ser59 phosphorylation shifts CRYAB condensates toward less
-      dynamic, more aggregate-prone states (condensatopathy), mislocalizing
+  - statement: Ser59 phosphorylation shifts CRYAB condensates toward less 
+      dynamic, more aggregate-prone states (condensatopathy), mislocalizing 
       cytoskeletal and sarcomeric client proteins
-  - statement: Phosphomimetic S59D behaves similarly to cardiomyopathy mutant
+  - statement: Phosphomimetic S59D behaves similarly to cardiomyopathy mutant 
       R120G in condensate behavior; S59A mitigates aggregate toxicity
 - id: file:human/CRYAB/CRYAB-deep-research-falcon.md
   title: Falcon deep research for human CRYAB
@@ -11216,7 +11207,7 @@ references:
     </div>
 
     <!-- Pathway Visualization Link -->
-
+    
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/CRYAB/CRYAB-ai-review.html
+++ b/genes/human/CRYAB/CRYAB-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>CRYAB</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P02511" target="_blank" class="term-link">
                         P02511
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>CRYAB (alpha-crystallin B chain, also known as HSPB5) is a small heat shock protein that functions as a molecular chaperone with holdase activity. It binds partially denatured or destabilized proteins in an ATP-independent manner to prevent their aggregation, but unlike HSP70-family foldase chaperones, it does NOT actively refold substrates. CRYAB forms large polydisperse oligomeric complexes, typically of 10-40 subunits, and can hetero-oligomerize with CRYAA (HSPB4). The canonical sHSP architecture comprises a central alpha-crystallin domain (ACD) flanked by a variable N-terminal domain (NTD) and a short C-terminal domain (CTD); chaperone activity is tightly coupled to oligomeric assembly and dynamic subunit exchange (DOI:10.1038/s41467-024-54647-7). A conserved N-terminal IXI-like motif (NT-IXI) engages the ACD hydrophobic groove, and perturbation of this motif transforms native assemblies into reversible elongated helical fibrils, as resolved by cryo-EM (DOI:10.1038/s41467-024-54647-7). Stress-activated phosphorylation at Ser19/Ser45/Ser59 by p38 MAPK modulates oligomeric state; the p38-CRYAB(pS59) cascade is a stress-response module that can shift CRYAB condensates toward less dynamic, aggregate-prone states under pathological conditions (DOI:10.1016/j.isci.2024.109510, DOI:10.1172/jci163730). In the eye lens, CRYAB serves dual roles as a structural protein contributing to transparency and refractive index, and as a chaperone preventing aggregation of damaged crystallins. Outside the lens, it is highly expressed in cardiac and skeletal muscle where it associates with cytoskeletal elements including desmin intermediate filaments and titin at Z-bands and intercalated disks. CRYAB also functions as a mitochondrial chaperone and anti-apoptotic protein, binding pro-apoptotic factors Bax, Bcl-X(S), cytochrome c, and VDAC; the E105K mutation causing hereditary optic atrophy reduces these interactions and impairs mitochondrial OXPHOS assembly (DOI:10.1172/jci.insight.182209). CRYAB is secreted via extracellular vesicles and exerts paracrine effects including promotion of angiogenesis in cardiac contexts (DOI:10.1186/s13287-023-03468-4, DOI:10.1038/s42003-022-04402-9). Mutations in CRYAB cause myofibrillar myopathy, cataracts, dilated cardiomyopathy, restrictive cardiomyopathy, and hereditary optic atrophy.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043066" target="_blank" class="term-link">
                                     GO:0043066
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of apoptotic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,64 +795,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for negative regulation of apoptotic process, phylogenetically propagated across small heat shock protein family members (CRYAA, CRYAB, HSPB1). CRYAB has well-documented anti-apoptotic activity. It binds pro-apoptotic Bax and Bcl-X(S) to prevent their translocation from cytosol to mitochondria during staurosporine-induced apoptosis (PMID:14752512). This preserves mitochondrial integrity and blocks caspase-3 activation and PARP degradation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CRYAB is a bona fide anti-apoptotic protein. PMID:14752512 demonstrates that alpha-crystallins bind Bax and Bcl-X(S) both in vitro and in vivo, preventing their translocation to mitochondria. The IBA annotation is phylogenetically appropriate and reflects a well-established function of CRYAB beyond its lens chaperone role. This is a core function of CRYAB, particularly in cardiac and muscle contexts.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link">
                                         PMID:14752512
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">alphaA- and alphaB-crystallins prevent staurosporine-induced apoptosis through interactions with members of the Bcl-2 family. Using GST pulldown assays and coimmunoprecipitations, we demonstrated that alpha-crystallins bind to Bax and Bcl-X(S) both in vitro and in vivo.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -864,64 +864,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for cytoplasm localization, phylogenetically propagated across sHSP family. CRYAB is a predominantly cytoplasmic protein. Multiple IDA annotations from different studies (PMID:19464326, PMID:20587334, PMID:14752512) confirm cytoplasmic localization. UniProt lists cytoplasm as a primary subcellular location.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasm is the primary localization of CRYAB. This is confirmed by multiple independent IDA studies (PMID:19464326, PMID:20587334, PMID:14752512) and is consistent with its role as a cytoplasmic holdase chaperone. The IBA annotation is appropriate and well-supported.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
                                         PMID:19464326
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Online databases did not accurately predict the sub-cellular distribution of all the HSPB members.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -933,64 +933,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for nuclear localization. CRYAB has been shown to translocate to the nucleus during heat shock, where it resides in SC35 speckles (nuclear splicing speckles) (PMID:19464326). It can also accumulate in the nucleus when co-expressed with LBH (PMID:20587334). Multiple IDA annotations support this.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear localization is confirmed by IDA evidence from PMID:19464326 and PMID:20587334. CRYAB translocates to the nucleus during heat stress and resides in SC35 speckles. This is a conditional/stress-dependent localization but is well-documented. The IBA annotation is appropriate.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
                                         PMID:19464326
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Some members also show a dynamic, stress-induced translocation to SC35 splicing speckles.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009408" target="_blank" class="term-link">
                                     GO:0009408
                                 </a>
                             </span>
                             <span class="term-label">response to heat</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1002,64 +1002,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for response to heat. CRYAB is a small heat shock protein (HSPB5) that is upregulated during heat stress and translocates to the nucleus (PMID:19464326). Its chaperone activity in preventing protein aggregation is central to its role in the heat shock response. The IBA is propagated from multiple Drosophila and C. elegans HSP orthologs.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Response to heat is a core function of CRYAB as a member of the small heat shock protein family. It is upregulated during heat stress and shows stress-induced nuclear translocation (PMID:19464326). The IBA annotation is phylogenetically appropriate and reflects the conserved heat stress response function of sHSPs.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
                                         PMID:19464326
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Unlike HSPB1 and HSPB5, that chaperoned heat unfolded substrates and kept them folding competent, HSPB7 did not support refolding.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1071,88 +1071,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA annotation for protein refolding, propagated from Drosophila sHSP orthologs. This is problematic for CRYAB specifically. While some sHSPs in other organisms may participate in protein refolding pathways (by passing substrates to foldase chaperones like HSP70), CRYAB itself is a holdase -- it prevents aggregation of denatured proteins but does NOT actively refold them. PMID:19464326 explicitly tested refolding activity: HSPB1 and HSPB5 chaperoned heat unfolded substrates and kept them folding competent, but the refolding itself depends on downstream HSP70/HSP40 machinery. The term protein refolding implies direct refolding activity which CRYAB does not have.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CRYAB is a holdase chaperone that prevents aggregation but does NOT perform protein refolding. The IBA may be appropriate at the broader sHSP family level where some members participate in refolding pathways, but for CRYAB specifically, protein refolding is misleading. CRYAB keeps substrates in a folding-competent state for downstream foldases (PMID:19464326), which is better captured by GO:0050821 protein stabilization (already annotated via IMP from PMID:12235146). The annotation should be modified to better reflect holdase/protein stabilization activity rather than direct refolding.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                     protein stabilization
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
                                         PMID:19464326
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSPB1 and HSPB5, that chaperoned heat unfolded substrates and kept them folding competent, HSPB7 did not support refolding.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link">
                                         PMID:16303126
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the major lenticular protein chaperones, alpha A- and alpha B-crystallin, increased the solubility of the T5P gamma C-crystallin both in vitro and in transfected cells.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1164,126 +1164,148 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). CRYAB/HSPB5 does bind partially denatured or destabilized proteins, but the term &#34;unfolded protein binding&#34; is problematic because it implies a simple binding function rather than the chaperone holdase activity that CRYAB performs. CRYAB acts as a molecular chaperone that suppresses aggregation of destabilized proteins in an ATP-independent manner (PMID:16303126), but unlike HSP70-family foldase chaperones, it does NOT actively refold substrates. The IBA annotation is phylogenetically propagated from sHSP family members, which is appropriate at the family level since small heat shock proteins share this holdase chaperone function. However, the term itself needs replacement. GO:0044183 &#34;protein folding chaperone&#34; (defined as &#34;Binding to a protein or a protein-containing complex to assist the protein folding process&#34;) is the closest available MF term. This is an imperfect replacement because CRYAB specifically does NOT assist in protein folding -- it prevents aggregation (holdase activity). A dedicated holdase-specific GO term does not yet exist and should be requested. UniProt describes CRYAB as having &#34;chaperone-like activity, preventing aggregation of various proteins under a wide range of stress conditions.&#34;
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. CRYAB has well-documented chaperone-like holdase activity: alpha-crystallins (including CRYAB) increase the solubility of destabilized T5P gamma C-crystallin and reduce the size of its aggregates both in vitro and in transfected cells (PMID:16303126). However, CRYAB does NOT refold proteins -- it is a holdase, not a foldase. The best available interim MF replacement is GO:0044183 &#34;protein folding chaperone,&#34; though this term is not ideal because its definition references &#34;protein folding process&#34; which is not what CRYAB does. A new holdase-specific term should be requested. GO:0050821 &#34;protein stabilization&#34; is appropriate as a BP term and is already annotated for CRYAB via PMID:12235146.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link">
                                         PMID:16303126
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the major lenticular protein chaperones, alpha A- and alpha B-crystallin, increased the solubility of the T5P gamma C-crystallin both in vitro and in transfected cells. More importantly, the size of the T5P gamma C-crystallin aggregates were also significantly reduced in the presence of the lenticular chaperones.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CRYAB/CRYAB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">These concepts are consistent with CRYAB being a small HSP chaperone/holdase, not an enzyme/transporter; therefore its “primary function” is ATP-independent chaperoning of destabilized proteins and stress-protective regulation of proteostasis.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005198" target="_blank" class="term-link">
                                     GO:0005198
                                 </a>
                             </span>
                             <span class="term-label">structural molecule activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P02511" data-a="GO:0005198" data-r="GO_REF:0000117" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P02511" data-a="GO:0005198" data-r="GO_REF:0000117" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from ARBA machine learning for structural molecule activity. CRYAB does indeed serve as a structural protein in the eye lens, contributing to transparency and refractive index. There is also an IDA annotation for this term from PMID:16303126. However, the more specific term GO:0005212 structural constituent of eye lens is also annotated and is more informative. This broader IEA annotation is acceptable as it also reflects the structural role in muscle (association with sarcomeric Z-discs and desmin filaments).
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> CRYAB has structural roles both in the lens (where it contributes to transparency) and in muscle (where it associates with desmin intermediate filaments and sarcomeric structures). The broader term structural molecule activity captures both contexts. The IDA annotation from PMID:16303126 provides independent experimental support.
+                            <strong>Reason:</strong> Structural molecule activity is broader than needed for CRYAB. The lens structural role is captured more precisely by GO:0005212 &#34;structural constituent of eye lens&#34;, while muscle/cytoskeletal contexts are better captured by cytoskeletal protein binding and localization annotations.
                         </div>
-                        
-                        
-                        
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005212" target="_blank" class="term-link">
+                                    structural constituent of eye lens
+                                </a>
+                            </span>
+
+                        </div>
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005212" target="_blank" class="term-link">
                                     GO:0005212
                                 </a>
                             </span>
                             <span class="term-label">structural constituent of eye lens</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1295,46 +1317,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from combined automated methods for structural constituent of eye lens. CRYAB is one of the major structural proteins of the eye lens. It contributes to lens transparency and refractive index. This is well-established from decades of crystallin research and is supported by the InterPro alpha-crystallin N-terminal domain annotation (IPR003090) and the UniProt eye lens protein keyword.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CRYAB is a major structural protein of the vertebrate eye lens. This is a core function. The annotation is appropriate and well-supported by the established biology of alpha-crystallins as both structural lens proteins and molecular chaperones.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
                                     GO:0005576
                                 </a>
                             </span>
                             <span class="term-label">extracellular region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1346,46 +1368,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from UniProt subcellular location mapping. UniProt annotates CRYAB as Secreted based on PMID:32272059, which showed CRYAB can be secreted via an unconventional TMED10-dependent pathway involving translocation to the ERGIC. Additionally, CRYAB is found in extracellular exosomes (PMID:23533145, PMID:19056867). The extracellular region annotation is therefore justified.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CRYAB has been shown to be secreted via an unconventional protein secretion pathway involving TMED10 (PMID:32272059) and is found in extracellular exosomes (PMID:23533145). The IEA annotation correctly reflects the UniProt subcellular location annotation for Secreted.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1397,46 +1419,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from UniProt subcellular location mapping for nucleus. This is a duplicate of the IBA annotation for nucleus, and is also supported by multiple IDA annotations (PMID:19464326, PMID:20587334). Nuclear localization is stress-dependent.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This IEA annotation is consistent with the IBA and IDA evidence. CRYAB translocates to the nucleus during heat stress (PMID:19464326). The IEA correctly maps the UniProt subcellular location annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1448,46 +1470,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from combined automated methods for cytoplasm localization. CRYAB is primarily a cytoplasmic protein, confirmed by multiple IDA annotations (PMID:19464326, PMID:20587334, PMID:14752512) and the IBA annotation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is redundant with the IBA and IDA annotations but is a correct broader IEA annotation. Cytoplasm is the primary localization of CRYAB.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005764" target="_blank" class="term-link">
                                     GO:0005764
                                 </a>
                             </span>
                             <span class="term-label">lysosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1499,46 +1521,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from UniProt subcellular location mapping. UniProt annotates CRYAB as localizing to the lysosome based on similarity to the mouse ortholog P23927 (ECO:0000250). This is supported by PMID:31786107, which shows that CRYAB forms a complex with ATP6V1A and mTOR and regulates lysosome activity in lens epithelial cells.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Lysosome localization is annotated by similarity to the mouse ortholog and is supported by the functional interaction between CRYAB, ATP6V1A (a lysosomal V-ATPase subunit) and mTOR (PMID:31786107). The IEA annotation is reasonable.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009892" target="_blank" class="term-link">
                                     GO:0009892
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of metabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1550,46 +1572,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from ARBA machine learning for negative regulation of metabolic process. This is an extremely broad BP term. CRYAB does negatively regulate some metabolic processes (e.g., negative regulation of apoptosis, negative regulation of protein aggregation), but this term is too general to be informative. More specific terms are already annotated.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is an overly broad term that does not add useful information beyond what is captured by more specific annotations such as GO:0043066 negative regulation of apoptotic process and GO:0031333 negative regulation of protein-containing complex assembly. The ARBA prediction likely derives from the general chaperone/anti-apoptotic activities but is too unspecific.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
                                     GO:0046872
                                 </a>
                             </span>
                             <span class="term-label">metal ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1601,57 +1623,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from UniProt keyword mapping for metal ion binding. CRYAB binds zinc ions through histidine residues (His-83, His-104, His-106, His-111, His-119) as documented in UniProt based on PMID:22890888. Zinc binding enhances oligomer stability.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CRYAB has documented zinc-binding sites identified by chemical modification and MALDI-TOF mass spectrometry (PMID:22890888). Multiple histidine residues coordinate zinc ions, and this inter-subunit bridging enhances structural stability. The IEA annotation from the UniProt metal-binding keyword is appropriate.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11700327" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11700327
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Detection of protein-protein interactions among lens crystal...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1663,57 +1685,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for protein binding from PMID:11700327 (Fu &amp; Liang 2002), which used a mammalian two-hybrid system to detect interactions among lens crystallins. The WITH/FROM column in GOA lists interactions with CRYAA (P02489), HSPB1 (P04792), CRYGC (P07315), and CRYBB2 (P43320). These are genuine crystallin-crystallin interactions. However, protein binding is uninformative; the interactions with CRYAA are better captured by identical protein binding or the broader chaperone complex context.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative per GO curation guidelines. The interactions detected in PMID:11700327 (crystallin-crystallin interactions in mammalian two-hybrid assay) are real but are better captured by more specific terms such as identical protein binding (for self-interaction) or the chaperone function annotations. The binding to other crystallins reflects CRYAB&#39;s chaperone/structural role in the lens.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12601044" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12601044
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Alteration of protein-protein interactions of congenital cat...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1725,57 +1747,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:12601044 (Fu &amp; Liang 2003), which characterized altered protein-protein interactions of congenital cataract crystallin mutants using a mammalian two-hybrid system. Interactions detected include CRYAB with CRYAA, HSPB1, CRYGC, and CRYBB2.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. The interactions described reflect crystallin-crystallin interactions relevant to lens function and are better captured by the identical protein binding and chaperone annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16049941" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16049941
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A pilot proteomic study of amyloid precursor interactors in ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1787,57 +1809,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:16049941, a pilot proteomic study of amyloid precursor protein (APP, P05067) interactors in Alzheimer&#39;s disease. CRYAB was identified as an interactor of APP.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. The interaction with APP is more specifically captured by the amyloid-beta binding annotation (GO:0001540) from PMID:23106396.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17046756" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17046756
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     alphaB-crystallin competes with Alzheimer&#39;s disease beta-amy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1849,57 +1871,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:17046756 (Narayanan et al. 2006), which showed CRYAB competes for amyloid-beta peptide interactions using NMR spectroscopy. The WITH/FROM is CRYBA1 (P05813). The study demonstrated that CRYAB interactions involve the hydrophobic core residues of Abeta.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. The interaction with amyloid-beta is better captured by GO:0001540 amyloid-beta binding (already annotated from PMID:23106396) and the negative regulation of amyloid fibril formation annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18330356" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18330356
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Construction and characterization of a normalized yeast two-...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1911,57 +1933,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:18330356, a large-scale normalized yeast two-hybrid library screen. The WITH/FROM is HSPB1 (P04792). CRYAB interaction with HSPB1 is well-established.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. CRYAB-HSPB1 interaction is well-documented and reflects sHSP hetero-oligomer formation. This is better captured by the protein-containing complex and identical protein binding annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19651604" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19651604
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The eye lens chaperone alpha-crystallin forms defined globul...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1973,57 +1995,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:19651604 (Peschek et al. 2009), which showed that alpha-crystallin forms defined globular assemblies. The WITH/FROM is CRYAA (P02489), reflecting the CRYAB-CRYAA hetero-oligomerization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. The CRYAB-CRYAA interaction reflects hetero-oligomer formation and is better captured by the identical protein binding and protein-containing complex annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22085609" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22085609
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Temperature-dependent structural and functional properties o...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2035,57 +2057,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:22085609, which studied the F71L mutant alphaA-crystallin and its effects on hetero-oligomeric complex stability. The WITH/FROM is CRYAA (P02489).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. This reflects CRYAB-CRYAA hetero-oligomerization. More specific annotations are already present.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22153508" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22153508
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The polydispersity of αB-crystallin is rationalized by an in...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2097,57 +2119,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:22153508 (Baldwin et al. 2011), which elucidated the polyhedral architecture of CRYAB oligomers. The WITH/FROM is CRYAA (P02489).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. This reflects CRYAB oligomerization dynamics. Better captured by identical protein binding and protein-containing complex annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22158051" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22158051
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tumor suppressor Alpha B-crystallin (CRYAB) associates with ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2159,57 +2181,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:22158051 (Huang et al. 2012), which showed CRYAB associates with the cadherin/catenin adherens junction. The WITH/FROM is beta-catenin (CTNNB1, P35222). CRYAB interacts with both E-cadherin and beta-catenin via its alpha-crystallin core domain, inhibiting E-cadherin internalization and NPC progression.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. The specific interaction with beta-catenin described in PMID:22158051 reflects CRYAB&#39;s role in cell adhesion regulation in cancer context. This is a secondary/non-core function and the term protein binding does not capture the functional significance.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23188086" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23188086
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Binding determinants of the small heat shock protein, αB-cry...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2221,57 +2243,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:23188086 (Delbecq et al. 2012), which studied the IxI motif binding determinants of CRYAB. The WITH/FROM includes CRYAA (P02489), HSPB1 (P04792), and HSPB2 (Q16082).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. The IxI motif interactions are critical for sHSP oligomer assembly and are better captured by the identical protein binding and oligomerization-related annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23542032" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23542032
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Protective role of the endoplasmic reticulum protein mitsugu...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2283,57 +2305,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:23542032 (Yamashita et al. 2013), which identified CRYAB as a binding partner of mitsugumin23 (TMEM109/MG23, mouse Q3UBX0). The interaction mediates a protective role against UVC-induced cell death by accumulating CRYAB near the ER.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. The CRYAB-TMEM109 interaction is functionally significant in the DNA damage response, but the protein binding term does not capture this. The functional role is partially captured by the regulation of programmed cell death annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24183572" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24183572
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Preferential and specific binding of human αB-crystallin to ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2345,57 +2367,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:24183572 (Kingsley et al. 2013), which showed preferential and specific binding of CRYAB to the cataract-related G18V variant of gammaS-crystallin (CRYGS, P22914). CRYAB binds more strongly to the variant via a well-defined interaction surface.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. This interaction reflects CRYAB&#39;s chaperone function in the lens -- it preferentially binds destabilized crystallin variants. This is better captured by the chaperone/holdase MF annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25910212
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Widespread macromolecular interaction perturbations in human...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2407,57 +2429,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:25910212, a large-scale study of macromolecular interaction perturbations in human genetic disorders. The WITH/FROM is CRYAA (P02489).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. Large-scale interaction studies do not provide functional specificity beyond what is already captured by more specific annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26465331" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26465331
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Characterization of the Cardiac Overexpression of HSPB2 Reve...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2469,57 +2491,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:26465331 (Grose et al. 2015), which characterized the cardiac HSPB2 interactome. The WITH/FROM is HSPB2 (Q16082). CRYAB interacts with HSPB2, consistent with sHSP hetero-oligomerization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. The CRYAB-HSPB2 interaction is part of the sHSP oligomeric network and is better captured by more specific annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28514442
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Architecture of the human interactome defines protein commun...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2531,57 +2553,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:28514442, a large-scale interactome mapping study. The WITH/FROM is HSPB1 (P04792).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. Large-scale interactome studies confirm known sHSP interactions but do not add functional specificity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32296183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A reference map of the human binary protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2593,57 +2615,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:32296183, a reference map of the human binary protein interactome. The WITH/FROM includes CRYAA (P02489), KRTAP6-1 (Q3LI64), and GORASP2 (Q9H8Y8).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. Large-scale binary interactome studies do not provide functional specificity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32814053
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interactome Mapping Provides a Network of Neurodegenerative ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2655,57 +2677,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:32814053, an interactome mapping study focused on neurodegenerative disease proteins. The WITH/FROM includes multiple proteins (APP/P05067, CTNNB1/P35222, EXOC5/O00471, ANXA4/P09525, PRPS1/P60891, CRMP1/Q14194, CORO6/Q6QEF8, ADAMTSL4/Q6UY14, PRUNE2/Q8WUY3, HSFY2/Q96LI6).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. This large-scale interactome study identifies many interactors but the term does not capture the functional significance of any of these interactions.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2717,57 +2739,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:33961781, a dual proteome-scale network study. The WITH/FROM is HSPB1 (P04792).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. Confirms CRYAB-HSPB1 interaction from large-scale proteomics.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:40205054
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Multimodal cell maps as a foundation for structural and func...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2779,57 +2801,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:40205054, multimodal cell maps study. The WITH/FROM is HSPB1 (P04792).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative per GO curation guidelines.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12601044" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12601044
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Alteration of protein-protein interactions of congenital cat...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2841,75 +2863,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for identical protein binding (CRYAB self-interaction) from PMID:12601044 (Fu &amp; Liang 2003). The study used mammalian two-hybrid to show CRYAB-CRYAB interaction, and that the R120G mutation decreases self-interaction. CRYAB forms large homo-oligomeric complexes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CRYAB self-association to form large homo-oligomeric complexes (typically 24-32 subunits) is a core feature of its biology. This is confirmed by multiple structural studies. The identical protein binding annotation is appropriate and more informative than generic protein binding.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12601044" target="_blank" class="term-link">
                                         PMID:12601044
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">for the R120G alphaB-crystallin, the interactions with alphaA- and alphaB-crystallin decreased, but those with betaB2- and gammaC-crystallin increased slightly.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18330356" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18330356
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Construction and characterization of a normalized yeast two-...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2921,57 +2943,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for identical protein binding from PMID:18330356 (normalized yeast two-hybrid library). Confirms CRYAB self-interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Confirms CRYAB homo-oligomerization by an independent method. Core property of CRYAB.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19651604" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19651604
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The eye lens chaperone alpha-crystallin forms defined globul...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2983,57 +3005,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:19651604 (Peschek et al. 2009), which demonstrated that alpha-crystallin forms defined globular assemblies. CRYAB self-interaction is central to its oligomeric architecture.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CRYAB homo-oligomerization is a core structural property documented by multiple biophysical approaches.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20802487" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20802487
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Solid-state NMR and SAXS studies provide a structural basis ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3045,57 +3067,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:20802487, which used solid-state NMR and SAXS to study CRYAB oligomer activation. Self-interaction confirmed by structural methods.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Confirms CRYAB self-association by biophysical methods. Core property.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21464278" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21464278
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     N-terminal domain of alphaB-crystallin provides a conformati...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3107,57 +3129,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:21464278, which showed that the N-terminal domain of CRYAB provides a conformational switch for multimerization and structural heterogeneity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Confirms CRYAB homo-oligomeric assembly, specifically identifying the N-terminal domain role. Core property.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22143763" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22143763
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Multiple molecular architectures of the eye lens chaperone α...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3169,57 +3191,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:22143763, which elucidated multiple molecular architectures of CRYAB oligomers using a triple hybrid approach.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Confirms CRYAB polydisperse homo-oligomeric assembly by multiple structural methods.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22153508" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22153508
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The polydispersity of αB-crystallin is rationalized by an in...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3231,75 +3253,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:22153508 (Baldwin et al. 2011), which demonstrated the interconverting polyhedral architecture of CRYAB oligomers using NMR, mass spectrometry, and electron microscopy.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Provides structural basis for CRYAB polydisperse oligomeric assembly. Core property.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22153508" target="_blank" class="term-link">
                                         PMID:22153508
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We report structural models for the most abundant oligomers populated by the polydisperse molecular chaperone alphaB-crystallin.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23188086" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23188086
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Binding determinants of the small heat shock protein, αB-cry...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3311,75 +3333,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:23188086 (Delbecq et al. 2012), which characterized the IxI motif binding to the alpha-crystallin domain groove. This inter-subunit interaction is critical for oligomer formation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The IxI motif interaction is a key determinant of sHSP oligomer assembly and client binding. This study provides molecular detail on CRYAB self-interaction. Core property.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23188086" target="_blank" class="term-link">
                                         PMID:23188086
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The most commonly observed inter-subunit interaction involves a highly conserved C-terminal &#39;IxI/V&#39; motif and a groove in the ACD that is also implicated in client binding.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24183572" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24183572
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Preferential and specific binding of human αB-crystallin to ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3391,57 +3413,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:24183572 (Kingsley et al. 2013). The WITH/FROM is CRYAB itself (P02511), reflecting self-interaction in the context of studying CRYAB binding to gammaS-crystallin variants.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Confirms CRYAB self-interaction. Core property.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26465331" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26465331
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Characterization of the Cardiac Overexpression of HSPB2 Reve...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3453,57 +3475,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:26465331 (Grose et al. 2015), cardiac HSPB2 interactome study. The WITH/FROM is CRYAB itself (P02511).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Confirms CRYAB self-interaction in cardiac context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27226619" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27226619
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Human 343delT HSPB5 Chaperone Associated with Early-onse...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3515,46 +3537,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:27226619, which studied the 343delT HSPB5 mutation associated with early-onset skeletal myopathy and its defects in protein solubility. Confirms CRYAB self-interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Confirms CRYAB self-interaction. Disease mutations affect oligomeric assembly, underscoring the functional importance of self-interaction.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3566,46 +3588,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer, based on mouse CRYAB (P23927). CRYAB has been reported to translocate to mitochondria in some contexts, particularly related to its anti-apoptotic function (sequestering Bax and Bcl-X(S) to prevent mitochondrial translocation, PMID:14752512). The anti-apoptotic mechanism involves preventing Bax translocation TO mitochondria rather than CRYAB being a mitochondrial resident protein.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Mitochondrial localization may occur transiently or in specific contexts (e.g., during apoptosis regulation), but CRYAB is not a constitutive mitochondrial protein. The annotation from Ensembl Compara mouse ortholog transfer is acceptable but represents a non-core, context-dependent localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3617,46 +3639,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for cytosol. CRYAB is primarily a cytosolic protein, supported by IDA evidence from GO_REF:0000052 (HPA immunofluorescence). Cytosol is consistent with the cytoplasm annotations.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol is the more specific subcellular compartment within cytoplasm where CRYAB resides. Supported by IDA from HPA data and consistent with CRYAB&#39;s known biology as a soluble cytoplasmic chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3668,46 +3690,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for plasma membrane. Also supported by IDA from HPA immunofluorescence (GO_REF:0000052). CRYAB has been reported at the plasma membrane in some contexts (e.g., association with cadherin/catenin complexes at the cell membrane, PMID:22158051).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Plasma membrane localization may occur in specific contexts (e.g., cell adhesion junctions) but is not a core localization of CRYAB. The HPA IDA data and mouse ortholog transfer provide some support, but cytoplasm/cytosol are the primary locations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -3719,75 +3741,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer (from rat) for protein folding. CRYAB is a holdase chaperone that prevents protein aggregation but does NOT actively fold proteins. It keeps substrates in a folding-competent state that can then be refolded by ATP-dependent foldase chaperones like HSP70. The term protein folding implies direct participation in the folding process, which is misleading for a holdase.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CRYAB is a holdase chaperone, not a foldase. It prevents aggregation and maintains substrates in a folding-competent state (PMID:19464326, PMID:16303126) but does not perform protein folding per se. GO:0050821 protein stabilization is more appropriate as a BP term. The annotation should be modified to reflect holdase activity rather than folding activity.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                     protein stabilization
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
                                         PMID:19464326
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HSPB1 and HSPB5, that chaperoned heat unfolded substrates and kept them folding competent, HSPB7 did not support refolding.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008017" target="_blank" class="term-link">
                                     GO:0008017
                                 </a>
                             </span>
                             <span class="term-label">microtubule binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3799,46 +3821,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer (from rat CRYAB) for microtubule binding. There is limited direct evidence for CRYAB binding microtubules in human. CRYAB is better known for binding intermediate filaments (desmin) and actin filaments. The rat data may reflect CRYAB&#39;s broader cytoskeletal interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Microtubule binding is plausible given CRYAB&#39;s known interactions with cytoskeletal elements (desmin intermediate filaments, actin), but the primary cytoskeletal interaction is with intermediate filaments (PMID:28470624). The broader cytoskeletal protein binding annotation (GO:0008092) is also present and may be more appropriate. This is a non-core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008092" target="_blank" class="term-link">
                                     GO:0008092
                                 </a>
                             </span>
                             <span class="term-label">cytoskeletal protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3850,64 +3872,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for cytoskeletal protein binding. CRYAB interacts with desmin intermediate filaments (PMID:28470624), titin (PMID:14676215), and associates with the sarcomeric cytoskeleton. This is well-supported.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CRYAB has well-documented interactions with cytoskeletal proteins including desmin (PMID:28470624) and titin (UniProt, PMID:14676215). Mutations in CRYAB cause desmin-related myopathy (PMID:9731540), underscoring the functional importance of this interaction. The IEA annotation is appropriate.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/28470624" target="_blank" class="term-link">
                                         PMID:28470624
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the binding of CRYAB to desmin is subject to its assembly status, to the subunit organization within filaments formed and to the integrity of the C-terminal tail domain of desmin.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009986" target="_blank" class="term-link">
                                     GO:0009986
                                 </a>
                             </span>
                             <span class="term-label">cell surface</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3919,46 +3941,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for cell surface. CRYAB is primarily an intracellular protein. Some evidence suggests it can be secreted (PMID:32272059) and found in exosomes, but cell surface localization is not well-established for human CRYAB.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cell surface localization is not well-documented for human CRYAB. It may be transiently present at the cell surface during unconventional secretion. This is a non-core, context-dependent localization transferred from rat ortholog.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030018" target="_blank" class="term-link">
                                     GO:0030018
                                 </a>
                             </span>
                             <span class="term-label">Z disc</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3970,46 +3992,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for Z disc localization. UniProt notes that CRYAB localizes at Z-bands and the intercalated disk in cardiomyocytes (PMID:28493373). This is consistent with its role in muscle and its interaction with desmin and titin.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Z disc localization is documented for human CRYAB in cardiomyocytes (PMID:28493373) and is consistent with its interaction with sarcomeric proteins desmin and titin. This is a core localization in muscle tissue.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030308" target="_blank" class="term-link">
                                     GO:0030308
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of cell growth</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4021,46 +4043,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for negative regulation of cell growth. CRYAB has been implicated in tumor suppression in some contexts (PMID:22158051 in NPC) and its overexpression can suppress tumor formation. However, this is not a core function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Negative regulation of cell growth is a secondary function of CRYAB, observed in certain cancer contexts (PMID:22158051). It is not a core function and likely reflects downstream consequences of its anti-apoptotic and chaperone activities rather than a direct growth regulatory function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030424" target="_blank" class="term-link">
                                     GO:0030424
                                 </a>
                             </span>
                             <span class="term-label">axon</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4072,46 +4094,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for axon localization. CRYAB is expressed in the nervous system and accumulates in Alexander&#39;s disease brain. Axonal localization is plausible but represents a tissue-specific localization rather than core biology.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Axon localization is transferred from rat ortholog. CRYAB is expressed in neural tissues and accumulates in neurological disease contexts, but axonal localization is not a core feature. Non-core tissue-specific localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031109" target="_blank" class="term-link">
                                     GO:0031109
                                 </a>
                             </span>
                             <span class="term-label">microtubule polymerization or depolymerization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -4123,46 +4145,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for microtubule polymerization or depolymerization. There is limited direct evidence for CRYAB regulating microtubule dynamics in human. This may be an over-annotation from the rat ortholog.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> There is insufficient evidence that CRYAB directly regulates microtubule polymerization or depolymerization in human. CRYAB&#39;s primary cytoskeletal interactions are with intermediate filaments (desmin) rather than microtubules. This annotation likely represents an over-annotation from ortholog transfer.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031430" target="_blank" class="term-link">
                                     GO:0031430
                                 </a>
                             </span>
                             <span class="term-label">M band</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4174,46 +4196,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for M band localization. CRYAB interacts with titin, which spans from Z disc to M band. M band localization is plausible in the context of sarcomeric association.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> M band localization is consistent with CRYAB&#39;s interaction with titin and its sarcomeric association. However, the primary sarcomeric localization documented for human CRYAB is at Z-bands (PMID:28493373). M band is a secondary localization from rat ortholog transfer.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031674" target="_blank" class="term-link">
                                     GO:0031674
                                 </a>
                             </span>
                             <span class="term-label">I band</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4225,46 +4247,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for I band localization. I band localization is consistent with CRYAB&#39;s association with sarcomeric structures and its interaction with titin (which spans the I band).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> I band localization is plausible given CRYAB&#39;s interaction with titin and sarcomeric structures, but is transferred from rat ortholog. Non-core but reasonable for muscle tissue context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032355" target="_blank" class="term-link">
                                     GO:0032355
                                 </a>
                             </span>
                             <span class="term-label">response to estradiol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4276,46 +4298,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for response to estradiol. CRYAB expression may be regulated by estradiol in certain tissues, but this is not a core function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Response to estradiol is a secondary, context-dependent process for CRYAB. Many stress-responsive genes show altered expression in response to various stimuli including hormones. This is not a core function and is transferred from rat ortholog.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032432" target="_blank" class="term-link">
                                     GO:0032432
                                 </a>
                             </span>
                             <span class="term-label">actin filament bundle</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4327,46 +4349,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for actin filament bundle localization. CRYAB has been reported to associate with actin cytoskeletal structures in addition to its well-known intermediate filament interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Actin filament bundle localization is a secondary cytoskeletal association for CRYAB. Its primary cytoskeletal interaction is with desmin intermediate filaments. Transferred from rat ortholog.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042542" target="_blank" class="term-link">
                                     GO:0042542
                                 </a>
                             </span>
                             <span class="term-label">response to hydrogen peroxide</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4378,46 +4400,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for response to hydrogen peroxide. As a stress-responsive chaperone, CRYAB is likely upregulated during oxidative stress including H2O2 exposure. UniProt notes susceptibility to oxidation at Met-48, Met-60, and Trp-68.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Response to hydrogen peroxide is consistent with CRYAB&#39;s role as a stress-responsive chaperone. It is a non-core, general stress response function rather than a specific core activity. Transferred from rat ortholog.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043066" target="_blank" class="term-link">
                                     GO:0043066
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of apoptotic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4429,46 +4451,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from combined automated methods for negative regulation of apoptotic process. This duplicates the IBA annotation and is also supported by IDA evidence from PMID:14752512. CRYAB&#39;s anti-apoptotic activity through binding Bax and Bcl-X(S) is well-established.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This IEA annotation is consistent with the IBA and IDA evidence for CRYAB&#39;s anti-apoptotic function. PMID:14752512 provides direct experimental evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043197" target="_blank" class="term-link">
                                     GO:0043197
                                 </a>
                             </span>
                             <span class="term-label">dendritic spine</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4480,46 +4502,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for dendritic spine localization. CRYAB is expressed in the nervous system and has been found in neural structures. Dendritic spine localization is plausible but represents a tissue-specific neural localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Dendritic spine localization is a neural tissue-specific localization transferred from rat ortholog. CRYAB is expressed in the brain and accumulates in neurological disease contexts. Non-core, tissue-specific.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043204" target="_blank" class="term-link">
                                     GO:0043204
                                 </a>
                             </span>
                             <span class="term-label">perikaryon</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4531,46 +4553,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for perikaryon (cell body of neuron) localization. CRYAB is expressed in neural tissues.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Perikaryon localization is a neural tissue-specific localization transferred from rat ortholog. Non-core.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043292" target="_blank" class="term-link">
                                     GO:0043292
                                 </a>
                             </span>
                             <span class="term-label">contractile muscle fiber</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4582,46 +4604,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for contractile muscle fiber localization. CRYAB is highly expressed in cardiac and skeletal muscle (HPA: tissue enhanced in heart muscle, skeletal muscle, tongue) and associates with sarcomeric structures.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CRYAB is highly expressed in muscle tissue and localizes to sarcomeric structures (Z-bands, intercalated disks) as documented by PMID:28493373. Contractile muscle fiber localization is consistent with CRYAB&#39;s role in muscle and its association with desmin and titin.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051403" target="_blank" class="term-link">
                                     GO:0051403
                                 </a>
                             </span>
                             <span class="term-label">stress-activated MAPK cascade</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4633,46 +4655,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for stress-activated MAPK cascade. CRYAB has been reported to modulate MAPK signaling in some stress contexts, but this is not a core function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Stress-activated MAPK cascade involvement is a secondary consequence of CRYAB&#39;s stress-protective functions rather than a direct core activity. Transferred from rat ortholog. Non-core.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097060" target="_blank" class="term-link">
                                     GO:0097060
                                 </a>
                             </span>
                             <span class="term-label">synaptic membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4684,46 +4706,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for synaptic membrane localization. CRYAB is expressed in neural tissues. Synaptic membrane localization is a tissue-specific neural localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Synaptic membrane localization is a neural tissue-specific localization transferred from rat ortholog. Non-core.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097512" target="_blank" class="term-link">
                                     GO:0097512
                                 </a>
                             </span>
                             <span class="term-label">cardiac myofibril</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4735,46 +4757,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for cardiac myofibril localization. CRYAB is highly expressed in cardiac muscle and localizes to sarcomeric structures including Z-bands and intercalated disks (PMID:28493373).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cardiac myofibril localization is well-supported by CRYAB&#39;s high expression in cardiac muscle (HPA, UniProt) and its documented localization at Z-bands and intercalated disks (PMID:28493373). CRYAB mutations cause cardiomyopathies, underscoring its cardiac muscle function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:2000378" target="_blank" class="term-link">
                                     GO:2000378
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of reactive oxygen species metabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4786,46 +4808,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from Ensembl Compara ortholog transfer for negative regulation of reactive oxygen species metabolic process. CRYAB has been implicated in oxidative stress protection, but this is a secondary function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Negative regulation of ROS is a downstream protective effect of CRYAB&#39;s chaperone activity rather than a direct core function. Transferred from rat ortholog. Non-core.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4837,46 +4859,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from HPA immunofluorescence curation for cytosol localization. CRYAB is a soluble cytoplasmic chaperone that resides in the cytosol under normal conditions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization is the primary subcellular localization of CRYAB under normal conditions. Supported by HPA immunofluorescence data and consistent with its role as a soluble chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4888,57 +4910,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from HPA immunofluorescence curation for plasma membrane. Some plasma membrane signal may be detected by immunofluorescence but CRYAB is primarily cytosolic.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Plasma membrane localization from HPA immunofluorescence is a secondary localization. CRYAB may associate with membrane-proximal structures in some contexts (e.g., cadherin/catenin complexes, PMID:22158051) but is primarily a cytosolic protein. Non-core.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043067" target="_blank" class="term-link">
                                     GO:0043067
                                 </a>
                             </span>
                             <span class="term-label">regulation of programmed cell death</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23542032" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23542032
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Protective role of the endoplasmic reticulum protein mitsugu...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4950,155 +4972,166 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IMP annotation from PMID:23542032 (Yamashita et al. 2013) for regulation of programmed cell death. The study showed that knockdown of CRYAB facilitates death of UVC-exposed cells, and that CRYAB expressed as an ER-anchored form lowered UVC sensitivity. CRYAB binding to MG23/TMEM109 mediates protection against UVC-induced cell death.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CRYAB&#39;s role in regulating programmed cell death is well-established. This annotation from PMID:23542032 specifically documents the protective role against UVC-induced cell death via interaction with TMEM109. This is consistent with CRYAB&#39;s broader anti-apoptotic function (PMID:14752512). The parent term regulation of programmed cell death is appropriate here since the paper demonstrates both protection and sensitization depending on CRYAB expression levels.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23542032" target="_blank" class="term-link">
                                         PMID:23542032
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The small heat shock protein αB-crystallin (αBC) is identified as a MG23 binding molecule and its knockdown facilitates death of UVC-exposed cells.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005198" target="_blank" class="term-link">
                                     GO:0005198
                                 </a>
                             </span>
                             <span class="term-label">structural molecule activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16303126
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Lenticular chaperones suppress the aggregation of the catara...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P02511" data-a="GO:0005198" data-r="PMID:16303126" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P02511" data-a="GO:0005198" data-r="PMID:16303126" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for structural molecule activity from PMID:16303126 (Pigaga &amp; Quinlan 2006). This paper primarily demonstrates chaperone-like activity of alpha-crystallins in suppressing aggregation of T5P gamma C-crystallin. The structural molecule activity annotation may reflect CRYAB&#39;s dual role in the lens as both a structural protein and a chaperone.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> CRYAB has a dual role in the lens as both a structural protein (contributing to lens transparency and refractive index) and a molecular chaperone (preventing aggregation of damaged crystallins). PMID:16303126 demonstrates both roles. The structural molecule activity annotation is appropriate for the structural lens function.
+                            <strong>Reason:</strong> PMID:16303126 supports CRYAB/alpha-crystallin suppression of aggregation of the cataract-causing T5P gamma C-crystallin, which is chaperone/holdase activity rather than generic structural molecule activity. The true lens structural role is already captured more precisely by GO:0005212 &#34;structural constituent of eye lens.&#34;
                         </div>
-                        
-                        
-                        
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
+                                    protein folding chaperone
+                                </a>
+                            </span>
+
+                        </div>
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link">
                                         PMID:16303126
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">These data therefore suggest a dual role for these chaperones in maintaining transparency in the lens.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
                                     GO:0032991
                                 </a>
                             </span>
                             <span class="term-label">protein-containing complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16303126
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Lenticular chaperones suppress the aggregation of the catara...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5110,57 +5143,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for protein-containing complex from PMID:16303126. CRYAB forms large oligomeric complexes, typically of 24-32 subunits. This is a fundamental feature of its biology as a small heat shock protein.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CRYAB forms large polydisperse homo-oligomeric and hetero-oligomeric complexes. This is a core structural feature well-documented by multiple biophysical studies (PMID:16303126, PMID:22153508, PMID:19651604).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16303126
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Lenticular chaperones suppress the aggregation of the catara...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5172,57 +5205,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation for identical protein binding from PMID:16303126, reflecting CRYAB self-association in the context of alpha-crystallin oligomeric complexes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Confirms CRYAB self-interaction, which is central to its oligomeric assembly. Core property.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031333" target="_blank" class="term-link">
                                     GO:0031333
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of protein-containing complex assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23106396" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23106396
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Amyloid-β oligomers are sequestered by both intracellular an...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5234,75 +5267,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from PMID:23106396 (Narayan et al. 2012) for negative regulation of protein-containing complex assembly. The study demonstrated that CRYAB binds to misfolded amyloid-beta oligomeric species, forming long-lived complexes that prevent further growth into fibrils and prevent their dissociation. This is a manifestation of CRYAB&#39;s holdase chaperone activity applied to amyloid aggregation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This annotation captures an important aspect of CRYAB&#39;s chaperone function -- it prevents further assembly of amyloid-beta oligomers into fibrils. PMID:23106396 provides direct experimental evidence using single-molecule fluorescence techniques.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23106396" target="_blank" class="term-link">
                                         PMID:23106396
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">both chaperones bind to misfolded oligomeric species and form long-lived complexes, thereby preventing both their further growth into fibrils and their dissociation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20587334" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20587334
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Synergistic efficacy of LBH and alphaB-crystallin through in...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -5314,57 +5347,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:20587334 (Deng et al. 2010), which identified LBH (Q53QV2) as a CRYAB-interacting partner by yeast two-hybrid and confirmed by co-immunoprecipitation and GST pull-down. The interaction leads to synergistic repression of p53 and p21 transcriptional activities.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. The CRYAB-LBH interaction is interesting but the term does not capture the functional significance. The downstream functional consequence is captured by the negative regulation of DNA-templated transcription annotation from the same paper.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20587334" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20587334
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Synergistic efficacy of LBH and alphaB-crystallin through in...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5376,75 +5409,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for nucleus localization from PMID:20587334. The study showed that CRYAB, which is normally cytoplasmic, accumulates partially in the nucleus when co-transfected with LBH in COS-7 cells.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear localization of CRYAB is confirmed by direct observation in PMID:20587334, consistent with other IDA evidence from PMID:19464326. CRYAB translocates to the nucleus under specific conditions.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20587334" target="_blank" class="term-link">
                                         PMID:20587334
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">alphaB-crystallin that is cytoplasmic alone, accumulates partialy in the nucleus when co-transfected with LBH.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20587334" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20587334
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Synergistic efficacy of LBH and alphaB-crystallin through in...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5456,57 +5489,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for cytoplasm localization from PMID:20587334. CRYAB is cytoplasmic when expressed alone in COS-7 cells.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasm is the primary localization of CRYAB, confirmed by direct observation in PMID:20587334.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
                                     GO:0032991
                                 </a>
                             </span>
                             <span class="term-label">protein-containing complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20587334" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20587334
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Synergistic efficacy of LBH and alphaB-crystallin through in...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5518,57 +5551,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation for protein-containing complex from PMID:20587334. CRYAB forms a complex with LBH as shown by co-immunoprecipitation and GST pull-down.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CRYAB forms complexes with multiple partners. The complex with LBH is documented by co-immunoprecipitation in PMID:20587334.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045892" target="_blank" class="term-link">
                                     GO:0045892
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of DNA-templated transcription</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20587334" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20587334
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Synergistic efficacy of LBH and alphaB-crystallin through in...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -5580,75 +5613,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from PMID:20587334 for negative regulation of DNA-templated transcription. Overexpression of CRYAB reduced the transcriptional activities of p53 and p21 promoters, and co-expression with LBH resulted in stronger repression. This is a secondary/non-core function of CRYAB.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While the experimental evidence from PMID:20587334 supports that CRYAB can repress transcription from p53 and p21 promoters, this is likely a secondary consequence of CRYAB&#39;s interaction with LBH and its general protein-binding chaperone activity rather than a core transcriptional regulatory function. CRYAB is not a transcription factor. This function is non-core.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20587334" target="_blank" class="term-link">
                                         PMID:20587334
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Transient transfection assays indicated that overexpression of LBH or alphaB-crystallin reduced the transcriptional activities of p53 and p21, respectively, Overexpression of both alphaB-crystallin and LBH together resulted in a stronger repression of the transcriptional activities of p21 and p53.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001540" target="_blank" class="term-link">
                                     GO:0001540
                                 </a>
                             </span>
                             <span class="term-label">amyloid-beta binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23106396" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23106396
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Amyloid-β oligomers are sequestered by both intracellular an...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5660,88 +5693,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:23106396 (Narayan et al. 2012) for amyloid-beta binding. Using single-molecule fluorescence techniques, the study demonstrated that CRYAB binds to amyloid-beta oligomeric species, forming long-lived complexes. The WITH/FROM is APP processed to amyloid-beta (P05067-PRO_0000000093).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CRYAB binding to amyloid-beta oligomers is well-documented (PMID:23106396, PMID:17046756). This is a specific manifestation of CRYAB&#39;s holdase chaperone activity -- it sequesters misfolded amyloid-beta species. CRYAB is found co-localized with amyloid-beta in senile plaques of Alzheimer&#39;s disease patients. This is a meaningful specific MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23106396" target="_blank" class="term-link">
                                         PMID:23106396
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">both chaperones bind to misfolded oligomeric species and form long-lived complexes, thereby preventing both their further growth into fibrils and their dissociation.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17046756" target="_blank" class="term-link">
                                         PMID:17046756
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Interactions between Abeta and alphaB-crystallin involve the hydrophobic core residues 17-21 as well as residues 31-32 of Abeta, and thus the same chemical groups which are important for Abeta aggregation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044877" target="_blank" class="term-link">
                                     GO:0044877
                                 </a>
                             </span>
                             <span class="term-label">protein-containing complex binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23106396" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23106396
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Amyloid-β oligomers are sequestered by both intracellular an...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5753,57 +5786,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:23106396 for protein-containing complex binding. The WITH/FROM is ComplexPortal:CPX-1180, which refers to the amyloid-beta oligomeric complex. CRYAB binds to these oligomeric complexes as shown by single-molecule fluorescence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CRYAB binds to amyloid-beta oligomeric complexes (PMID:23106396). This annotation specifically captures the binding to a protein-containing complex (the amyloid-beta oligomer) as opposed to individual amyloid-beta monomers. This reflects CRYAB&#39;s holdase function of sequestering aggregation-prone complexes.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28470624" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28470624
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     αB-crystallin is a sensor for assembly intermediates and for...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -5815,86 +5848,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:28470624 (Sharma et al. 2017), which showed CRYAB is a sensor for assembly intermediates and subunit topology of desmin intermediate filaments. The WITH/FROM is desmin (DES, P17661). CRYAB binds rapidly during early stages of desmin filament assembly.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. The CRYAB-desmin interaction is a functionally significant interaction that reflects CRYAB&#39;s role as a chaperone for cytoskeletal assembly. This should be annotated as cytoskeletal protein binding (GO:0008092) which is already present as an IEA annotation, providing experimental support for that more specific term.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008092" target="_blank" class="term-link">
                                     cytoskeletal protein binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/28470624" target="_blank" class="term-link">
                                         PMID:28470624
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the binding of CRYAB to desmin is subject to its assembly status, to the subunit organization within filaments formed and to the integrity of the C-terminal tail domain of desmin.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905907" target="_blank" class="term-link">
                                     GO:1905907
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of amyloid fibril formation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23106396" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23106396
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Amyloid-β oligomers are sequestered by both intracellular an...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5906,75 +5939,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from PMID:23106396 for negative regulation of amyloid fibril formation. CRYAB sequesters amyloid-beta oligomers, preventing their further growth into fibrils. This is a specific application of CRYAB&#39;s holdase chaperone function to amyloid aggregation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PMID:23106396 directly demonstrates that CRYAB prevents amyloid-beta oligomers from growing into fibrils using single-molecule fluorescence techniques. This is a well-supported annotation that captures a specific biological consequence of CRYAB&#39;s holdase activity.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23106396" target="_blank" class="term-link">
                                         PMID:23106396
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">both chaperones bind to misfolded oligomeric species and form long-lived complexes, thereby preventing both their further growth into fibrils and their dissociation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12235146" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12235146
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Role of the C-terminal extensions of alpha-crystallins. Swap...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -5986,57 +6019,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:12235146 (Pasta et al. 2002), which studied C-terminal extension swapping between alphaA- and alphaB-crystallins. The WITH/FROM includes aldolase (P00883) and rhodanese (P11415), which are substrate proteins used in chaperone activity assays. CRYAB binding to these substrates reflects its holdase chaperone activity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. The interactions with aldolase and rhodanese are chaperone-substrate interactions used as in vitro assay substrates. This is better captured by the chaperone function annotations (GO:0044183 or GO:0050821).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                     GO:0050821
                                 </a>
                             </span>
                             <span class="term-label">protein stabilization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12235146" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12235146
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Role of the C-terminal extensions of alpha-crystallins. Swap...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6048,64 +6081,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IMP annotation from PMID:12235146 (Pasta et al. 2002) for protein stabilization. The study demonstrated that CRYAB (and chimeric variants) prevent aggregation of various substrate proteins (thermal and non-thermal models), demonstrating chaperone-like activity. The C-terminal extension plays a crucial role in structure and chaperone activity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein stabilization is an excellent BP term for CRYAB&#39;s holdase chaperone activity. CRYAB prevents aggregation of denatured proteins and maintains them in a soluble, folding-competent state. This is a core function of CRYAB. PMID:12235146 provides direct evidence for chaperone-like activity using multiple protein substrates.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12235146" target="_blank" class="term-link">
                                         PMID:12235146
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We have used thermal and non-thermal models of protein aggregation and found that the chimeric alphaB with the C-terminal extension of alphaA-crystallin, alphaBAc, exhibits dramatically enhanced chaperone-like activity.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5082356
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6117,57 +6150,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation from Reactome pathway R-HSA-5082356 (HSF1-mediated gene expression) for nucleoplasm localization. CRYAB translocates to the nucleus during heat stress (PMID:19464326) and specifically resides in SC35 speckles within the nucleoplasm.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nucleoplasm localization is consistent with CRYAB&#39;s documented nuclear translocation during heat stress (PMID:19464326). SC35 speckles are nucleoplasmic structures. The Reactome annotation for HSF1-mediated gene expression context is appropriate.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
                                     GO:0070062
                                 </a>
                             </span>
                             <span class="term-label">extracellular exosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23533145
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     In-depth proteomic analyses of exosomes isolated from expres...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6179,57 +6212,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HDA annotation from PMID:23533145, an in-depth proteomic study of exosomes isolated from expressed prostatic secretions in urine. CRYAB was identified in exosome fractions by mass spectrometry.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CRYAB has been identified in extracellular exosomes by proteomic studies (PMID:23533145). This is consistent with the unconventional secretion pathway described in PMID:32272059.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
                                     GO:0070062
                                 </a>
                             </span>
                             <span class="term-label">extracellular exosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19056867
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Large-scale proteomics and phosphoproteomics of urinary exos...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6241,137 +6274,148 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HDA annotation from PMID:19056867, a large-scale proteomics and phosphoproteomics study of urinary exosomes. CRYAB was identified in exosome fractions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Independent confirmation of CRYAB in extracellular exosomes by urinary exosome proteomics.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071480" target="_blank" class="term-link">
                                     GO:0071480
                                 </a>
                             </span>
                             <span class="term-label">cellular response to gamma radiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23542032" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23542032
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Protective role of the endoplasmic reticulum protein mitsugu...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P02511" data-a="GO:0071480" data-r="PMID:23542032" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P02511" data-a="GO:0071480" data-r="PMID:23542032" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IMP annotation from PMID:23542032 for cellular response to gamma radiation. The paper actually studies UVC-induced cell death, not gamma radiation specifically. It shows CRYAB knockdown facilitates death of UVC-exposed cells. This annotation may reflect broader DNA damage response involvement.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> PMID:23542032 specifically demonstrates CRYAB&#39;s protective role against UVC-induced cell death, not gamma radiation per se. The annotation was made by MGI, suggesting it may be based on mouse data related to radiation response. CRYAB&#39;s role in DNA damage response is secondary to its core chaperone and anti-apoptotic functions. Non-core.
+                            <strong>Reason:</strong> PMID:23542032 specifically demonstrates CRYAB&#39;s protective role against UVC-induced cell death, not gamma radiation. The correct response term for this evidence is cellular response to UV-C, and CRYAB&#39;s role in DNA damage response is secondary to its core chaperone and anti-apoptotic functions.
                         </div>
-                        
-                        
-                        
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071494" target="_blank" class="term-link">
+                                    cellular response to UV-C
+                                </a>
+                            </span>
+
+                        </div>
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23542032" target="_blank" class="term-link">
                                         PMID:23542032
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">knockdown of the ER protein mitsugumin23 (MG23) enhances cell death induced by ultraviolet C (UVC), which causes DNA damage.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14752512
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human alphaA- and alphaB-crystallins bind to Bax and Bcl-X(S...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -6383,57 +6427,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:14752512 (Mao et al. 2004). The WITH/FROM includes Bax (Q07812) and Bcl-X(S) (Q07817). CRYAB binds pro-apoptotic Bax and Bcl-X(S) to sequester their translocation during apoptosis.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding is uninformative. The functionally significant interaction with Bax and Bcl-X(S) is better captured by the negative regulation of apoptotic process annotations. The specific anti-apoptotic mechanism involves sequestering these pro-apoptotic factors in the cytoplasm.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19464326
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HSPB7 is a SC35 speckle resident small heat shock protein.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6445,75 +6489,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from PMID:19464326 (Vos et al. 2009) for nucleus localization. The study used confocal microscopy to show CRYAB (HSPB5) translocates to the nucleus during heat shock, where it resides in SC35 speckles. This is a well-documented stress-dependent nuclear localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct microscopy evidence for CRYAB nuclear translocation during heat stress. PMID:19464326 is the key study documenting stress-dependent nuclear localization and SC35 speckle residence for CRYAB.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
                                         PMID:19464326
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Some members also show a dynamic, stress-induced translocation to SC35 splicing speckles.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19464326
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HSPB7 is a SC35 speckle resident small heat shock protein.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6525,46 +6569,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from PMID:19464326 for cytoplasm localization. CRYAB localizes to the cytoplasm under normal (unstressed) conditions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct microscopy evidence for cytoplasmic localization under normal conditions (PMID:19464326).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000054
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6576,57 +6620,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from GO_REF:0000054, based on curation of intracellular localizations of expressed fusion proteins in living cells (LIFEdb). Confirms cytoplasmic localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Independent confirmation of cytoplasmic localization from expressed fusion protein imaging.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042803" target="_blank" class="term-link">
                                     GO:0042803
                                 </a>
                             </span>
                             <span class="term-label">protein homodimerization activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19646995" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19646995
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Crystal structures of alpha-crystallin domain dimers of alph...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6638,75 +6682,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI annotation from PMID:19646995 (Bagneris et al. 2009) for protein homodimerization activity. The crystal structure of the alpha-crystallin domain dimer of CRYAB was solved at 2.63 angstroms, showing that the alpha- crystallin domain forms homodimers with a shared groove at the interface. The dimer is the basic building block for higher-order oligomeric assembly.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The crystal structure of CRYAB alpha-crystallin domain homodimers (PMID:19646995) directly demonstrates protein homodimerization activity. The dimer is the fundamental building block of the CRYAB oligomeric assembly. This is a core structural property.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19646995" target="_blank" class="term-link">
                                         PMID:19646995
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">crystal structures of excised alpha-crystallin domain from rat Hsp20 and that from human alphaB-crystallin show that they form homodimers with a shared groove at the interface by extending a beta sheet.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16303126
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Lenticular chaperones suppress the aggregation of the catara...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -6718,99 +6762,99 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). This IPI annotation is based on PMID:16303126, which demonstrated that alpha B-crystallin (CRYAB) suppresses the aggregation of the cataract-causing T5P mutant gamma C-crystallin. In this study, CRYAB increased the solubility of T5P gamma C-crystallin both in vitro (by sedimentation assay and sucrose gradient centrifugation) and in transfected cells, and significantly reduced the size of T5P gamma C-crystallin aggregates. The interacting partner (WITH/FROM) is the destabilized T5P gamma C-crystallin. The paper describes this as &#34;chaperone-like activity&#34; with a &#34;dual role&#34; -- increasing soluble protein fraction and reducing aggregate size. This is classic holdase activity: CRYAB binds partially denatured proteins and prevents their aggregation, but does NOT refold them. The term GO:0044183 &#34;protein folding chaperone&#34; is the best available interim replacement MF term, though it is imperfect because CRYAB does not assist in protein folding per se -- it prevents aggregation. A holdase-specific GO term does not yet exist and should be requested.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. The experimental evidence from PMID:16303126 clearly demonstrates holdase chaperone activity -- CRYAB suppresses aggregation of the destabilized T5P mutant gamma C-crystallin and increases its solubility. The paper explicitly describes &#34;a dual role for these chaperones in maintaining transparency in the lens&#34;: increasing the proportion of soluble protein and reducing aggregate size. This is not passive &#34;unfolded protein binding&#34; but active suppression of aggregation (holdase function). The IPI evidence with T5P gamma C-crystallin as the interacting partner is strong. GO:0044183 &#34;protein folding chaperone&#34; is the closest current MF term, but a holdase-specific term is needed since CRYAB does NOT refold proteins.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link">
                                         PMID:16303126
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the major lenticular protein chaperones, alpha A- and alpha B-crystallin, increased the solubility of the T5P gamma C-crystallin both in vitro and in transfected cells. More importantly, the size of the T5P gamma C-crystallin aggregates were also significantly reduced in the presence of the lenticular chaperones.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link">
                                         PMID:16303126
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">These data therefore suggest a dual role for these chaperones in maintaining transparency in the lens. The first is that these protein chaperones increase the proportion of the soluble T5P gamma C-crystallin and the second is that they also reduce light scatter by reducing the aggregate size of T5P gamma C-crystallin.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14752512
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human alphaA- and alphaB-crystallins bind to Bax and Bcl-X(S...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6822,75 +6866,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from PMID:14752512 (Mao et al. 2004) for cytoplasm localization. The study demonstrated that CRYAB is cytoplasmic and prevents translocation of Bax and Bcl-X(S) from cytosol into mitochondria.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization confirmed by direct observation in PMID:14752512. The anti-apoptotic mechanism requires CRYAB to be cytoplasmic to sequester pro-apoptotic factors.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link">
                                         PMID:14752512
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">alpha-crystallins prevent the translocation of Bax and Bcl-X(S) from cytosol into mitochondria during staurosporine-induced apoptosis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032387" target="_blank" class="term-link">
                                     GO:0032387
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of intracellular transport</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14752512
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human alphaA- and alphaB-crystallins bind to Bax and Bcl-X(S...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6902,75 +6946,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from PMID:14752512 for negative regulation of intracellular transport. CRYAB prevents the translocation of Bax and Bcl-X(S) from the cytosol to mitochondria during staurosporine-induced apoptosis. This sequestration of pro-apoptotic factors is a specific form of negative regulation of intracellular transport.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PMID:14752512 directly demonstrates that CRYAB prevents the cytosol-to-mitochondria translocation of Bax and Bcl-X(S). This is a specific anti-apoptotic mechanism involving negative regulation of intracellular protein transport. The annotation is well-supported by direct experimental evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link">
                                         PMID:14752512
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Through the interaction, alpha-crystallins prevent the translocation of Bax and Bcl-X(S) from cytosol into mitochondria during staurosporine-induced apoptosis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043066" target="_blank" class="term-link">
                                     GO:0043066
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of apoptotic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14752512
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human alphaA- and alphaB-crystallins bind to Bax and Bcl-X(S...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6982,75 +7026,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from PMID:14752512 for negative regulation of apoptotic process. The study demonstrates a clear anti-apoptotic mechanism: CRYAB binds Bax and Bcl-X(S) to prevent their mitochondrial translocation, preserves mitochondrial integrity, restricts cytochrome c release, represses caspase-3 activation, and blocks PARP degradation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is one of the strongest pieces of evidence for CRYAB&#39;s anti-apoptotic function. PMID:14752512 provides a complete mechanistic pathway from initial binding (Bax/Bcl-X(S) sequestration) to downstream consequences (preserved mitochondrial integrity, blocked caspase-3 activation). This is a core function of CRYAB.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link">
                                         PMID:14752512
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">alpha-crystallins preserve the integrity of mitochondria, restrict release of cytochrome c, repress activation of caspase-3 and block degradation of PARP. Thus, our results demonstrate a novel antiapoptotic mechanism for alpha-crystallins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9731540" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9731540
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A missense mutation in the alphaB-crystallin chaperone gene ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -7062,86 +7106,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NAS annotation from PMID:9731540 (Vicart et al. 1998) for protein folding. The paper identified the R120G mutation in CRYAB that causes desmin-related myopathy and describes CRYAB as possessing molecular chaperone activity. However, CRYAB is a holdase, not a foldase. It prevents aggregation but does not actively fold proteins.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PMID:9731540 describes CRYAB as a molecular chaperone but does not demonstrate protein folding activity. CRYAB prevents protein aggregation (holdase activity) but does not refold denatured proteins. GO:0050821 protein stabilization is more appropriate. The NAS evidence code itself is weak (non-traceable author statement).
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                     protein stabilization
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9731540" target="_blank" class="term-link">
                                         PMID:9731540
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">AlphaB-crystallin is a member of the small heat shock protein (shsp) family and possesses molecular chaperone activity.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006936" target="_blank" class="term-link">
                                     GO:0006936
                                 </a>
                             </span>
                             <span class="term-label">muscle contraction</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9731540" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9731540
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A missense mutation in the alphaB-crystallin chaperone gene ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -7153,50 +7197,50 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS annotation from PMID:9731540 for muscle contraction. The paper identified the CRYAB R120G mutation causing desmin-related myopathy. While CRYAB is important for muscle function (interacting with desmin and titin), it is not a direct participant in the muscle contraction machinery. Rather, it serves as a chaperone for muscle structural proteins.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CRYAB is not directly involved in the muscle contraction mechanism. Its role in muscle is as a chaperone for cytoskeletal and sarcomeric proteins (desmin, titin). Loss of CRYAB function leads to myopathy through aggregation of desmin, not through direct contractile defects. The TAS evidence is weak, and the association with muscle contraction is indirect. Non-core.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9731540" target="_blank" class="term-link">
                                         PMID:9731540
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We identified an R120G missense mutation in CRYAB that co-segregates with the disease phenotype in this family.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>CRYAB (HSPB5) is a small heat shock protein that functions as an ATP-independent holdase chaperone. It binds partially denatured or destabilized proteins to prevent their aggregation, maintaining clients in a refolding-competent state for downstream ATP-dependent chaperone systems such as HSP70, but does NOT actively refold substrates itself. CRYAB forms highly polydisperse oligomers (approximately 10-40 subunits) with rapid subunit exchange dynamics that are important for chaperone activity (DOI:10.1038/s41467-024-54647-7). The canonical architecture comprises a central alpha-crystallin domain (ACD) mediating dimerization, flanked by a variable N-terminal domain (NTD) and a short C-terminal domain (CTD). A conserved N-terminal IXI-like motif (NT-IXI) engages the ACD hydrophobic groove to govern assembly; perturbation of this motif transforms native assemblies into reversible elongated helical fibrils as resolved by cryo-EM (DOI:10.1038/s41467-024-54647-7). Stress-activated phosphorylation (notably p38 MAPK targeting Ser59) modulates oligomeric state and can shift CRYAB condensates toward protective or pathological material states (DOI:10.1016/j.isci.2024.109510, DOI:10.1172/jci163730). Substrates bound by CRYAB can subsequently be refolded by HSP70/HSP40 foldase chaperones, or routed to the ubiquitin-proteasome system for degradation.</h3>
                 <span class="vote-buttons" data-g="P02511" data-a="FUNCTION: CRYAB (HSPB5) is a small heat shock protein that f..." data-r="" data-act="CORE_FUNCTION">
@@ -7204,10 +7248,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -7216,138 +7260,151 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                 protein stabilization
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009408" target="_blank" class="term-link">
                                 response to heat
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905907" target="_blank" class="term-link">
                                 negative regulation of amyloid fibril formation
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Substrates:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.uniprot.org/uniprotkb/P17661" target="_blank" class="term-link">
                                 desmin
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.uniprot.org/uniprotkb/P05067-PRO_0000000093" target="_blank" class="term-link">
                                 amyloid-beta
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link">
                                 PMID:16303126
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">the major lenticular protein chaperones, alpha A- and alpha B-crystallin, increased the solubility of the T5P gamma C-crystallin both in vitro and in transfected cells. More importantly, the size of the T5P gamma C-crystallin aggregates were also significantly reduced in the presence of the lenticular chaperones.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
                                 PMID:19464326
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">HSPB1 and HSPB5, that chaperoned heat unfolded substrates and kept them folding competent.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23106396" target="_blank" class="term-link">
                                 PMID:23106396
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">both chaperones bind to misfolded oligomeric species and form long-lived complexes, thereby preventing both their further growth into fibrils and their dissociation.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17046756" target="_blank" class="term-link">
+                                PMID:17046756
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">alphaB-crystallin competes efficiently for Abeta monomer-monomer interactions. Interactions between Abeta and alphaB-crystallin involve the hydrophobic core residues 17-21 as well as residues 31-32 of Abeta.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12235146" target="_blank" class="term-link">
                                 PMID:12235146
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">We have used thermal and non-thermal models of protein aggregation and found that the chimeric alphaB with the C-terminal extension of alphaA-crystallin, alphaBAc, exhibits dramatically enhanced chaperone-like activity</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>CRYAB is one of the major structural proteins of the vertebrate eye lens, contributing to lens transparency and refractive index. In the lens, it serves a dual role as both a structural protein (maintaining lens transparency through high concentration and ordered short-range interactions) and a chaperone (preventing aggregation of damaged crystallins that would cause light-scattering opacification).</h3>
                 <span class="vote-buttons" data-g="P02511" data-a="FUNCTION: CRYAB is one of the major structural proteins of t..." data-r="" data-act="CORE_FUNCTION">
@@ -7355,10 +7412,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -7367,55 +7424,55 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
 
-                
+
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link">
                                 PMID:16303126
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">These data therefore suggest a dual role for these chaperones in maintaining transparency in the lens.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>CRYAB binds desmin intermediate filaments in a manner dependent on desmin assembly status and subunit organization, acting as a sensor for assembly intermediates. In cardiac and skeletal muscle, CRYAB associates with sarcomeric structures including Z-bands and intercalated disks, and interacts with titin. Mutations in CRYAB (e.g., R120G) cause desmin-related myopathy through aggregation of desmin filaments. Recent work shows that phosphorylation at Ser59 can shift CRYAB condensates toward less dynamic, aggregate-prone states that mislocalize cytoskeletal and sarcomeric client proteins, a pathological mechanism termed condensatopathy; the phosphomimetic S59D behaves similarly to the R120G cardiomyopathy mutant (DOI:10.1172/jci163730).</h3>
                 <span class="vote-buttons" data-g="P02511" data-a="FUNCTION: CRYAB binds desmin intermediate filaments in a man..." data-r="" data-act="CORE_FUNCTION">
@@ -7423,10 +7480,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -7435,1117 +7492,1034 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                 protein stabilization
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030018" target="_blank" class="term-link">
                                 Z disc
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097512" target="_blank" class="term-link">
                                 cardiac myofibril
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Substrates:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.uniprot.org/uniprotkb/P17661" target="_blank" class="term-link">
                                 desmin
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28470624" target="_blank" class="term-link">
                                 PMID:28470624
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">the binding of CRYAB to desmin is subject to its assembly status, to the subunit organization within filaments formed and to the integrity of the C-terminal tail domain of desmin.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9731540" target="_blank" class="term-link">
                                 PMID:9731540
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">A missense mutation in the alphaB-crystallin chaperone gene causes a desmin-related myopathy.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
+
         </div>
-        
-        <div class="core-function-card">
-            
-            <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>CRYAB directly binds amyloid-beta oligomeric species and forms long-lived complexes, preventing both further growth of oligomers into fibrils and their dissociation. This represents a specific application of CRYAB holdase activity to amyloidogenic substrates. CRYAB is found co-localized with amyloid-beta in senile plaques of Alzheimer disease patients.</h3>
-                <span class="vote-buttons" data-g="P02511" data-a="FUNCTION: CRYAB directly binds amyloid-beta oligomeric speci..." data-r="" data-act="CORE_FUNCTION">
-                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
-                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
-                </span>
-            </div>
-            
 
-            <div class="core-function-terms">
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">Molecular Function:</div>
-                    <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001540" target="_blank" class="term-link">
-                            amyloid-beta binding
-                        </a>
-                    </span>
-                </div>
-                
-
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">Directly Involved In:</div>
-                    <div class="function-annotations">
-                        
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043066" target="_blank" class="term-link">
-                                negative regulation of apoptotic process
-                            </a>
-                        </span>
-                        
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905907" target="_blank" class="term-link">
-                                negative regulation of amyloid fibril formation
-                            </a>
-                        </span>
-                        
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031333" target="_blank" class="term-link">
-                                negative regulation of protein-containing complex assembly
-                            </a>
-                        </span>
-                        
-                    </div>
-                </div>
-                
-
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">Cellular Locations:</div>
-                    <div class="function-annotations">
-                        
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
-                                cytosol
-                            </a>
-                        </span>
-                        
-                    </div>
-                </div>
-                
-
-                
-
-                
-            </div>
-
-            
-            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
-                <strong>Supporting Evidence:</strong>
-                <ul class="findings-list">
-                    
-                    <li class="finding-item">
-                        <span class="reference-id">
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/23106396" target="_blank" class="term-link">
-                                PMID:23106396
-                            </a>
-                            
-                        </span>
-                        
-                        <div class="finding-text">both chaperones bind to misfolded oligomeric species and form long-lived complexes, thereby preventing both their further growth into fibrils and their dissociation.</div>
-                        
-                    </li>
-                    
-                    <li class="finding-item">
-                        <span class="reference-id">
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/17046756" target="_blank" class="term-link">
-                                PMID:17046756
-                            </a>
-                            
-                        </span>
-                        
-                        <div class="finding-text">alphaB-crystallin competes efficiently for Abeta monomer-monomer interactions. Interactions between Abeta and alphaB-crystallin involve the hydrophobic core residues 17-21 as well as residues 31-32 of Abeta.</div>
-                        
-                    </li>
-                    
-                </ul>
-            </div>
-            
-        </div>
-        
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
                             GO_REF:0000052
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000054.md" target="_blank" class="term-link">
                             GO_REF:0000054
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on curation of intracellular localizations of expressed fusion proteins in living cells</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
                             GO_REF:0000107
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11700327" target="_blank" class="term-link">
                             PMID:11700327
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Detection of protein-protein interactions among lens crystallins in a mammalian two-hybrid system assay.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12235146" target="_blank" class="term-link">
                             PMID:12235146
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Role of the C-terminal extensions of alpha-crystallins. Swapping the C-terminal extension of alpha-crystallin to alphaB-crystallin results in enhanced chaperone activity.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12601044" target="_blank" class="term-link">
                             PMID:12601044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Alteration of protein-protein interactions of congenital cataract crystallin mutants.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14752512" target="_blank" class="term-link">
                             PMID:14752512
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Human alphaA- and alphaB-crystallins bind to Bax and Bcl-X(S) to sequester their translocation during staurosporine-induced apoptosis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16049941" target="_blank" class="term-link">
                             PMID:16049941
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A pilot proteomic study of amyloid precursor interactors in Alzheimer&#39;s disease.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16303126" target="_blank" class="term-link">
                             PMID:16303126
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Lenticular chaperones suppress the aggregation of the cataract-causing mutant T5P gamma C-crystallin.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17046756" target="_blank" class="term-link">
                             PMID:17046756
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">alphaB-crystallin competes with Alzheimer&#39;s disease beta-amyloid peptide for peptide-peptide interactions and induces oxidation of Abeta-Met35.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18330356" target="_blank" class="term-link">
                             PMID:18330356
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Construction and characterization of a normalized yeast two-hybrid library derived from a human protein-coding clone collection.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link">
                             PMID:19056867
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Large-scale proteomics and phosphoproteomics of urinary exosomes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19464326" target="_blank" class="term-link">
                             PMID:19464326
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSPB7 is a SC35 speckle resident small heat shock protein.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19646995" target="_blank" class="term-link">
                             PMID:19646995
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Crystal structures of alpha-crystallin domain dimers of alphaB-crystallin and Hsp20.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19651604" target="_blank" class="term-link">
                             PMID:19651604
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The eye lens chaperone alpha-crystallin forms defined globular assemblies.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20587334" target="_blank" class="term-link">
                             PMID:20587334
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Synergistic efficacy of LBH and alphaB-crystallin through inhibiting transcriptional activities of p53 and p21.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20802487" target="_blank" class="term-link">
                             PMID:20802487
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Solid-state NMR and SAXS studies provide a structural basis for the activation of alphaB-crystallin oligomers.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21464278" target="_blank" class="term-link">
                             PMID:21464278
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">N-terminal domain of alphaB-crystallin provides a conformational switch for multimerization and structural heterogeneity.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22085609" target="_blank" class="term-link">
                             PMID:22085609
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Temperature-dependent structural and functional properties of a mutant (F71L) αA-crystallin: molecular basis for early onset of age-related cataract.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22143763" target="_blank" class="term-link">
                             PMID:22143763
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Multiple molecular architectures of the eye lens chaperone αB-crystallin elucidated by a triple hybrid approach.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22153508" target="_blank" class="term-link">
                             PMID:22153508
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The polydispersity of αB-crystallin is rationalized by an interconverting polyhedral architecture.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22158051" target="_blank" class="term-link">
                             PMID:22158051
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Tumor suppressor Alpha B-crystallin (CRYAB) associates with the cadherin/catenin adherens junction and impairs NPC progression-associated properties.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23106396" target="_blank" class="term-link">
                             PMID:23106396
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Amyloid-β oligomers are sequestered by both intracellular and extracellular chaperones.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23188086" target="_blank" class="term-link">
                             PMID:23188086
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Binding determinants of the small heat shock protein, αB-crystallin: recognition of the &#39;IxI&#39; motif.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link">
                             PMID:23533145
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">In-depth proteomic analyses of exosomes isolated from expressed prostatic secretions in urine.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23542032" target="_blank" class="term-link">
                             PMID:23542032
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Protective role of the endoplasmic reticulum protein mitsugumin23 against ultraviolet C-induced cell death.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24183572" target="_blank" class="term-link">
                             PMID:24183572
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Preferential and specific binding of human αB-crystallin to a cataract-related variant of γS-crystallin.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link">
                             PMID:25910212
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Widespread macromolecular interaction perturbations in human genetic disorders.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26465331" target="_blank" class="term-link">
                             PMID:26465331
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Characterization of the Cardiac Overexpression of HSPB2 Reveals Mitochondrial and Myogenic Roles Supported by a Cardiac HspB2 Interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27226619" target="_blank" class="term-link">
                             PMID:27226619
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The Human 343delT HSPB5 Chaperone Associated with Early-onset Skeletal Myopathy Causes Defects in Protein Solubility.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28470624" target="_blank" class="term-link">
                             PMID:28470624
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">αB-crystallin is a sensor for assembly intermediates and for the subunit topology of desmin intermediate filaments.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28493373" target="_blank" class="term-link">
                             PMID:28493373
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The novel αB-crystallin (CRYAB) mutation p.D109G causes restrictive cardiomyopathy.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
                             PMID:28514442
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32272059" target="_blank" class="term-link">
                             PMID:32272059
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A Translocation Pathway for Vesicle-Mediated Unconventional Protein Secretion.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                             PMID:32296183
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A reference map of the human binary protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
                             PMID:32814053
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
                             PMID:40205054
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9731540" target="_blank" class="term-link">
                             PMID:9731540
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A missense mutation in the alphaB-crystallin chaperone gene causes a desmin-related myopathy.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5082356
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HSF1-mediated gene expression</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1038/s41467-024-54647-7
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dynamic fibrillar assembly of alphaB-crystallin induced by perturbation of the conserved NT-IXI motif resolved by cryo-EM</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">CRYAB exists in highly polydisperse oligomers (approximately 10-40 subunits) with rapid subunit exchange dynamics important for chaperone activity</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">The conserved N-terminal IXI-like motif (NT-IXI) engages the ACD hydrophobic groove, governing assembly; perturbation transforms native assemblies into reversible elongated helical fibrils resolved by cryo-EM</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1172/jci.insight.182209
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Mutation of CRYAB encoding a conserved mitochondrial chaperone and antiapoptotic protein causes hereditary optic atrophy</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">CRYAB E105K (within the ACD) causes autosomal dominant optic atrophy by reducing oligomer formation, chaperone activity, and interactions with cytochrome c and VDAC</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">CRYAB deficiency/mutation leads to increased apoptosis, mitochondrial dysfunction, and impaired OXPHOS assembly in retinal ganglion cells</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1016/j.isci.2024.109510
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The activation of LBH-CRYAB signaling promotes cardiac protection against I/R injury by inhibiting apoptosis and ferroptosis</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">LBH enhances p38 phosphorylation and CRYAB Ser59 phosphorylation; p38 inhibitor abolishes LBH-induced CRYAB pS59</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Phosphorylated CRYAB facilitates NRF2 upregulation/nuclear translocation and contributes to ferroptosis resistance via GPX4 in cardiomyocytes</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1186/s13287-023-03468-4
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Mature human induced pluripotent stem cell-derived cardiomyocytes promote angiogenesis through alpha-B crystallin</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">CRYAB is upregulated in mature hiPSC-derived cardiomyocytes and is secreted via exosomes</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">CRYAB siRNA knockdown significantly inhibits HUVEC migration and tube formation, demonstrating CRYAB is necessary for pro-angiogenic paracrine effects</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1038/s42003-022-04402-9
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Single-cell transcriptomics reveal extracellular vesicles secretion with a cardiomyocyte proteostasis signature during pathological remodeling</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Stressed cardiomyocytes secrete EVs enriched in protein-quality-control factors including CRYAB during pathological remodeling</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">CRYAB accumulates in recipient cells exposed to stressed cardiomyocyte-derived EVs</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         DOI:10.1172/jci163730
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Phosphorylation of CRYAB induces a condensatopathy to worsen post-myocardial infarction left ventricular remodeling</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Ser59 phosphorylation shifts CRYAB condensates toward less dynamic, more aggregate-prone states (condensatopathy), mislocalizing cytoskeletal and sarcomeric client proteins</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Phosphomimetic S59D behaves similarly to cardiomyopathy mutant R120G in condensate behavior; S59A mitigates aggregate toxicity</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/CRYAB/CRYAB-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research for human CRYAB</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Falcon synthesis supports CRYAB/HSPB5 as an ATP-independent small heat shock protein holdase chaperone whose oligomerization, phosphorylation, cytoskeletal clients, and mitochondrial anti-apoptotic roles define its core and context-specific functions.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -8892,9 +8866,9 @@ this with annotations you find in gene/protein databases, but these can be outda
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -8906,7 +8880,7 @@ this with annotations you find in gene/protein databases, but these can be outda
                 <pre><code>id: P02511
 gene_symbol: CRYAB
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -9148,6 +9122,12 @@ existing_annotations:
         transfected cells. More importantly, the size of the T5P gamma C-crystallin
         aggregates were also significantly reduced in the presence of the lenticular
         chaperones.
+    - reference_id: file:human/CRYAB/CRYAB-deep-research-falcon.md
+      supporting_text: &gt;-
+        These concepts are consistent with CRYAB being a small HSP
+        chaperone/holdase, not an enzyme/transporter; therefore its “primary
+        function” is ATP-independent chaperoning of destabilized proteins and
+        stress-protective regulation of proteostasis.
 - term:
     id: GO:0005198
     label: structural molecule activity
@@ -9164,13 +9144,15 @@ existing_annotations:
       constituent of eye lens is also annotated and is more informative. This broader
       IEA annotation is acceptable as it also reflects the structural role in muscle
       (association with sarcomeric Z-discs and desmin filaments).
-    action: ACCEPT
+    action: MODIFY
     reason: &gt;-
-      CRYAB has structural roles both in the lens (where it contributes to
-      transparency) and in muscle (where it associates with desmin intermediate
-      filaments and sarcomeric structures). The broader term structural molecule
-      activity captures both contexts. The IDA annotation from PMID:16303126 provides
-      independent experimental support.
+      Structural molecule activity is broader than needed for CRYAB. The lens
+      structural role is captured more precisely by GO:0005212 &#34;structural
+      constituent of eye lens&#34;, while muscle/cytoskeletal contexts are better
+      captured by cytoskeletal protein binding and localization annotations.
+    proposed_replacement_terms:
+    - id: GO:0005212
+      label: structural constituent of eye lens
 - term:
     id: GO:0005212
     label: structural constituent of eye lens
@@ -10229,13 +10211,16 @@ existing_annotations:
       alpha-crystallins in suppressing aggregation of T5P gamma C-crystallin. The
       structural molecule activity annotation may reflect CRYAB&#39;s dual role in the
       lens as both a structural protein and a chaperone.
-    action: ACCEPT
+    action: MODIFY
     reason: &gt;-
-      CRYAB has a dual role in the lens as both a structural protein (contributing
-      to lens transparency and refractive index) and a molecular chaperone
-      (preventing aggregation of damaged crystallins). PMID:16303126 demonstrates
-      both roles. The structural molecule activity annotation is appropriate for
-      the structural lens function.
+      PMID:16303126 supports CRYAB/alpha-crystallin suppression of aggregation
+      of the cataract-causing T5P gamma C-crystallin, which is chaperone/holdase
+      activity rather than generic structural molecule activity. The true lens
+      structural role is already captured more precisely by GO:0005212
+      &#34;structural constituent of eye lens.&#34;
+    proposed_replacement_terms:
+    - id: GO:0044183
+      label: protein folding chaperone
     supported_by:
     - reference_id: PMID:16303126
       supporting_text: &gt;-
@@ -10584,13 +10569,15 @@ existing_annotations:
       The paper actually studies UVC-induced cell death, not gamma radiation
       specifically. It shows CRYAB knockdown facilitates death of UVC-exposed
       cells. This annotation may reflect broader DNA damage response involvement.
-    action: KEEP_AS_NON_CORE
+    action: MODIFY
     reason: &gt;-
       PMID:23542032 specifically demonstrates CRYAB&#39;s protective role against
-      UVC-induced cell death, not gamma radiation per se. The annotation was made
-      by MGI, suggesting it may be based on mouse data related to radiation
-      response. CRYAB&#39;s role in DNA damage response is secondary to its core
-      chaperone and anti-apoptotic functions. Non-core.
+      UVC-induced cell death, not gamma radiation. The correct response term for
+      this evidence is cellular response to UV-C, and CRYAB&#39;s role in DNA damage
+      response is secondary to its core chaperone and anti-apoptotic functions.
+    proposed_replacement_terms:
+    - id: GO:0071494
+      label: cellular response to UV-C
     supported_by:
     - reference_id: PMID:23542032
       supporting_text: &gt;-
@@ -10917,6 +10904,11 @@ core_functions:
       both chaperones bind to misfolded oligomeric species and form long-lived
       complexes, thereby preventing both their further growth into fibrils and
       their dissociation.
+  - reference_id: PMID:17046756
+    supporting_text: &gt;-
+      alphaB-crystallin competes efficiently for Abeta monomer-monomer interactions.
+      Interactions between Abeta and alphaB-crystallin involve the hydrophobic core
+      residues 17-21 as well as residues 31-32 of Abeta.
   - reference_id: PMID:12235146
     supporting_text: &gt;-
       We have used thermal and non-thermal models of protein aggregation and found
@@ -10978,37 +10970,6 @@ core_functions:
     supporting_text: &gt;-
       A missense mutation in the alphaB-crystallin chaperone gene causes a
       desmin-related myopathy.
-- molecular_function:
-    id: GO:0001540
-    label: amyloid-beta binding
-  description: &gt;-
-    CRYAB directly binds amyloid-beta oligomeric species and forms long-lived complexes,
-    preventing both further growth of oligomers into fibrils and their dissociation.
-    This
-    represents a specific application of CRYAB holdase activity to amyloidogenic substrates.
-    CRYAB is found co-localized with amyloid-beta in senile plaques of Alzheimer disease
-    patients.
-  directly_involved_in:
-  - id: GO:0043066
-    label: negative regulation of apoptotic process
-  - id: GO:1905907
-    label: negative regulation of amyloid fibril formation
-  - id: GO:0031333
-    label: negative regulation of protein-containing complex assembly
-  locations:
-  - id: GO:0005829
-    label: cytosol
-  supported_by:
-  - reference_id: PMID:23106396
-    supporting_text: &gt;-
-      both chaperones bind to misfolded oligomeric species and form long-lived
-      complexes, thereby preventing both their further growth into fibrils and
-      their dissociation.
-  - reference_id: PMID:17046756
-    supporting_text: &gt;-
-      alphaB-crystallin competes efficiently for Abeta monomer-monomer interactions.
-      Interactions between Abeta and alphaB-crystallin involve the hydrophobic core
-      residues 17-21 as well as residues 31-32 of Abeta.
 references:
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
@@ -11017,7 +10978,7 @@ references:
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular 
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular
     Location vocabulary mapping, accompanied by conservative changes to GO terms
     applied by UniProt
   findings: []
@@ -11025,7 +10986,7 @@ references:
   title: Gene Ontology annotation based on curation of immunofluorescence data
   findings: []
 - id: GO_REF:0000054
-  title: Gene Ontology annotation based on curation of intracellular 
+  title: Gene Ontology annotation based on curation of intracellular
     localizations of expressed fusion proteins in living cells
   findings: []
 - id: GO_REF:0000107
@@ -11033,27 +10994,27 @@ references:
     to orthologs using Ensembl Compara
   findings: []
 - id: GO_REF:0000117
-  title: Electronic Gene Ontology annotations created by ARBA machine learning 
+  title: Electronic Gene Ontology annotations created by ARBA machine learning
     models
   findings: []
 - id: GO_REF:0000120
   title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
 - id: PMID:11700327
-  title: Detection of protein-protein interactions among lens crystallins in a 
+  title: Detection of protein-protein interactions among lens crystallins in a
     mammalian two-hybrid system assay.
   findings: []
 - id: PMID:12235146
-  title: Role of the C-terminal extensions of alpha-crystallins. Swapping the 
-    C-terminal extension of alpha-crystallin to alphaB-crystallin results in 
+  title: Role of the C-terminal extensions of alpha-crystallins. Swapping the
+    C-terminal extension of alpha-crystallin to alphaB-crystallin results in
     enhanced chaperone activity.
   findings: []
 - id: PMID:12601044
-  title: Alteration of protein-protein interactions of congenital cataract 
+  title: Alteration of protein-protein interactions of congenital cataract
     crystallin mutants.
   findings: []
 - id: PMID:14752512
-  title: Human alphaA- and alphaB-crystallins bind to Bax and Bcl-X(S) to 
+  title: Human alphaA- and alphaB-crystallins bind to Bax and Bcl-X(S) to
     sequester their translocation during staurosporine-induced apoptosis.
   findings: []
 - id: PMID:16049941
@@ -11061,16 +11022,16 @@ references:
     disease.
   findings: []
 - id: PMID:16303126
-  title: Lenticular chaperones suppress the aggregation of the cataract-causing 
+  title: Lenticular chaperones suppress the aggregation of the cataract-causing
     mutant T5P gamma C-crystallin.
   findings: []
 - id: PMID:17046756
-  title: alphaB-crystallin competes with Alzheimer&#39;s disease beta-amyloid 
-    peptide for peptide-peptide interactions and induces oxidation of 
+  title: alphaB-crystallin competes with Alzheimer&#39;s disease beta-amyloid
+    peptide for peptide-peptide interactions and induces oxidation of
     Abeta-Met35.
   findings: []
 - id: PMID:18330356
-  title: Construction and characterization of a normalized yeast two-hybrid 
+  title: Construction and characterization of a normalized yeast two-hybrid
     library derived from a human protein-coding clone collection.
   findings: []
 - id: PMID:19056867
@@ -11080,19 +11041,19 @@ references:
   title: HSPB7 is a SC35 speckle resident small heat shock protein.
   findings: []
 - id: PMID:19646995
-  title: Crystal structures of alpha-crystallin domain dimers of 
+  title: Crystal structures of alpha-crystallin domain dimers of
     alphaB-crystallin and Hsp20.
   findings: []
 - id: PMID:19651604
-  title: The eye lens chaperone alpha-crystallin forms defined globular 
+  title: The eye lens chaperone alpha-crystallin forms defined globular
     assemblies.
   findings: []
 - id: PMID:20587334
-  title: Synergistic efficacy of LBH and alphaB-crystallin through inhibiting 
+  title: Synergistic efficacy of LBH and alphaB-crystallin through inhibiting
     transcriptional activities of p53 and p21.
   findings: []
 - id: PMID:20802487
-  title: Solid-state NMR and SAXS studies provide a structural basis for the 
+  title: Solid-state NMR and SAXS studies provide a structural basis for the
     activation of alphaB-crystallin oligomers.
   findings: []
 - id: PMID:21464278
@@ -11104,7 +11065,7 @@ references:
     αA-crystallin: molecular basis for early onset of age-related cataract.&#39;
   findings: []
 - id: PMID:22143763
-  title: Multiple molecular architectures of the eye lens chaperone 
+  title: Multiple molecular architectures of the eye lens chaperone
     αB-crystallin elucidated by a triple hybrid approach.
   findings: []
 - id: PMID:22153508
@@ -11112,8 +11073,8 @@ references:
     polyhedral architecture.&#39;
   findings: []
 - id: PMID:22158051
-  title: Tumor suppressor Alpha B-crystallin (CRYAB) associates with the 
-    cadherin/catenin adherens junction and impairs NPC progression-associated 
+  title: Tumor suppressor Alpha B-crystallin (CRYAB) associates with the
+    cadherin/catenin adherens junction and impairs NPC progression-associated
     properties.
   findings: []
 - id: PMID:23106396
@@ -11125,11 +11086,11 @@ references:
     of the &#39;IxI&#39; motif.&#34;
   findings: []
 - id: PMID:23533145
-  title: In-depth proteomic analyses of exosomes isolated from expressed 
+  title: In-depth proteomic analyses of exosomes isolated from expressed
     prostatic secretions in urine.
   findings: []
 - id: PMID:23542032
-  title: Protective role of the endoplasmic reticulum protein mitsugumin23 
+  title: Protective role of the endoplasmic reticulum protein mitsugumin23
     against ultraviolet C-induced cell death.
   findings: []
 - id: PMID:24183572
@@ -11137,15 +11098,15 @@ references:
     variant of γS-crystallin.&#39;
   findings: []
 - id: PMID:25910212
-  title: Widespread macromolecular interaction perturbations in human genetic 
+  title: Widespread macromolecular interaction perturbations in human genetic
     disorders.
   findings: []
 - id: PMID:26465331
-  title: Characterization of the Cardiac Overexpression of HSPB2 Reveals 
+  title: Characterization of the Cardiac Overexpression of HSPB2 Reveals
     Mitochondrial and Myogenic Roles Supported by a Cardiac HspB2 Interactome.
   findings: []
 - id: PMID:27226619
-  title: The Human 343delT HSPB5 Chaperone Associated with Early-onset Skeletal 
+  title: The Human 343delT HSPB5 Chaperone Associated with Early-onset Skeletal
     Myopathy Causes Defects in Protein Solubility.
   findings: []
 - id: PMID:28470624
@@ -11156,30 +11117,30 @@ references:
   title: &#39;The novel αB-crystallin (CRYAB) mutation p.D109G causes restrictive cardiomyopathy.&#39;
   findings: []
 - id: PMID:28514442
-  title: Architecture of the human interactome defines protein communities and 
+  title: Architecture of the human interactome defines protein communities and
     disease networks.
   findings: []
 - id: PMID:32272059
-  title: A Translocation Pathway for Vesicle-Mediated Unconventional Protein 
+  title: A Translocation Pathway for Vesicle-Mediated Unconventional Protein
     Secretion.
   findings: []
 - id: PMID:32296183
   title: A reference map of the human binary protein interactome.
   findings: []
 - id: PMID:32814053
-  title: Interactome Mapping Provides a Network of Neurodegenerative Disease 
+  title: Interactome Mapping Provides a Network of Neurodegenerative Disease
     Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.
   findings: []
 - id: PMID:33961781
-  title: Dual proteome-scale networks reveal cell-specific remodeling of the 
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the
     human interactome.
   findings: []
 - id: PMID:40205054
-  title: Multimodal cell maps as a foundation for structural and functional 
+  title: Multimodal cell maps as a foundation for structural and functional
     genomics.
   findings: []
 - id: PMID:9731540
-  title: A missense mutation in the alphaB-crystallin chaperone gene causes a 
+  title: A missense mutation in the alphaB-crystallin chaperone gene causes a
     desmin-related myopathy.
   findings: []
 - id: Reactome:R-HSA-5082356
@@ -11189,65 +11150,73 @@ references:
   title: Dynamic fibrillar assembly of alphaB-crystallin induced by perturbation
     of the conserved NT-IXI motif resolved by cryo-EM
   findings:
-  - statement: CRYAB exists in highly polydisperse oligomers (approximately 
-      10-40 subunits) with rapid subunit exchange dynamics important for 
+  - statement: CRYAB exists in highly polydisperse oligomers (approximately
+      10-40 subunits) with rapid subunit exchange dynamics important for
       chaperone activity
-  - statement: The conserved N-terminal IXI-like motif (NT-IXI) engages the ACD 
-      hydrophobic groove, governing assembly; perturbation transforms native 
+  - statement: The conserved N-terminal IXI-like motif (NT-IXI) engages the ACD
+      hydrophobic groove, governing assembly; perturbation transforms native
       assemblies into reversible elongated helical fibrils resolved by cryo-EM
 - id: DOI:10.1172/jci.insight.182209
-  title: Mutation of CRYAB encoding a conserved mitochondrial chaperone and 
+  title: Mutation of CRYAB encoding a conserved mitochondrial chaperone and
     antiapoptotic protein causes hereditary optic atrophy
   findings:
-  - statement: CRYAB E105K (within the ACD) causes autosomal dominant optic 
-      atrophy by reducing oligomer formation, chaperone activity, and 
+  - statement: CRYAB E105K (within the ACD) causes autosomal dominant optic
+      atrophy by reducing oligomer formation, chaperone activity, and
       interactions with cytochrome c and VDAC
-  - statement: CRYAB deficiency/mutation leads to increased apoptosis, 
-      mitochondrial dysfunction, and impaired OXPHOS assembly in retinal 
+  - statement: CRYAB deficiency/mutation leads to increased apoptosis,
+      mitochondrial dysfunction, and impaired OXPHOS assembly in retinal
       ganglion cells
 - id: DOI:10.1016/j.isci.2024.109510
-  title: The activation of LBH-CRYAB signaling promotes cardiac protection 
+  title: The activation of LBH-CRYAB signaling promotes cardiac protection
     against I/R injury by inhibiting apoptosis and ferroptosis
   findings:
   - statement: LBH enhances p38 phosphorylation and CRYAB Ser59 phosphorylation;
       p38 inhibitor abolishes LBH-induced CRYAB pS59
-  - statement: Phosphorylated CRYAB facilitates NRF2 upregulation/nuclear 
-      translocation and contributes to ferroptosis resistance via GPX4 in 
+  - statement: Phosphorylated CRYAB facilitates NRF2 upregulation/nuclear
+      translocation and contributes to ferroptosis resistance via GPX4 in
       cardiomyocytes
 - id: DOI:10.1186/s13287-023-03468-4
-  title: Mature human induced pluripotent stem cell-derived cardiomyocytes 
+  title: Mature human induced pluripotent stem cell-derived cardiomyocytes
     promote angiogenesis through alpha-B crystallin
   findings:
-  - statement: CRYAB is upregulated in mature hiPSC-derived cardiomyocytes and 
+  - statement: CRYAB is upregulated in mature hiPSC-derived cardiomyocytes and
       is secreted via exosomes
-  - statement: CRYAB siRNA knockdown significantly inhibits HUVEC migration and 
-      tube formation, demonstrating CRYAB is necessary for pro-angiogenic 
+  - statement: CRYAB siRNA knockdown significantly inhibits HUVEC migration and
+      tube formation, demonstrating CRYAB is necessary for pro-angiogenic
       paracrine effects
 - id: DOI:10.1038/s42003-022-04402-9
-  title: Single-cell transcriptomics reveal extracellular vesicles secretion 
+  title: Single-cell transcriptomics reveal extracellular vesicles secretion
     with a cardiomyocyte proteostasis signature during pathological remodeling
   findings:
-  - statement: Stressed cardiomyocytes secrete EVs enriched in 
-      protein-quality-control factors including CRYAB during pathological 
+  - statement: Stressed cardiomyocytes secrete EVs enriched in
+      protein-quality-control factors including CRYAB during pathological
       remodeling
-  - statement: CRYAB accumulates in recipient cells exposed to stressed 
+  - statement: CRYAB accumulates in recipient cells exposed to stressed
       cardiomyocyte-derived EVs
 - id: DOI:10.1172/jci163730
-  title: Phosphorylation of CRYAB induces a condensatopathy to worsen 
+  title: Phosphorylation of CRYAB induces a condensatopathy to worsen
     post-myocardial infarction left ventricular remodeling
   findings:
-  - statement: Ser59 phosphorylation shifts CRYAB condensates toward less 
-      dynamic, more aggregate-prone states (condensatopathy), mislocalizing 
+  - statement: Ser59 phosphorylation shifts CRYAB condensates toward less
+      dynamic, more aggregate-prone states (condensatopathy), mislocalizing
       cytoskeletal and sarcomeric client proteins
-  - statement: Phosphomimetic S59D behaves similarly to cardiomyopathy mutant 
+  - statement: Phosphomimetic S59D behaves similarly to cardiomyopathy mutant
       R120G in condensate behavior; S59A mitigates aggregate toxicity
+- id: file:human/CRYAB/CRYAB-deep-research-falcon.md
+  title: Falcon deep research for human CRYAB
+  findings:
+  - statement: &gt;-
+      Falcon synthesis supports CRYAB/HSPB5 as an ATP-independent small heat
+      shock protein holdase chaperone whose oligomerization, phosphorylation,
+      cytoskeletal clients, and mitochondrial anti-apoptotic roles define its
+      core and context-specific functions.
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/CRYAB/CRYAB-ai-review.yaml
+++ b/genes/human/CRYAB/CRYAB-ai-review.yaml
@@ -206,15 +206,11 @@ existing_annotations:
       since
       small heat shock proteins share this holdase chaperone function. However, the
       term
-      itself needs replacement. GO:0044183 "protein folding chaperone" (defined as
-      "Binding
-      to a protein or a protein-containing complex to assist the protein folding process")
-      is the closest available MF term. This is an imperfect replacement because CRYAB
-      specifically does NOT assist in protein folding -- it prevents aggregation (holdase
-      activity). A dedicated holdase-specific GO term does not yet exist and should
-      be
-      requested. UniProt describes CRYAB as having "chaperone-like activity, preventing
-      aggregation of various proteins under a wide range of stress conditions."
+      itself needs replacement. GO:0140309 "unfolded protein holdase activity" is
+      the appropriate MF term for ATP-independent binding to unfolded or destabilized
+      proteins to prevent their aggregation without active refolding. UniProt describes
+      CRYAB as having "chaperone-like activity, preventing aggregation of various proteins
+      under a wide range of stress conditions."
     action: MODIFY
     reason: >-
       GO:0051082 is being obsoleted. CRYAB has well-documented chaperone-like holdase
@@ -223,15 +219,12 @@ existing_annotations:
       in
       transfected cells (PMID:16303126). However, CRYAB does NOT refold proteins --
       it is a
-      holdase, not a foldase. The best available interim MF replacement is GO:0044183
-      "protein folding chaperone," though this term is not ideal because its definition
-      references "protein folding process" which is not what CRYAB does. A new
-      holdase-specific term should be requested. GO:0050821 "protein stabilization"
-      is
-      appropriate as a BP term and is already annotated for CRYAB via PMID:12235146.
+      holdase, not a foldase. The appropriate MF replacement is GO:0140309 "unfolded
+      protein holdase activity." GO:0050821 "protein stabilization" is appropriate
+      as a BP term and is already annotated for CRYAB via PMID:12235146.
     proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+    - id: GO:0140309
+      label: unfolded protein holdase activity
     additional_reference_ids:
     - PMID:16303126
     - PMID:12235146
@@ -1340,8 +1333,8 @@ existing_annotations:
       structural role is already captured more precisely by GO:0005212
       "structural constituent of eye lens."
     proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+    - id: GO:0140309
+      label: unfolded protein holdase activity
     supported_by:
     - reference_id: PMID:16303126
       supporting_text: >-
@@ -1605,7 +1598,7 @@ existing_annotations:
     reason: >-
       Protein binding is uninformative. The interactions with aldolase and rhodanese
       are chaperone-substrate interactions used as in vitro assay substrates. This
-      is better captured by the chaperone function annotations (GO:0044183 or
+      is better captured by the chaperone function annotations (GO:0140309 or
       GO:0050821).
 - term:
     id: GO:0050821
@@ -1812,10 +1805,8 @@ existing_annotations:
       activity" with a "dual role" -- increasing soluble protein fraction and reducing
       aggregate size. This is classic holdase activity: CRYAB binds partially denatured
       proteins and prevents their aggregation, but does NOT refold them. The term
-      GO:0044183 "protein folding chaperone" is the best available interim replacement
-      MF term, though it is imperfect because CRYAB does not assist in protein folding
-      per se -- it prevents aggregation. A holdase-specific GO term does not yet exist
-      and should be requested.
+      GO:0140309 "unfolded protein holdase activity" is the appropriate MF replacement
+      term because CRYAB prevents aggregation without active refolding.
     action: MODIFY
     reason: >-
       GO:0051082 is being obsoleted. The experimental evidence from PMID:16303126
@@ -1825,12 +1816,12 @@ existing_annotations:
       transparency in the lens": increasing the proportion of soluble protein and
       reducing aggregate size. This is not passive "unfolded protein binding" but
       active suppression of aggregation (holdase function). The IPI evidence with
-      T5P gamma C-crystallin as the interacting partner is strong. GO:0044183 "protein
-      folding chaperone" is the closest current MF term, but a holdase-specific term
-      is needed since CRYAB does NOT refold proteins.
+      T5P gamma C-crystallin as the interacting partner is strong. GO:0140309 "unfolded
+      protein holdase activity" is the correct current MF term since CRYAB prevents
+      aggregation but does NOT refold proteins.
     proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+    - id: GO:0140309
+      label: unfolded protein holdase activity
     additional_reference_ids:
     - PMID:12235146
     supported_by:
@@ -1972,8 +1963,8 @@ existing_annotations:
         with the disease phenotype in this family.
 core_functions:
 - molecular_function:
-    id: GO:0044183
-    label: protein folding chaperone
+    id: GO:0140309
+    label: unfolded protein holdase activity
   description: >-
     CRYAB (HSPB5) is a small heat shock protein that functions as an ATP-independent
     holdase chaperone. It binds partially denatured or destabilized proteins to prevent

--- a/genes/human/CRYAB/CRYAB-ai-review.yaml
+++ b/genes/human/CRYAB/CRYAB-ai-review.yaml
@@ -1,7 +1,7 @@
 id: P02511
 gene_symbol: CRYAB
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -243,6 +243,12 @@ existing_annotations:
         transfected cells. More importantly, the size of the T5P gamma C-crystallin
         aggregates were also significantly reduced in the presence of the lenticular
         chaperones.
+    - reference_id: file:human/CRYAB/CRYAB-deep-research-falcon.md
+      supporting_text: >-
+        These concepts are consistent with CRYAB being a small HSP
+        chaperone/holdase, not an enzyme/transporter; therefore its “primary
+        function” is ATP-independent chaperoning of destabilized proteins and
+        stress-protective regulation of proteostasis.
 - term:
     id: GO:0005198
     label: structural molecule activity
@@ -259,13 +265,15 @@ existing_annotations:
       constituent of eye lens is also annotated and is more informative. This broader
       IEA annotation is acceptable as it also reflects the structural role in muscle
       (association with sarcomeric Z-discs and desmin filaments).
-    action: ACCEPT
+    action: MODIFY
     reason: >-
-      CRYAB has structural roles both in the lens (where it contributes to
-      transparency) and in muscle (where it associates with desmin intermediate
-      filaments and sarcomeric structures). The broader term structural molecule
-      activity captures both contexts. The IDA annotation from PMID:16303126 provides
-      independent experimental support.
+      Structural molecule activity is broader than needed for CRYAB. The lens
+      structural role is captured more precisely by GO:0005212 "structural
+      constituent of eye lens", while muscle/cytoskeletal contexts are better
+      captured by cytoskeletal protein binding and localization annotations.
+    proposed_replacement_terms:
+    - id: GO:0005212
+      label: structural constituent of eye lens
 - term:
     id: GO:0005212
     label: structural constituent of eye lens
@@ -1324,13 +1332,16 @@ existing_annotations:
       alpha-crystallins in suppressing aggregation of T5P gamma C-crystallin. The
       structural molecule activity annotation may reflect CRYAB's dual role in the
       lens as both a structural protein and a chaperone.
-    action: ACCEPT
+    action: MODIFY
     reason: >-
-      CRYAB has a dual role in the lens as both a structural protein (contributing
-      to lens transparency and refractive index) and a molecular chaperone
-      (preventing aggregation of damaged crystallins). PMID:16303126 demonstrates
-      both roles. The structural molecule activity annotation is appropriate for
-      the structural lens function.
+      PMID:16303126 supports CRYAB/alpha-crystallin suppression of aggregation
+      of the cataract-causing T5P gamma C-crystallin, which is chaperone/holdase
+      activity rather than generic structural molecule activity. The true lens
+      structural role is already captured more precisely by GO:0005212
+      "structural constituent of eye lens."
+    proposed_replacement_terms:
+    - id: GO:0044183
+      label: protein folding chaperone
     supported_by:
     - reference_id: PMID:16303126
       supporting_text: >-
@@ -1679,13 +1690,15 @@ existing_annotations:
       The paper actually studies UVC-induced cell death, not gamma radiation
       specifically. It shows CRYAB knockdown facilitates death of UVC-exposed
       cells. This annotation may reflect broader DNA damage response involvement.
-    action: KEEP_AS_NON_CORE
+    action: MODIFY
     reason: >-
       PMID:23542032 specifically demonstrates CRYAB's protective role against
-      UVC-induced cell death, not gamma radiation per se. The annotation was made
-      by MGI, suggesting it may be based on mouse data related to radiation
-      response. CRYAB's role in DNA damage response is secondary to its core
-      chaperone and anti-apoptotic functions. Non-core.
+      UVC-induced cell death, not gamma radiation. The correct response term for
+      this evidence is cellular response to UV-C, and CRYAB's role in DNA damage
+      response is secondary to its core chaperone and anti-apoptotic functions.
+    proposed_replacement_terms:
+    - id: GO:0071494
+      label: cellular response to UV-C
     supported_by:
     - reference_id: PMID:23542032
       supporting_text: >-
@@ -2012,6 +2025,11 @@ core_functions:
       both chaperones bind to misfolded oligomeric species and form long-lived
       complexes, thereby preventing both their further growth into fibrils and
       their dissociation.
+  - reference_id: PMID:17046756
+    supporting_text: >-
+      alphaB-crystallin competes efficiently for Abeta monomer-monomer interactions.
+      Interactions between Abeta and alphaB-crystallin involve the hydrophobic core
+      residues 17-21 as well as residues 31-32 of Abeta.
   - reference_id: PMID:12235146
     supporting_text: >-
       We have used thermal and non-thermal models of protein aggregation and found
@@ -2073,37 +2091,6 @@ core_functions:
     supporting_text: >-
       A missense mutation in the alphaB-crystallin chaperone gene causes a
       desmin-related myopathy.
-- molecular_function:
-    id: GO:0001540
-    label: amyloid-beta binding
-  description: >-
-    CRYAB directly binds amyloid-beta oligomeric species and forms long-lived complexes,
-    preventing both further growth of oligomers into fibrils and their dissociation.
-    This
-    represents a specific application of CRYAB holdase activity to amyloidogenic substrates.
-    CRYAB is found co-localized with amyloid-beta in senile plaques of Alzheimer disease
-    patients.
-  directly_involved_in:
-  - id: GO:0043066
-    label: negative regulation of apoptotic process
-  - id: GO:1905907
-    label: negative regulation of amyloid fibril formation
-  - id: GO:0031333
-    label: negative regulation of protein-containing complex assembly
-  locations:
-  - id: GO:0005829
-    label: cytosol
-  supported_by:
-  - reference_id: PMID:23106396
-    supporting_text: >-
-      both chaperones bind to misfolded oligomeric species and form long-lived
-      complexes, thereby preventing both their further growth into fibrils and
-      their dissociation.
-  - reference_id: PMID:17046756
-    supporting_text: >-
-      alphaB-crystallin competes efficiently for Abeta monomer-monomer interactions.
-      Interactions between Abeta and alphaB-crystallin involve the hydrophobic core
-      residues 17-21 as well as residues 31-32 of Abeta.
 references:
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
@@ -2336,3 +2323,11 @@ references:
       cytoskeletal and sarcomeric client proteins
   - statement: Phosphomimetic S59D behaves similarly to cardiomyopathy mutant 
       R120G in condensate behavior; S59A mitigates aggregate toxicity
+- id: file:human/CRYAB/CRYAB-deep-research-falcon.md
+  title: Falcon deep research for human CRYAB
+  findings:
+  - statement: >-
+      Falcon synthesis supports CRYAB/HSPB5 as an ATP-independent small heat
+      shock protein holdase chaperone whose oligomerization, phosphorylation,
+      cytoskeletal clients, and mitochondrial anti-apoptotic roles define its
+      core and context-specific functions.

--- a/genes/human/GRPEL1/GRPEL1-ai-review.html
+++ b/genes/human/GRPEL1/GRPEL1-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>GRPEL1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/Q9HAV7" target="_blank" class="term-link">
                         Q9HAV7
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>GRPEL1 encodes the primary human mitochondrial GrpE-like nucleotide exchange factor (NEF) that functions within the TIM23/PAM import motor complex. It accelerates ADP release from mitochondrial HSP70 (HSPA9/mortalin), enabling the chaperone to rebind ATP and release substrate proteins. GRPEL1 is essential for mitochondrial protein import, matrix protein folding, and Fe-S cluster biogenesis. It binds HSPA9 with high affinity (KD ~39 nM) and forms a stable hetero-oligomer with its paralog GRPEL2. GRPEL1 is the essential basal NEF (pLI ~0.90), while GRPEL2 provides stress-adaptive redox regulation.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000774" target="_blank" class="term-link">
                                     GO:0000774
                                 </a>
                             </span>
                             <span class="term-label">adenyl-nucleotide exchange factor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,64 +795,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GRPEL1 is a nucleotide exchange factor (NEF) for mitochondrial HSP70 (HSPA9). It accelerates ADP release and ATP rebinding on HSPA9, which is the defining biochemical activity of an adenyl-nucleotide exchange factor. Quantitative binding data show GRPEL1 binds HSPA9 with KD ~39 nM and inhibits single-turnover ATP hydrolysis at saturating concentrations, consistent with NEF activity (Srivastava et al., JBC 2017). The IBA annotation is phylogenetically well-supported, as GrpE family members across bacteria and eukaryotes share this conserved NEF function. This is the core molecular function of GRPEL1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Adenyl-nucleotide exchange factor activity is the defining molecular function of GRPEL1. This is strongly supported by in vitro biochemical data (Srivastava et al., JBC 2017) showing direct NEF activity on HSPA9, as well as by conserved domain architecture (GrpE family) and phylogenetic inference.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11311562" target="_blank" class="term-link">
-                                        PMID:11311562
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28848044" target="_blank" class="term-link">
+                                        PMID:28848044
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">HMGE expressed in E. coli as a GST fusion protein co-purified with the E. coli Hsp70 protein DnaK in the absence of ATP. DnaK could be released from the GST-HMGE with a Mg-ATP wash.</div>
-                                
+
+                                <div class="support-text">Nucleotide exchange factors (NEFs) play a crucial role in exchanging ADP for ATP at mtHsp70&#39;s nucleotide-binding domain, thereby modulating mtHsp70&#39;s chaperone activity.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GRPEL1/GRPEL1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">GRPEL1 is a nucleotide exchange factor for mitochondrial Hsp70 (HSPA9). It accelerates ADP release and ATP rebinding on HSPA9, controlling substrate binding and release during protein folding and import.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001405" target="_blank" class="term-link">
                                     GO:0001405
                                 </a>
                             </span>
                             <span class="term-label">PAM complex, Tim23 associated import motor</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -864,64 +875,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GRPEL1 is a component of the PAM (presequence translocase-associated motor) complex. Co-immunoprecipitation experiments in mitochondrial lysates show GRPEL1 associates with HSPA9 and TIMM44 (Srivastava et al., JBC 2017). UniProt lists GRPEL1 as a component of the TIM23 complex (ComplexPortal CPX-6129 and CPX-6130). The IBA annotation is phylogenetically well-supported from the yeast Mge1p ortholog.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Multiple lines of evidence confirm GRPEL1 as a PAM complex component: co-immunoprecipitation with HSPA9 and TIMM44 (Srivastava et al., JBC 2017), functional conservation with yeast Mge1p in the import motor, and ComplexPortal entries for TIM23 complexes listing GRPEL1.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11311562" target="_blank" class="term-link">
-                                        PMID:11311562
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28848044" target="_blank" class="term-link">
+                                        PMID:28848044
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Subcellular fractionation and immunocytochemistry studies using antisera raized against HMGE show that it is a mitochondrial protein.</div>
-                                
+
+                                <div class="support-text">We found that both GrpEL1 and GrpEL2 associate with mtHsp70 as a hetero-oligomeric subcomplex and regulate mtHsp70 function.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GRPEL1/GRPEL1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Co-immunoprecipitation in mitochondrial lysates shows GRPEL1/GRPEL2 associate with HSPA9 and TIMM44; ATP addition dissociates HSPA9-TIMM44 while the GRPEL1-GRPEL2 subcomplex remains stable, consistent with co-recruitment of the NEFs alongside HSPA9 at the import site.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
                                     GO:0030150
                                 </a>
                             </span>
                             <span class="term-label">protein import into mitochondrial matrix</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -933,46 +955,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GRPEL1 participates in protein import into the mitochondrial matrix as the NEF for HSPA9 within the PAM/TIM23 import motor. By cycling HSPA9 between ADP- and ATP-bound states, GRPEL1 enables the ratchet mechanism that drives preprotein translocation through the TIM23 channel (Srivastava et al., JBC 2017; Havalova et al., IJMS 2021). The IBA annotation from yeast Mge1p is well-supported.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GRPEL1 is directly involved in mitochondrial protein import as the NEF component of the PAM import motor. This is the primary biological process in which GRPEL1 functions, supported by its PAM complex membership and essential role in HSPA9 cycling during preprotein translocation.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28848044" target="_blank" class="term-link">
+                                        PMID:28848044
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The formation of this subcomplex was critical for conferring stability to the NEFs, helped fine-tune mitochondrial protein quality control, and regulated crucial mtHsp70 functions, such as import of preproteins and biogenesis of Fe-S clusters.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -984,64 +1024,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This annotation attributes direct unfolded protein binding to GRPEL1. However, GRPEL1 is a nucleotide exchange factor, not a substrate-binding chaperone. The unfolded protein binding activity in the Hsp70 system resides with HSPA9 itself (via its substrate-binding domain) and J-protein co-chaperones that deliver substrates. GRPEL1 acts on the nucleotide-binding domain of HSPA9 to accelerate ADP release, which indirectly causes substrate release. There is no evidence that GRPEL1 directly binds unfolded polypeptide substrates. The IBA annotation propagates from an IDA (PMID:11311562) that conflated the co-chaperone&#39;s role in the chaperone cycle with direct substrate binding.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GRPEL1 is a nucleotide exchange factor that acts on the ATPase domain of HSPA9; it does not directly bind unfolded protein substrates. The chaperone system as a whole handles unfolded proteins, but GRPEL1&#39;s specific role is nucleotide exchange. This annotation confuses the system-level function with the molecular-level activity of this specific component. The core MF annotation should be GO:0000774 (adenyl-nucleotide exchange factor activity). The underlying IDA (PMID:11311562) does not demonstrate direct unfolded protein binding by GRPEL1.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11311562" target="_blank" class="term-link">
                                         PMID:11311562
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HMGE expressed in E. coli as a GST fusion protein co-purified with the E. coli Hsp70 protein DnaK in the absence of ATP. DnaK could be released from the GST-HMGE with a Mg-ATP wash.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000774" target="_blank" class="term-link">
                                     GO:0000774
                                 </a>
                             </span>
                             <span class="term-label">adenyl-nucleotide exchange factor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1053,46 +1093,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from InterPro domain mapping (IPR000740, GrpE domain). The GrpE domain is the defining structural feature of nucleotide exchange factors for DnaK/Hsp70 chaperones. This electronic annotation is fully consistent with the IBA annotation and experimental evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Correct IEA mapping. The GrpE domain (IPR000740) is a reliable predictor of adenyl-nucleotide exchange factor activity, and this is confirmed by both phylogenetic (IBA) and experimental evidence for GRPEL1.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
                                     GO:0005759
                                 </a>
                             </span>
                             <span class="term-label">mitochondrial matrix</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1104,46 +1144,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from UniProtKB subcellular location vocabulary mapping. GRPEL1 is annotated in UniProt as localizing to the mitochondrial matrix based on PMID:11311562. This electronic annotation is consistent with the IDA annotation from the same publication.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Correct IEA mapping consistent with experimental IDA evidence. Mitochondrial matrix localization is well established for GRPEL1 by subcellular fractionation and immunocytochemistry (PMID:11311562) and by the Srivastava et al. (JBC 2017) study.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1155,46 +1195,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from InterPro domain mapping. GrpE family proteins participate in the Hsp70 chaperone cycle, which assists protein folding. GRPEL1 contributes to protein folding indirectly by enabling HSPA9 to cycle through substrate binding and release, supporting folding of newly imported and misfolded matrix proteins. However, GRPEL1 is not itself a folding chaperone; it is a co-chaperone (NEF) that regulates the chaperone cycle.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While GRPEL1 participates in the protein folding process through its NEF function in the HSPA9 chaperone cycle, protein folding is not its core evolved function. Its core function is nucleotide exchange factor activity (GO:0000774) within the mitochondrial protein import system. Protein folding is a downstream consequence of HSPA9 cycling that GRPEL1 facilitates, making it a non-core annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1206,46 +1246,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from ARBA machine learning. GRPEL1 does form homo-oligomers as shown by size exclusion chromatography and native gel experiments (Srivastava et al., JBC 2017), though the physiologically relevant form appears to be the GRPEL1-GRPEL2 hetero-oligomer (~150-160 kDa). The IPI annotation from PMID:32296183 provides experimental support for self-association.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GRPEL1 self-association is experimentally supported by IPI data (PMID:32296183) and by biochemical studies showing GRPEL1 homo-oligomerization (Srivastava et al., JBC 2017), though the heteromeric complex with GRPEL2 is the predominant physiological form.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042803" target="_blank" class="term-link">
                                     GO:0042803
                                 </a>
                             </span>
                             <span class="term-label">protein homodimerization activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1257,46 +1297,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from InterPro domain mapping. GrpE family members are known to dimerize. Bacterial GrpE forms a homodimer. GRPEL1 can self-associate as shown by co-IP and Y2H data (PMID:32296183), and purified GRPEL1 forms oligomers (Srivastava et al., JBC 2017), though the predominant physiological form is the GRPEL1-GRPEL2 hetero-oligomer.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Homodimerization is a conserved property of GrpE family proteins, and there is experimental evidence that GRPEL1 can self-associate. However, note that in vivo the GRPEL1-GRPEL2 hetero-oligomer may be the predominant species.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1308,75 +1348,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from InterPro domain mapping. GRPEL1 directly binds the protein-folding chaperone HSPA9/mortalin with high affinity (KD ~39 nM; Srivastava et al., JBC 2017). The original characterization paper (PMID:11311562) also showed GRPEL1 binding to HSP70, HSC70, and HSJ1b. This annotation accurately captures the binding interaction between GRPEL1 and its chaperone partner HSPA9.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GRPEL1 is a co-chaperone that directly binds the protein-folding chaperone HSPA9 with high affinity. This binding is central to its nucleotide exchange factor function. Supported by multiple lines of evidence including co-IP, biolayer interferometry, and functional assays.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11311562" target="_blank" class="term-link">
                                         PMID:11311562
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HMGE expressed in E. coli as a GST fusion protein co-purified with the E. coli Hsp70 protein DnaK in the absence of ATP. DnaK could be released from the GST-HMGE with a Mg-ATP wash. ...HMGE also appears to bind the constitutive cytosolic Hsp70, Hsc70, in addition to mitochondrial Hsp70, Mt-Hsp70.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28514442
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Architecture of the human interactome defines protein commun...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1388,57 +1428,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> High-throughput interactome study. The WITH/FROM field indicates interaction with HSPA9 (P38646), which is the known physiological partner of GRPEL1. However, protein binding is uninformative as a GO term; the specific interaction is better captured by GO:0051087 (protein-folding chaperone binding) and GO:0000774 (adenyl-nucleotide exchange factor activity).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding (GO:0005515) is uninformative per GO curation guidelines. The GRPEL1-HSPA9 interaction is better captured by more specific terms already annotated (GO:0051087 and GO:0000774).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30021884" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30021884
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Histone Interaction Landscapes Visualized by Crosslinking Ma...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1450,57 +1490,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> High-throughput crosslinking mass spectrometry study of histone interactions in cell nuclei. The WITH/FROM field indicates interaction with HSPA9 (P38646). The study context (histone interaction landscapes in nuclei) is not directly relevant to GRPEL1&#39;s mitochondrial function. The GRPEL1-HSPA9 interaction is well established but protein binding is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding (GO:0005515) is uninformative. The GRPEL1-HSPA9 interaction is real but already captured by more specific terms. The study context (nuclear histone interactions) is tangential to GRPEL1&#39;s mitochondrial function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32296183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A reference map of the human binary protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1512,57 +1552,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Reference map of the human binary protein interactome (HuRI). Multiple interactors detected for GRPEL1 including POLR1C (O15160), GALT (P07902), CCDC57 (Q2TAC2-2), and SPG21 (Q9NZD8). These are high-throughput Y2H interactions. Some may represent artifacts from overexpression; GALT and POLR1C are not established mitochondrial matrix proteins. Protein binding is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding (GO:0005515) is uninformative per GO curation guidelines. Several of the detected interactors (GALT, POLR1C, CCDC57, SPG21) are from high-throughput Y2H and may not represent physiologically relevant interactions for a mitochondrial matrix protein.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1574,57 +1614,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Dual proteome-scale network study detecting GRPEL1 interaction with HSPA9 (P38646). This confirms the well-established GRPEL1-HSPA9 interaction, but protein binding is uninformative as a GO term.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein binding (GO:0005515) is uninformative. The GRPEL1-HSPA9 interaction is the core functional interaction already captured by more specific terms (GO:0051087, GO:0000774).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32296183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A reference map of the human binary protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1636,46 +1676,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> The HuRI binary interactome study detected GRPEL1 self-interaction (WITH/FROM: Q9HAV7). This is consistent with the known oligomeric behavior of GrpE family proteins. Srivastava et al. (JBC 2017) showed that purified GRPEL1 forms oligomers, though the physiologically predominant form is the GRPEL1-GRPEL2 hetero-oligomer.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Experimental IPI evidence for GRPEL1 self-interaction from a binary interactome study. This is consistent with known GrpE family homodimerization and biochemical evidence of GRPEL1 oligomerization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1687,75 +1727,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from HPA immunofluorescence data. GRPEL1 mitochondrial localization is well established by multiple methods including subcellular fractionation and immunocytochemistry (PMID:11311562), and microscopy with mitochondrial markers (Srivastava et al., JBC 2017). This is a broader term than GO:0005759 (mitochondrial matrix) but still correct.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Mitochondrial localization is firmly established for GRPEL1. While GO:0005759 (mitochondrial matrix) is more specific, this broader IDA annotation from HPA immunofluorescence is also correct and independently confirms the localization.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11311562" target="_blank" class="term-link">
                                         PMID:11311562
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Subcellular fractionation and immunocytochemistry studies using antisera raized against HMGE show that it is a mitochondrial protein.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
                                     GO:0005743
                                 </a>
                             </span>
                             <span class="term-label">mitochondrial inner membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10339406
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Genetic and structural characterization of the human mitocho...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1767,57 +1807,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NAS annotation from ComplexPortal based on Bauer et al. (1999) which characterized the human TIM23 translocase. The paper describes hTim44 localization in the matrix and TIM23/TIM17 in the inner membrane. GRPEL1 itself was not characterized in this paper (it was identified later in 2001). GRPEL1 is a soluble matrix protein that associates with the inner membrane via its interaction with the PAM/TIM23 complex. The annotation likely reflects its association with the inner membrane-bound TIM23 complex rather than intrinsic membrane localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GRPEL1 is primarily a soluble mitochondrial matrix protein that peripherally associates with the inner membrane through its interactions with the PAM/TIM23 complex. The annotation is not wrong per se, as GRPEL1 does associate with inner membrane complexes, but GO:0005759 (mitochondrial matrix) is the more accurate primary localization. The cited paper (PMID:10339406) predates the identification of GRPEL1 and describes the TIM23 translocase in general.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006886" target="_blank" class="term-link">
                                     GO:0006886
                                 </a>
                             </span>
                             <span class="term-label">intracellular protein transport</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10339406
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Genetic and structural characterization of the human mitocho...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1829,68 +1869,68 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NAS annotation from ComplexPortal. GRPEL1 is involved in intracellular protein transport as part of the mitochondrial import machinery. However, this term is overly broad; the more specific term GO:0030150 (protein import into mitochondrial matrix) better captures GRPEL1&#39;s role. The cited paper (PMID:10339406) describes the TIM23 translocase but predates GRPEL1&#39;s identification.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While GRPEL1 is involved in intracellular protein transport, this term is too general. The more specific term GO:0030150 (protein import into mitochondrial matrix) precisely describes GRPEL1&#39;s role in the TIM23/PAM-dependent import of preproteins into the matrix, and is already annotated via IBA.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
                                     protein import into mitochondrial matrix
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HTP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:34800366
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Quantitative high-confidence human mitochondrial proteome an...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1902,57 +1942,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HTP annotation from a quantitative high-confidence human mitochondrial proteome study. GRPEL1 was identified in the mitochondrial proteome with high confidence. This is consistent with all other localization evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> High-throughput proteomic confirmation of GRPEL1 mitochondrial localization. Consistent with all other evidence (IDA from HPA, IDA from PMID:11311562, and functional studies).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11311562" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11311562
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of a human mitochondrial...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1964,75 +2004,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IDA annotation claims direct assay evidence for GRPEL1 binding unfolded proteins based on PMID:11311562 (Choglay et al., 2001). However, careful reading of the paper reveals that the experiments demonstrated GRPEL1 (HMGE) binding to Hsp70 proteins (DnaK, Hsc70, Mt-Hsp70) and inhibiting HSJ1b-enhanced Hsc70 ATPase activity, not direct binding to unfolded protein substrates. The study characterized GRPEL1 as a GrpE homolog that interacts with Hsp70 chaperones, which is nucleotide exchange factor activity, not unfolded protein binding. The annotation appears to be a misinterpretation of the co-chaperone&#39;s role in the chaperone cycle as direct substrate binding.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The cited paper (PMID:11311562) does not demonstrate direct binding of GRPEL1 to unfolded proteins. The experiments showed GRPEL1 binding to Hsp70 chaperones (DnaK, Hsc70, Mt-Hsp70) and inhibiting co-chaperone-stimulated ATPase activity. These are hallmarks of nucleotide exchange factor activity (GO:0000774), not unfolded protein binding. GRPEL1 acts on the nucleotide-binding domain of Hsp70 to catalyze ADP/ATP exchange; it does not directly engage unfolded polypeptide substrates. This annotation likely arose from conflating the system-level function (chaperone cycle handles unfolded proteins) with the specific molecular activity of this component.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11311562" target="_blank" class="term-link">
                                         PMID:11311562
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HMGE expressed in E. coli as a GST fusion protein co-purified with the E. coli Hsp70 protein DnaK in the absence of ATP. DnaK could be released from the GST-HMGE with a Mg-ATP wash. ...HMGE was found to inhibit the HSJ1b-enhanced Hsc70 ATPase activity and may mediate this inhibition by binding the DnaJ-protein, HSJ1b.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
                                     GO:0005759
                                 </a>
                             </span>
                             <span class="term-label">mitochondrial matrix</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11311562" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11311562
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of a human mitochondrial...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2044,50 +2084,50 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation based on subcellular fractionation and immunocytochemistry from the original characterization paper (Choglay et al., 2001). The paper demonstrates GRPEL1 (HMGE) is a mitochondrial protein using antisera and subcellular fractionation. This is further confirmed by Srivastava et al. (JBC 2017) showing matrix localization by microscopy with mitochondrial markers.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Well-supported by direct experimental evidence from subcellular fractionation and immunocytochemistry in the original characterization paper. Independently confirmed by Srivastava et al. (JBC 2017). Mitochondrial matrix is the specific subcellular location where GRPEL1 performs its NEF function within the PAM/TIM23 complex.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11311562" target="_blank" class="term-link">
                                         PMID:11311562
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Subcellular fractionation and immunocytochemistry studies using antisera raized against HMGE show that it is a mitochondrial protein.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>GRPEL1 is the primary mitochondrial GrpE-like nucleotide exchange factor (NEF) for HSPA9/mortalin. It accelerates ADP release from HSPA9, enabling ATP rebinding and substrate release. This NEF activity is essential for the PAM import motor that drives preprotein translocation through the TIM23 channel into the mitochondrial matrix.</h3>
                 <span class="vote-buttons" data-g="Q9HAV7" data-a="FUNCTION: GRPEL1 is the primary mitochondrial GrpE-like nucl..." data-r="" data-act="CORE_FUNCTION">
@@ -2095,10 +2135,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -2107,39 +2147,39 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
                                 protein import into mitochondrial matrix
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
                                 mitochondrial matrix
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">In Complex:</div>
                     <span class="badge">
@@ -2148,273 +2188,323 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/11311562" target="_blank" class="term-link">
-                                PMID:11311562
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28848044" target="_blank" class="term-link">
+                                PMID:28848044
                             </a>
-                            
+
                         </span>
-                        
-                        <div class="finding-text">HMGE expressed in E. coli as a GST fusion protein co-purified with the E. coli Hsp70 protein DnaK in the absence of ATP. DnaK could be released from the GST-HMGE with a Mg-ATP wash.</div>
-                        
+
+                        <div class="finding-text">Here, we report that two putative NEF orthologs, GrpE-like 1 (GrpEL1) and GrpEL2, modulate mtHsp70&#39;s function in human cells.</div>
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
                             GO_REF:0000052
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link">
                             PMID:10339406
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Genetic and structural characterization of the human mitochondrial inner membrane translocase.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Describes the human TIM23/TIM17 translocase complex, including Tim44 matrix localization and two TIM17 variants. GRPEL1 was not yet identified at the time of this study.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11311562" target="_blank" class="term-link">
                             PMID:11311562
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Identification and characterization of a human mitochondrial homologue of the bacterial co-chaperone GrpE.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Original identification of GRPEL1 (HMGE). Demonstrated mitochondrial localization by subcellular fractionation and immunocytochemistry. Showed binding to DnaK, Hsc70, and Mt-Hsp70. Demonstrated inhibition of HSJ1b-enhanced Hsc70 ATPase activity. Modeled on the E. coli GrpE crystal structure with significant structural conservation.</div>
-                        
+
                         <div class="finding-text">"HMGE expressed in E. coli as a GST fusion protein co-purified with the E. coli Hsp70 protein DnaK in the absence of ATP. DnaK could be released from the GST-HMGE with a Mg-ATP wash. ...Subcellular fractionation and immunocytochemistry studies using antisera raized against HMGE show that it is a mitochondrial protein."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28848044" target="_blank" class="term-link">
+                            PMID:28848044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Regulation of mitochondrial protein import by the nucleotide exchange factors GrpEL1 and GrpEL2 in human cells.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Demonstrates that human GRPEL1/GrpEL1 acts with GRPEL2 as a mitochondrial NEF system for mtHsp70/HSPA9, regulating mtHsp70 function, preprotein import, Fe-S cluster biogenesis, and mitochondrial protein quality control.</div>
+
+                        <div class="finding-text">"We found that both GrpEL1 and GrpEL2 associate with mtHsp70 as a hetero-oligomeric subcomplex and regulate mtHsp70 function. The formation of this subcomplex was critical for conferring stability to the NEFs, helped fine-tune mitochondrial protein quality control, and regulated crucial mtHsp70 functions, such as import of preproteins and biogenesis of Fe-S clusters."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
                             PMID:28514442
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/30021884" target="_blank" class="term-link">
                             PMID:30021884
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Histone Interaction Landscapes Visualized by Crosslinking Mass Spectrometry in Intact Cell Nuclei.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                             PMID:32296183
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A reference map of the human binary protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
                             PMID:34800366
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
-                
-                
+
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/GRPEL1/GRPEL1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research for human GRPEL1</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Falcon synthesis supports GRPEL1 as the primary mitochondrial GrpE-like nucleotide exchange factor for HSPA9 in the TIM23/PAM import and matrix proteostasis system.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -2616,9 +2706,9 @@ GRPEL1 (Q9HAV7) is the primary human mitochondrial GrpE-like NEF that localizes 
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -2630,7 +2720,7 @@ GRPEL1 (Q9HAV7) is the primary human mitochondrial GrpE-like NEF that localizes 
                 <pre><code>id: Q9HAV7
 gene_symbol: GRPEL1
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -2662,10 +2752,17 @@ existing_annotations:
       strongly supported by in vitro biochemical data (Srivastava et al., JBC 2017) showing direct NEF
       activity on HSPA9, as well as by conserved domain architecture (GrpE family) and phylogenetic inference.
     supported_by:
-      - reference_id: PMID:11311562
+      - reference_id: PMID:28848044
         supporting_text: &gt;-
-          HMGE expressed in E. coli as a GST fusion protein co-purified with the E. coli Hsp70 protein DnaK
-          in the absence of ATP. DnaK could be released from the GST-HMGE with a Mg-ATP wash.
+          Nucleotide exchange factors (NEFs) play a crucial role in exchanging ADP
+          for ATP at mtHsp70&#39;s nucleotide-binding domain, thereby modulating mtHsp70&#39;s
+          chaperone activity.
+      - reference_id: file:human/GRPEL1/GRPEL1-deep-research-falcon.md
+        supporting_text: &gt;-
+          GRPEL1 is a nucleotide exchange factor for mitochondrial Hsp70
+          (HSPA9). It accelerates ADP release and ATP rebinding on HSPA9,
+          controlling substrate binding and release during protein folding and
+          import.
 
 - term:
     id: GO:0001405
@@ -2684,10 +2781,16 @@ existing_annotations:
       HSPA9 and TIMM44 (Srivastava et al., JBC 2017), functional conservation with yeast Mge1p in the
       import motor, and ComplexPortal entries for TIM23 complexes listing GRPEL1.
     supported_by:
-      - reference_id: PMID:11311562
+      - reference_id: PMID:28848044
         supporting_text: &gt;-
-          Subcellular fractionation and immunocytochemistry studies using antisera raized against HMGE show
-          that it is a mitochondrial protein.
+          We found that both GrpEL1 and GrpEL2 associate with mtHsp70 as a
+          hetero-oligomeric subcomplex and regulate mtHsp70 function.
+      - reference_id: file:human/GRPEL1/GRPEL1-deep-research-falcon.md
+        supporting_text: &gt;-
+          Co-immunoprecipitation in mitochondrial lysates shows GRPEL1/GRPEL2
+          associate with HSPA9 and TIMM44; ATP addition dissociates HSPA9-TIMM44
+          while the GRPEL1-GRPEL2 subcomplex remains stable, consistent with
+          co-recruitment of the NEFs alongside HSPA9 at the import site.
 
 - term:
     id: GO:0030150
@@ -2705,6 +2808,13 @@ existing_annotations:
       GRPEL1 is directly involved in mitochondrial protein import as the NEF component of the PAM import
       motor. This is the primary biological process in which GRPEL1 functions, supported by its PAM complex
       membership and essential role in HSPA9 cycling during preprotein translocation.
+    supported_by:
+      - reference_id: PMID:28848044
+        supporting_text: &gt;-
+          The formation of this subcomplex was critical for conferring stability
+          to the NEFs, helped fine-tune mitochondrial protein quality control, and
+          regulated crucial mtHsp70 functions, such as import of preproteins and
+          biogenesis of Fe-S clusters.
 
 - term:
     id: GO:0051082
@@ -3077,10 +3187,10 @@ core_functions:
     id: GO:0001405
     label: PAM complex, Tim23 associated import motor
   supported_by:
-    - reference_id: PMID:11311562
+    - reference_id: PMID:28848044
       supporting_text: &gt;-
-        HMGE expressed in E. coli as a GST fusion protein co-purified with the E. coli Hsp70 protein DnaK
-        in the absence of ATP. DnaK could be released from the GST-HMGE with a Mg-ATP wash.
+        Here, we report that two putative NEF orthologs, GrpE-like 1 (GrpEL1)
+        and GrpEL2, modulate mtHsp70&#39;s function in human cells.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
@@ -3121,6 +3231,21 @@ references:
         in the absence of ATP. DnaK could be released from the GST-HMGE with a Mg-ATP wash.
         ...Subcellular fractionation and immunocytochemistry studies using antisera raized against HMGE show
         that it is a mitochondrial protein.
+- id: PMID:28848044
+  title: Regulation of mitochondrial protein import by the nucleotide exchange factors
+    GrpEL1 and GrpEL2 in human cells.
+  findings:
+    - statement: &gt;-
+        Demonstrates that human GRPEL1/GrpEL1 acts with GRPEL2 as a mitochondrial
+        NEF system for mtHsp70/HSPA9, regulating mtHsp70 function, preprotein
+        import, Fe-S cluster biogenesis, and mitochondrial protein quality control.
+      supporting_text: &gt;-
+        We found that both GrpEL1 and GrpEL2 associate with mtHsp70 as a
+        hetero-oligomeric subcomplex and regulate mtHsp70 function. The formation
+        of this subcomplex was critical for conferring stability to the NEFs,
+        helped fine-tune mitochondrial protein quality control, and regulated
+        crucial mtHsp70 functions, such as import of preproteins and biogenesis
+        of Fe-S clusters.
 - id: PMID:28514442
   title: Architecture of the human interactome defines protein communities and disease
     networks.
@@ -3140,13 +3265,20 @@ references:
   title: Quantitative high-confidence human mitochondrial proteome and its dynamics
     in cellular context.
   findings: []
+- id: file:human/GRPEL1/GRPEL1-deep-research-falcon.md
+  title: Falcon deep research for human GRPEL1
+  findings:
+    - statement: &gt;-
+        Falcon synthesis supports GRPEL1 as the primary mitochondrial GrpE-like
+        nucleotide exchange factor for HSPA9 in the TIM23/PAM import and matrix
+        proteostasis system.
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/GRPEL1/GRPEL1-ai-review.yaml
+++ b/genes/human/GRPEL1/GRPEL1-ai-review.yaml
@@ -1,7 +1,7 @@
 id: Q9HAV7
 gene_symbol: GRPEL1
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -33,10 +33,17 @@ existing_annotations:
       strongly supported by in vitro biochemical data (Srivastava et al., JBC 2017) showing direct NEF
       activity on HSPA9, as well as by conserved domain architecture (GrpE family) and phylogenetic inference.
     supported_by:
-      - reference_id: PMID:11311562
+      - reference_id: PMID:28848044
         supporting_text: >-
-          HMGE expressed in E. coli as a GST fusion protein co-purified with the E. coli Hsp70 protein DnaK
-          in the absence of ATP. DnaK could be released from the GST-HMGE with a Mg-ATP wash.
+          Nucleotide exchange factors (NEFs) play a crucial role in exchanging ADP
+          for ATP at mtHsp70's nucleotide-binding domain, thereby modulating mtHsp70's
+          chaperone activity.
+      - reference_id: file:human/GRPEL1/GRPEL1-deep-research-falcon.md
+        supporting_text: >-
+          GRPEL1 is a nucleotide exchange factor for mitochondrial Hsp70
+          (HSPA9). It accelerates ADP release and ATP rebinding on HSPA9,
+          controlling substrate binding and release during protein folding and
+          import.
 
 - term:
     id: GO:0001405
@@ -55,10 +62,16 @@ existing_annotations:
       HSPA9 and TIMM44 (Srivastava et al., JBC 2017), functional conservation with yeast Mge1p in the
       import motor, and ComplexPortal entries for TIM23 complexes listing GRPEL1.
     supported_by:
-      - reference_id: PMID:11311562
+      - reference_id: PMID:28848044
         supporting_text: >-
-          Subcellular fractionation and immunocytochemistry studies using antisera raized against HMGE show
-          that it is a mitochondrial protein.
+          We found that both GrpEL1 and GrpEL2 associate with mtHsp70 as a
+          hetero-oligomeric subcomplex and regulate mtHsp70 function.
+      - reference_id: file:human/GRPEL1/GRPEL1-deep-research-falcon.md
+        supporting_text: >-
+          Co-immunoprecipitation in mitochondrial lysates shows GRPEL1/GRPEL2
+          associate with HSPA9 and TIMM44; ATP addition dissociates HSPA9-TIMM44
+          while the GRPEL1-GRPEL2 subcomplex remains stable, consistent with
+          co-recruitment of the NEFs alongside HSPA9 at the import site.
 
 - term:
     id: GO:0030150
@@ -76,6 +89,13 @@ existing_annotations:
       GRPEL1 is directly involved in mitochondrial protein import as the NEF component of the PAM import
       motor. This is the primary biological process in which GRPEL1 functions, supported by its PAM complex
       membership and essential role in HSPA9 cycling during preprotein translocation.
+    supported_by:
+      - reference_id: PMID:28848044
+        supporting_text: >-
+          The formation of this subcomplex was critical for conferring stability
+          to the NEFs, helped fine-tune mitochondrial protein quality control, and
+          regulated crucial mtHsp70 functions, such as import of preproteins and
+          biogenesis of Fe-S clusters.
 
 - term:
     id: GO:0051082
@@ -448,10 +468,10 @@ core_functions:
     id: GO:0001405
     label: PAM complex, Tim23 associated import motor
   supported_by:
-    - reference_id: PMID:11311562
+    - reference_id: PMID:28848044
       supporting_text: >-
-        HMGE expressed in E. coli as a GST fusion protein co-purified with the E. coli Hsp70 protein DnaK
-        in the absence of ATP. DnaK could be released from the GST-HMGE with a Mg-ATP wash.
+        Here, we report that two putative NEF orthologs, GrpE-like 1 (GrpEL1)
+        and GrpEL2, modulate mtHsp70's function in human cells.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
@@ -492,6 +512,21 @@ references:
         in the absence of ATP. DnaK could be released from the GST-HMGE with a Mg-ATP wash.
         ...Subcellular fractionation and immunocytochemistry studies using antisera raized against HMGE show
         that it is a mitochondrial protein.
+- id: PMID:28848044
+  title: Regulation of mitochondrial protein import by the nucleotide exchange factors
+    GrpEL1 and GrpEL2 in human cells.
+  findings:
+    - statement: >-
+        Demonstrates that human GRPEL1/GrpEL1 acts with GRPEL2 as a mitochondrial
+        NEF system for mtHsp70/HSPA9, regulating mtHsp70 function, preprotein
+        import, Fe-S cluster biogenesis, and mitochondrial protein quality control.
+      supporting_text: >-
+        We found that both GrpEL1 and GrpEL2 associate with mtHsp70 as a
+        hetero-oligomeric subcomplex and regulate mtHsp70 function. The formation
+        of this subcomplex was critical for conferring stability to the NEFs,
+        helped fine-tune mitochondrial protein quality control, and regulated
+        crucial mtHsp70 functions, such as import of preproteins and biogenesis
+        of Fe-S clusters.
 - id: PMID:28514442
   title: Architecture of the human interactome defines protein communities and disease
     networks.
@@ -511,3 +546,10 @@ references:
   title: Quantitative high-confidence human mitochondrial proteome and its dynamics
     in cellular context.
   findings: []
+- id: file:human/GRPEL1/GRPEL1-deep-research-falcon.md
+  title: Falcon deep research for human GRPEL1
+  findings:
+    - statement: >-
+        Falcon synthesis supports GRPEL1 as the primary mitochondrial GrpE-like
+        nucleotide exchange factor for HSPA9 in the TIM23/PAM import and matrix
+        proteostasis system.

--- a/genes/human/VBP1/VBP1-ai-review.html
+++ b/genes/human/VBP1/VBP1-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>VBP1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P61758" target="_blank" class="term-link">
                         P61758
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>VBP1 (von Hippel-Lindau binding protein 1, also known as PFDN3) encodes an alpha-type subunit of the heterohexameric prefoldin complex. The prefoldin complex is a jellyfish-shaped molecular chaperone composed of two alpha subunits (PFDN3/VBP1 and PFDN5) and four beta subunits (PFDN1, PFDN2, PFDN4, PFDN6). Prefoldin functions as a co-chaperone/holdase that captures unfolded nascent polypeptides -- primarily actin and tubulin -- and delivers them to the TRiC/CCT chaperonin for ATP-dependent folding. VBP1 was originally identified through its binding to pVHL (the von Hippel-Lindau tumor suppressor), and as part of the prefoldin complex it helps prevent pVHL aggregation and supports its maturation, thereby contributing to HIF-alpha degradation. Beyond its canonical cytoplasmic role, prefoldin has nuclear functions influencing transcription elongation and co-transcriptional splicing. VBP1 is ubiquitously expressed and located on the X chromosome.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,146 +795,146 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005737 &#34;cytoplasm&#34; is an appropriate cellular component annotation for VBP1. This IBA annotation was inferred from phylogenetic analysis (PANTHER) with evidence from Drosophila (FB:FBgn0264694), yeast (SGD:S000003310), Arabidopsis, C. elegans, and human VBP1 itself. The prefoldin complex is a cytoplasmic chaperone that operates in the cytosol to capture unfolded nascent polypeptides and deliver them to the cytosolic chaperonin TRiC/CCT (PMID:9630229). Liang et al. 2020 (PMID:32699605) describe prefoldin as &#34;a cytoplasmic chaperone protein.&#34; The term &#34;cytoplasm&#34; is appropriately broad, as a more specific CC annotation to &#34;prefoldin complex&#34; (GO:0016272) is already present. Having both is correct: one describes subcellular location and the other describes complex membership.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> VBP1 operates as part of the cytoplasmic prefoldin complex. The cytoplasm annotation is well-supported and appropriately broad, complementing the more specific prefoldin complex (GO:0016272) annotation. The IBA phylogenetic inference is sound (PMID:9630229, PMID:32699605).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link">
                                         PMID:32699605
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">As a cytoplasmic chaperone protein, the prefoldin complex is a hybrid oligomer assembled from six different proteins (six subunits).</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007017" target="_blank" class="term-link">
                                     GO:0007017
                                 </a>
                             </span>
                             <span class="term-label">microtubule-based process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P61758" data-a="GO:0007017" data-r="GO_REF:0000033" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P61758" data-a="GO:0007017" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0007017 &#34;microtubule-based process&#34; is a well-supported biological process annotation for VBP1. This IBA annotation was inferred from phylogenetic analysis (PANTHER) with evidence from Drosophila and Arabidopsis orthologs. The prefoldin complex delivers unfolded tubulin to TRiC/CCT for folding, and loss of prefoldin subunits disrupts microtubule dynamics and cytoskeletal homeostasis (PMID:9630229). Vainberg et al. 1998 showed that &#34;Deletion of the gene encoding a prefoldin subunit in S. cerevisiae results in a phenotype similar to those found when c-cpn is mutated, namely impaired functions of the actin and tubulin-based cytoskeleton.&#34; This is a direct consequence of the prefoldin chaperone function rather than a core process per se, but it is a well-established downstream effect.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Microtubule-based process is a well-established downstream consequence of prefoldin&#39;s role in tubulin folding. The IBA annotation is phylogenetically well-supported, with evidence from yeast genetic studies showing that prefoldin loss impairs tubulin-based cytoskeleton function (PMID:9630229).
+                            <strong>Reason:</strong> Microtubule-based process is a well-established downstream consequence of prefoldin&#39;s role in tubulin folding, but it is not the core process directly executed by VBP1. The more precise core biological process is tubulin complex assembly (GO:0007021); this broader term can be retained as a non-core downstream consequence.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Deletion of the gene encoding a prefoldin subunit in S. cerevisiae results in a phenotype similar to those found when c-cpn is mutated, namely impaired functions of the actin and tubulin-based cytoskeleton.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016272" target="_blank" class="term-link">
                                     GO:0016272
                                 </a>
                             </span>
                             <span class="term-label">prefoldin complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -946,77 +946,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0016272 &#34;prefoldin complex&#34; is an unambiguous and well-supported CC annotation. VBP1 (PFDN3) is one of the two alpha subunits of the heterohexameric prefoldin complex (PMID:9630229, PMID:32699605). This IBA annotation was inferred from phylogenetic analysis with evidence from Drosophila, yeast, and human VBP1 itself. Structural data from cryo-EM (PMID:30955883, PDB: 6NR8, 7WU7) directly shows VBP1 as a structural component of the human prefoldin complex. The complex is also registered in ComplexPortal as CPX-6149 and CPX-25767.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> VBP1 is a core structural alpha subunit of the prefoldin complex. This is the defining complex membership for VBP1. The IBA annotation is phylogenetically well-supported and confirmed by multiple independent experimental studies (PMID:9630229, PMID:30955883, PMID:23614719).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We describe the discovery of a heterohexameric chaperone protein, prefoldin, based on its ability to capture unfolded actin.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Maintaining proteostasis in eukaryotic protein folding involves cooperation of distinct chaperone systems. To understand how the essential ring-shaped chaperonin TRiC/CCT cooperates with the chaperone prefoldin/GIMc (PFD), we integrate cryoelectron microscopy (cryo-EM), crosslinking-mass-spectrometry and biochemical and cellular approaches to elucidate the structural and functional interplay between TRiC/CCT and PFD.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007021" target="_blank" class="term-link">
                                     GO:0007021
                                 </a>
                             </span>
                             <span class="term-label">tubulin complex assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1028,64 +1028,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0007021 &#34;tubulin complex assembly&#34; is supported by the canonical function of the prefoldin complex. This IBA annotation was inferred from phylogenetic analysis with evidence from yeast (SGD:S000003310). The prefoldin complex captures nascent tubulin monomers and delivers them to TRiC/CCT for folding, which is a prerequisite for tubulin heterodimer assembly (PMID:9630229). Vainberg et al. 1998 showed prefoldin promotes tubulin folding, and deletion of prefoldin subunit genes in yeast results in impaired tubulin-based cytoskeleton function. This is a core function of all prefoldin subunits.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Tubulin complex assembly is a direct consequence of the prefoldin complex&#39;s chaperone function in delivering unfolded tubulin to TRiC/CCT. The IBA annotation is phylogenetically well-supported (PMID:9630229).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We describe the discovery of a heterohexameric chaperone protein, prefoldin, based on its ability to capture unfolded actin. Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/VBP1/VBP1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VBP1 encodes the α-type prefoldin subunit 3, a component of the heterohexameric prefoldin cochaperone that captures nascent polypeptides—most prominently actin and tubulin monomers—and delivers them to the TRiC/CCT chaperonin for ATP-dependent folding.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015631" target="_blank" class="term-link">
                                     GO:0015631
                                 </a>
                             </span>
                             <span class="term-label">tubulin binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1097,133 +1108,133 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0015631 &#34;tubulin binding&#34; reflects the canonical substrate specificity of the prefoldin complex. This IBA annotation was inferred from phylogenetic analysis with evidence from Drosophila and yeast. The prefoldin complex binds unfolded tubulin monomers and delivers them to TRiC/CCT (PMID:9630229). However, tubulin binding is a consequence of the broader protein folding chaperone function, and the prefoldin complex also binds actin and other substrates including VHL. The annotation is correct but represents a substrate specificity rather than a mechanistic function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Tubulin binding is a well-established substrate specificity of the prefoldin complex. The IBA annotation is phylogenetically well-supported and consistent with the seminal characterization of prefoldin (PMID:9630229). While somewhat reductionist (prefoldin also binds actin and other substrates), tubulin is one of the primary substrates and this annotation captures an important specificity.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Deletion of the gene encoding a prefoldin subunit in S. cerevisiae results in a phenotype similar to those found when c-cpn is mutated, namely impaired functions of the actin and tubulin-based cytoskeleton.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P61758" data-a="GO:0005634" data-r="GO_REF:0000044" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P61758" data-a="GO:0005634" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> GO:0005634 &#34;nucleus&#34; was inferred electronically from the UniProt subcellular location annotation for VBP1. The UniProt record states &#34;Cytoplasm. Nucleus. Note=In complex with VHL can translocate to the nucleus.&#34; Nuclear localization of VBP1/prefoldin has been confirmed by multiple studies showing that prefoldin subunits localize to transcribed chromatin and modulate RNA Pol II CTD phosphorylation and co-transcriptional splicing (Payan-Bravo et al. 2021, PMID:32699605). VBP1 can also translocate to the nucleus in complex with VHL (PMID:8674032). This annotation is consistent with known biology.
+                            <strong>Summary:</strong> GO:0005634 &#34;nucleus&#34; was inferred electronically from the UniProt subcellular location annotation for VBP1. The UniProt record states &#34;Cytoplasm. Nucleus. Note=In complex with VHL can translocate to the nucleus.&#34; The cached direct support is the original VBP1/VHL paper, which reports cytoplasmic localization when VBP1 is expressed alone and VHL-dependent nuclear translocation (PMID:8674032). This is a context-dependent localization, not the primary site of VBP1 prefoldin chaperone activity.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Nuclear localization of VBP1 is supported by both the VHL-dependent nuclear translocation described in the original VBP1 discovery paper (PMID:8674032) and the nuclear functions of prefoldin in transcription/splicing regulation described in recent studies (PMID:32699605). The IEA annotation is accurate.
+                            <strong>Reason:</strong> VBP1 can translocate to the nucleus in complex with VHL, but its core role is as a cytosolic prefoldin subunit delivering actin/tubulin substrates to TRiC/CCT. Keep the nuclear localization as a non-core, context-dependent localization.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link">
-                                        PMID:32699605
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8674032" target="_blank" class="term-link">
+                                        PMID:8674032
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">The prefoldin complex helps protein fold correctly and prevents aggregation by providing class II chaperones (Hsp60 molecular chaperones found in archaebacteria and eukaryotic cytoplasm) with a linear, unnatural substrate in the cytoplasm</div>
-                                
+
+                                <div class="support-text">When the VBP-1 protein was solely expressed, it located to the cytoplasm and did not localize to the nucleus. However, when coexpressed with VHL, it can translocate to the nucleus.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1235,46 +1246,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005737 &#34;cytoplasm&#34; was inferred electronically by the combined automated annotation pipeline. This is consistent with the IBA annotation to the same term and the well-established cytoplasmic localization of the prefoldin complex (PMID:9630229, PMID:32699605).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasm is the primary site of prefoldin chaperone activity. This IEA annotation is consistent with higher-confidence IBA and TAS annotations to the same term.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1286,46 +1297,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0006457 &#34;protein folding&#34; was inferred electronically from InterPro domain mapping (IPR016655, the PFD3/prefoldin subunit 3 domain). This IEA annotation is consistent with IDA and NAS annotations to the same term, and with the well-established role of the prefoldin complex in protein folding (PMID:9630229, PMID:30955883).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The IEA annotation to protein folding via InterPro is correct and consistent with higher-confidence IDA and NAS annotations. The PFD3 domain (IPR016655) is specifically associated with the protein folding function of the prefoldin complex (PMID:9630229, PMID:30955883).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016272" target="_blank" class="term-link">
                                     GO:0016272
                                 </a>
                             </span>
                             <span class="term-label">prefoldin complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1337,46 +1348,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0016272 &#34;prefoldin complex&#34; was inferred electronically from InterPro domain mapping (IPR016655, the PFD3 domain). VBP1 (PFDN3) is one of the two alpha subunits of the heterohexameric prefoldin complex (PMID:9630229, PMID:32699605). This IEA annotation is consistent with IBA and IDA annotations to the same term from PMID:30955883 and PMID:23614719.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> VBP1 is a core structural subunit of the prefoldin complex. The IEA mapping from the PFD3 domain (IPR016655) to prefoldin complex membership is appropriate and consistent with experimental evidence (PMID:9630229, PMID:30955883).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
                                     GO:0032991
                                 </a>
                             </span>
                             <span class="term-label">protein-containing complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1388,57 +1399,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0032991 &#34;protein-containing complex&#34; was inferred electronically by the ARBA machine learning model (ARBA:ARBA00028902). While technically correct -- VBP1 is part of the prefoldin complex, which is a protein-containing complex -- this annotation is redundant and overly general given the more specific GO:0016272 &#34;prefoldin complex&#34; annotation that is already present from IBA, IEA, and IDA evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is an overly general annotation. VBP1 is part of the prefoldin complex (GO:0016272), which is a child term of protein-containing complex. The more specific term is already annotated with IBA, IEA, and IDA evidence. The generic &#34;protein-containing complex&#34; adds no useful information.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17698809" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17698809
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     von Hippel Lindau binding protein 1-mediated degradation of ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1450,57 +1461,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:P35963/HIV-1 gag-pol polyprotein) from an IntAct interaction study (PMID:17698809). This interaction between VBP1 and the HIV-1 gag-pol polyprotein was detected in a protein interaction screen. While viral proteins may interact with prefoldin subunits (consistent with the known nuclear role of prefoldin in HIV integrase ubiquitination), &#34;protein binding&#34; is an uninformative GO term that does not describe any specific molecular function.
+                            <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:P35963/HIV-1 gag-pol polyprotein) from an IntAct interaction study (PMID:17698809). This interaction between VBP1 and the HIV-1 integrase/gag-pol context reflects a focused mechanism in which VBP1 bridges HIV-1 integrase to the Cul2/VHL ubiquitin ligase for degradation. This viral integrase/VHL-proteasome context is not the core prefoldin function, and &#34;protein binding&#34; is an uninformative GO term that does not describe a specific molecular function.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. The interaction with HIV-1 gag-pol is from a high-throughput screen and the term provides no functional insight. The core molecular function of VBP1 is better captured by GO:0044183 &#34;protein folding chaperone.&#34;
+                            <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. The cited paper describes a non-core viral integrase/VHL/Cul2 degradation mechanism rather than a generic high-throughput hit or the core prefoldin chaperone function. The core molecular function of VBP1 is better captured by GO:0044183 &#34;protein folding chaperone.&#34;
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22190034" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22190034
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Global landscape of HIV-human protein complexes.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1512,57 +1523,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:Q9Q2G4/viral ORF) from Jager et al. 2012 (PMID:22190034), a study mapping the global landscape of HIV-human protein complexes. The interaction between VBP1 and a viral protein was identified in this high-throughput study. &#34;Protein binding&#34; is an uninformative GO term.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. This high-throughput HIV-host interactome screen detection does not provide functional insight for VBP1. The core molecular function is already captured by more specific terms.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25416956
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A proteome-scale map of the human interactome network.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1574,57 +1585,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:Q8ND90/PNMA1, Q96S82/UBL7, Q9NQP4/PFDN4) from Rolland et al. 2014 (PMID:25416956), a proteome-scale map of the human interactome network. The interaction with PFDN4 reflects intra-complex interactions expected for prefoldin subunits. The interactions with PNMA1 and UBL7 are from a large-scale Y2H screen. &#34;Protein binding&#34; is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. The VBP1-PFDN4 interaction reflects co-membership in the prefoldin complex (already captured by GO:0016272). The other interactions are from high-throughput screens and do not provide functional insight.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28514442
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Architecture of the human interactome defines protein commun...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1636,57 +1647,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:Q96S82/UBL7, Q99471/PFDN5, Q9NQP4/PFDN4, Q9UHV9/PFDN2) from Huttlin et al. 2017 (PMID:28514442), the BioPlex human interactome study. The interactions with PFDN2, PFDN4, and PFDN5 are expected intra-complex interactions since all are subunits of the prefoldin hexamer. The UBL7 interaction is from a large-scale screen. &#34;Protein binding&#34; is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. The interactions with PFDN2, PFDN4, and PFDN5 reflect co-membership in the prefoldin complex, already captured by GO:0016272. High-throughput interactome data does not add functional insight beyond complex membership.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32296183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A reference map of the human binary protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1698,57 +1709,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with many partners including PFDN2, PFDN4, PFDN5, and numerous other proteins) from Luck et al. 2020 (PMID:32296183), a reference map of the human binary protein interactome (HuRI). This study detected numerous interactions for VBP1 in a large-scale Y2H screen. The prefoldin subunit interactions are expected. The many other interactions (with transcription factors, kinases, etc.) may reflect the broad substrate recognition capacity of prefoldin or may be false positives in a high-throughput screen. &#34;Protein binding&#34; is uninformative in all cases.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. This is a large-scale interactome study with many detected partners. The prefoldin subunit interactions are already captured by GO:0016272. The non-prefoldin interactions do not provide functional insight and the generic GO term adds no value.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32814053
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interactome Mapping Provides a Network of Neurodegenerative ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1760,57 +1771,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with multiple partners including PFDN2 and various other proteins) from Metzger et al. 2020 (PMID:32814053), an interactome mapping study of neurodegenerative disease proteins. The interaction with PFDN2 is expected as both are prefoldin subunits. The other interactions are from a high-throughput screen focused on neurodegeneration-related proteins. &#34;Protein binding&#34; is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. The PFDN2 interaction reflects prefoldin complex membership (GO:0016272). The other high-throughput interactions do not provide functional insight. The core molecular function is already captured by more specific terms.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1822,57 +1833,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:Q96S82/UBL7, Q99471/PFDN5, Q9NQP4/PFDN4, Q9UHV9/PFDN2) from Huttlin et al. 2021 (PMID:33961781), a dual proteome-scale network study. This confirms previously observed interactions: the intra-prefoldin subunit interactions (PFDN2, PFDN4, PFDN5) and UBL7. &#34;Protein binding&#34; remains uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. These are replications of previously observed interactions (intra-prefoldin complex; UBL7) that do not add functional insight beyond what is captured by GO:0016272 (prefoldin complex).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:40205054
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Multimodal cell maps as a foundation for structural and func...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1884,46 +1895,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:Q9NQP4/PFDN4 and Q9UHV9/PFDN2) from multimodal cell maps study (PMID:40205054). This is yet another replication of VBP1-PFDN2 and VBP1-PFDN4 intra-complex interactions. &#34;Protein binding&#34; is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. This is a further replication of known intra-prefoldin complex interactions from a large-scale study. The relevant functions are already captured by GO:0016272 (prefoldin complex).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1935,75 +1946,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005829 &#34;cytosol&#34; was annotated by the Human Protein Atlas (HPA) based on curation of immunofluorescence data (GO_REF:0000052). The prefoldin complex operates primarily in the cytosol to capture unfolded nascent polypeptides and deliver them to TRiC/CCT (PMID:9630229). This is a more specific subcellular localization than &#34;cytoplasm&#34; (GO:0005737) and is consistent with the known biology. Cytosol is a child of cytoplasm.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol localization is well-supported by the known biology of the prefoldin complex operating in the cytosol to deliver substrates to TRiC/CCT. The HPA immunofluorescence data provides direct evidence. This is a more specific and informative term than the broader &#34;cytoplasm&#34; annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32699605
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The functions and mechanisms of prefoldin complex and prefol...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2015,75 +2026,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0006457 &#34;protein folding&#34; (NAS) from ComplexPortal, citing Liang et al. 2020 (PMID:32699605), a comprehensive review of prefoldin complex functions. The review describes how &#34;the prefoldin complex helps protein fold correctly and prevents aggregation by providing class II chaperones ... with a linear, unnatural substrate in the cytoplasm.&#34; This NAS annotation is consistent with IBA and IDA annotations to the same term and is well-supported.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein folding is the core biological process for VBP1. This NAS annotation from ComplexPortal cites a well-sourced review (PMID:32699605) that accurately describes the protein folding function of the prefoldin complex. Consistent with IDA evidence from PMID:30955883.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link">
                                         PMID:32699605
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The prefoldin complex helps protein fold correctly and prevents aggregation by providing class II chaperones (Hsp60 molecular chaperones found in archaebacteria and eukaryotic cytoplasm) with a linear, unnatural substrate in the cytoplasm [2]</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/34761191" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:34761191
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A comprehensive analysis of prefoldins and their implication...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2095,75 +2106,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0006457 &#34;protein folding&#34; (NAS) from ComplexPortal, citing Herranz-Montoya et al. 2021 (PMID:34761191), a comprehensive analysis of prefoldins and their implication in cancer. The review describes prefoldins as &#34;evolutionary conserved co-chaperones&#34; that &#34;act as co-chaperones escorting misfolded or non-native proteins to group II chaperonins.&#34; This NAS annotation is consistent with IDA and IBA annotations to the same term.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Protein folding is the core biological process for VBP1. This NAS annotation from ComplexPortal cites a comprehensive review (PMID:34761191) that accurately describes the co-chaperone function of prefoldin subunits. Consistent with IDA evidence from PMID:30955883.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/34761191" target="_blank" class="term-link">
                                         PMID:34761191
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFDNs are prevalently organized into hetero-hexameric complexes. Although they have been overlooked since their discovery and their functions remain elusive, several reports indicate they act as co-chaperones escorting misfolded or non-native proteins to group II chaperonins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                     GO:0050821
                                 </a>
                             </span>
                             <span class="term-label">protein stabilization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/34761191" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:34761191
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A comprehensive analysis of prefoldins and their implication...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2175,75 +2186,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0050821 &#34;protein stabilization&#34; (NAS) from ComplexPortal, citing Herranz-Montoya et al. 2021 (PMID:34761191). The GO definition of protein stabilization is &#34;Any process involved in maintaining the structure and integrity of a protein and preventing it from degradation or aggregation.&#34; Prefoldin does prevent aggregation of unfolded substrates by capturing them and delivering them to TRiC/CCT (PMID:9630229). For VBP1 specifically, there is additional evidence that prefoldin/VBP1 prevents pVHL aggregation and supports its maturation (deep research: Le Goff et al. 2016, Tahmaz et al. 2022). However, &#34;protein stabilization&#34; typically implies maintaining a folded protein in its native state, whereas prefoldin acts primarily on unfolded nascent polypeptides as a holdase. The term is not entirely wrong but mischaracterizes the primary chaperone activity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While prefoldin does prevent protein aggregation (which is part of the GO definition of protein stabilization), and VBP1/prefoldin specifically helps prevent pVHL aggregation, the primary function is to capture unfolded substrates and transfer them to TRiC/CCT for folding. &#34;Protein stabilization&#34; represents a secondary aspect rather than the core activity. The core process (protein folding, GO:0006457) is already well-annotated.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/34761191" target="_blank" class="term-link">
                                         PMID:34761191
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFDNs are prevalently organized into hetero-hexameric complexes. Although they have been overlooked since their discovery and their functions remain elusive, several reports indicate they act as co-chaperones escorting misfolded or non-native proteins to group II chaperonins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30955883
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Chaperonin TRiC/CCT Associates with Prefoldin through a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2255,88 +2266,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0006457 &#34;protein folding&#34; (IDA) from Gestaut et al. 2019 (PMID:30955883), which used cryo-EM, crosslinking mass spectrometry, and biochemical reconstitution to characterize the structural and functional interplay between the prefoldin (PFD) complex and TRiC/CCT chaperonin. The study demonstrates that &#34;PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles,&#34; directly showing involvement in protein folding. This is the highest-quality direct experimental evidence for the protein folding function of the prefoldin complex including VBP1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This IDA annotation is supported by strong direct experimental evidence from Gestaut et al. 2019 (PMID:30955883), which demonstrated through cryo-EM and biochemical approaches that the PFD-TRiC supra-chaperone assembly enhances protein folding rates. Protein folding is the core biological process for VBP1.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The supra-chaperone assembly formed by PFD and TRiC is essential to prevent toxic conformations and ensure effective cellular proteostasis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016272" target="_blank" class="term-link">
                                     GO:0016272
                                 </a>
                             </span>
                             <span class="term-label">prefoldin complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30955883
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Chaperonin TRiC/CCT Associates with Prefoldin through a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2348,75 +2359,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0016272 &#34;prefoldin complex&#34; (IDA) from Gestaut et al. 2019 (PMID:30955883). This study used reconstituted human prefoldin complex containing all six subunits including VBP1/PFDN3 and characterized its structure through cryo-EM and crosslinking mass spectrometry. The study resolved the architecture of the PFD-TRiC supra-chaperone complex, directly demonstrating that VBP1 is a component of the prefoldin complex. The cryo-EM structures (PDB: 6NR8, 6NR9, 6NRB, 6NRC, 6NRD) include VBP1 as chain 3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> VBP1 is a core structural alpha subunit of the prefoldin complex. This IDA annotation is supported by high-resolution cryo-EM structural data from Gestaut et al. 2019 (PMID:30955883) that directly demonstrates VBP1 as a component of the human prefoldin complex.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Maintaining proteostasis in eukaryotic protein folding involves cooperation of distinct chaperone systems. To understand how the essential ring-shaped chaperonin TRiC/CCT cooperates with the chaperone prefoldin/GIMc (PFD), we integrate cryoelectron microscopy (cryo-EM), crosslinking-mass-spectrometry and biochemical and cellular approaches to elucidate the structural and functional interplay between TRiC/CCT and PFD.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30955883
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Chaperonin TRiC/CCT Associates with Prefoldin through a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -2428,112 +2439,112 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0051082 &#34;unfolded protein binding&#34; is being obsoleted (go-ontology#30962). This IDA annotation cites Gestaut et al. 2019 (PMID:30955883), which demonstrated that prefoldin associates with TRiC through a conserved electrostatic interface and undergoes conformational cycling between &#34;latched&#34; (open) and &#34;engaged&#34; (closed) states during substrate transfer. The paper shows that PFD functions not merely as a passive binder of unfolded substrates but as an active co-chaperone that enhances folding rates. GO:0044183 &#34;protein folding chaperone&#34; (defined as &#34;Binding to a protein or a protein-containing complex to assist the protein folding process&#34;) is the appropriate replacement, capturing the functional holdase/transfer chaperone role.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is being obsoleted. Gestaut et al. 2019 (PMID:30955883) demonstrates that prefoldin functions as a co-chaperone/holdase that cooperates with TRiC/CCT in substrate folding, not merely as an unfolded protein binder. GO:0044183 &#34;protein folding chaperone&#34; accurately describes the co-chaperone activity of VBP1 as part of the prefoldin complex.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Disrupting the TRiC-PFD interaction in vivo is strongly deleterious, leading to accumulation of amyloid aggregates.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it. ... prefoldin promotes folding in an environment in which there are many competing pathways for nonnative proteins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001540" target="_blank" class="term-link">
                                     GO:0001540
                                 </a>
                             </span>
                             <span class="term-label">amyloid-beta binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23614719
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human prefoldin inhibits amyloid-β (Aβ) fibrillation and con...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2545,75 +2556,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0001540 &#34;amyloid-beta binding&#34; (IDA) from Sorgjerd et al. 2013 (PMID:23614719). This study demonstrated that recombinant human prefoldin (hPFD) inhibits amyloid-beta (Abeta 1-42) fibrillation in vitro and induces formation of soluble Abeta oligomers with reduced toxicity. Thioflavin T measurements and immunoblotting showed that hPFD directly interacts with Abeta peptides. While this demonstrates that the prefoldin complex can bind Abeta, this is not the core function of VBP1 -- it reflects the general chaperone/holdase property of prefoldin applied to an amyloidogenic substrate. The annotation was made on the intact prefoldin complex, not VBP1 individually.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Amyloid-beta binding is a secondary, non-core function that reflects the general holdase/chaperone activity of the prefoldin complex applied to an amyloidogenic substrate. The study (PMID:23614719) used the intact hexameric complex rather than individual VBP1. While the data are solid, this represents a peripheral function compared to the core role in actin/tubulin folding via TRiC/CCT delivery.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                                         PMID:23614719
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we investigated the effect of recombinant human PFD (hPFD) on Abeta(1-42) aggregation in vitro and found that hPFD inhibited Abeta fibrillation and induced formation of soluble Abeta oligomers.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016272" target="_blank" class="term-link">
                                     GO:0016272
                                 </a>
                             </span>
                             <span class="term-label">prefoldin complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23614719
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human prefoldin inhibits amyloid-β (Aβ) fibrillation and con...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2625,75 +2636,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0016272 &#34;prefoldin complex&#34; (IDA) from Sorgjerd et al. 2013 (PMID:23614719). This study expressed and purified recombinant human prefoldin complex (hPFD) containing all six subunits including VBP1/PFDN3 to investigate its effect on amyloid-beta aggregation. The successful reconstitution and purification of the hexameric complex provides direct evidence for VBP1 membership in the prefoldin complex. Consistent with IDA from PMID:30955883 and IBA/IEA annotations.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> VBP1 is a core structural alpha subunit of the prefoldin complex. This IDA annotation from PMID:23614719 provides independent experimental evidence through reconstitution of the human prefoldin hexamer, consistent with the structural data from PMID:30955883.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                                         PMID:23614719
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Prefoldin (PFD) is a molecular chaperone that prevents aggregation of misfolded proteins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905907" target="_blank" class="term-link">
                                     GO:1905907
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of amyloid fibril formation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23614719
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human prefoldin inhibits amyloid-β (Aβ) fibrillation and con...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2705,88 +2716,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:1905907 &#34;negative regulation of amyloid fibril formation&#34; (IDA) from Sorgjerd et al. 2013 (PMID:23614719). The study demonstrated that recombinant human prefoldin &#34;inhibited Abeta fibrillation and induced formation of soluble Abeta oligomers&#34; that were 30-40% less toxic than Abeta fibrils. Thioflavin T measurements confirmed reduced fibril formation. While the experimental evidence is sound, this represents a non-core function of the prefoldin complex -- an extension of its general holdase/chaperone properties to amyloidogenic substrates. The study was performed on the intact hexameric complex, not VBP1 individually.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The experimental evidence from PMID:23614719 is solid, but this is a secondary function reflecting the general anti-aggregation properties of the prefoldin complex rather than its core role in delivering unfolded actin/tubulin to TRiC/CCT. The study was performed in vitro on the intact hexameric complex, and the relevance to VBP1 specifically (as opposed to the complex as a whole) is indirect.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                                         PMID:23614719
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we investigated the effect of recombinant human PFD (hPFD) on Abeta(1-42) aggregation in vitro and found that hPFD inhibited Abeta fibrillation and induced formation of soluble Abeta oligomers.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                                         PMID:23614719
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Our findings show a relation between cytotoxicity of Abeta oligomers and structure and suggest a possible protective role of PFD in AD.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/8674032" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:8674032
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification of a novel protein (VBP-1) binding to the von...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2798,57 +2809,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0005737 &#34;cytoplasm&#34; (TAS) from Tsuchiya et al. 1996 (PMID:8674032), the original paper that identified VBP1 as a protein binding to the VHL tumor suppressor. This study characterized VBP1 and showed its cytoplasmic localization, with the note that in complex with VHL it can translocate to the nucleus. This is the foundational localization study for VBP1 and is consistent with the IBA and IEA annotations to the same term.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization of VBP1 is well-established from the original discovery paper (PMID:8674032) and is consistent with the known biology of the prefoldin complex operating in the cytoplasm (PMID:9630229). This TAS annotation is appropriate and well-supported.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     GO:0044183
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30955883
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Chaperonin TRiC/CCT Associates with Prefoldin through a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-new">
@@ -2860,63 +2871,63 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> GO:0044183 &#34;protein folding chaperone&#34; is the most appropriate molecular function term for VBP1. Unlike PFDN1, VBP1 lacks an IBA annotation to this term. Gestaut et al. 2019 (PMID:30955883) demonstrated through cryo-EM and biochemical reconstitution that the prefoldin complex (containing VBP1) functions as a co-chaperone that delivers unfolded substrates to TRiC/CCT and enhances the rate and yield of folding. Vainberg et al. 1998 (PMID:9630229) originally characterized prefoldin as &#34;a chaperone that delivers unfolded proteins to cytosolic chaperonin.&#34; The GO:0044183 definition (&#34;Binding to a protein or a protein-containing complex to assist the protein folding process&#34;) precisely captures the holdase/transfer chaperone function of VBP1 within the prefoldin complex. This is also the recommended replacement for the obsoleting GO:0051082.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0044183 &#34;protein folding chaperone&#34; is the core molecular function of VBP1 as part of the prefoldin complex. This term is missing from the current annotation set (unlike PFDN1 which has it via IBA). The evidence from PMID:30955883 and PMID:9630229 directly supports this annotation. This is also the recommended replacement for GO:0051082 &#34;unfolded protein binding&#34; which is being obsoleted.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                         PMID:30955883
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                         PMID:9630229
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We describe the discovery of a heterohexameric chaperone protein, prefoldin, based on its ability to capture unfolded actin. Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>VBP1 (PFDN3) is an alpha-type subunit of the heterohexameric prefoldin co-chaperone complex that captures unfolded nascent polypeptides (primarily actin and tubulin) and delivers them to the TRiC/CCT chaperonin for ATP-dependent folding. As one of the two alpha subunits (with PFDN5), VBP1 forms the longer coiled-coil tentacles of the jellyfish-shaped prefoldin architecture. Cryo-EM structural data show VBP1 as chain 3 in the PFD-TRiC supra-chaperone complex. The prefoldin-TRiC interaction enhances protein folding rates and suppresses non-productive reaction cycles. Disrupting this interaction in vivo leads to accumulation of toxic amyloid aggregates.</h3>
                 <span class="vote-buttons" data-g="P61758" data-a="FUNCTION: VBP1 (PFDN3) is an alpha-type subunit of the heter..." data-r="" data-act="CORE_FUNCTION">
@@ -2924,10 +2935,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -2936,51 +2947,45 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                 protein folding
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007021" target="_blank" class="term-link">
                                 tubulin complex assembly
                             </a>
                         </span>
-                        
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007017" target="_blank" class="term-link">
-                                microtubule-based process
-                            </a>
-                        </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">In Complex:</div>
                     <span class="badge">
@@ -2989,407 +2994,430 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                 PMID:9630229
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">We describe the discovery of a heterohexameric chaperone protein, prefoldin, based on its ability to capture unfolded actin. Prefoldin binds specifically to cytosolic chaperonin (c-cpn) and transfers target proteins to it.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                                 PMID:30955883
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">PFD can act after TRiC bound its substrates to enhance the rate and yield of the folding reaction, suppressing non-productive reaction cycles.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                                 PMID:9630229
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">Deletion of the gene encoding a prefoldin subunit in S. cerevisiae results in a phenotype similar to those found when c-cpn is mutated, namely impaired functions of the actin and tubulin-based cytoskeleton.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
                             GO_REF:0000052
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/8674032" target="_blank" class="term-link">
                             PMID:8674032
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Identification of a novel protein (VBP-1) binding to the von Hippel-Lindau (VHL) tumor suppressor gene product.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9630229" target="_blank" class="term-link">
                             PMID:9630229
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Prefoldin, a chaperone that delivers unfolded proteins to cytosolic chaperonin.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17698809" target="_blank" class="term-link">
                             PMID:17698809
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">von Hippel Lindau binding protein 1-mediated degradation of integrase affects HIV-1 gene expression at a postintegration step.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22190034" target="_blank" class="term-link">
                             PMID:22190034
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Global landscape of HIV-human protein complexes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23614719" target="_blank" class="term-link">
                             PMID:23614719
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Human prefoldin inhibits amyloid-β (Aβ) fibrillation and contributes to formation of nontoxic Aβ aggregates.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
                             PMID:25416956
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A proteome-scale map of the human interactome network.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
                             PMID:28514442
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/30955883" target="_blank" class="term-link">
                             PMID:30955883
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The Chaperonin TRiC/CCT Associates with Prefoldin through a Conserved Electrostatic Interface Essential for Cellular Proteostasis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                             PMID:32296183
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A reference map of the human binary protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32699605" target="_blank" class="term-link">
                             PMID:32699605
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The functions and mechanisms of prefoldin complex and prefoldin-subunits.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
                             PMID:32814053
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/34761191" target="_blank" class="term-link">
                             PMID:34761191
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A comprehensive analysis of prefoldins and their implication in cancer.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
                             PMID:40205054
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
-                
-                
+
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/VBP1/VBP1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research for human VBP1</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Falcon synthesis supports VBP1/PFDN3 as an alpha-type prefoldin subunit in the cytosolic prefoldin-TRiC/CCT chaperone pathway, with additional nuclear and pVHL-linked functions treated as non-core context.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -3692,9 +3720,9 @@ VBP1 encodes the α-type prefoldin subunit 3, a component of the heterohexameric
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -3706,7 +3734,7 @@ VBP1 encodes the α-type prefoldin subunit 3, a component of the heterohexameric
                 <pre><code>id: P61758
 gene_symbol: VBP1
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -3784,12 +3812,13 @@ existing_annotations:
       tubulin-based cytoskeleton.&#34; This is a direct consequence of the prefoldin
       chaperone function rather than a core process per se, but it is a well-established
       downstream effect.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
       Microtubule-based process is a well-established downstream consequence of
-      prefoldin&#39;s role in tubulin folding. The IBA annotation is phylogenetically
-      well-supported, with evidence from yeast genetic studies showing that prefoldin
-      loss impairs tubulin-based cytoskeleton function (PMID:9630229).
+      prefoldin&#39;s role in tubulin folding, but it is not the core process directly
+      executed by VBP1. The more precise core biological process is tubulin complex
+      assembly (GO:0007021); this broader term can be retained as a non-core
+      downstream consequence.
     supported_by:
     - reference_id: PMID:9630229
       supporting_text: &gt;-
@@ -3855,6 +3884,12 @@ existing_annotations:
         We describe the discovery of a heterohexameric chaperone protein, prefoldin,
         based on its ability to capture unfolded actin. Prefoldin binds specifically
         to cytosolic chaperonin (c-cpn) and transfers target proteins to it.
+    - reference_id: file:human/VBP1/VBP1-deep-research-falcon.md
+      supporting_text: &gt;-
+        VBP1 encodes the α-type prefoldin subunit 3, a component of the
+        heterohexameric prefoldin cochaperone that captures nascent
+        polypeptides—most prominently actin and tubulin monomers—and delivers
+        them to the TRiC/CCT chaperonin for ATP-dependent folding.
 - term:
     id: GO:0015631
     label: tubulin binding
@@ -3895,25 +3930,22 @@ existing_annotations:
     summary: &gt;-
       GO:0005634 &#34;nucleus&#34; was inferred electronically from the UniProt subcellular
       location annotation for VBP1. The UniProt record states &#34;Cytoplasm. Nucleus.
-      Note=In complex with VHL can translocate to the nucleus.&#34; Nuclear localization
-      of VBP1/prefoldin has been confirmed by multiple studies showing that prefoldin
-      subunits localize to transcribed chromatin and modulate RNA Pol II CTD
-      phosphorylation and co-transcriptional splicing (Payan-Bravo et al. 2021,
-      PMID:32699605). VBP1 can also translocate to the nucleus in complex with VHL
-      (PMID:8674032). This annotation is consistent with known biology.
-    action: ACCEPT
+      Note=In complex with VHL can translocate to the nucleus.&#34; The cached direct
+      support is the original VBP1/VHL paper, which reports cytoplasmic localization
+      when VBP1 is expressed alone and VHL-dependent nuclear translocation
+      (PMID:8674032). This is a context-dependent localization, not the primary site
+      of VBP1 prefoldin chaperone activity.
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Nuclear localization of VBP1 is supported by both the VHL-dependent nuclear
-      translocation described in the original VBP1 discovery paper (PMID:8674032) and
-      the nuclear functions of prefoldin in transcription/splicing regulation described
-      in recent studies (PMID:32699605). The IEA annotation is accurate.
+      VBP1 can translocate to the nucleus in complex with VHL, but its core role is
+      as a cytosolic prefoldin subunit delivering actin/tubulin substrates to TRiC/CCT.
+      Keep the nuclear localization as a non-core, context-dependent localization.
     supported_by:
-    - reference_id: PMID:32699605
+    - reference_id: PMID:8674032
       supporting_text: &gt;-
-        The prefoldin complex helps protein fold correctly and prevents aggregation
-        by providing class II chaperones (Hsp60 molecular chaperones found in
-        archaebacteria and eukaryotic cytoplasm) with a linear, unnatural substrate
-        in the cytoplasm
+        When the VBP-1 protein was solely expressed, it located to the cytoplasm
+        and did not localize to the nucleus. However, when coexpressed with VHL,
+        it can translocate to the nucleus.
 - term:
     id: GO:0005737
     label: cytoplasm
@@ -3996,16 +4028,17 @@ existing_annotations:
     summary: &gt;-
       GO:0005515 &#34;protein binding&#34; (IPI with UniProtKB:P35963/HIV-1 gag-pol polyprotein)
       from an IntAct interaction study (PMID:17698809). This interaction between VBP1
-      and the HIV-1 gag-pol polyprotein was detected in a protein interaction screen.
-      While viral proteins may interact with prefoldin subunits (consistent with the
-      known nuclear role of prefoldin in HIV integrase ubiquitination), &#34;protein binding&#34;
-      is an uninformative GO term that does not describe any specific molecular function.
+      and the HIV-1 integrase/gag-pol context reflects a focused mechanism in which
+      VBP1 bridges HIV-1 integrase to the Cul2/VHL ubiquitin ligase for degradation.
+      This viral integrase/VHL-proteasome context is not the core prefoldin function,
+      and &#34;protein binding&#34; is an uninformative GO term that does not describe a
+      specific molecular function.
     action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      &#34;Protein binding&#34; is uninformative. The interaction with HIV-1 gag-pol is from
-      a high-throughput screen and the term provides no functional insight. The core
-      molecular function of VBP1 is better captured by GO:0044183 &#34;protein folding
-      chaperone.&#34;
+      &#34;Protein binding&#34; is uninformative. The cited paper describes a non-core viral
+      integrase/VHL/Cul2 degradation mechanism rather than a generic high-throughput
+      hit or the core prefoldin chaperone function. The core molecular function of
+      VBP1 is better captured by GO:0044183 &#34;protein folding chaperone.&#34;
 - term:
     id: GO:0005515
     label: protein binding
@@ -4526,8 +4559,6 @@ core_functions:
       label: protein folding
     - id: GO:0007021
       label: tubulin complex assembly
-    - id: GO:0007017
-      label: microtubule-based process
   locations:
     - id: GO:0005829
       label: cytosol
@@ -4620,13 +4651,20 @@ references:
 - id: PMID:40205054
   title: Multimodal cell maps as a foundation for structural and functional genomics.
   findings: []
+- id: file:human/VBP1/VBP1-deep-research-falcon.md
+  title: Falcon deep research for human VBP1
+  findings:
+    - statement: &gt;-
+        Falcon synthesis supports VBP1/PFDN3 as an alpha-type prefoldin subunit
+        in the cytosolic prefoldin-TRiC/CCT chaperone pathway, with additional
+        nuclear and pVHL-linked functions treated as non-core context.
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/VBP1/VBP1-ai-review.yaml
+++ b/genes/human/VBP1/VBP1-ai-review.yaml
@@ -1,7 +1,7 @@
 id: P61758
 gene_symbol: VBP1
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -79,12 +79,13 @@ existing_annotations:
       tubulin-based cytoskeleton." This is a direct consequence of the prefoldin
       chaperone function rather than a core process per se, but it is a well-established
       downstream effect.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
       Microtubule-based process is a well-established downstream consequence of
-      prefoldin's role in tubulin folding. The IBA annotation is phylogenetically
-      well-supported, with evidence from yeast genetic studies showing that prefoldin
-      loss impairs tubulin-based cytoskeleton function (PMID:9630229).
+      prefoldin's role in tubulin folding, but it is not the core process directly
+      executed by VBP1. The more precise core biological process is tubulin complex
+      assembly (GO:0007021); this broader term can be retained as a non-core
+      downstream consequence.
     supported_by:
     - reference_id: PMID:9630229
       supporting_text: >-
@@ -150,6 +151,12 @@ existing_annotations:
         We describe the discovery of a heterohexameric chaperone protein, prefoldin,
         based on its ability to capture unfolded actin. Prefoldin binds specifically
         to cytosolic chaperonin (c-cpn) and transfers target proteins to it.
+    - reference_id: file:human/VBP1/VBP1-deep-research-falcon.md
+      supporting_text: >-
+        VBP1 encodes the α-type prefoldin subunit 3, a component of the
+        heterohexameric prefoldin cochaperone that captures nascent
+        polypeptides—most prominently actin and tubulin monomers—and delivers
+        them to the TRiC/CCT chaperonin for ATP-dependent folding.
 - term:
     id: GO:0015631
     label: tubulin binding
@@ -190,25 +197,22 @@ existing_annotations:
     summary: >-
       GO:0005634 "nucleus" was inferred electronically from the UniProt subcellular
       location annotation for VBP1. The UniProt record states "Cytoplasm. Nucleus.
-      Note=In complex with VHL can translocate to the nucleus." Nuclear localization
-      of VBP1/prefoldin has been confirmed by multiple studies showing that prefoldin
-      subunits localize to transcribed chromatin and modulate RNA Pol II CTD
-      phosphorylation and co-transcriptional splicing (Payan-Bravo et al. 2021,
-      PMID:32699605). VBP1 can also translocate to the nucleus in complex with VHL
-      (PMID:8674032). This annotation is consistent with known biology.
-    action: ACCEPT
+      Note=In complex with VHL can translocate to the nucleus." The cached direct
+      support is the original VBP1/VHL paper, which reports cytoplasmic localization
+      when VBP1 is expressed alone and VHL-dependent nuclear translocation
+      (PMID:8674032). This is a context-dependent localization, not the primary site
+      of VBP1 prefoldin chaperone activity.
+    action: KEEP_AS_NON_CORE
     reason: >-
-      Nuclear localization of VBP1 is supported by both the VHL-dependent nuclear
-      translocation described in the original VBP1 discovery paper (PMID:8674032) and
-      the nuclear functions of prefoldin in transcription/splicing regulation described
-      in recent studies (PMID:32699605). The IEA annotation is accurate.
+      VBP1 can translocate to the nucleus in complex with VHL, but its core role is
+      as a cytosolic prefoldin subunit delivering actin/tubulin substrates to TRiC/CCT.
+      Keep the nuclear localization as a non-core, context-dependent localization.
     supported_by:
-    - reference_id: PMID:32699605
+    - reference_id: PMID:8674032
       supporting_text: >-
-        The prefoldin complex helps protein fold correctly and prevents aggregation
-        by providing class II chaperones (Hsp60 molecular chaperones found in
-        archaebacteria and eukaryotic cytoplasm) with a linear, unnatural substrate
-        in the cytoplasm
+        When the VBP-1 protein was solely expressed, it located to the cytoplasm
+        and did not localize to the nucleus. However, when coexpressed with VHL,
+        it can translocate to the nucleus.
 - term:
     id: GO:0005737
     label: cytoplasm
@@ -291,16 +295,17 @@ existing_annotations:
     summary: >-
       GO:0005515 "protein binding" (IPI with UniProtKB:P35963/HIV-1 gag-pol polyprotein)
       from an IntAct interaction study (PMID:17698809). This interaction between VBP1
-      and the HIV-1 gag-pol polyprotein was detected in a protein interaction screen.
-      While viral proteins may interact with prefoldin subunits (consistent with the
-      known nuclear role of prefoldin in HIV integrase ubiquitination), "protein binding"
-      is an uninformative GO term that does not describe any specific molecular function.
+      and the HIV-1 integrase/gag-pol context reflects a focused mechanism in which
+      VBP1 bridges HIV-1 integrase to the Cul2/VHL ubiquitin ligase for degradation.
+      This viral integrase/VHL-proteasome context is not the core prefoldin function,
+      and "protein binding" is an uninformative GO term that does not describe a
+      specific molecular function.
     action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      "Protein binding" is uninformative. The interaction with HIV-1 gag-pol is from
-      a high-throughput screen and the term provides no functional insight. The core
-      molecular function of VBP1 is better captured by GO:0044183 "protein folding
-      chaperone."
+      "Protein binding" is uninformative. The cited paper describes a non-core viral
+      integrase/VHL/Cul2 degradation mechanism rather than a generic high-throughput
+      hit or the core prefoldin chaperone function. The core molecular function of
+      VBP1 is better captured by GO:0044183 "protein folding chaperone."
 - term:
     id: GO:0005515
     label: protein binding
@@ -821,8 +826,6 @@ core_functions:
       label: protein folding
     - id: GO:0007021
       label: tubulin complex assembly
-    - id: GO:0007017
-      label: microtubule-based process
   locations:
     - id: GO:0005829
       label: cytosol
@@ -915,3 +918,10 @@ references:
 - id: PMID:40205054
   title: Multimodal cell maps as a foundation for structural and functional genomics.
   findings: []
+- id: file:human/VBP1/VBP1-deep-research-falcon.md
+  title: Falcon deep research for human VBP1
+  findings:
+    - statement: >-
+        Falcon synthesis supports VBP1/PFDN3 as an alpha-type prefoldin subunit
+        in the cytosolic prefoldin-TRiC/CCT chaperone pathway, with additional
+        nuclear and pVHL-linked functions treated as non-core context.

--- a/publications/PMID_28848044.md
+++ b/publications/PMID_28848044.md
@@ -1,0 +1,106 @@
+---
+pmid: '28848044'
+title: Regulation of mitochondrial protein import by the nucleotide exchange factors
+  GrpEL1 and GrpEL2 in human cells.
+authors:
+- Srivastava S
+- Savanur MA
+- Sinha D
+- Birje A
+- R V
+- Saha PP
+- D'Silva P
+journal: J Biol Chem
+year: '2017'
+full_text_available: true
+full_text_extraction_method: html
+pmcid: PMC5672033
+doi: 10.1074/jbc.M117.788463
+---
+
+# Regulation of mitochondrial protein import by the nucleotide exchange factors GrpEL1 and GrpEL2 in human cells.
+**Authors:** Srivastava S, Savanur MA, Sinha D, Birje A, R V, Saha PP, D'Silva P
+**Journal:** J Biol Chem (2017)
+**DOI:** [10.1074/jbc.M117.788463](https://doi.org/10.1074/jbc.M117.788463)
+**PMC:** [PMC5672033](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5672033/)
+
+## Abstract
+
+1. J Biol Chem. 2017 Nov 3;292(44):18075-18090. doi: 10.1074/jbc.M117.788463.
+Epub  2017 Aug 28.
+
+Regulation of mitochondrial protein import by the nucleotide exchange factors 
+GrpEL1 and GrpEL2 in human cells.
+
+Srivastava S(1), Savanur MA(1), Sinha D(1), Birje A(1), R V(1), Saha PP(1), 
+D'Silva P(2).
+
+Author information:
+(1)From the Department of Biochemistry, Indian Institute of Science, Bangalore 
+560012, India.
+(2)From the Department of Biochemistry, Indian Institute of Science, Bangalore 
+560012, India patrick@iisc.ac.in.
+
+Mitochondria are organelles indispensable for maintenance of cellular energy 
+homeostasis. Most mitochondrial proteins are nuclearly encoded and are imported 
+into the matrix compartment where they are properly folded. This process is 
+facilitated by the mitochondrial heat shock protein 70 (mtHsp70), a chaperone 
+contributing to mitochondrial protein quality control. The affinity of mtHsp70 
+for its protein clients and its chaperone function are regulated by binding of 
+ATP/ADP to mtHsp70's nucleotide-binding domain. Nucleotide exchange factors 
+(NEFs) play a crucial role in exchanging ADP for ATP at mtHsp70's 
+nucleotide-binding domain, thereby modulating mtHsp70's chaperone activity. A 
+single NEF, Mge1, regulates mtHsp70's chaperone activity in lower eukaryotes, 
+but the mammalian orthologs are unknown. Here, we report that two putative NEF 
+orthologs, GrpE-like 1 (GrpEL1) and GrpEL2, modulate mtHsp70's function in human 
+cells. We found that both GrpEL1 and GrpEL2 associate with mtHsp70 as a 
+hetero-oligomeric subcomplex and regulate mtHsp70 function. The formation of 
+this subcomplex was critical for conferring stability to the NEFs, helped 
+fine-tune mitochondrial protein quality control, and regulated crucial mtHsp70 
+functions, such as import of preproteins and biogenesis of Fe-S clusters. Our 
+results also suggested that GrpEL2 has evolved as a possible stress resistance 
+protein in higher vertebrates to maintain chaperone activity under stress 
+conditions. In conclusion, our findings support the idea that GrpEL1 has a role 
+as a stress modulator in mammalian cells and highlight that multiple NEFs are 
+involved in controlling protein quality in mammalian mitochondria.
+
+© 2017 by The American Society for Biochemistry and Molecular Biology, Inc.
+
+DOI: 10.1074/jbc.M117.788463
+PMCID: PMC5672033
+PMID: 28848044 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare that they have no conflicts 
+of interest with the contents of this article
+
+## Full Text
+
+Abstract
+
+Mitochondria are organelles indispensable for maintenance of cellular energy homeostasis. Most mitochondrial proteins are nuclearly encoded and are imported into the matrix compartment where they are properly folded. This process is facilitated by the mitochondrial heat shock protein 70 (mtHsp70), a chaperone contributing to mitochondrial protein quality control. The affinity of mtHsp70 for its protein clients and its chaperone function are regulated by binding of ATP/ADP to mtHsp70's nucleotide-binding domain. Nucleotide exchange factors (NEFs) play a crucial role in exchanging ADP for ATP at mtHsp70's nucleotide-binding domain, thereby modulating mtHsp70's chaperone activity. A single NEF, Mge1, regulates mtHsp70's chaperone activity in lower eukaryotes, but the mammalian orthologs are unknown. Here, we report that two putative NEF orthologs, GrpE-like 1 (GrpEL1) and GrpEL2, modulate mtHsp70's function in human cells. We found that both GrpEL1 and GrpEL2 associate with mtHsp70 as a hetero-oligomeric subcomplex and regulate mtHsp70 function. The formation of this subcomplex was critical for conferring stability to the NEFs, helped fine-tune mitochondrial protein quality control, and regulated crucial mtHsp70 functions, such as import of preproteins and biogenesis of Fe–S clusters. Our results also suggested that GrpEL2 has evolved as a possible stress resistance protein in higher vertebrates to maintain chaperone activity under stress conditions. In conclusion, our findings support the idea that GrpEL1 has a role as a stress modulator in mammalian cells and highlight that multiple NEFs are involved in controlling protein quality in mammalian mitochondria.
+
+Introduction
+
+Mitochondria are essential organelles involved in multiple aspects of physiological functions, including energy metabolism, redox homeostasis, apoptosis, and metabolic switch. The constitutive functions of mitochondria are regulated by a plethora of proteins, acting together to maintain cellular and organellar homeostasis. Although mitochondria contain their own genome, most of the mitochondrial proteins are nuclearly encoded and translocated inside the organelle through dedicated translocases present on the outer and inner membranes ( 1 – 6 ). The inner membrane translocase, also known as presequence translocase, comprises TIM23-core complex and matrix-directed import motor subunit. The mtHsp70 forms the core of the import motor, which translocates matrix-targeted proteins with the assistance of J-proteins and nucleotide exchange factors (NEFs) 4 followed by subsequent folding into their native conformation, and thus maintains proteostasis and organellar health ( 4 , 5 , 7 , 8 ).
+
+The import motor functions through a regulated cycling of mtHsp70 at the import channel, and its chaperoning activity is modulated by the presence of J-proteins and NEFs ( 7 , 9 , 10 ). During the import process, binding and release of polypeptides occurs at the mtHsp70 substrate-binding domain in a cyclic manner, which is governed by the sequestration of ADP or ATP at the N-terminal nucleotide-binding pocket ( 7 , 8 , 11 – 13 ). In the ATP-bound state, mtHsp70 has low affinity for the substrate with higher association rate ( K on ). Subsequent hydrolysis of bound ATP to ADP triggered by peptide binding and J-proteins transforms the substrate-binding domain into its high-affinity state with lower dissociation rate ( K off ) ( 13 – 18 ). The NEF functions by exchanging ADP with ATP at the nucleotide-binding pocket. This promotes release of substrate and makes the chaperone ready for the next phase of the substrate binding-release cycle ( 13 , 19 – 22 ). Through the transformation of high/low-affinity states, which depends upon cyclic hydrolysis of ATP, mtHsp70 vectorially pulls the polypeptide into the matrix. This highlights the important synergistic action of J-proteins and NEFs in the import process and overall mitochondrial function ( 12 , 18 , 21 , 23 – 25 ).
+
+Recent discoveries highlight moonlighting functions for various components of the mitochondrial protein transport machinery. Differential expression of DnaJC15, a cochaperone of mtHsp70 at the import motor, is responsible for altering the sensitivity of patients to chemotherapeutic drugs. A recent report has linked it as a modulator of cell death pathways through regulation of mitochondrial permeability transition ( 26 , 27 ). DnaJC15 also regulates mitochondrial respiration as an inhibitor of respiratory complex I ( 28 ). Its paralog, DnaJC19, which has housekeeping functions in protein import, independently forms a complex with prohibitins to maintain cardiolipin metabolism in mitochondrial membranes ( 29 – 31 ). Magmas, which regulates mtHsp70's activity at the import channel, additionally functions as a reactive oxygen species (ROS) regulator and assists in maintenance of redox homeostasis ( 30 , 32 ). Interestingly, preliminary reports in yeast have shown that activity of the NEF Mge1 is sensitive to oxidative stress ( 33 ). This further supports the view of high involvement of human NEFs in multiple pathways with potential moonlighting functions in mitochondria.
+
+Previous in vitro reconstitution studies have shown that GrpEL1 functions as a nucleotide exchange factor for mtHsp70 in humans that could replace ADP with ATP and promote mtHsp70 chaperone activity ( 34 ). Interestingly, in silico and experimental evidence from the mammalian system reveals the existence of a second mitochondrial NEF, GrpEL2 ( 35 ). This is an intriguing observation because other species except mammals encode for a single NEF for the mitochondrial function. Despite having two NEFs as cochaperones for mtHsp70 machinery, their specific role in fine-tuning import and folding pathways in the maintenance of organellar homeostasis in humans is still elusive.
+
+The current studies highlight the nucleotide exchange abilities of two NEFs, EL1 and EL2, in regulating human mtHsp70's function. The human NEFs showed significant difference in their complex organization as compared with the yeast NEF Mge1. Human NEFs EL1 and EL2 function as a heterosubcomplex at the import channel by stabilizing the aggregation-prone individual homo-oligomers. Strikingly, our findings reveal that EL2 has evolved as a stress resistance protein in higher vertebrates to regulate threshold mtHsp70 activity and thus modulates overall organellar function under stress conditions. Together, we propose that the interplay between the two human NEFs is utilized by the cell to regulate mitochondrial functions.
+
+Discussion
+
+Mitochondria play an essential role in regulation of cellular metabolic and stress conditions. To adapt in a complex cellular environment in a mammalian system, mitochondria have diversified their protein import machinery ( 4 , 5 , 43 ). It is quite well known that relative distribution of certain molecules in the organelle reprograms mitochondrial functions as a part of homeostatic mechanisms within the cell ( 4 , 43 – 45 ). Because the majority of these proteins localize in the mitochondrial matrix, regulated functioning of mtHsp70 as a core component of the import motor is critical. Evidently, the functional diversity of mtHsp70 in humans is enhanced by the presence of two J-proteins, which suitably modulate its activity for its housekeeping role or response to xenobiotic stress ( 26 , 27 , 31 ). mtHsp70 mainly functions through a cycle of substrate binding and release at its substrate-binding domain, which in turn depends on ATP binding and hydrolysis in the nucleotide-binding domain. Exchange of fresh ATP by NEF in mtHsp70's nucleotide-binding domain makes it available for the next series of the cycle, highlighting the importance of NEFs in maintenance of mitochondrial homeostasis ( 18 , 21 , 24 ).
+
+In the present study, we propose diversification of human NEF into two paralogs, EL1 and EL2, for better maintenance of mitochondrial functions. It is evident from our results that EL1 has a higher affinity for mtHsp70 as compared with EL2. Under normal cellular conditions, EL1 and EL2 function as a higher-order oligomer in contrast to NEF dimers traditionally observed in lower organisms ( Fig. 7 ). The individual paralogs, along with the EL1-EL2 heterosubcomplex, exhibit similar nucleotide exchange ability at saturating concentrations with the nucleotide-bound state of mtHsp70. However, at stoichiometric concentrations, EL1 and EL1-EL2 heterosubcomplex showed a better exchange of nucleotides than EL2. The physiological significance of formation of this heterosubcomplex is to maintain the aggregation-prone human NEFs in the soluble state. At the same time, the aggregation propensity of EL1 and EL2 did not reflect on their respective ability to maintain NEF function.
+
+Both NEFs have the ability to be recruited at the import channel independently or as heterosubcomplex to modulate mtHsp70 chaperone activity. Moreover, co-recruitment of EL1 and EL2 provides the first evidence for the mutual complementation of transport functions to maintain threshold levels of protein import by both NEFs. The maintenance of one NEF's function in the absence of the other is probably contributed by the high-turnover rate and feedback overexpression observed in these proteins under stress conditions ( Fig. 7 ). Besides, both NEFs can perform the cochaperone function in assisting mtHsp70 chaperone-mediated folding of precursor proteins in the matrix compartment, thereby maintaining quality control and organellar homeostasis.
+
+Although the constitutive functions are performed by a single NEF in lower eukaryotes, the presence of two orthologs in higher eukaryotes raises a beguiling question, whether it provides additional physiological significance in the mammalian system. Being a complex organism, human cells are vulnerable to many external stresses, such as oxidative stress, which is a major by-product of mitochondrial metabolism ( 46 , 47 ). Although ROS play an important role in various physiological functions within the cell, exposure to excessive stress is harmful for cell survival ( 40 , 48 ). The defense response toward accumulation of ROS might trigger the cell to fine-tune the biogenesis of mitochondria, the major ROS-producing organelles. Indeed, it has been previously discussed in several studies on the role of different transcription factors, such as Nrf1, Nrf2, and PGC-1α, in regulating biogenesis of mitochondria in response to oxidative stress ( 49 ). Under stress, the less aggregation-prone stress-resistant EL2 performs the threshold level of activity at comparatively lower efficiency due to stress-induced loss of EL1 expression and subsequent dissociation from the heterosubcomplex ( Fig. 7 ). This in turn is reflected in the reduced biogenesis of mitochondria under stress conditions, thereby maintaining redox homeostasis. The idea is supported by unaltered mitochondrial biogenesis even under oxidative stress when the levels of EL1 and EL1-EL2 heterosubcomplex formation are maintained by their exogenous expression.
+
+In the mammalian system, moonlighting functions have been reported for the components of the inner mitochondrial membrane import machinery. For example, two translocation machineries are involved in protein import, namely translocase A, which contains Tim17a and DnaJC15, and translocase B with Tim17b and DnaJC19 paralogs. The subunits of translocase B are essential for constitutive organellar functions. In contrast, the components of translocase A, Tim17a and DnaJC15 paralogs, are involved in cellular oncogenesis and development of chemoresistance, respectively ( 26 , 31 , 50 ). Such moonlighting secondary functions in proteins are usually incorporated as a result of gene duplication or due to random genetic drift, providing the organism a selective advantage for better adaptation in adverse environmental conditions ( 51 ). Therefore, we envision that the evolutionary incorporation of two NEFs in human mitochondria occurred to regulate the organellar stress response without altering the mitochondrial import process under stress.
+
+In summary, we report here the existence of two NEFs in humans that are potentially utilized by the import machinery in regulating mitochondrial proteostasis. Together, we propose that dynamic association of EL1 and EL2, in cooperation with their differential nucleotide exchange rates, is utilized by the cell for reprogramming the mitochondrial life cycle and cellular energy demand. However, it will be imperative to understand the underlying molecular interactions between the human NEFs and other stress-sensitive factors that govern the overall redox regulatory processes. In addition, our observations will also expose new avenues to understand the novel regulators of the mitochondrial stress response.


### PR DESCRIPTION
## Summary

Adds completed human gene reviews for five chaperone/co-chaperone genes:

- AIP
- VBP1
- GRPEL1
- CRYAA
- CRYAB

This batch integrates Falcon deep research, subagent review findings, and updated rendered HTML. It also caches PMID:28848044 for GRPEL1 primary evidence and updates the local GO cache label for GO:0140309 to the current QuickGO name, `unfolded protein holdase activity`.

## Review Follow-up Addressed

- AIP: moved non-core/high-throughput generic protein-binding calls from `ACCEPT` to `UNDECIDED` where cached evidence does not verify the specific pair.
- VBP1: made nucleus and broad microtubule-process annotations non-core, removed microtubule-based process from core functions, and corrected HIV integrase/VHL evidence wording.
- GRPEL1: added PMID:28848044 support for NEF, PAM/import, and core-function claims.
- CRYAA: replaced holdase-related `GO:0044183` proposals with `GO:0140309`, retained the negated protein-refolding annotation, fixed non-matching protein-binding replacements, and grounded nuclear localization in UniProt text.
- CRYAB: corrected UVC response, structural-molecule action/replacements, and folded amyloid-beta binding evidence into the general holdase core function.

## Validation

- `just validate human AIP`
- `just validate human VBP1`
- `just validate human GRPEL1`
- `just validate human CRYAA` (passes with one warning for positive vs NOT `GO:0042026` action consistency; the NOT annotation is intentionally retained)
- `just validate human CRYAB`
- `just mypy`
- `just pytest`