### PR TITLE
[codex] Review yeast NSG1 CCT3 CCT5 CCT6 CNE1

### DIFF
--- a/genes/yeast/CCT3/CCT3-ai-review.html
+++ b/genes/yeast/CCT3/CCT3-ai-review.html
@@ -1663,13 +1663,13 @@
                             <div class="support-item">
                                 <span class="support-ref">
 
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15704212" target="_blank" class="term-link">
-                                        PMID:15704212
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
                                     </a>
 
                                 </span>
 
-                                <div class="support-text">Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed of a stoichiometric array of eight different subunits</div>
+                                <div class="support-text">The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose action is required for folding the cytoskeletal proteins actin and tubulin</div>
 
                             </div>
 
@@ -2895,10 +2895,10 @@ existing_annotations:
       Complex membership is central to the gene product function and is supported by yeast CCT complex
       literature and family evidence.
     supported_by:
-    - reference_id: PMID:15704212
+    - reference_id: PMID:16762366
       supporting_text: &gt;-
-        Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
-        of a stoichiometric array of eight different subunits
+        The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine
+        whose action is required for folding the cytoskeletal proteins actin and tubulin
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005832

--- a/genes/yeast/CCT3/CCT3-ai-review.html
+++ b/genes/yeast/CCT3/CCT3-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>CCT3</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P39077" target="_blank" class="term-link">
                         P39077
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Saccharomyces cerevisiae</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,24 +728,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="P39077" data-a="DESCRIPTION: TODO: Add description for CCT3..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="P39077" data-a="DESCRIPTION: CCT3 encodes the gamma subunit of the cytosolic gr..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TODO: Add description for CCT3</p>
+        <p>CCT3 encodes the gamma subunit of the cytosolic group II chaperonin TRiC/CCT. As one of eight obligate paralogous subunits in each ring, Cct3 contributes ATPase and substrate-contact surfaces to the hetero-oligomeric folding chamber that matures actin, tubulin, and other cytosolic clients. Its curated core function is complex-level ATP-dependent protein folding, not nonspecific protein binding.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,46 +795,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein folding is consistent with known biology of CCT3.
+                            <strong>Summary:</strong> CCT3 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin that folds actin, tubulin, and other clients.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Protein folding is the correct biological-process context for the chaperonin complex, supported by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/CCT3/CCT3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The CCT/TRiC complex is a double-ring ATP-driven folding machine</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005832" target="_blank" class="term-link">
                                     GO:0005832
                                 </a>
                             </span>
                             <span class="term-label">chaperonin-containing T-complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -846,46 +862,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: chaperonin-containing T-complex is consistent with known biology of CCT3.
+                            <strong>Summary:</strong> CCT3 is a named subunit of the chaperonin-containing T-complex.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Complex membership is central to the gene product function and is supported by yeast CCT complex literature and family evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -897,159 +913,159 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT3.
+                            <strong>Summary:</strong> unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than the ATP-dependent folding chaperone function of the complex.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
+                            <strong>Reason:</strong> Replace generic substrate-binding language with the specific chaperonin activity supported by yeast CCT actin-folding assays and domain evidence.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
+                                    ATP-dependent protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000166" target="_blank" class="term-link">
                                     GO:0000166
                                 </a>
                             </span>
                             <span class="term-label">nucleotide binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P39077" data-a="GO:0000166" data-r="GO_REF:0000043" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P39077" data-a="GO:0000166" data-r="GO_REF:0000043" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: nucleotide binding is consistent with known biology of CCT3.
+                            <strong>Summary:</strong> nucleotide binding is a true but overly broad family/keyword annotation for CCT3; ATP binding, ATP hydrolysis, and ATP-dependent chaperone annotations capture the specific chemistry.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Generic nucleotide binding does not add useful functional information beyond the more specific ATP-related chaperonin annotations already present.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
                                     GO:0005524
                                 </a>
                             </span>
                             <span class="term-label">ATP binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P39077" data-a="GO:0005524" data-r="GO_REF:0000120" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P39077" data-a="GO:0005524" data-r="GO_REF:0000120" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ATP binding is consistent with known biology of CCT3.
+                            <strong>Summary:</strong> CCT3 contains a conserved chaperonin ATP-binding site, but ATP binding alone is a domain property rather than the core biological function.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Keep as a valid supporting molecular property of the CCT ATPase cycle, while treating ATP hydrolysis and complex-level protein folding as the core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1061,46 +1077,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cytoplasm is consistent with known biology of CCT3.
+                            <strong>Summary:</strong> CCT3 functions as part of the cytosolic TRiC/CCT chaperonin.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Cytoplasm is the established location of the CCT/TRiC folding machine.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005832" target="_blank" class="term-link">
                                     GO:0005832
                                 </a>
                             </span>
                             <span class="term-label">chaperonin-containing T-complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1112,46 +1128,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: chaperonin-containing T-complex is consistent with known biology of CCT3.
+                            <strong>Summary:</strong> CCT3 is a named subunit of the chaperonin-containing T-complex.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Complex membership is central to the gene product function and is supported by yeast CCT complex literature and family evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1163,46 +1179,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein folding is consistent with known biology of CCT3.
+                            <strong>Summary:</strong> CCT3 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin that folds actin, tubulin, and other clients.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Protein folding is the correct biological-process context for the chaperonin complex, supported by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1214,46 +1230,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ATP hydrolysis activity is consistent with known biology of CCT3.
+                            <strong>Summary:</strong> CCT3 is a TCP-1/CCT chaperonin subunit with conserved ATPase machinery that powers TRiC/CCT conformational cycling.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> ATP hydrolysis is a defensible subunit-level molecular function for CCT family members and is directly tied to the chaperonin folding cycle.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1265,57 +1281,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT3.
+                            <strong>Summary:</strong> unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than the ATP-dependent folding chaperone function of the complex.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
+                            <strong>Reason:</strong> Replace generic substrate-binding language with the specific chaperonin activity supported by yeast CCT actin-folding assays and domain evidence.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
+                                    ATP-dependent protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
                                     GO:0140662
                                 </a>
                             </span>
                             <span class="term-label">ATP-dependent protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1327,57 +1343,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ATP-dependent protein folding chaperone is consistent with known biology of CCT3.
+                            <strong>Summary:</strong> CCT3 is an obligate subunit of the ATP-dependent TRiC/CCT folding machine.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The term is appropriate as a complex-level chaperonin function; in the synthesized core function it is modeled as a contributed-to molecular function rather than a standalone activity of an isolated subunit.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose action is required for folding the cytoskeletal proteins actin and tubulin</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19536198
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An atlas of chaperone-protein interactions in Saccharomyces ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1389,57 +1423,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for CCT3.
+                            <strong>Summary:</strong> protein binding is too generic for a CCT subunit and does not describe the chaperonin mechanism or substrate class.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Physical-interaction datasets are useful evidence context, but generic protein binding should not stand as a functional annotation when the specific TRiC/CCT chaperonin role is known.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link">
+                                        PMID:19536198
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">It should be emphasized that the interactions presented are indirect TAP-tag based interactions and not direct binary interactions.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/37968396" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:37968396
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The social and structural architecture of the yeast protein ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1451,57 +1503,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for CCT3.
+                            <strong>Summary:</strong> protein binding is too generic for a CCT subunit and does not describe the chaperonin mechanism or substrate class.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Physical-interaction datasets are useful evidence context, but generic protein binding should not stand as a functional annotation when the specific TRiC/CCT chaperonin role is known.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16762366
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Quantitative actin folding reactions using yeast CCT purifie...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1513,57 +1565,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein folding is consistent with known biology of CCT3.
+                            <strong>Summary:</strong> CCT3 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin that folds actin, tubulin, and other clients.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Protein folding is the correct biological-process context for the chaperonin complex, supported by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose action is required for folding the cytoskeletal proteins actin and tubulin</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005832" target="_blank" class="term-link">
                                     GO:0005832
                                 </a>
                             </span>
                             <span class="term-label">chaperonin-containing T-complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15704212" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15704212
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Physiological effects of unassembled chaperonin Cct subunits...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1575,57 +1645,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: chaperonin-containing T-complex is consistent with known biology of CCT3.
+                            <strong>Summary:</strong> CCT3 is a named subunit of the chaperonin-containing T-complex.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Complex membership is central to the gene product function and is supported by yeast CCT complex literature and family evidence.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15704212" target="_blank" class="term-link">
+                                        PMID:15704212
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed of a stoichiometric array of eight different subunits</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005832" target="_blank" class="term-link">
                                     GO:0005832
                                 </a>
                             </span>
                             <span class="term-label">chaperonin-containing T-complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16762366
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Quantitative actin folding reactions using yeast CCT purifie...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1637,57 +1725,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: chaperonin-containing T-complex is consistent with known biology of CCT3.
+                            <strong>Summary:</strong> CCT3 is a named subunit of the chaperonin-containing T-complex.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Complex membership is central to the gene product function and is supported by yeast CCT complex literature and family evidence.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15704212" target="_blank" class="term-link">
+                                        PMID:15704212
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed of a stoichiometric array of eight different subunits</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16762366
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Quantitative actin folding reactions using yeast CCT purifie...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1699,220 +1805,784 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT3.
+                            <strong>Summary:</strong> unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than the ATP-dependent folding chaperone function of the complex.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
+                            <strong>Reason:</strong> Replace generic substrate-binding language with the specific chaperonin activity supported by yeast CCT actin-folding assays and domain evidence.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
+                                    ATP-dependent protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose action is required for folding the cytoskeletal proteins actin and tubulin</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>CCT3 is the gamma subunit of the cytosolic TRiC/CCT chaperonin. The subunit contributes ATPase and substrate-contact surfaces to the hetero-oligomeric double-ring complex, whose ATP-dependent conformational cycle folds actin, tubulin, and other cytosolic client proteins. The synthesized function is modeled as subunit ATP hydrolysis contributing to the complex-level ATP-dependent protein folding chaperone activity.</h3>
+                <span class="vote-buttons" data-g="P39077" data-a="FUNCTION: CCT3 is the gamma subunit of the cytosolic TRiC/CC..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
+                            ATP hydrolysis activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                protein folding
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005832" target="_blank" class="term-link">
+                            chaperonin-containing T-complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                PMID:16762366
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose action is required for folding the cytoskeletal proteins actin and tubulin</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15704212" target="_blank" class="term-link">
+                                PMID:15704212
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed of a stoichiometric array of eight different subunits</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15704212" target="_blank" class="term-link">
                             PMID:15704212
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Physiological effects of unassembled chaperonin Cct subunits in the yeast Saccharomyces cerevisiae.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Yeast CCT is a double-ring complex with a stoichiometric set of eight distinct Cct subunits.</div>
+
+                        <div class="finding-text">"Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed of a stoichiometric array of eight different subunits"</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
                             PMID:16762366
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Quantitative actin folding reactions using yeast CCT purified via an internal tag in the CCT3/gamma subunit.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Purified yeast CCT, tagged through CCT3, catalyzes ATP-dependent actin folding; this supports protein-folding and chaperonin activity annotations for CCT3 as a TRiC/CCT subunit.</div>
+
+                        <div class="finding-text">"The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose action is required for folding the cytoskeletal proteins actin and tubulin"</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link">
                             PMID:19536198
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding pathways in the cell.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The chaperone interactome study is useful context for CCT contacts but reports indirect TAP-tag interactions rather than a specific molecular activity.</div>
+
+                        <div class="finding-text">"It should be emphasized that the interactions presented are indirect TAP-tag based interactions and not direct binary interactions."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/37968396" target="_blank" class="term-link">
                             PMID:37968396
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The social and structural architecture of the yeast protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/CCT3/CCT3-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for CCT3</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The Falcon report was reviewed and synthesized into the CCT3 curation, including core-function framing, family/PANTHER context, and evidence limitations.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which yeast client proteins depend specifically on Cct3 apical-domain contacts rather than on generic TRiC/CCT chamber activity?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P39077" data-a="Q: Which yeast client proteins depend specifically on..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Profile client aggregation, solubility, and folding reporter behavior in conditional CCT3 mutants under permissive and restrictive conditions, with actin and tubulin reporters as controls.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Cct3 contributes subunit-specific contacts for a subset of aggregation-prone or Q/N-rich clients.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: conditional mutant proteostasis profiling</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P39077" data-a="EXPERIMENT: Profile client aggregation, solubility, and foldin..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(CCT3-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P39077" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-04T10:26:00.366159'<br />
+end_time: '2026-05-04T10:35:33.501432'<br />
+duration_seconds: 573.14<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: yeast<br />
+  gene_id: CCT3<br />
+  gene_symbol: CCT3<br />
+  uniprot_accession: P39077<br />
+  protein_description: 'RecName: Full=T-complex protein 1 subunit gamma; Short=TCP-1-gamma;<br />
+    AltName: Full=CCT-gamma;'<br />
+  gene_info: Name=CCT3; Synonyms=BIN2, TCP3; OrderedLocusNames=YJL014W; ORFNames=J1336;<br />
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).<br />
+  protein_family: Belongs to the TCP-1 chaperonin family. .<br />
+  protein_domains: Chap_CCT_gamma. (IPR012719); Chaperone_TCP-1. (IPR017998); Chaperonin_TCP-1_CS.<br />
+    (IPR002194); Cpn60/GroEL/TCP-1. (IPR002423); GroEL-like_apical_dom_sf. (IPR027409)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 24</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P39077</li>
+<li><strong>Protein Description:</strong> RecName: Full=T-complex protein 1 subunit gamma; Short=TCP-1-gamma; AltName: Full=CCT-gamma;</li>
+<li><strong>Gene Information:</strong> Name=CCT3; Synonyms=BIN2, TCP3; OrderedLocusNames=YJL014W; ORFNames=J1336;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the TCP-1 chaperonin family. .</li>
+<li><strong>Key Domains:</strong> Chap_CCT_gamma. (IPR012719); Chaperone_TCP-1. (IPR017998); Chaperonin_TCP-1_CS. (IPR002194); Cpn60/GroEL/TCP-1. (IPR002423); GroEL-like_apical_dom_sf. (IPR027409)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "CCT3" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'CCT3' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>CCT3</strong> (gene ID: CCT3, UniProt: P39077) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P39077</li>
+<li><strong>Protein Description:</strong> RecName: Full=T-complex protein 1 subunit gamma; Short=TCP-1-gamma; AltName: Full=CCT-gamma;</li>
+<li><strong>Gene Information:</strong> Name=CCT3; Synonyms=BIN2, TCP3; OrderedLocusNames=YJL014W; ORFNames=J1336;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the TCP-1 chaperonin family. .</li>
+<li><strong>Key Domains:</strong> Chap_CCT_gamma. (IPR012719); Chaperone_TCP-1. (IPR017998); Chaperonin_TCP-1_CS. (IPR002194); Cpn60/GroEL/TCP-1. (IPR002423); GroEL-like_apical_dom_sf. (IPR027409)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "CCT3" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'CCT3' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>CCT3</strong> (gene ID: CCT3, UniProt: P39077) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="comprehensive-research-report-saccharomyces-cerevisiae-cct3-uniprot-p39077-orf-yjl014w-functional-annotation">Comprehensive research report: <em>Saccharomyces cerevisiae</em> <strong>CCT3</strong> (UniProt <strong>P39077</strong>; ORF <strong>YJL014W</strong>) — functional annotation</h2>
+<h3 id="executive-summary">Executive summary</h3>
+<p>CCT3 encodes <strong>T-complex protein 1 subunit gamma (CCTγ; TRiC/CCT subunit 3)</strong>, one of eight essential subunits comprising the eukaryotic cytosolic <strong>group II chaperonin</strong> CCT/TRiC. The CCT/TRiC complex is a double-ring ATP-driven folding machine that is required for proteostasis, including folding of key cytoskeletal proteins such as actin and tubulin. Yeast-specific evidence indicates that CCT3 has detectable <strong>subunit-specific client preferences</strong>, particularly affecting <strong>Q/N-rich proteins</strong> and <strong>P-body-associated proteins</strong>, and that perturbing CCT3 function produces broad stress sensitivities including ethanol and cell-wall integrity–associated phenotypes. (grantham2020themolecularchaperone pages 1-2, nadlerholly2012interactionsofsubunit pages 2-2, narayanan2016defectsinprotein pages 4-6)</p>
+<h3 id="1-geneprotein-identity-verification-critical-disambiguation">1) Gene/protein identity verification (critical disambiguation)</h3>
+<p>The literature summarized here pertains to <em>Saccharomyces cerevisiae</em> (S288C) <strong>CCT3/YJL014W</strong>, encoding a subunit of the <strong>CCT/TRiC chaperonin complex</strong>. This is consistent with the UniProt description for P39077 as a TCP-1 chaperonin family member (CCTγ) and with yeast genetics studies that explicitly mutate <strong>CCT3</strong> and assay phenotypes in yeast (e.g., CCT3 D91E; cct3-1). (nadlerholly2012interactionsofsubunit pages 2-2, narayanan2016defectsinprotein pages 2-4)</p>
+<h3 id="2-key-concepts-and-definitions-current-understanding">2) Key concepts and definitions (current understanding)</h3>
+<h4 id="21-what-is-ccttric-and-where-does-cct3-fit">2.1 What is CCT/TRiC, and where does CCT3 fit?</h4>
+<p><strong>CCT/TRiC</strong> (chaperonin-containing TCP-1; tailless complex polypeptide 1 ring complex) is a eukaryotic <strong>ATP-dependent chaperonin</strong>. It is an obligate hetero-oligomer composed of <strong>two rings</strong>, each containing <strong>eight distinct subunits</strong> (commonly denoted CCT1–CCT8 or α–θ), generating a central chamber where client proteins fold. (grantham2020themolecularchaperone pages 1-2)</p>
+<p>CCT3 is one of these eight distinct subunits. Structural/mechanistic work synthesized in the literature places CCT3 as part of a subunit pairing/grouping (e.g., CCT1–CCT3) and within a <strong>lower ATP-affinity hemisphere</strong> of the ring (CCT3/6/7/8) relative to a higher-affinity hemisphere (CCT1/2/4/5), implying subunit-specialized contributions to the ATPase cycle. (kelly2020structuralandfunctional pages 42-48)</p>
+<h4 id="22-mechanism-of-action-atp-driven-conformational-cycle-and-substrate-folding">2.2 Mechanism of action: ATP-driven conformational cycle and substrate folding</h4>
+<p>CCT/TRiC operates via a coordinated ATPase-driven conformational cycle: substrate binds to apical domains, ATP binding/hydrolysis drives ring closure and encapsulation, and conformational changes promote folding. This general mechanism and architecture are described in authoritative reviews emphasizing the complex’s role as an essential proteostasis component. (grantham2020themolecularchaperone pages 1-2, que2024theroleof pages 1-2)</p>
+<p>A mechanistic quantitative detail highlighted in structural/functional synthesis is that, <strong>on average, ~4 subunits per ring are occupied under saturating ATP</strong>, consistent with asymmetric ATP usage across subunits and supporting the view that not all subunits contribute equivalently to nucleotide binding/hydrolysis at a given time. CCT3 is categorized among lower ATP-affinity subunits in this model. (kelly2020structuralandfunctional pages 42-48)</p>
+<h3 id="3-primary-biological-function-of-yeast-cct3">3) Primary biological function of yeast CCT3</h3>
+<h4 id="31-core-function-proteostasis-via-foldingassembly-of-complex-cytosolic-proteins">3.1 Core function: proteostasis via folding/assembly of complex cytosolic proteins</h4>
+<p>CCT/TRiC is described as required for folding of the abundant cytoskeletal proteins <strong>actin and tubulin</strong>, which are central to microfilament and microtubule assembly. These clients are repeatedly treated as key/obligate substrates of the complex in reviews and in yeast stress-phenotype work that links impaired folding to cytoskeleton-mediated stress adaptation. (grantham2020themolecularchaperone pages 1-2, narayanan2016defectsinprotein pages 4-6)</p>
+<h4 id="32-subunit-specific-client-interactions-qn-rich-proteins-and-p-body-biology-yeast-specific">3.2 Subunit-specific client interactions: Q/N-rich proteins and P-body biology (yeast-specific)</h4>
+<p>A yeast-focused PNAS study directly probed subunit specialization using ATP-site mutations in CCT3 vs CCT6 and high-throughput microscopy. A CCT3 mutant (D91E; “MA3”) produced a strong, specific phenotype: <strong>dramatic accumulation of P-bodies</strong>, with multiple known P-body proteins forming prominent cytoplasmic puncta that colocalize with an established P-body marker. (nadlerholly2012interactionsofsubunit pages 2-2, nadlerholly2012interactionsofsubunit media 88c0bc6b)</p>
+<p>Quantitatively, the same study reported that in MA3 relative to wild type, <strong>46 proteins increased and 18 decreased</strong> at <strong>P &lt; 0.01</strong>, and that the screen involved ~<strong>5,100 GFP-tagged</strong> strains, supporting a large-scale systematic assessment of proteome-level changes in a CCT3-perturbed background. (nadlerholly2012interactionsofsubunit pages 2-2)</p>
+<p>The authors further concluded that subunit CCT3 shows a stronger in vivo interaction with <strong>Q/N-rich proteins</strong> than CCT6 and proposed that CCT3 contains features compatible with binding Q/N-rich segments, linking CCT3 activity to proteostasis of aggregation-prone regions commonly enriched in P-body components. (nadlerholly2012interactionsofsubunit pages 2-2, nadlerholly2012interactionsofsubunit pages 4-5)</p>
+<h3 id="4-subcellular-localization-and-where-cct3-carries-out-its-function">4) Subcellular localization and where CCT3 carries out its function</h3>
+<h4 id="41-cytosolic-role-dominantestablished">4.1 Cytosolic role (dominant/established)</h4>
+<p>CCT/TRiC is classically treated as a <strong>cytosolic</strong> chaperonin that acts on cytosolic proteins, consistent with its canonical substrates (actin/tubulin) and broad role in folding newly synthesized proteins. (grantham2020themolecularchaperone pages 1-2, que2024theroleof pages 1-2)</p>
+<h4 id="42-nuclear-roles-emerging-yeast-relevant">4.2 Nuclear roles (emerging, yeast-relevant)</h4>
+<p>A 2024 yeast preprint reports that TRiC/CCT <strong>governs RNA polymerase II activity in the nucleus</strong> to support RNA homeostasis, indicating that in yeast the complex has functionally relevant nuclear activity beyond canonical cytosolic folding. The study used yeast TRiC purification and nuclear extract transcription assays (including <strong>100 ng</strong> immobilized DNA template and <strong>100 µg</strong> nuclear extract), supporting mechanistic investigation of nuclear transcription outputs in a TRiC-compromised condition (cct1-2). Although this is not CCT3-specific, it is a recent yeast development expanding the functional landscape in which CCT subunits operate. (gvozdenov2024triccctchaperoningoverns pages 30-33)</p>
+<h3 id="5-phenotypes-and-essentiality">5) Phenotypes and essentiality</h3>
+<h4 id="51-essentiality">5.1 Essentiality</h4>
+<p>CCT/TRiC subunits are encoded by <strong>essential yeast genes</strong>, consistent with the central role of TRiC/CCT in folding core cellular proteins and maintaining homeostasis. (grantham2020themolecularchaperone pages 1-2)</p>
+<h4 id="52-stress-tolerance-ethanol-tolerance-and-cell-wall-integrity-phenotypes-cct3-alleles">5.2 Stress tolerance, ethanol tolerance, and cell wall integrity phenotypes (cct3 alleles)</h4>
+<p>A focused phenotyping study of yeast folding-machinery mutants reports that the <strong>cct3-1</strong> mutant shows sensitivity to diverse stressors. In the authors’ categorical scoring, cct3-1 was sensitive/supersensitive across multiple conditions including <strong>ethanol</strong>, <strong>NaCl</strong>, <strong>DTT</strong>, <strong>arsenate</strong>, <strong>H2O2</strong>, <strong>SDS</strong> (cell-wall integrity proxy), and <strong>methanol</strong>, and was <strong>supersensitive to TBZ</strong> (a microtubule/actin-related stressor used in the study). (narayanan2016defectsinprotein pages 2-4)</p>
+<p>The same work reports ethanol-specific findings: cct3-1 is noted as sensitive at <strong>3% ethanol</strong>, and while all tested cct mutants failed to grow at <strong>8% ethanol</strong>, many recovered tolerance to <strong>6% ethanol</strong> by <strong>48 h</strong>—with <strong>cct1 and cct3 mutants</strong> highlighted as exceptions in this recovery pattern. The authors also used Congo Red and zymolyase sensitivity and SEM morphology changes to support that defects in the folding machinery correlate with <strong>cell wall integrity defects</strong>, providing a plausible mechanistic link between CCT3 impairment, actin/cytoskeletal dysfunction, and cell-wall biosynthetic/maintenance pathways. (narayanan2016defectsinprotein pages 4-6)</p>
+<h4 id="53-cct3-perturbation-and-rna-granulesp-bodies">5.3 CCT3 perturbation and RNA granules/P-bodies</h4>
+<p>The yeast CCT3 D91E mutant (MA3) triggers prominent P-body formation and altered abundance/localization of multiple P-body components; this is consistent with the hypothesis that CCT3 function supports folding/stability of specific aggregation-prone/QN-rich components that influence ribonucleoprotein granule formation. (nadlerholly2012interactionsofsubunit pages 2-2, nadlerholly2012interactionsofsubunit media 88c0bc6b)</p>
+<h3 id="6-signalingbiochemical-pathways-and-process-level-placement">6) Signaling/biochemical pathways and process-level placement</h3>
+<h4 id="61-proteostasis-network-positioning">6.1 Proteostasis network positioning</h4>
+<p>CCT/TRiC is positioned as a major node in cellular proteostasis, supporting folding and suppressing aggregation, and it participates in protein biogenesis processes that intersect with translation. (grantham2020themolecularchaperone pages 1-2, que2024theroleof pages 1-2)</p>
+<h4 id="62-translation-coupling-recent-synthesis">6.2 Translation coupling (recent synthesis)</h4>
+<p>A 2024 review synthesizes evidence that CCT/TRiC has multiple roles related to <strong>translation elongation</strong>, including interacting with emerging peptides to protect them from aggregation/degradation and facilitating proper folding programs during protein synthesis. This provides a modern conceptual framework for interpreting CCT3 function as part of a chaperonin machine integrated with translation and nascent-chain quality control (even when the review is not yeast-exclusive). (que2024theroleof pages 1-2)</p>
+<h3 id="7-recent-developments-prioritizing-20232024">7) Recent developments (prioritizing 2023–2024)</h3>
+<h4 id="71-2024-ccttric-in-translation-elongation-review">7.1 2024: CCT/TRiC in translation elongation (review)</h4>
+<p>Que et al. (Heliyon; available online 1 Apr 2024) frame CCT/TRiC as an essential molecular chaperone in the elongation phase of eukaryotic translation and summarize how it contributes to maintaining balance among synthesis, folding, assembly, and degradation—an updated synthesis of field consensus relevant to interpreting yeast CCT3 phenotypes in conditions that stress protein biogenesis. URL: https://doi.org/10.1016/j.heliyon.2024.e29029 (que2024theroleof pages 1-2)</p>
+<h4 id="72-2024-nuclear-tric-activity-in-yeast-transcription-preprint">7.2 2024: Nuclear TRiC activity in yeast transcription (preprint)</h4>
+<p>Gvozdenov et al. (bioRxiv; posted 26 Sep 2024) report that TRiC/CCT supports <strong>RNA polymerase II activity</strong> in the yeast nucleus, expanding the apparent functional reach of TRiC beyond canonical cytosolic folding and suggesting that TRiC perturbation can impact RNA homeostasis. URL: https://doi.org/10.1101/2024.09.26.615188 (gvozdenov2024triccctchaperoningoverns pages 30-33)</p>
+<h4 id="73-2023-subunit-resolved-substrate-contacts-cct3-involvement">7.3 2023: Subunit-resolved substrate contacts (CCT3 involvement)</h4>
+<p>A 2023 structural study of TRiC-mediated tubulin folding reports that near-natively folded tubulin engages mainly with the <strong>CCT3/6/8</strong> subunits through electrostatic/hydrophilic interactions in the closed chamber (in a human TRiC system). While not yeast-specific, this provides current mechanistic support for why CCT3 subunits can contribute specialized binding surfaces for key cytoskeletal clients—consistent with long-standing yeast genetics emphasizing actin/tubulin dependence on TRiC. URL: https://doi.org/10.1038/s42003-023-04915-x (gvozdenov2024triccctchaperoningoverns pages 33-36)</p>
+<h3 id="8-current-applications-and-real-world-implementations">8) Current applications and real-world implementations</h3>
+<h4 id="81-structural-biology-tool-development-yeast-cct3-as-an-engineering-handle">8.1 Structural biology tool development (yeast CCT3 as an engineering handle)</h4>
+<p>A practical implementation in yeast structural biology is the use of CCT3 as a subunit for internal tagging: Zang et al. (Scientific Reports; Feb 2018) describe a yeast internal-subunit eGFP labeling strategy (YISEL) and note purification of yeast CCT via an internal tag in the <strong>CCT3/γ</strong> subunit to enable cryo-EM subunit assignment. This is a concrete experimental application leveraging the endogenous yeast CCT3 locus. URL: https://doi.org/10.1038/s41598-017-18962-y (zang2018developmentofa pages 7-8)</p>
+<h4 id="82-industrially-relevant-stress-tolerance-phenotyping">8.2 Industrially relevant stress tolerance phenotyping</h4>
+<p>Ethanol tolerance and cell wall integrity are central to industrial yeast performance. The observation that cct3-1 mutants show ethanol sensitivity and cell-wall-related phenotypes suggests that CCT3/TRiC integrity is a factor to consider in strain robustness under high-ethanol fermentations or other envelope-stressing conditions (noting that the cited study is phenotyping-focused rather than an industrial deployment report). URL: https://doi.org/10.1007/s00284-016-1024-x (narayanan2016defectsinprotein pages 4-6)</p>
+<h3 id="9-expert-opinions-and-analysis-authoritative-interpretation-of-evidence">9) Expert opinions and analysis (authoritative interpretation of evidence)</h3>
+<ol>
+<li><strong>Subunit specialization is biologically meaningful.</strong> The yeast CCT3 D91E study demonstrates that perturbing different TRiC subunits can yield qualitatively different cellular phenotypes, supporting the view that TRiC is not merely an eightfold-redundant machine but has subunit-specific substrate interfaces and cellular roles. (nadlerholly2012interactionsofsubunit pages 2-2)</li>
+<li><strong>CCT3 links folding capacity to RNP granule dynamics.</strong> The strong P-body phenotype in CCT3 mutant yeast provides a plausible mechanistic bridge between proteostasis and post-transcriptional RNA regulation, aligning with 2024 yeast work implicating TRiC in nuclear RNA homeostasis (though via a different experimental angle). (nadlerholly2012interactionsofsubunit pages 2-2, gvozdenov2024triccctchaperoningoverns pages 30-33)</li>
+<li><strong>Stress phenotypes likely reflect multiple downstream failures.</strong> Broad cct3-1 sensitivity (ethanol, SDS, oxidative/reductive stressors) is consistent with a folding-factor deficit affecting cytoskeletal organization, membrane/cell-wall maintenance, and generalized proteostasis under stress. The cell-wall integrity assays (SDS, Congo Red, zymolyase) provide process-level evidence that CCT perturbation couples protein folding to envelope robustness. (narayanan2016defectsinprotein pages 2-4, narayanan2016defectsinprotein pages 4-6)</li>
+</ol>
+<h3 id="10-key-statistics-and-data-points-from-cited-studies">10) Key statistics and data points (from cited studies)</h3>
+<ul>
+<li>TRiC/CCT architecture: <strong>2 rings × 8 distinct subunits</strong> (16 total subunits per complex). (grantham2020themolecularchaperone pages 1-2)</li>
+<li>ATP occupancy asymmetry (model/synthesis): <strong>~4 subunits per ring occupied</strong> under saturating ATP; CCT3 in low ATP-affinity hemisphere. (kelly2020structuralandfunctional pages 42-48)</li>
+<li>Yeast CCT3 mutant proteome changes: <strong>46 upregulated</strong>, <strong>18 downregulated</strong> proteins in CCT3 D91E (MA3) vs wild type at <strong>P &lt; 0.01</strong>; screen size ~<strong>5,100</strong> GFP-tagged strains. (nadlerholly2012interactionsofsubunit pages 2-2)</li>
+<li>Ethanol tolerance phenotypes: <strong>cct3-1 sensitive at 3% ethanol</strong>; <strong>all cct mutants fail at 8% ethanol</strong> in the cited study; differential recovery to 6% by <strong>48 h</strong> reported with cct1/cct3 as exceptions. (narayanan2016defectsinprotein pages 4-6)</li>
+<li>Nuclear transcription assay conditions in yeast TRiC study (supporting methods transparency): <strong>100 ng</strong> DNA template and <strong>100 µg</strong> nuclear extract per reaction. (gvozdenov2024triccctchaperoningoverns pages 30-33)</li>
+</ul>
+<h3 id="visual-evidence-figure-citations">Visual evidence (figure citations)</h3>
+<p>Microscopy and quantitative panels illustrating that CCT3 mutation (MA3) causes P-body accumulation and stronger Q/N-rich protein effects than a CCT6 mutant are shown in the retrieved figure crops from Nadler-Holly et al. (PNAS, 2012). (nadlerholly2012interactionsofsubunit media 88c0bc6b, nadlerholly2012interactionsofsubunit media 61c31059, nadlerholly2012interactionsofsubunit media 27997266)</p>
+<h3 id="evidence-backed-annotation-summary-table">Evidence-backed annotation summary table</h3>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>Key points</th>
+<th>Best supporting citations</th>
+<th>Key source URLs+publication dates</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>identity/synonyms</td>
+<td>• Verified target is <strong>Saccharomyces cerevisiae CCT3 / YJL014W</strong>, encoding the <strong>TRiC/CCT chaperonin subunit gamma (CCTγ)</strong>. • CCT3 is one of the eight distinct paralogous subunits of the eukaryotic cytosolic chaperonin CCT/TRiC. • The literature also uses the CCT/TRiC-wide naming scheme <strong>CCT1–CCT8 / α–θ</strong>, so care is needed to avoid mixing with non-yeast CCT3 orthologs.</td>
+<td>(grantham2020themolecularchaperone pages 1-2, gvozdenov2024triccctchaperoningoverns pages 33-36, kelly2020structuralandfunctional pages 42-48)</td>
+<td>https://doi.org/10.3389/fgene.2020.00172 (Mar 2020); https://doi.org/10.1101/2024.09.26.615188 (Sep 26, 2024); https://doi.org/10.1073/pnas.1209277109 (Oct 2012)</td>
+</tr>
+<tr>
+<td>complex</td>
+<td>• CCT3 functions as a subunit of the <strong>CCT/TRiC hetero-oligomer</strong>, a barrel-shaped chaperonin with <strong>two rings of eight distinct subunits each</strong>. • Each subunit occupies a defined position within the ring. • Structural work places CCT3 in the <strong>CCT1–CCT3 apical-domain pair</strong> and in the <strong>low-ATP-affinity hemisphere (CCT3/6/7/8)</strong>.</td>
+<td>(grantham2020themolecularchaperone pages 1-2, kelly2020structuralandfunctional pages 42-48, zang2018developmentofa pages 7-8)</td>
+<td>https://doi.org/10.3389/fgene.2020.00172 (Mar 2020); https://doi.org/10.1038/s41598-017-18962-y (Feb 2018)</td>
+</tr>
+<tr>
+<td>mechanism</td>
+<td>• CCT/TRiC is an <strong>ATP-dependent folding machine</strong> with substrate-binding apical domains and nucleotide-binding equatorial domains. • For CCT3 specifically, structural/functional characterization places it among the <strong>lower ATP-affinity subunits</strong>; under saturating ATP, an average of <strong>~4 subunits per ring</strong> are occupied. • CCT3 contributes to the <strong>inter-ring interaction network</strong> via its N-terminus in models of ring closure.</td>
+<td>(grantham2020themolecularchaperone pages 1-2, kelly2020structuralandfunctional pages 42-48)</td>
+<td>https://doi.org/10.3389/fgene.2020.00172 (Mar 2020)</td>
+</tr>
+<tr>
+<td>localization</td>
+<td>• The strongest supported localization for the yeast complex is the <strong>cytosol/cytoplasm</strong>, consistent with its role folding newly made cytosolic proteins. • Recent yeast work also supports a <strong>nuclear role for TRiC/CCT</strong> in RNA polymerase II activity and RNA homeostasis, though this was shown for the complex rather than CCT3 specifically. • Older cited background also notes reports of association with <strong>Golgi membranes, nuclear matrix, and heterochromatin</strong> for CCT/TRiC literature more broadly.</td>
+<td>(gvozdenov2024triccctchaperoningoverns pages 30-33, gvozdenov2024triccctchaperoningoverns pages 33-36, que2024theroleof pages 1-2)</td>
+<td>https://doi.org/10.1101/2024.09.26.615188 (Sep 26, 2024); https://doi.org/10.1016/j.heliyon.2024.e29029 (Apr 1, 2024)</td>
+</tr>
+<tr>
+<td>substrates/clients</td>
+<td>• Canonical CCT/TRiC clients include <strong>actin and tubulin</strong>, described as major/obligate substrates of the complex. • A CCT3-specific yeast study found stronger interaction of CCT3 than CCT6 with <strong>Q/N-rich proteins</strong>, especially proteins linked to <strong>P-bodies</strong>. • In the CCT3 mutant screen, <strong>46 proteins increased and 18 decreased</strong> relative to wild type, and <strong>8 of 9</strong> most-changed proteins had physical/genetic interactions with Q/N-rich proteins.</td>
+<td>(nadlerholly2012interactionsofsubunit pages 2-2, grantham2020themolecularchaperone pages 1-2, nadlerholly2012interactionsofsubunit pages 4-5, nadlerholly2012interactionsofsubunit pages 5-6)</td>
+<td>https://doi.org/10.1073/pnas.1209277109 (Oct 2012); https://doi.org/10.3389/fgene.2020.00172 (Mar 2020)</td>
+</tr>
+<tr>
+<td>phenotypes</td>
+<td>• Yeast <strong>CCT genes are essential</strong>, and the review literature states CCT subunits are encoded by essential yeast genes. • A CCT3 ATP-site mutant (<strong>D91E/MA3</strong>) caused strong <strong>P-body accumulation</strong>; several canonical P-body proteins formed prominent puncta, and the screen covered <strong>~5,100 GFP-tagged strains</strong>. • In stress-phenotype work, <strong>cct3-1</strong> showed sensitivity to multiple stressors including <strong>ethanol, NaCl, DTT, arsenate, H2O2, SDS, methanol</strong>, and was reported as <strong>supersensitive to TBZ</strong>; cct3-1 was sensitive at <strong>3% ethanol</strong>, and cct3 mutants were among strains not recovering tolerance like most others by <strong>48 h</strong>.</td>
+<td>(nadlerholly2012interactionsofsubunit pages 2-2, grantham2020themolecularchaperone pages 1-2, narayanan2016defectsinprotein pages 2-4, narayanan2016defectsinprotein pages 4-6)</td>
+<td>https://doi.org/10.1073/pnas.1209277109 (Oct 2012); https://doi.org/10.1007/s00284-016-1024-x (Mar 2016); https://doi.org/10.3389/fgene.2020.00172 (Mar 2020)</td>
+</tr>
+<tr>
+<td>recent 2023-2024 developments</td>
+<td>• A 2024 review emphasizes CCT/TRiC as an important regulator of <strong>translation elongation/protein synthesis coupling</strong>. • A 2023 structural study on TRiC-mediated tubulin folding captured a near-native folding intermediate engaging mainly <strong>CCT3/6/8</strong> subunits in the closed chamber, supporting subunit-specialized substrate contacts. • A 2024 yeast preprint reports <strong>nuclear TRiC/CCT support of RNA polymerase II activity</strong> and RNA homeostasis.</td>
+<td>(gvozdenov2024triccctchaperoningoverns pages 30-33, que2024theroleof pages 1-2)</td>
+<td>https://doi.org/10.1016/j.heliyon.2024.e29029 (Apr 1, 2024); https://doi.org/10.1038/s42003-023-04915-x (May 2023); https://doi.org/10.1101/2024.09.26.615188 (Sep 26, 2024)</td>
+</tr>
+<tr>
+<td>applications</td>
+<td>• Yeast CCT3 has been used experimentally as an anchor for <strong>internal subunit eGFP labeling</strong> to map TRiC/CCT subunit arrangement in cryo-EM studies. • CCT/TRiC is used as a model system for studying <strong>proteostasis, aggregation control, and folding of complex proteins</strong>. • Stress-sensitive yeast cct mutants, including <strong>cct3-1</strong>, provide practical models for probing <strong>cell wall integrity and ethanol tolerance</strong> relevant to industrial/biotechnology contexts.</td>
+<td>(zang2018developmentofa pages 7-8, grantham2020themolecularchaperone pages 1-2, narayanan2016defectsinprotein pages 4-6)</td>
+<td>https://doi.org/10.1038/s41598-017-18962-y (Feb 2018); https://doi.org/10.3389/fgene.2020.00172 (Mar 2020); https://doi.org/10.1007/s00284-016-1024-x (Mar 2016)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the evidence-supported functional annotation of Saccharomyces cerevisiae CCT3/YJL014W, including complex membership, mechanism, localization, substrates, phenotypes, and recent developments. It is useful as a compact reference anchored to specific context IDs and source URLs.</em></p>
+<h3 id="limitations-of-the-current-evidence-set">Limitations of the current evidence set</h3>
+<ul>
+<li>The most detailed yeast CCT3 functional specificity evidence in the retrieved set is from 2012 (PNAS). While still high-quality, yeast CCT3-specific primary literature in 2023–2024 was not directly retrieved here; recent work largely focuses on TRiC/CCT more generally or in other organisms, and should be integrated cautiously when making yeast-subunit-specific claims. (nadlerholly2012interactionsofsubunit pages 2-2, que2024theroleof pages 1-2)</li>
+</ul>
+<h3 id="key-sources-urls-and-publication-dates">Key sources (URLs and publication dates)</h3>
+<ul>
+<li>Nadler-Holly et al. <strong>2012-10</strong>. <em>PNAS</em>. “Interactions of subunit CCT3 in the yeast chaperonin CCT/TRiC with Q/N-rich proteins…” https://doi.org/10.1073/pnas.1209277109 (nadlerholly2012interactionsofsubunit pages 2-2)</li>
+<li>Narayanan et al. <strong>2016-03</strong>. <em>Current Microbiology</em>. “Defects in Protein Folding Machinery Affect Cell Wall Integrity and Reduce Ethanol Tolerance…” https://doi.org/10.1007/s00284-016-1024-x (narayanan2016defectsinprotein pages 4-6)</li>
+<li>Grantham <strong>2020-03</strong>. <em>Frontiers in Genetics</em>. “The Molecular Chaperone CCT/TRiC…” https://doi.org/10.3389/fgene.2020.00172 (grantham2020themolecularchaperone pages 1-2)</li>
+<li>Zang et al. <strong>2018-02</strong>. <em>Scientific Reports</em>. “Development of a yeast internal-subunit eGFP labeling strategy…” https://doi.org/10.1038/s41598-017-18962-y (zang2018developmentofa pages 7-8)</li>
+<li>Que et al. <strong>2024-04-01 (online)</strong>. <em>Heliyon</em>. “The role of molecular chaperone CCT/TRiC in translation elongation…” https://doi.org/10.1016/j.heliyon.2024.e29029 (que2024theroleof pages 1-2)</li>
+<li>Gvozdenov et al. <strong>2024-09-26 (posted)</strong>. <em>bioRxiv</em>. “TRiC/CCT Chaperonin Governs RNA Polymerase II Activity in the Nucleus…” https://doi.org/10.1101/2024.09.26.615188 (gvozdenov2024triccctchaperoningoverns pages 30-33)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(grantham2020themolecularchaperone pages 1-2): Julie Grantham. The molecular chaperone cct/tric: an essential component of proteostasis and a potential modulator of protein aggregation. Frontiers in Genetics, Mar 2020. URL: https://doi.org/10.3389/fgene.2020.00172, doi:10.3389/fgene.2020.00172. This article has 139 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nadlerholly2012interactionsofsubunit pages 2-2): Michal Nadler-Holly, Michal Breker, Ranit Gruber, Ariel Azia, Melissa Gymrek, Miriam Eisenstein, Keith R. Willison, Maya Schuldiner, and Amnon Horovitz. Interactions of subunit cct3 in the yeast chaperonin cct/tric with q/n-rich proteins revealed by high-throughput microscopy analysis. Proceedings of the National Academy of Sciences, 109:18833-18838, Oct 2012. URL: https://doi.org/10.1073/pnas.1209277109, doi:10.1073/pnas.1209277109. This article has 52 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(narayanan2016defectsinprotein pages 4-6): Aswathy Narayanan, Dileep Pullepu, Praveen Kumar Reddy, Wasim Uddin, and M. Anaul Kabir. Defects in protein folding machinery affect cell wall integrity and reduce ethanol tolerance in s. cerevisiae. Current Microbiology, 73:38-45, Mar 2016. URL: https://doi.org/10.1007/s00284-016-1024-x, doi:10.1007/s00284-016-1024-x. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(narayanan2016defectsinprotein pages 2-4): Aswathy Narayanan, Dileep Pullepu, Praveen Kumar Reddy, Wasim Uddin, and M. Anaul Kabir. Defects in protein folding machinery affect cell wall integrity and reduce ethanol tolerance in s. cerevisiae. Current Microbiology, 73:38-45, Mar 2016. URL: https://doi.org/10.1007/s00284-016-1024-x, doi:10.1007/s00284-016-1024-x. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kelly2020structuralandfunctional pages 42-48): J Kelly. Structural and functional characterisation of the group ii chaperonin cct/tric. Unknown journal, 2020.</p>
+</li>
+<li>
+<p>(que2024theroleof pages 1-2): Yueyue Que, Yudan Qiu, Zheyu Ding, Shanshan Zhang, Rong Wei, Jianing Xia, and Yingying Lin. The role of molecular chaperone cct/tric in translation elongation: a literature review. Heliyon, 10:e29029, Apr 2024. URL: https://doi.org/10.1016/j.heliyon.2024.e29029, doi:10.1016/j.heliyon.2024.e29029. This article has 12 citations.</p>
+</li>
+<li>
+<p>(nadlerholly2012interactionsofsubunit media 88c0bc6b): Michal Nadler-Holly, Michal Breker, Ranit Gruber, Ariel Azia, Melissa Gymrek, Miriam Eisenstein, Keith R. Willison, Maya Schuldiner, and Amnon Horovitz. Interactions of subunit cct3 in the yeast chaperonin cct/tric with q/n-rich proteins revealed by high-throughput microscopy analysis. Proceedings of the National Academy of Sciences, 109:18833-18838, Oct 2012. URL: https://doi.org/10.1073/pnas.1209277109, doi:10.1073/pnas.1209277109. This article has 52 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nadlerholly2012interactionsofsubunit pages 4-5): Michal Nadler-Holly, Michal Breker, Ranit Gruber, Ariel Azia, Melissa Gymrek, Miriam Eisenstein, Keith R. Willison, Maya Schuldiner, and Amnon Horovitz. Interactions of subunit cct3 in the yeast chaperonin cct/tric with q/n-rich proteins revealed by high-throughput microscopy analysis. Proceedings of the National Academy of Sciences, 109:18833-18838, Oct 2012. URL: https://doi.org/10.1073/pnas.1209277109, doi:10.1073/pnas.1209277109. This article has 52 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gvozdenov2024triccctchaperoningoverns pages 30-33): Zlata Gvozdenov, Audrey Yi Tyan Peng, Anusmita Biswas, Zeno Barcutean, Daniel Gestaut, Judith Frydman, Kevin Struhl, and Brian C. Freeman. Tric/cct chaperonin governs rna polymerase ii activity in the nucleus to support rna homeostasis. bioRxiv, Sep 2024. URL: https://doi.org/10.1101/2024.09.26.615188, doi:10.1101/2024.09.26.615188. This article has 3 citations.</p>
+</li>
+<li>
+<p>(gvozdenov2024triccctchaperoningoverns pages 33-36): Zlata Gvozdenov, Audrey Yi Tyan Peng, Anusmita Biswas, Zeno Barcutean, Daniel Gestaut, Judith Frydman, Kevin Struhl, and Brian C. Freeman. Tric/cct chaperonin governs rna polymerase ii activity in the nucleus to support rna homeostasis. bioRxiv, Sep 2024. URL: https://doi.org/10.1101/2024.09.26.615188, doi:10.1101/2024.09.26.615188. This article has 3 citations.</p>
+</li>
+<li>
+<p>(zang2018developmentofa pages 7-8): Yunxiang Zang, Huping Wang, Zhicheng Cui, Mingliang Jin, Caixuan Liu, Wenyu Han, Yanxing Wang, and Yao Cong. Development of a yeast internal-subunit egfp labeling strategy and its application in subunit identification in eukaryotic group ii chaperonin tric/cct. Scientific Reports, Feb 2018. URL: https://doi.org/10.1038/s41598-017-18962-y, doi:10.1038/s41598-017-18962-y. This article has 22 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nadlerholly2012interactionsofsubunit media 61c31059): Michal Nadler-Holly, Michal Breker, Ranit Gruber, Ariel Azia, Melissa Gymrek, Miriam Eisenstein, Keith R. Willison, Maya Schuldiner, and Amnon Horovitz. Interactions of subunit cct3 in the yeast chaperonin cct/tric with q/n-rich proteins revealed by high-throughput microscopy analysis. Proceedings of the National Academy of Sciences, 109:18833-18838, Oct 2012. URL: https://doi.org/10.1073/pnas.1209277109, doi:10.1073/pnas.1209277109. This article has 52 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nadlerholly2012interactionsofsubunit media 27997266): Michal Nadler-Holly, Michal Breker, Ranit Gruber, Ariel Azia, Melissa Gymrek, Miriam Eisenstein, Keith R. Willison, Maya Schuldiner, and Amnon Horovitz. Interactions of subunit cct3 in the yeast chaperonin cct/tric with q/n-rich proteins revealed by high-throughput microscopy analysis. Proceedings of the National Academy of Sciences, 109:18833-18838, Oct 2012. URL: https://doi.org/10.1073/pnas.1209277109, doi:10.1073/pnas.1209277109. This article has 52 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nadlerholly2012interactionsofsubunit pages 5-6): Michal Nadler-Holly, Michal Breker, Ranit Gruber, Ariel Azia, Melissa Gymrek, Miriam Eisenstein, Keith R. Willison, Maya Schuldiner, and Amnon Horovitz. Interactions of subunit cct3 in the yeast chaperonin cct/tric with q/n-rich proteins revealed by high-throughput microscopy analysis. Proceedings of the National Academy of Sciences, 109:18833-18838, Oct 2012. URL: https://doi.org/10.1073/pnas.1209277109, doi:10.1073/pnas.1209277109. This article has 52 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>grantham2020themolecularchaperone pages 1-2</li>
+<li>kelly2020structuralandfunctional pages 42-48</li>
+<li>nadlerholly2012interactionsofsubunit pages 2-2</li>
+<li>gvozdenov2024triccctchaperoningoverns pages 30-33</li>
+<li>narayanan2016defectsinprotein pages 2-4</li>
+<li>narayanan2016defectsinprotein pages 4-6</li>
+<li>que2024theroleof pages 1-2</li>
+<li>gvozdenov2024triccctchaperoningoverns pages 33-36</li>
+<li>zang2018developmentofa pages 7-8</li>
+<li>nadlerholly2012interactionsofsubunit pages 4-5</li>
+<li>nadlerholly2012interactionsofsubunit pages 5-6</li>
+<li>https://doi.org/10.1016/j.heliyon.2024.e29029</li>
+<li>https://doi.org/10.1101/2024.09.26.615188</li>
+<li>https://doi.org/10.1038/s42003-023-04915-x</li>
+<li>https://doi.org/10.1038/s41598-017-18962-y</li>
+<li>https://doi.org/10.1007/s00284-016-1024-x</li>
+<li>https://doi.org/10.3389/fgene.2020.00172</li>
+<li>https://doi.org/10.1073/pnas.1209277109</li>
+<li>https://doi.org/10.3389/fgene.2020.00172,</li>
+<li>https://doi.org/10.1073/pnas.1209277109,</li>
+<li>https://doi.org/10.1007/s00284-016-1024-x,</li>
+<li>https://doi.org/10.1016/j.heliyon.2024.e29029,</li>
+<li>https://doi.org/10.1101/2024.09.26.615188,</li>
+<li>https://doi.org/10.1038/s41598-017-18962-y,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -1924,174 +2594,15 @@
                 <pre><code>id: P39077
 gene_symbol: CCT3
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: &#39;TODO: Add description for CCT3&#39;
-existing_annotations:
-- term:
-    id: GO:0006457
-    label: protein folding
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: &#39;Manual review: protein folding is consistent with known biology of CCT3.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005832
-    label: chaperonin-containing T-complex
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: &#39;Manual review: chaperonin-containing T-complex is consistent with known biology of CCT3.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: &#39;Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT3.&#39;
-    action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
-- term:
-    id: GO:0000166
-    label: nucleotide binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000043
-  review:
-    summary: &#39;Manual review: nucleotide binding is consistent with known biology of CCT3.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005524
-    label: ATP binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000120
-  review:
-    summary: &#39;Manual review: ATP binding is consistent with known biology of CCT3.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005737
-    label: cytoplasm
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000044
-  review:
-    summary: &#39;Manual review: cytoplasm is consistent with known biology of CCT3.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005832
-    label: chaperonin-containing T-complex
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000117
-  review:
-    summary: &#39;Manual review: chaperonin-containing T-complex is consistent with known biology of CCT3.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0006457
-    label: protein folding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000120
-  review:
-    summary: &#39;Manual review: protein folding is consistent with known biology of CCT3.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0016887
-    label: ATP hydrolysis activity
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: &#39;Manual review: ATP hydrolysis activity is consistent with known biology of CCT3.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000120
-  review:
-    summary: &#39;Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT3.&#39;
-    action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
-- term:
-    id: GO:0140662
-    label: ATP-dependent protein folding chaperone
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: &#39;Manual review: ATP-dependent protein folding chaperone is consistent with known biology of CCT3.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:19536198
-  review:
-    summary: &#39;Manual review: protein binding is too generic or over-extended for CCT3.&#39;
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:37968396
-  review:
-    summary: &#39;Manual review: protein binding is too generic or over-extended for CCT3.&#39;
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0006457
-    label: protein folding
-  evidence_type: IDA
-  original_reference_id: PMID:16762366
-  review:
-    summary: &#39;Manual review: protein folding is consistent with known biology of CCT3.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005832
-    label: chaperonin-containing T-complex
-  evidence_type: IPI
-  original_reference_id: PMID:15704212
-  review:
-    summary: &#39;Manual review: chaperonin-containing T-complex is consistent with known biology of CCT3.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005832
-    label: chaperonin-containing T-complex
-  evidence_type: IDA
-  original_reference_id: PMID:16762366
-  review:
-    summary: &#39;Manual review: chaperonin-containing T-complex is consistent with known biology of CCT3.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IDA
-  original_reference_id: PMID:16762366
-  review:
-    summary: &#39;Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT3.&#39;
-    action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+description: &gt;-
+  CCT3 encodes the gamma subunit of the cytosolic group II chaperonin TRiC/CCT. As one of eight obligate
+  paralogous subunits in each ring, Cct3 contributes ATPase and substrate-contact surfaces to the hetero-oligomeric
+  folding chamber that matures actin, tubulin, and other cytosolic clients. Its curated core function
+  is complex-level ATP-dependent protein folding, not nonspecific protein binding.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -2103,7 +2614,9 @@ references:
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
+  title: &gt;-
+    Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied
+    by conservative changes to GO terms applied by UniProt
   findings: []
 - id: GO_REF:0000117
   title: Electronic Gene Ontology annotations created by ARBA machine learning models
@@ -2113,23 +2626,372 @@ references:
   findings: []
 - id: PMID:15704212
   title: Physiological effects of unassembled chaperonin Cct subunits in the yeast Saccharomyces cerevisiae.
-  findings: []
+  findings:
+  - statement: Yeast CCT is a double-ring complex with a stoichiometric set of eight distinct Cct subunits.
+    supporting_text: &gt;-
+      Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
+      of a stoichiometric array of eight different subunits
 - id: PMID:16762366
-  title: Quantitative actin folding reactions using yeast CCT purified via an internal tag in the CCT3/gamma subunit.
-  findings: []
+  title: &gt;-
+    Quantitative actin folding reactions using yeast CCT purified via an internal tag in the CCT3/gamma
+    subunit.
+  findings:
+  - statement: &gt;-
+      Purified yeast CCT, tagged through CCT3, catalyzes ATP-dependent actin folding; this supports protein-folding
+      and chaperonin activity annotations for CCT3 as a TRiC/CCT subunit.
+    supporting_text: &gt;-
+      The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose
+      action is required for folding the cytoskeletal proteins actin and tubulin
 - id: PMID:19536198
-  title: &#39;An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding pathways in the cell.&#39;
-  findings: []
+  title: &gt;-
+    An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding
+    pathways in the cell.
+  findings:
+  - statement: &gt;-
+      The chaperone interactome study is useful context for CCT contacts but reports indirect TAP-tag
+      interactions rather than a specific molecular activity.
+    supporting_text: &gt;-
+      It should be emphasized that the interactions presented are indirect TAP-tag based interactions
+      and not direct binary interactions.
 - id: PMID:37968396
   title: The social and structural architecture of the yeast protein interactome.
   findings: []
+- id: file:yeast/CCT3/CCT3-deep-research-falcon.md
+  title: Falcon deep research report for CCT3
+  findings:
+  - statement: &gt;-
+      The Falcon report was reviewed and synthesized into the CCT3 curation, including core-function framing,
+      family/PANTHER context, and evidence limitations.
+existing_annotations:
+- term:
+    id: GO:0006457
+    label: protein folding
+  qualifier: involved_in
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: &gt;-
+      CCT3 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin
+      that folds actin, tubulin, and other clients.
+    action: ACCEPT
+    reason: &gt;-
+      Protein folding is the correct biological-process context for the chaperonin complex, supported
+      by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
+    supported_by:
+    - reference_id: file:yeast/CCT3/CCT3-deep-research-falcon.md
+      supporting_text: The CCT/TRiC complex is a double-ring ATP-driven folding machine
+- term:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  qualifier: part_of
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: CCT3 is a named subunit of the chaperonin-containing T-complex.
+    action: ACCEPT
+    reason: &gt;-
+      Complex membership is central to the gene product function and is supported by yeast CCT complex
+      literature and family evidence.
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: &gt;-
+      unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than
+      the ATP-dependent folding chaperone function of the complex.
+    action: MODIFY
+    reason: &gt;-
+      Replace generic substrate-binding language with the specific chaperonin activity supported by yeast
+      CCT actin-folding assays and domain evidence.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+- term:
+    id: GO:0000166
+    label: nucleotide binding
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: &gt;-
+      nucleotide binding is a true but overly broad family/keyword annotation for CCT3; ATP binding, ATP
+      hydrolysis, and ATP-dependent chaperone annotations capture the specific chemistry.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Generic nucleotide binding does not add useful functional information beyond the more specific ATP-related
+      chaperonin annotations already present.
+- term:
+    id: GO:0005524
+    label: ATP binding
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: &gt;-
+      CCT3 contains a conserved chaperonin ATP-binding site, but ATP binding alone is a domain property
+      rather than the core biological function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Keep as a valid supporting molecular property of the CCT ATPase cycle, while treating ATP hydrolysis
+      and complex-level protein folding as the core function.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  qualifier: located_in
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: CCT3 functions as part of the cytosolic TRiC/CCT chaperonin.
+    action: ACCEPT
+    reason: Cytoplasm is the established location of the CCT/TRiC folding machine.
+- term:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  qualifier: part_of
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: CCT3 is a named subunit of the chaperonin-containing T-complex.
+    action: ACCEPT
+    reason: &gt;-
+      Complex membership is central to the gene product function and is supported by yeast CCT complex
+      literature and family evidence.
+- term:
+    id: GO:0006457
+    label: protein folding
+  qualifier: involved_in
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: &gt;-
+      CCT3 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin
+      that folds actin, tubulin, and other clients.
+    action: ACCEPT
+    reason: &gt;-
+      Protein folding is the correct biological-process context for the chaperonin complex, supported
+      by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
+- term:
+    id: GO:0016887
+    label: ATP hydrolysis activity
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: &gt;-
+      CCT3 is a TCP-1/CCT chaperonin subunit with conserved ATPase machinery that powers TRiC/CCT conformational
+      cycling.
+    action: ACCEPT
+    reason: &gt;-
+      ATP hydrolysis is a defensible subunit-level molecular function for CCT family members and is directly
+      tied to the chaperonin folding cycle.
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: &gt;-
+      unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than
+      the ATP-dependent folding chaperone function of the complex.
+    action: MODIFY
+    reason: &gt;-
+      Replace generic substrate-binding language with the specific chaperonin activity supported by yeast
+      CCT actin-folding assays and domain evidence.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+- term:
+    id: GO:0140662
+    label: ATP-dependent protein folding chaperone
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: CCT3 is an obligate subunit of the ATP-dependent TRiC/CCT folding machine.
+    action: ACCEPT
+    reason: &gt;-
+      The term is appropriate as a complex-level chaperonin function; in the synthesized core function
+      it is modeled as a contributed-to molecular function rather than a standalone activity of an isolated
+      subunit.
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: &gt;-
+        The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine
+        whose action is required for folding the cytoskeletal proteins actin and tubulin
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005515
+    label: protein binding
+  qualifier: enables
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  supporting_entities:
+  - UniProtKB:P32324
+  review:
+    summary: &gt;-
+      protein binding is too generic for a CCT subunit and does not describe the chaperonin mechanism
+      or substrate class.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Physical-interaction datasets are useful evidence context, but generic protein binding should not
+      stand as a functional annotation when the specific TRiC/CCT chaperonin role is known.
+    supported_by:
+    - reference_id: PMID:19536198
+      supporting_text: &gt;-
+        It should be emphasized that the interactions presented are indirect TAP-tag based interactions
+        and not direct binary interactions.
+- term:
+    id: GO:0005515
+    label: protein binding
+  qualifier: enables
+  evidence_type: IPI
+  original_reference_id: PMID:37968396
+  supporting_entities:
+  - UniProtKB:P32324
+  review:
+    summary: &gt;-
+      protein binding is too generic for a CCT subunit and does not describe the chaperonin mechanism
+      or substrate class.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Physical-interaction datasets are useful evidence context, but generic protein binding should not
+      stand as a functional annotation when the specific TRiC/CCT chaperonin role is known.
+- term:
+    id: GO:0006457
+    label: protein folding
+  qualifier: involved_in
+  evidence_type: IDA
+  original_reference_id: PMID:16762366
+  review:
+    summary: &gt;-
+      CCT3 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin
+      that folds actin, tubulin, and other clients.
+    action: ACCEPT
+    reason: &gt;-
+      Protein folding is the correct biological-process context for the chaperonin complex, supported
+      by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: &gt;-
+        The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine
+        whose action is required for folding the cytoskeletal proteins actin and tubulin
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  qualifier: part_of
+  evidence_type: IPI
+  original_reference_id: PMID:15704212
+  supporting_entities:
+  - SGD:S000002596
+  review:
+    summary: CCT3 is a named subunit of the chaperonin-containing T-complex.
+    action: ACCEPT
+    reason: &gt;-
+      Complex membership is central to the gene product function and is supported by yeast CCT complex
+      literature and family evidence.
+    supported_by:
+    - reference_id: PMID:15704212
+      supporting_text: &gt;-
+        Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
+        of a stoichiometric array of eight different subunits
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  qualifier: part_of
+  evidence_type: IDA
+  original_reference_id: PMID:16762366
+  review:
+    summary: CCT3 is a named subunit of the chaperonin-containing T-complex.
+    action: ACCEPT
+    reason: &gt;-
+      Complex membership is central to the gene product function and is supported by yeast CCT complex
+      literature and family evidence.
+    supported_by:
+    - reference_id: PMID:15704212
+      supporting_text: &gt;-
+        Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
+        of a stoichiometric array of eight different subunits
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IDA
+  original_reference_id: PMID:16762366
+  review:
+    summary: &gt;-
+      unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than
+      the ATP-dependent folding chaperone function of the complex.
+    action: MODIFY
+    reason: &gt;-
+      Replace generic substrate-binding language with the specific chaperonin activity supported by yeast
+      CCT actin-folding assays and domain evidence.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: &gt;-
+        The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine
+        whose action is required for folding the cytoskeletal proteins actin and tubulin
+      reference_section_type: ABSTRACT
+core_functions:
+- description: &gt;-
+    CCT3 is the gamma subunit of the cytosolic TRiC/CCT chaperonin. The subunit contributes ATPase and
+    substrate-contact surfaces to the hetero-oligomeric double-ring complex, whose ATP-dependent conformational
+    cycle folds actin, tubulin, and other cytosolic client proteins. The synthesized function is modeled
+    as subunit ATP hydrolysis contributing to the complex-level ATP-dependent protein folding chaperone
+    activity.
+  molecular_function:
+    id: GO:0016887
+    label: ATP hydrolysis activity
+  contributes_to_molecular_function:
+    id: GO:0140662
+    label: ATP-dependent protein folding chaperone
+  directly_involved_in:
+  - id: GO:0006457
+    label: protein folding
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+  in_complex:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  supported_by:
+  - reference_id: PMID:16762366
+    supporting_text: &gt;-
+      The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose
+      action is required for folding the cytoskeletal proteins actin and tubulin
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:15704212
+    supporting_text: &gt;-
+      Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
+      of a stoichiometric array of eight different subunits
+    reference_section_type: ABSTRACT
+suggested_questions:
+- question: &gt;-
+    Which yeast client proteins depend specifically on Cct3 apical-domain contacts rather than on generic
+    TRiC/CCT chamber activity?
+suggested_experiments:
+- hypothesis: Cct3 contributes subunit-specific contacts for a subset of aggregation-prone or Q/N-rich
+    clients.
+  description: &gt;-
+    Profile client aggregation, solubility, and folding reporter behavior in conditional CCT3 mutants
+    under permissive and restrictive conditions, with actin and tubulin reporters as controls.
+  experiment_type: conditional mutant proteostasis profiling
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/yeast/CCT3/CCT3-ai-review.yaml
+++ b/genes/yeast/CCT3/CCT3-ai-review.yaml
@@ -1,174 +1,15 @@
 id: P39077
 gene_symbol: CCT3
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: 'TODO: Add description for CCT3'
-existing_annotations:
-- term:
-    id: GO:0006457
-    label: protein folding
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: 'Manual review: protein folding is consistent with known biology of CCT3.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005832
-    label: chaperonin-containing T-complex
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: 'Manual review: chaperonin-containing T-complex is consistent with known biology of CCT3.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: 'Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT3.'
-    action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
-- term:
-    id: GO:0000166
-    label: nucleotide binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000043
-  review:
-    summary: 'Manual review: nucleotide binding is consistent with known biology of CCT3.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005524
-    label: ATP binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000120
-  review:
-    summary: 'Manual review: ATP binding is consistent with known biology of CCT3.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005737
-    label: cytoplasm
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000044
-  review:
-    summary: 'Manual review: cytoplasm is consistent with known biology of CCT3.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005832
-    label: chaperonin-containing T-complex
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000117
-  review:
-    summary: 'Manual review: chaperonin-containing T-complex is consistent with known biology of CCT3.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0006457
-    label: protein folding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000120
-  review:
-    summary: 'Manual review: protein folding is consistent with known biology of CCT3.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0016887
-    label: ATP hydrolysis activity
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: 'Manual review: ATP hydrolysis activity is consistent with known biology of CCT3.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000120
-  review:
-    summary: 'Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT3.'
-    action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
-- term:
-    id: GO:0140662
-    label: ATP-dependent protein folding chaperone
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: 'Manual review: ATP-dependent protein folding chaperone is consistent with known biology of CCT3.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:19536198
-  review:
-    summary: 'Manual review: protein binding is too generic or over-extended for CCT3.'
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:37968396
-  review:
-    summary: 'Manual review: protein binding is too generic or over-extended for CCT3.'
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0006457
-    label: protein folding
-  evidence_type: IDA
-  original_reference_id: PMID:16762366
-  review:
-    summary: 'Manual review: protein folding is consistent with known biology of CCT3.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005832
-    label: chaperonin-containing T-complex
-  evidence_type: IPI
-  original_reference_id: PMID:15704212
-  review:
-    summary: 'Manual review: chaperonin-containing T-complex is consistent with known biology of CCT3.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005832
-    label: chaperonin-containing T-complex
-  evidence_type: IDA
-  original_reference_id: PMID:16762366
-  review:
-    summary: 'Manual review: chaperonin-containing T-complex is consistent with known biology of CCT3.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IDA
-  original_reference_id: PMID:16762366
-  review:
-    summary: 'Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT3.'
-    action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+description: >-
+  CCT3 encodes the gamma subunit of the cytosolic group II chaperonin TRiC/CCT. As one of eight obligate
+  paralogous subunits in each ring, Cct3 contributes ATPase and substrate-contact surfaces to the hetero-oligomeric
+  folding chamber that matures actin, tubulin, and other cytosolic clients. Its curated core function
+  is complex-level ATP-dependent protein folding, not nonspecific protein binding.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -180,7 +21,9 @@ references:
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
+  title: >-
+    Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied
+    by conservative changes to GO terms applied by UniProt
   findings: []
 - id: GO_REF:0000117
   title: Electronic Gene Ontology annotations created by ARBA machine learning models
@@ -190,13 +33,362 @@ references:
   findings: []
 - id: PMID:15704212
   title: Physiological effects of unassembled chaperonin Cct subunits in the yeast Saccharomyces cerevisiae.
-  findings: []
+  findings:
+  - statement: Yeast CCT is a double-ring complex with a stoichiometric set of eight distinct Cct subunits.
+    supporting_text: >-
+      Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
+      of a stoichiometric array of eight different subunits
 - id: PMID:16762366
-  title: Quantitative actin folding reactions using yeast CCT purified via an internal tag in the CCT3/gamma subunit.
-  findings: []
+  title: >-
+    Quantitative actin folding reactions using yeast CCT purified via an internal tag in the CCT3/gamma
+    subunit.
+  findings:
+  - statement: >-
+      Purified yeast CCT, tagged through CCT3, catalyzes ATP-dependent actin folding; this supports protein-folding
+      and chaperonin activity annotations for CCT3 as a TRiC/CCT subunit.
+    supporting_text: >-
+      The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose
+      action is required for folding the cytoskeletal proteins actin and tubulin
 - id: PMID:19536198
-  title: 'An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding pathways in the cell.'
-  findings: []
+  title: >-
+    An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding
+    pathways in the cell.
+  findings:
+  - statement: >-
+      The chaperone interactome study is useful context for CCT contacts but reports indirect TAP-tag
+      interactions rather than a specific molecular activity.
+    supporting_text: >-
+      It should be emphasized that the interactions presented are indirect TAP-tag based interactions
+      and not direct binary interactions.
 - id: PMID:37968396
   title: The social and structural architecture of the yeast protein interactome.
   findings: []
+- id: file:yeast/CCT3/CCT3-deep-research-falcon.md
+  title: Falcon deep research report for CCT3
+  findings:
+  - statement: >-
+      The Falcon report was reviewed and synthesized into the CCT3 curation, including core-function framing,
+      family/PANTHER context, and evidence limitations.
+existing_annotations:
+- term:
+    id: GO:0006457
+    label: protein folding
+  qualifier: involved_in
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: >-
+      CCT3 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin
+      that folds actin, tubulin, and other clients.
+    action: ACCEPT
+    reason: >-
+      Protein folding is the correct biological-process context for the chaperonin complex, supported
+      by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
+    supported_by:
+    - reference_id: file:yeast/CCT3/CCT3-deep-research-falcon.md
+      supporting_text: The CCT/TRiC complex is a double-ring ATP-driven folding machine
+- term:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  qualifier: part_of
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: CCT3 is a named subunit of the chaperonin-containing T-complex.
+    action: ACCEPT
+    reason: >-
+      Complex membership is central to the gene product function and is supported by yeast CCT complex
+      literature and family evidence.
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: >-
+      unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than
+      the ATP-dependent folding chaperone function of the complex.
+    action: MODIFY
+    reason: >-
+      Replace generic substrate-binding language with the specific chaperonin activity supported by yeast
+      CCT actin-folding assays and domain evidence.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+- term:
+    id: GO:0000166
+    label: nucleotide binding
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: >-
+      nucleotide binding is a true but overly broad family/keyword annotation for CCT3; ATP binding, ATP
+      hydrolysis, and ATP-dependent chaperone annotations capture the specific chemistry.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Generic nucleotide binding does not add useful functional information beyond the more specific ATP-related
+      chaperonin annotations already present.
+- term:
+    id: GO:0005524
+    label: ATP binding
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: >-
+      CCT3 contains a conserved chaperonin ATP-binding site, but ATP binding alone is a domain property
+      rather than the core biological function.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Keep as a valid supporting molecular property of the CCT ATPase cycle, while treating ATP hydrolysis
+      and complex-level protein folding as the core function.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  qualifier: located_in
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: CCT3 functions as part of the cytosolic TRiC/CCT chaperonin.
+    action: ACCEPT
+    reason: Cytoplasm is the established location of the CCT/TRiC folding machine.
+- term:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  qualifier: part_of
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: CCT3 is a named subunit of the chaperonin-containing T-complex.
+    action: ACCEPT
+    reason: >-
+      Complex membership is central to the gene product function and is supported by yeast CCT complex
+      literature and family evidence.
+- term:
+    id: GO:0006457
+    label: protein folding
+  qualifier: involved_in
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: >-
+      CCT3 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin
+      that folds actin, tubulin, and other clients.
+    action: ACCEPT
+    reason: >-
+      Protein folding is the correct biological-process context for the chaperonin complex, supported
+      by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
+- term:
+    id: GO:0016887
+    label: ATP hydrolysis activity
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: >-
+      CCT3 is a TCP-1/CCT chaperonin subunit with conserved ATPase machinery that powers TRiC/CCT conformational
+      cycling.
+    action: ACCEPT
+    reason: >-
+      ATP hydrolysis is a defensible subunit-level molecular function for CCT family members and is directly
+      tied to the chaperonin folding cycle.
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: >-
+      unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than
+      the ATP-dependent folding chaperone function of the complex.
+    action: MODIFY
+    reason: >-
+      Replace generic substrate-binding language with the specific chaperonin activity supported by yeast
+      CCT actin-folding assays and domain evidence.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+- term:
+    id: GO:0140662
+    label: ATP-dependent protein folding chaperone
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: CCT3 is an obligate subunit of the ATP-dependent TRiC/CCT folding machine.
+    action: ACCEPT
+    reason: >-
+      The term is appropriate as a complex-level chaperonin function; in the synthesized core function
+      it is modeled as a contributed-to molecular function rather than a standalone activity of an isolated
+      subunit.
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: >-
+        The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine
+        whose action is required for folding the cytoskeletal proteins actin and tubulin
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005515
+    label: protein binding
+  qualifier: enables
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  supporting_entities:
+  - UniProtKB:P32324
+  review:
+    summary: >-
+      protein binding is too generic for a CCT subunit and does not describe the chaperonin mechanism
+      or substrate class.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Physical-interaction datasets are useful evidence context, but generic protein binding should not
+      stand as a functional annotation when the specific TRiC/CCT chaperonin role is known.
+    supported_by:
+    - reference_id: PMID:19536198
+      supporting_text: >-
+        It should be emphasized that the interactions presented are indirect TAP-tag based interactions
+        and not direct binary interactions.
+- term:
+    id: GO:0005515
+    label: protein binding
+  qualifier: enables
+  evidence_type: IPI
+  original_reference_id: PMID:37968396
+  supporting_entities:
+  - UniProtKB:P32324
+  review:
+    summary: >-
+      protein binding is too generic for a CCT subunit and does not describe the chaperonin mechanism
+      or substrate class.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Physical-interaction datasets are useful evidence context, but generic protein binding should not
+      stand as a functional annotation when the specific TRiC/CCT chaperonin role is known.
+- term:
+    id: GO:0006457
+    label: protein folding
+  qualifier: involved_in
+  evidence_type: IDA
+  original_reference_id: PMID:16762366
+  review:
+    summary: >-
+      CCT3 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin
+      that folds actin, tubulin, and other clients.
+    action: ACCEPT
+    reason: >-
+      Protein folding is the correct biological-process context for the chaperonin complex, supported
+      by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: >-
+        The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine
+        whose action is required for folding the cytoskeletal proteins actin and tubulin
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  qualifier: part_of
+  evidence_type: IPI
+  original_reference_id: PMID:15704212
+  supporting_entities:
+  - SGD:S000002596
+  review:
+    summary: CCT3 is a named subunit of the chaperonin-containing T-complex.
+    action: ACCEPT
+    reason: >-
+      Complex membership is central to the gene product function and is supported by yeast CCT complex
+      literature and family evidence.
+    supported_by:
+    - reference_id: PMID:15704212
+      supporting_text: >-
+        Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
+        of a stoichiometric array of eight different subunits
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  qualifier: part_of
+  evidence_type: IDA
+  original_reference_id: PMID:16762366
+  review:
+    summary: CCT3 is a named subunit of the chaperonin-containing T-complex.
+    action: ACCEPT
+    reason: >-
+      Complex membership is central to the gene product function and is supported by yeast CCT complex
+      literature and family evidence.
+    supported_by:
+    - reference_id: PMID:15704212
+      supporting_text: >-
+        Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
+        of a stoichiometric array of eight different subunits
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IDA
+  original_reference_id: PMID:16762366
+  review:
+    summary: >-
+      unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than
+      the ATP-dependent folding chaperone function of the complex.
+    action: MODIFY
+    reason: >-
+      Replace generic substrate-binding language with the specific chaperonin activity supported by yeast
+      CCT actin-folding assays and domain evidence.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: >-
+        The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine
+        whose action is required for folding the cytoskeletal proteins actin and tubulin
+      reference_section_type: ABSTRACT
+core_functions:
+- description: >-
+    CCT3 is the gamma subunit of the cytosolic TRiC/CCT chaperonin. The subunit contributes ATPase and
+    substrate-contact surfaces to the hetero-oligomeric double-ring complex, whose ATP-dependent conformational
+    cycle folds actin, tubulin, and other cytosolic client proteins. The synthesized function is modeled
+    as subunit ATP hydrolysis contributing to the complex-level ATP-dependent protein folding chaperone
+    activity.
+  molecular_function:
+    id: GO:0016887
+    label: ATP hydrolysis activity
+  contributes_to_molecular_function:
+    id: GO:0140662
+    label: ATP-dependent protein folding chaperone
+  directly_involved_in:
+  - id: GO:0006457
+    label: protein folding
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+  in_complex:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  supported_by:
+  - reference_id: PMID:16762366
+    supporting_text: >-
+      The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose
+      action is required for folding the cytoskeletal proteins actin and tubulin
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:15704212
+    supporting_text: >-
+      Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
+      of a stoichiometric array of eight different subunits
+    reference_section_type: ABSTRACT
+suggested_questions:
+- question: >-
+    Which yeast client proteins depend specifically on Cct3 apical-domain contacts rather than on generic
+    TRiC/CCT chamber activity?
+suggested_experiments:
+- hypothesis: Cct3 contributes subunit-specific contacts for a subset of aggregation-prone or Q/N-rich
+    clients.
+  description: >-
+    Profile client aggregation, solubility, and folding reporter behavior in conditional CCT3 mutants
+    under permissive and restrictive conditions, with actin and tubulin reporters as controls.
+  experiment_type: conditional mutant proteostasis profiling

--- a/genes/yeast/CCT3/CCT3-ai-review.yaml
+++ b/genes/yeast/CCT3/CCT3-ai-review.yaml
@@ -302,10 +302,10 @@ existing_annotations:
       Complex membership is central to the gene product function and is supported by yeast CCT complex
       literature and family evidence.
     supported_by:
-    - reference_id: PMID:15704212
+    - reference_id: PMID:16762366
       supporting_text: >-
-        Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
-        of a stoichiometric array of eight different subunits
+        The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine
+        whose action is required for folding the cytoskeletal proteins actin and tubulin
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005832

--- a/genes/yeast/CCT3/CCT3-deep-research-falcon.md
+++ b/genes/yeast/CCT3/CCT3-deep-research-falcon.md
@@ -1,0 +1,316 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-04T10:26:00.366159'
+end_time: '2026-05-04T10:35:33.501432'
+duration_seconds: 573.14
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: yeast
+  gene_id: CCT3
+  gene_symbol: CCT3
+  uniprot_accession: P39077
+  protein_description: 'RecName: Full=T-complex protein 1 subunit gamma; Short=TCP-1-gamma;
+    AltName: Full=CCT-gamma;'
+  gene_info: Name=CCT3; Synonyms=BIN2, TCP3; OrderedLocusNames=YJL014W; ORFNames=J1336;
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+  protein_family: Belongs to the TCP-1 chaperonin family. .
+  protein_domains: Chap_CCT_gamma. (IPR012719); Chaperone_TCP-1. (IPR017998); Chaperonin_TCP-1_CS.
+    (IPR002194); Cpn60/GroEL/TCP-1. (IPR002423); GroEL-like_apical_dom_sf. (IPR027409)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 24
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P39077
+- **Protein Description:** RecName: Full=T-complex protein 1 subunit gamma; Short=TCP-1-gamma; AltName: Full=CCT-gamma;
+- **Gene Information:** Name=CCT3; Synonyms=BIN2, TCP3; OrderedLocusNames=YJL014W; ORFNames=J1336;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the TCP-1 chaperonin family. .
+- **Key Domains:** Chap_CCT_gamma. (IPR012719); Chaperone_TCP-1. (IPR017998); Chaperonin_TCP-1_CS. (IPR002194); Cpn60/GroEL/TCP-1. (IPR002423); GroEL-like_apical_dom_sf. (IPR027409)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "CCT3" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'CCT3' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **CCT3** (gene ID: CCT3, UniProt: P39077) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P39077
+- **Protein Description:** RecName: Full=T-complex protein 1 subunit gamma; Short=TCP-1-gamma; AltName: Full=CCT-gamma;
+- **Gene Information:** Name=CCT3; Synonyms=BIN2, TCP3; OrderedLocusNames=YJL014W; ORFNames=J1336;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the TCP-1 chaperonin family. .
+- **Key Domains:** Chap_CCT_gamma. (IPR012719); Chaperone_TCP-1. (IPR017998); Chaperonin_TCP-1_CS. (IPR002194); Cpn60/GroEL/TCP-1. (IPR002423); GroEL-like_apical_dom_sf. (IPR027409)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "CCT3" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'CCT3' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **CCT3** (gene ID: CCT3, UniProt: P39077) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Comprehensive research report: *Saccharomyces cerevisiae* **CCT3** (UniProt **P39077**; ORF **YJL014W**) — functional annotation
+
+### Executive summary
+CCT3 encodes **T-complex protein 1 subunit gamma (CCTγ; TRiC/CCT subunit 3)**, one of eight essential subunits comprising the eukaryotic cytosolic **group II chaperonin** CCT/TRiC. The CCT/TRiC complex is a double-ring ATP-driven folding machine that is required for proteostasis, including folding of key cytoskeletal proteins such as actin and tubulin. Yeast-specific evidence indicates that CCT3 has detectable **subunit-specific client preferences**, particularly affecting **Q/N-rich proteins** and **P-body-associated proteins**, and that perturbing CCT3 function produces broad stress sensitivities including ethanol and cell-wall integrity–associated phenotypes. (grantham2020themolecularchaperone pages 1-2, nadlerholly2012interactionsofsubunit pages 2-2, narayanan2016defectsinprotein pages 4-6)
+
+### 1) Gene/protein identity verification (critical disambiguation)
+The literature summarized here pertains to *Saccharomyces cerevisiae* (S288C) **CCT3/YJL014W**, encoding a subunit of the **CCT/TRiC chaperonin complex**. This is consistent with the UniProt description for P39077 as a TCP-1 chaperonin family member (CCTγ) and with yeast genetics studies that explicitly mutate **CCT3** and assay phenotypes in yeast (e.g., CCT3 D91E; cct3-1). (nadlerholly2012interactionsofsubunit pages 2-2, narayanan2016defectsinprotein pages 2-4)
+
+### 2) Key concepts and definitions (current understanding)
+
+#### 2.1 What is CCT/TRiC, and where does CCT3 fit?
+**CCT/TRiC** (chaperonin-containing TCP-1; tailless complex polypeptide 1 ring complex) is a eukaryotic **ATP-dependent chaperonin**. It is an obligate hetero-oligomer composed of **two rings**, each containing **eight distinct subunits** (commonly denoted CCT1–CCT8 or α–θ), generating a central chamber where client proteins fold. (grantham2020themolecularchaperone pages 1-2)
+
+CCT3 is one of these eight distinct subunits. Structural/mechanistic work synthesized in the literature places CCT3 as part of a subunit pairing/grouping (e.g., CCT1–CCT3) and within a **lower ATP-affinity hemisphere** of the ring (CCT3/6/7/8) relative to a higher-affinity hemisphere (CCT1/2/4/5), implying subunit-specialized contributions to the ATPase cycle. (kelly2020structuralandfunctional pages 42-48)
+
+#### 2.2 Mechanism of action: ATP-driven conformational cycle and substrate folding
+CCT/TRiC operates via a coordinated ATPase-driven conformational cycle: substrate binds to apical domains, ATP binding/hydrolysis drives ring closure and encapsulation, and conformational changes promote folding. This general mechanism and architecture are described in authoritative reviews emphasizing the complex’s role as an essential proteostasis component. (grantham2020themolecularchaperone pages 1-2, que2024theroleof pages 1-2)
+
+A mechanistic quantitative detail highlighted in structural/functional synthesis is that, **on average, ~4 subunits per ring are occupied under saturating ATP**, consistent with asymmetric ATP usage across subunits and supporting the view that not all subunits contribute equivalently to nucleotide binding/hydrolysis at a given time. CCT3 is categorized among lower ATP-affinity subunits in this model. (kelly2020structuralandfunctional pages 42-48)
+
+### 3) Primary biological function of yeast CCT3
+
+#### 3.1 Core function: proteostasis via folding/assembly of complex cytosolic proteins
+CCT/TRiC is described as required for folding of the abundant cytoskeletal proteins **actin and tubulin**, which are central to microfilament and microtubule assembly. These clients are repeatedly treated as key/obligate substrates of the complex in reviews and in yeast stress-phenotype work that links impaired folding to cytoskeleton-mediated stress adaptation. (grantham2020themolecularchaperone pages 1-2, narayanan2016defectsinprotein pages 4-6)
+
+#### 3.2 Subunit-specific client interactions: Q/N-rich proteins and P-body biology (yeast-specific)
+A yeast-focused PNAS study directly probed subunit specialization using ATP-site mutations in CCT3 vs CCT6 and high-throughput microscopy. A CCT3 mutant (D91E; “MA3”) produced a strong, specific phenotype: **dramatic accumulation of P-bodies**, with multiple known P-body proteins forming prominent cytoplasmic puncta that colocalize with an established P-body marker. (nadlerholly2012interactionsofsubunit pages 2-2, nadlerholly2012interactionsofsubunit media 88c0bc6b)
+
+Quantitatively, the same study reported that in MA3 relative to wild type, **46 proteins increased and 18 decreased** at **P < 0.01**, and that the screen involved ~**5,100 GFP-tagged** strains, supporting a large-scale systematic assessment of proteome-level changes in a CCT3-perturbed background. (nadlerholly2012interactionsofsubunit pages 2-2)
+
+The authors further concluded that subunit CCT3 shows a stronger in vivo interaction with **Q/N-rich proteins** than CCT6 and proposed that CCT3 contains features compatible with binding Q/N-rich segments, linking CCT3 activity to proteostasis of aggregation-prone regions commonly enriched in P-body components. (nadlerholly2012interactionsofsubunit pages 2-2, nadlerholly2012interactionsofsubunit pages 4-5)
+
+### 4) Subcellular localization and where CCT3 carries out its function
+
+#### 4.1 Cytosolic role (dominant/established)
+CCT/TRiC is classically treated as a **cytosolic** chaperonin that acts on cytosolic proteins, consistent with its canonical substrates (actin/tubulin) and broad role in folding newly synthesized proteins. (grantham2020themolecularchaperone pages 1-2, que2024theroleof pages 1-2)
+
+#### 4.2 Nuclear roles (emerging, yeast-relevant)
+A 2024 yeast preprint reports that TRiC/CCT **governs RNA polymerase II activity in the nucleus** to support RNA homeostasis, indicating that in yeast the complex has functionally relevant nuclear activity beyond canonical cytosolic folding. The study used yeast TRiC purification and nuclear extract transcription assays (including **100 ng** immobilized DNA template and **100 µg** nuclear extract), supporting mechanistic investigation of nuclear transcription outputs in a TRiC-compromised condition (cct1-2). Although this is not CCT3-specific, it is a recent yeast development expanding the functional landscape in which CCT subunits operate. (gvozdenov2024triccctchaperoningoverns pages 30-33)
+
+### 5) Phenotypes and essentiality
+
+#### 5.1 Essentiality
+CCT/TRiC subunits are encoded by **essential yeast genes**, consistent with the central role of TRiC/CCT in folding core cellular proteins and maintaining homeostasis. (grantham2020themolecularchaperone pages 1-2)
+
+#### 5.2 Stress tolerance, ethanol tolerance, and cell wall integrity phenotypes (cct3 alleles)
+A focused phenotyping study of yeast folding-machinery mutants reports that the **cct3-1** mutant shows sensitivity to diverse stressors. In the authors’ categorical scoring, cct3-1 was sensitive/supersensitive across multiple conditions including **ethanol**, **NaCl**, **DTT**, **arsenate**, **H2O2**, **SDS** (cell-wall integrity proxy), and **methanol**, and was **supersensitive to TBZ** (a microtubule/actin-related stressor used in the study). (narayanan2016defectsinprotein pages 2-4)
+
+The same work reports ethanol-specific findings: cct3-1 is noted as sensitive at **3% ethanol**, and while all tested cct mutants failed to grow at **8% ethanol**, many recovered tolerance to **6% ethanol** by **48 h**—with **cct1 and cct3 mutants** highlighted as exceptions in this recovery pattern. The authors also used Congo Red and zymolyase sensitivity and SEM morphology changes to support that defects in the folding machinery correlate with **cell wall integrity defects**, providing a plausible mechanistic link between CCT3 impairment, actin/cytoskeletal dysfunction, and cell-wall biosynthetic/maintenance pathways. (narayanan2016defectsinprotein pages 4-6)
+
+#### 5.3 CCT3 perturbation and RNA granules/P-bodies
+The yeast CCT3 D91E mutant (MA3) triggers prominent P-body formation and altered abundance/localization of multiple P-body components; this is consistent with the hypothesis that CCT3 function supports folding/stability of specific aggregation-prone/QN-rich components that influence ribonucleoprotein granule formation. (nadlerholly2012interactionsofsubunit pages 2-2, nadlerholly2012interactionsofsubunit media 88c0bc6b)
+
+### 6) Signaling/biochemical pathways and process-level placement
+
+#### 6.1 Proteostasis network positioning
+CCT/TRiC is positioned as a major node in cellular proteostasis, supporting folding and suppressing aggregation, and it participates in protein biogenesis processes that intersect with translation. (grantham2020themolecularchaperone pages 1-2, que2024theroleof pages 1-2)
+
+#### 6.2 Translation coupling (recent synthesis)
+A 2024 review synthesizes evidence that CCT/TRiC has multiple roles related to **translation elongation**, including interacting with emerging peptides to protect them from aggregation/degradation and facilitating proper folding programs during protein synthesis. This provides a modern conceptual framework for interpreting CCT3 function as part of a chaperonin machine integrated with translation and nascent-chain quality control (even when the review is not yeast-exclusive). (que2024theroleof pages 1-2)
+
+### 7) Recent developments (prioritizing 2023–2024)
+
+#### 7.1 2024: CCT/TRiC in translation elongation (review)
+Que et al. (Heliyon; available online 1 Apr 2024) frame CCT/TRiC as an essential molecular chaperone in the elongation phase of eukaryotic translation and summarize how it contributes to maintaining balance among synthesis, folding, assembly, and degradation—an updated synthesis of field consensus relevant to interpreting yeast CCT3 phenotypes in conditions that stress protein biogenesis. URL: https://doi.org/10.1016/j.heliyon.2024.e29029 (que2024theroleof pages 1-2)
+
+#### 7.2 2024: Nuclear TRiC activity in yeast transcription (preprint)
+Gvozdenov et al. (bioRxiv; posted 26 Sep 2024) report that TRiC/CCT supports **RNA polymerase II activity** in the yeast nucleus, expanding the apparent functional reach of TRiC beyond canonical cytosolic folding and suggesting that TRiC perturbation can impact RNA homeostasis. URL: https://doi.org/10.1101/2024.09.26.615188 (gvozdenov2024triccctchaperoningoverns pages 30-33)
+
+#### 7.3 2023: Subunit-resolved substrate contacts (CCT3 involvement)
+A 2023 structural study of TRiC-mediated tubulin folding reports that near-natively folded tubulin engages mainly with the **CCT3/6/8** subunits through electrostatic/hydrophilic interactions in the closed chamber (in a human TRiC system). While not yeast-specific, this provides current mechanistic support for why CCT3 subunits can contribute specialized binding surfaces for key cytoskeletal clients—consistent with long-standing yeast genetics emphasizing actin/tubulin dependence on TRiC. URL: https://doi.org/10.1038/s42003-023-04915-x (gvozdenov2024triccctchaperoningoverns pages 33-36)
+
+### 8) Current applications and real-world implementations
+
+#### 8.1 Structural biology tool development (yeast CCT3 as an engineering handle)
+A practical implementation in yeast structural biology is the use of CCT3 as a subunit for internal tagging: Zang et al. (Scientific Reports; Feb 2018) describe a yeast internal-subunit eGFP labeling strategy (YISEL) and note purification of yeast CCT via an internal tag in the **CCT3/γ** subunit to enable cryo-EM subunit assignment. This is a concrete experimental application leveraging the endogenous yeast CCT3 locus. URL: https://doi.org/10.1038/s41598-017-18962-y (zang2018developmentofa pages 7-8)
+
+#### 8.2 Industrially relevant stress tolerance phenotyping
+Ethanol tolerance and cell wall integrity are central to industrial yeast performance. The observation that cct3-1 mutants show ethanol sensitivity and cell-wall-related phenotypes suggests that CCT3/TRiC integrity is a factor to consider in strain robustness under high-ethanol fermentations or other envelope-stressing conditions (noting that the cited study is phenotyping-focused rather than an industrial deployment report). URL: https://doi.org/10.1007/s00284-016-1024-x (narayanan2016defectsinprotein pages 4-6)
+
+### 9) Expert opinions and analysis (authoritative interpretation of evidence)
+
+1. **Subunit specialization is biologically meaningful.** The yeast CCT3 D91E study demonstrates that perturbing different TRiC subunits can yield qualitatively different cellular phenotypes, supporting the view that TRiC is not merely an eightfold-redundant machine but has subunit-specific substrate interfaces and cellular roles. (nadlerholly2012interactionsofsubunit pages 2-2)
+2. **CCT3 links folding capacity to RNP granule dynamics.** The strong P-body phenotype in CCT3 mutant yeast provides a plausible mechanistic bridge between proteostasis and post-transcriptional RNA regulation, aligning with 2024 yeast work implicating TRiC in nuclear RNA homeostasis (though via a different experimental angle). (nadlerholly2012interactionsofsubunit pages 2-2, gvozdenov2024triccctchaperoningoverns pages 30-33)
+3. **Stress phenotypes likely reflect multiple downstream failures.** Broad cct3-1 sensitivity (ethanol, SDS, oxidative/reductive stressors) is consistent with a folding-factor deficit affecting cytoskeletal organization, membrane/cell-wall maintenance, and generalized proteostasis under stress. The cell-wall integrity assays (SDS, Congo Red, zymolyase) provide process-level evidence that CCT perturbation couples protein folding to envelope robustness. (narayanan2016defectsinprotein pages 2-4, narayanan2016defectsinprotein pages 4-6)
+
+### 10) Key statistics and data points (from cited studies)
+- TRiC/CCT architecture: **2 rings × 8 distinct subunits** (16 total subunits per complex). (grantham2020themolecularchaperone pages 1-2)
+- ATP occupancy asymmetry (model/synthesis): **~4 subunits per ring occupied** under saturating ATP; CCT3 in low ATP-affinity hemisphere. (kelly2020structuralandfunctional pages 42-48)
+- Yeast CCT3 mutant proteome changes: **46 upregulated**, **18 downregulated** proteins in CCT3 D91E (MA3) vs wild type at **P < 0.01**; screen size ~**5,100** GFP-tagged strains. (nadlerholly2012interactionsofsubunit pages 2-2)
+- Ethanol tolerance phenotypes: **cct3-1 sensitive at 3% ethanol**; **all cct mutants fail at 8% ethanol** in the cited study; differential recovery to 6% by **48 h** reported with cct1/cct3 as exceptions. (narayanan2016defectsinprotein pages 4-6)
+- Nuclear transcription assay conditions in yeast TRiC study (supporting methods transparency): **100 ng** DNA template and **100 µg** nuclear extract per reaction. (gvozdenov2024triccctchaperoningoverns pages 30-33)
+
+### Visual evidence (figure citations)
+Microscopy and quantitative panels illustrating that CCT3 mutation (MA3) causes P-body accumulation and stronger Q/N-rich protein effects than a CCT6 mutant are shown in the retrieved figure crops from Nadler-Holly et al. (PNAS, 2012). (nadlerholly2012interactionsofsubunit media 88c0bc6b, nadlerholly2012interactionsofsubunit media 61c31059, nadlerholly2012interactionsofsubunit media 27997266)
+
+### Evidence-backed annotation summary table
+| Aspect | Key points | Best supporting citations | Key source URLs+publication dates |
+|---|---|---|---|
+| identity/synonyms | • Verified target is **Saccharomyces cerevisiae CCT3 / YJL014W**, encoding the **TRiC/CCT chaperonin subunit gamma (CCTγ)**. • CCT3 is one of the eight distinct paralogous subunits of the eukaryotic cytosolic chaperonin CCT/TRiC. • The literature also uses the CCT/TRiC-wide naming scheme **CCT1–CCT8 / α–θ**, so care is needed to avoid mixing with non-yeast CCT3 orthologs. | (grantham2020themolecularchaperone pages 1-2, gvozdenov2024triccctchaperoningoverns pages 33-36, kelly2020structuralandfunctional pages 42-48) | https://doi.org/10.3389/fgene.2020.00172 (Mar 2020); https://doi.org/10.1101/2024.09.26.615188 (Sep 26, 2024); https://doi.org/10.1073/pnas.1209277109 (Oct 2012) |
+| complex | • CCT3 functions as a subunit of the **CCT/TRiC hetero-oligomer**, a barrel-shaped chaperonin with **two rings of eight distinct subunits each**. • Each subunit occupies a defined position within the ring. • Structural work places CCT3 in the **CCT1–CCT3 apical-domain pair** and in the **low-ATP-affinity hemisphere (CCT3/6/7/8)**. | (grantham2020themolecularchaperone pages 1-2, kelly2020structuralandfunctional pages 42-48, zang2018developmentofa pages 7-8) | https://doi.org/10.3389/fgene.2020.00172 (Mar 2020); https://doi.org/10.1038/s41598-017-18962-y (Feb 2018) |
+| mechanism | • CCT/TRiC is an **ATP-dependent folding machine** with substrate-binding apical domains and nucleotide-binding equatorial domains. • For CCT3 specifically, structural/functional characterization places it among the **lower ATP-affinity subunits**; under saturating ATP, an average of **~4 subunits per ring** are occupied. • CCT3 contributes to the **inter-ring interaction network** via its N-terminus in models of ring closure. | (grantham2020themolecularchaperone pages 1-2, kelly2020structuralandfunctional pages 42-48) | https://doi.org/10.3389/fgene.2020.00172 (Mar 2020) |
+| localization | • The strongest supported localization for the yeast complex is the **cytosol/cytoplasm**, consistent with its role folding newly made cytosolic proteins. • Recent yeast work also supports a **nuclear role for TRiC/CCT** in RNA polymerase II activity and RNA homeostasis, though this was shown for the complex rather than CCT3 specifically. • Older cited background also notes reports of association with **Golgi membranes, nuclear matrix, and heterochromatin** for CCT/TRiC literature more broadly. | (gvozdenov2024triccctchaperoningoverns pages 30-33, gvozdenov2024triccctchaperoningoverns pages 33-36, que2024theroleof pages 1-2) | https://doi.org/10.1101/2024.09.26.615188 (Sep 26, 2024); https://doi.org/10.1016/j.heliyon.2024.e29029 (Apr 1, 2024) |
+| substrates/clients | • Canonical CCT/TRiC clients include **actin and tubulin**, described as major/obligate substrates of the complex. • A CCT3-specific yeast study found stronger interaction of CCT3 than CCT6 with **Q/N-rich proteins**, especially proteins linked to **P-bodies**. • In the CCT3 mutant screen, **46 proteins increased and 18 decreased** relative to wild type, and **8 of 9** most-changed proteins had physical/genetic interactions with Q/N-rich proteins. | (nadlerholly2012interactionsofsubunit pages 2-2, grantham2020themolecularchaperone pages 1-2, nadlerholly2012interactionsofsubunit pages 4-5, nadlerholly2012interactionsofsubunit pages 5-6) | https://doi.org/10.1073/pnas.1209277109 (Oct 2012); https://doi.org/10.3389/fgene.2020.00172 (Mar 2020) |
+| phenotypes | • Yeast **CCT genes are essential**, and the review literature states CCT subunits are encoded by essential yeast genes. • A CCT3 ATP-site mutant (**D91E/MA3**) caused strong **P-body accumulation**; several canonical P-body proteins formed prominent puncta, and the screen covered **~5,100 GFP-tagged strains**. • In stress-phenotype work, **cct3-1** showed sensitivity to multiple stressors including **ethanol, NaCl, DTT, arsenate, H2O2, SDS, methanol**, and was reported as **supersensitive to TBZ**; cct3-1 was sensitive at **3% ethanol**, and cct3 mutants were among strains not recovering tolerance like most others by **48 h**. | (nadlerholly2012interactionsofsubunit pages 2-2, grantham2020themolecularchaperone pages 1-2, narayanan2016defectsinprotein pages 2-4, narayanan2016defectsinprotein pages 4-6) | https://doi.org/10.1073/pnas.1209277109 (Oct 2012); https://doi.org/10.1007/s00284-016-1024-x (Mar 2016); https://doi.org/10.3389/fgene.2020.00172 (Mar 2020) |
+| recent 2023-2024 developments | • A 2024 review emphasizes CCT/TRiC as an important regulator of **translation elongation/protein synthesis coupling**. • A 2023 structural study on TRiC-mediated tubulin folding captured a near-native folding intermediate engaging mainly **CCT3/6/8** subunits in the closed chamber, supporting subunit-specialized substrate contacts. • A 2024 yeast preprint reports **nuclear TRiC/CCT support of RNA polymerase II activity** and RNA homeostasis. | (gvozdenov2024triccctchaperoningoverns pages 30-33, que2024theroleof pages 1-2) | https://doi.org/10.1016/j.heliyon.2024.e29029 (Apr 1, 2024); https://doi.org/10.1038/s42003-023-04915-x (May 2023); https://doi.org/10.1101/2024.09.26.615188 (Sep 26, 2024) |
+| applications | • Yeast CCT3 has been used experimentally as an anchor for **internal subunit eGFP labeling** to map TRiC/CCT subunit arrangement in cryo-EM studies. • CCT/TRiC is used as a model system for studying **proteostasis, aggregation control, and folding of complex proteins**. • Stress-sensitive yeast cct mutants, including **cct3-1**, provide practical models for probing **cell wall integrity and ethanol tolerance** relevant to industrial/biotechnology contexts. | (zang2018developmentofa pages 7-8, grantham2020themolecularchaperone pages 1-2, narayanan2016defectsinprotein pages 4-6) | https://doi.org/10.1038/s41598-017-18962-y (Feb 2018); https://doi.org/10.3389/fgene.2020.00172 (Mar 2020); https://doi.org/10.1007/s00284-016-1024-x (Mar 2016) |
+
+
+*Table: This table summarizes the evidence-supported functional annotation of Saccharomyces cerevisiae CCT3/YJL014W, including complex membership, mechanism, localization, substrates, phenotypes, and recent developments. It is useful as a compact reference anchored to specific context IDs and source URLs.*
+
+### Limitations of the current evidence set
+- The most detailed yeast CCT3 functional specificity evidence in the retrieved set is from 2012 (PNAS). While still high-quality, yeast CCT3-specific primary literature in 2023–2024 was not directly retrieved here; recent work largely focuses on TRiC/CCT more generally or in other organisms, and should be integrated cautiously when making yeast-subunit-specific claims. (nadlerholly2012interactionsofsubunit pages 2-2, que2024theroleof pages 1-2)
+
+### Key sources (URLs and publication dates)
+- Nadler-Holly et al. **2012-10**. *PNAS*. “Interactions of subunit CCT3 in the yeast chaperonin CCT/TRiC with Q/N-rich proteins…” https://doi.org/10.1073/pnas.1209277109 (nadlerholly2012interactionsofsubunit pages 2-2)
+- Narayanan et al. **2016-03**. *Current Microbiology*. “Defects in Protein Folding Machinery Affect Cell Wall Integrity and Reduce Ethanol Tolerance…” https://doi.org/10.1007/s00284-016-1024-x (narayanan2016defectsinprotein pages 4-6)
+- Grantham **2020-03**. *Frontiers in Genetics*. “The Molecular Chaperone CCT/TRiC…” https://doi.org/10.3389/fgene.2020.00172 (grantham2020themolecularchaperone pages 1-2)
+- Zang et al. **2018-02**. *Scientific Reports*. “Development of a yeast internal-subunit eGFP labeling strategy…” https://doi.org/10.1038/s41598-017-18962-y (zang2018developmentofa pages 7-8)
+- Que et al. **2024-04-01 (online)**. *Heliyon*. “The role of molecular chaperone CCT/TRiC in translation elongation…” https://doi.org/10.1016/j.heliyon.2024.e29029 (que2024theroleof pages 1-2)
+- Gvozdenov et al. **2024-09-26 (posted)**. *bioRxiv*. “TRiC/CCT Chaperonin Governs RNA Polymerase II Activity in the Nucleus…” https://doi.org/10.1101/2024.09.26.615188 (gvozdenov2024triccctchaperoningoverns pages 30-33)
+
+
+References
+
+1. (grantham2020themolecularchaperone pages 1-2): Julie Grantham. The molecular chaperone cct/tric: an essential component of proteostasis and a potential modulator of protein aggregation. Frontiers in Genetics, Mar 2020. URL: https://doi.org/10.3389/fgene.2020.00172, doi:10.3389/fgene.2020.00172. This article has 139 citations and is from a peer-reviewed journal.
+
+2. (nadlerholly2012interactionsofsubunit pages 2-2): Michal Nadler-Holly, Michal Breker, Ranit Gruber, Ariel Azia, Melissa Gymrek, Miriam Eisenstein, Keith R. Willison, Maya Schuldiner, and Amnon Horovitz. Interactions of subunit cct3 in the yeast chaperonin cct/tric with q/n-rich proteins revealed by high-throughput microscopy analysis. Proceedings of the National Academy of Sciences, 109:18833-18838, Oct 2012. URL: https://doi.org/10.1073/pnas.1209277109, doi:10.1073/pnas.1209277109. This article has 52 citations and is from a highest quality peer-reviewed journal.
+
+3. (narayanan2016defectsinprotein pages 4-6): Aswathy Narayanan, Dileep Pullepu, Praveen Kumar Reddy, Wasim Uddin, and M. Anaul Kabir. Defects in protein folding machinery affect cell wall integrity and reduce ethanol tolerance in s. cerevisiae. Current Microbiology, 73:38-45, Mar 2016. URL: https://doi.org/10.1007/s00284-016-1024-x, doi:10.1007/s00284-016-1024-x. This article has 7 citations and is from a peer-reviewed journal.
+
+4. (narayanan2016defectsinprotein pages 2-4): Aswathy Narayanan, Dileep Pullepu, Praveen Kumar Reddy, Wasim Uddin, and M. Anaul Kabir. Defects in protein folding machinery affect cell wall integrity and reduce ethanol tolerance in s. cerevisiae. Current Microbiology, 73:38-45, Mar 2016. URL: https://doi.org/10.1007/s00284-016-1024-x, doi:10.1007/s00284-016-1024-x. This article has 7 citations and is from a peer-reviewed journal.
+
+5. (kelly2020structuralandfunctional pages 42-48): J Kelly. Structural and functional characterisation of the group ii chaperonin cct/tric. Unknown journal, 2020.
+
+6. (que2024theroleof pages 1-2): Yueyue Que, Yudan Qiu, Zheyu Ding, Shanshan Zhang, Rong Wei, Jianing Xia, and Yingying Lin. The role of molecular chaperone cct/tric in translation elongation: a literature review. Heliyon, 10:e29029, Apr 2024. URL: https://doi.org/10.1016/j.heliyon.2024.e29029, doi:10.1016/j.heliyon.2024.e29029. This article has 12 citations.
+
+7. (nadlerholly2012interactionsofsubunit media 88c0bc6b): Michal Nadler-Holly, Michal Breker, Ranit Gruber, Ariel Azia, Melissa Gymrek, Miriam Eisenstein, Keith R. Willison, Maya Schuldiner, and Amnon Horovitz. Interactions of subunit cct3 in the yeast chaperonin cct/tric with q/n-rich proteins revealed by high-throughput microscopy analysis. Proceedings of the National Academy of Sciences, 109:18833-18838, Oct 2012. URL: https://doi.org/10.1073/pnas.1209277109, doi:10.1073/pnas.1209277109. This article has 52 citations and is from a highest quality peer-reviewed journal.
+
+8. (nadlerholly2012interactionsofsubunit pages 4-5): Michal Nadler-Holly, Michal Breker, Ranit Gruber, Ariel Azia, Melissa Gymrek, Miriam Eisenstein, Keith R. Willison, Maya Schuldiner, and Amnon Horovitz. Interactions of subunit cct3 in the yeast chaperonin cct/tric with q/n-rich proteins revealed by high-throughput microscopy analysis. Proceedings of the National Academy of Sciences, 109:18833-18838, Oct 2012. URL: https://doi.org/10.1073/pnas.1209277109, doi:10.1073/pnas.1209277109. This article has 52 citations and is from a highest quality peer-reviewed journal.
+
+9. (gvozdenov2024triccctchaperoningoverns pages 30-33): Zlata Gvozdenov, Audrey Yi Tyan Peng, Anusmita Biswas, Zeno Barcutean, Daniel Gestaut, Judith Frydman, Kevin Struhl, and Brian C. Freeman. Tric/cct chaperonin governs rna polymerase ii activity in the nucleus to support rna homeostasis. bioRxiv, Sep 2024. URL: https://doi.org/10.1101/2024.09.26.615188, doi:10.1101/2024.09.26.615188. This article has 3 citations.
+
+10. (gvozdenov2024triccctchaperoningoverns pages 33-36): Zlata Gvozdenov, Audrey Yi Tyan Peng, Anusmita Biswas, Zeno Barcutean, Daniel Gestaut, Judith Frydman, Kevin Struhl, and Brian C. Freeman. Tric/cct chaperonin governs rna polymerase ii activity in the nucleus to support rna homeostasis. bioRxiv, Sep 2024. URL: https://doi.org/10.1101/2024.09.26.615188, doi:10.1101/2024.09.26.615188. This article has 3 citations.
+
+11. (zang2018developmentofa pages 7-8): Yunxiang Zang, Huping Wang, Zhicheng Cui, Mingliang Jin, Caixuan Liu, Wenyu Han, Yanxing Wang, and Yao Cong. Development of a yeast internal-subunit egfp labeling strategy and its application in subunit identification in eukaryotic group ii chaperonin tric/cct. Scientific Reports, Feb 2018. URL: https://doi.org/10.1038/s41598-017-18962-y, doi:10.1038/s41598-017-18962-y. This article has 22 citations and is from a peer-reviewed journal.
+
+12. (nadlerholly2012interactionsofsubunit media 61c31059): Michal Nadler-Holly, Michal Breker, Ranit Gruber, Ariel Azia, Melissa Gymrek, Miriam Eisenstein, Keith R. Willison, Maya Schuldiner, and Amnon Horovitz. Interactions of subunit cct3 in the yeast chaperonin cct/tric with q/n-rich proteins revealed by high-throughput microscopy analysis. Proceedings of the National Academy of Sciences, 109:18833-18838, Oct 2012. URL: https://doi.org/10.1073/pnas.1209277109, doi:10.1073/pnas.1209277109. This article has 52 citations and is from a highest quality peer-reviewed journal.
+
+13. (nadlerholly2012interactionsofsubunit media 27997266): Michal Nadler-Holly, Michal Breker, Ranit Gruber, Ariel Azia, Melissa Gymrek, Miriam Eisenstein, Keith R. Willison, Maya Schuldiner, and Amnon Horovitz. Interactions of subunit cct3 in the yeast chaperonin cct/tric with q/n-rich proteins revealed by high-throughput microscopy analysis. Proceedings of the National Academy of Sciences, 109:18833-18838, Oct 2012. URL: https://doi.org/10.1073/pnas.1209277109, doi:10.1073/pnas.1209277109. This article has 52 citations and is from a highest quality peer-reviewed journal.
+
+14. (nadlerholly2012interactionsofsubunit pages 5-6): Michal Nadler-Holly, Michal Breker, Ranit Gruber, Ariel Azia, Melissa Gymrek, Miriam Eisenstein, Keith R. Willison, Maya Schuldiner, and Amnon Horovitz. Interactions of subunit cct3 in the yeast chaperonin cct/tric with q/n-rich proteins revealed by high-throughput microscopy analysis. Proceedings of the National Academy of Sciences, 109:18833-18838, Oct 2012. URL: https://doi.org/10.1073/pnas.1209277109, doi:10.1073/pnas.1209277109. This article has 52 citations and is from a highest quality peer-reviewed journal.
+
+## Citations
+
+1. grantham2020themolecularchaperone pages 1-2
+2. kelly2020structuralandfunctional pages 42-48
+3. nadlerholly2012interactionsofsubunit pages 2-2
+4. gvozdenov2024triccctchaperoningoverns pages 30-33
+5. narayanan2016defectsinprotein pages 2-4
+6. narayanan2016defectsinprotein pages 4-6
+7. que2024theroleof pages 1-2
+8. gvozdenov2024triccctchaperoningoverns pages 33-36
+9. zang2018developmentofa pages 7-8
+10. nadlerholly2012interactionsofsubunit pages 4-5
+11. nadlerholly2012interactionsofsubunit pages 5-6
+12. https://doi.org/10.1016/j.heliyon.2024.e29029
+13. https://doi.org/10.1101/2024.09.26.615188
+14. https://doi.org/10.1038/s42003-023-04915-x
+15. https://doi.org/10.1038/s41598-017-18962-y
+16. https://doi.org/10.1007/s00284-016-1024-x
+17. https://doi.org/10.3389/fgene.2020.00172
+18. https://doi.org/10.1073/pnas.1209277109
+19. https://doi.org/10.3389/fgene.2020.00172,
+20. https://doi.org/10.1073/pnas.1209277109,
+21. https://doi.org/10.1007/s00284-016-1024-x,
+22. https://doi.org/10.1016/j.heliyon.2024.e29029,
+23. https://doi.org/10.1101/2024.09.26.615188,
+24. https://doi.org/10.1038/s41598-017-18962-y,

--- a/genes/yeast/CCT5/CCT5-ai-review.html
+++ b/genes/yeast/CCT5/CCT5-ai-review.html
@@ -1663,13 +1663,13 @@
                             <div class="support-item">
                                 <span class="support-ref">
 
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15704212" target="_blank" class="term-link">
-                                        PMID:15704212
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
                                     </a>
 
                                 </span>
 
-                                <div class="support-text">Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed of a stoichiometric array of eight different subunits</div>
+                                <div class="support-text">The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose action is required for folding the cytoskeletal proteins actin and tubulin</div>
 
                             </div>
 
@@ -2991,10 +2991,10 @@ existing_annotations:
       Complex membership is central to the gene product function and is supported by yeast CCT complex
       literature and family evidence.
     supported_by:
-    - reference_id: PMID:15704212
+    - reference_id: PMID:16762366
       supporting_text: &gt;-
-        Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
-        of a stoichiometric array of eight different subunits
+        The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine
+        whose action is required for folding the cytoskeletal proteins actin and tubulin
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005832

--- a/genes/yeast/CCT5/CCT5-ai-review.html
+++ b/genes/yeast/CCT5/CCT5-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>CCT5</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P40413" target="_blank" class="term-link">
                         P40413
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Saccharomyces cerevisiae</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,24 +728,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="P40413" data-a="DESCRIPTION: TODO: Add description for CCT5..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="P40413" data-a="DESCRIPTION: CCT5 encodes the epsilon subunit of the cytosolic ..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TODO: Add description for CCT5</p>
+        <p>CCT5 encodes the epsilon subunit of the cytosolic group II chaperonin TRiC/CCT. Cct5 is an obligate subunit of the ATP-driven double-ring folding machine, contributes one ATPase/substrate-contact module to the chamber, and is best curated as part of the complex that folds actin, tubulin, and other cytosolic clients. The subunit-specific literature emphasizes ATP-cycle asymmetry and chamber architecture rather than a separate standalone activity.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,46 +795,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein folding is consistent with known biology of CCT5.
+                            <strong>Summary:</strong> CCT5 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin that folds actin, tubulin, and other clients.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Protein folding is the correct biological-process context for the chaperonin complex, supported by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/CCT5/CCT5-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">CCT5 is best defined as a **structural and catalytic component**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005832" target="_blank" class="term-link">
                                     GO:0005832
                                 </a>
                             </span>
                             <span class="term-label">chaperonin-containing T-complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -846,46 +862,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: chaperonin-containing T-complex is consistent with known biology of CCT5.
+                            <strong>Summary:</strong> CCT5 is a named subunit of the chaperonin-containing T-complex.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Complex membership is central to the gene product function and is supported by yeast CCT complex literature and family evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -897,159 +913,159 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT5.
+                            <strong>Summary:</strong> unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than the ATP-dependent folding chaperone function of the complex.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
+                            <strong>Reason:</strong> Replace generic substrate-binding language with the specific chaperonin activity supported by yeast CCT actin-folding assays and domain evidence.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
+                                    ATP-dependent protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000166" target="_blank" class="term-link">
                                     GO:0000166
                                 </a>
                             </span>
                             <span class="term-label">nucleotide binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P40413" data-a="GO:0000166" data-r="GO_REF:0000043" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P40413" data-a="GO:0000166" data-r="GO_REF:0000043" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: nucleotide binding is consistent with known biology of CCT5.
+                            <strong>Summary:</strong> nucleotide binding is a true but overly broad family/keyword annotation for CCT5; ATP binding, ATP hydrolysis, and ATP-dependent chaperone annotations capture the specific chemistry.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Generic nucleotide binding does not add useful functional information beyond the more specific ATP-related chaperonin annotations already present.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
                                     GO:0005524
                                 </a>
                             </span>
                             <span class="term-label">ATP binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P40413" data-a="GO:0005524" data-r="GO_REF:0000120" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P40413" data-a="GO:0005524" data-r="GO_REF:0000120" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ATP binding is consistent with known biology of CCT5.
+                            <strong>Summary:</strong> CCT5 contains a conserved chaperonin ATP-binding site, but ATP binding alone is a domain property rather than the core biological function.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Keep as a valid supporting molecular property of the CCT ATPase cycle, while treating ATP hydrolysis and complex-level protein folding as the core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1061,46 +1077,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cytoplasm is consistent with known biology of CCT5.
+                            <strong>Summary:</strong> CCT5 functions as part of the cytosolic TRiC/CCT chaperonin.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Cytoplasm is the established location of the CCT/TRiC folding machine.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005832" target="_blank" class="term-link">
                                     GO:0005832
                                 </a>
                             </span>
                             <span class="term-label">chaperonin-containing T-complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1112,46 +1128,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: chaperonin-containing T-complex is consistent with known biology of CCT5.
+                            <strong>Summary:</strong> CCT5 is a named subunit of the chaperonin-containing T-complex.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Complex membership is central to the gene product function and is supported by yeast CCT complex literature and family evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1163,46 +1179,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein folding is consistent with known biology of CCT5.
+                            <strong>Summary:</strong> CCT5 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin that folds actin, tubulin, and other clients.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Protein folding is the correct biological-process context for the chaperonin complex, supported by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1214,46 +1230,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ATP hydrolysis activity is consistent with known biology of CCT5.
+                            <strong>Summary:</strong> CCT5 is a TCP-1/CCT chaperonin subunit with conserved ATPase machinery that powers TRiC/CCT conformational cycling.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> ATP hydrolysis is a defensible subunit-level molecular function for CCT family members and is directly tied to the chaperonin folding cycle.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1265,57 +1281,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT5.
+                            <strong>Summary:</strong> unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than the ATP-dependent folding chaperone function of the complex.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
+                            <strong>Reason:</strong> Replace generic substrate-binding language with the specific chaperonin activity supported by yeast CCT actin-folding assays and domain evidence.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
+                                    ATP-dependent protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
                                     GO:0140662
                                 </a>
                             </span>
                             <span class="term-label">ATP-dependent protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1327,57 +1343,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ATP-dependent protein folding chaperone is consistent with known biology of CCT5.
+                            <strong>Summary:</strong> CCT5 is an obligate subunit of the ATP-dependent TRiC/CCT folding machine.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The term is appropriate as a complex-level chaperonin function; in the synthesized core function it is modeled as a contributed-to molecular function rather than a standalone activity of an isolated subunit.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose action is required for folding the cytoskeletal proteins actin and tubulin</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19536198
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An atlas of chaperone-protein interactions in Saccharomyces ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1389,57 +1423,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for CCT5.
+                            <strong>Summary:</strong> protein binding is too generic for a CCT subunit and does not describe the chaperonin mechanism or substrate class.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Physical-interaction datasets are useful evidence context, but generic protein binding should not stand as a functional annotation when the specific TRiC/CCT chaperonin role is known.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link">
+                                        PMID:19536198
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">It should be emphasized that the interactions presented are indirect TAP-tag based interactions and not direct binary interactions.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/37968396" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:37968396
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The social and structural architecture of the yeast protein ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1451,57 +1503,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for CCT5.
+                            <strong>Summary:</strong> protein binding is too generic for a CCT subunit and does not describe the chaperonin mechanism or substrate class.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Physical-interaction datasets are useful evidence context, but generic protein binding should not stand as a functional annotation when the specific TRiC/CCT chaperonin role is known.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16762366
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Quantitative actin folding reactions using yeast CCT purifie...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1513,57 +1565,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein folding is consistent with known biology of CCT5.
+                            <strong>Summary:</strong> CCT5 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin that folds actin, tubulin, and other clients.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Protein folding is the correct biological-process context for the chaperonin complex, supported by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose action is required for folding the cytoskeletal proteins actin and tubulin</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005832" target="_blank" class="term-link">
                                     GO:0005832
                                 </a>
                             </span>
                             <span class="term-label">chaperonin-containing T-complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15704212" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15704212
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Physiological effects of unassembled chaperonin Cct subunits...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1575,57 +1645,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: chaperonin-containing T-complex is consistent with known biology of CCT5.
+                            <strong>Summary:</strong> CCT5 is a named subunit of the chaperonin-containing T-complex.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Complex membership is central to the gene product function and is supported by yeast CCT complex literature and family evidence.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15704212" target="_blank" class="term-link">
+                                        PMID:15704212
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed of a stoichiometric array of eight different subunits</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005832" target="_blank" class="term-link">
                                     GO:0005832
                                 </a>
                             </span>
                             <span class="term-label">chaperonin-containing T-complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16762366
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Quantitative actin folding reactions using yeast CCT purifie...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1637,57 +1725,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: chaperonin-containing T-complex is consistent with known biology of CCT5.
+                            <strong>Summary:</strong> CCT5 is a named subunit of the chaperonin-containing T-complex.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Complex membership is central to the gene product function and is supported by yeast CCT complex literature and family evidence.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15704212" target="_blank" class="term-link">
+                                        PMID:15704212
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed of a stoichiometric array of eight different subunits</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16762366
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Quantitative actin folding reactions using yeast CCT purifie...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1699,220 +1805,879 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT5.
+                            <strong>Summary:</strong> unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than the ATP-dependent folding chaperone function of the complex.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
+                            <strong>Reason:</strong> Replace generic substrate-binding language with the specific chaperonin activity supported by yeast CCT actin-folding assays and domain evidence.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
+                                    ATP-dependent protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose action is required for folding the cytoskeletal proteins actin and tubulin</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>CCT5 is the epsilon subunit of the cytosolic TRiC/CCT chaperonin. The subunit contributes ATPase and substrate-contact surfaces to the hetero-oligomeric double-ring complex, whose ATP-dependent conformational cycle folds actin, tubulin, and other cytosolic client proteins. The synthesized function is modeled as subunit ATP hydrolysis contributing to the complex-level ATP-dependent protein folding chaperone activity.</h3>
+                <span class="vote-buttons" data-g="P40413" data-a="FUNCTION: CCT5 is the epsilon subunit of the cytosolic TRiC/..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
+                            ATP hydrolysis activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                protein folding
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005832" target="_blank" class="term-link">
+                            chaperonin-containing T-complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                PMID:16762366
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose action is required for folding the cytoskeletal proteins actin and tubulin</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15704212" target="_blank" class="term-link">
+                                PMID:15704212
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed of a stoichiometric array of eight different subunits</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15704212" target="_blank" class="term-link">
                             PMID:15704212
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Physiological effects of unassembled chaperonin Cct subunits in the yeast Saccharomyces cerevisiae.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Yeast CCT is a double-ring complex with a stoichiometric set of eight distinct Cct subunits.</div>
+
+                        <div class="finding-text">"Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed of a stoichiometric array of eight different subunits"</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
                             PMID:16762366
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Quantitative actin folding reactions using yeast CCT purified via an internal tag in the CCT3/gamma subunit.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Purified yeast CCT, tagged through CCT3, catalyzes ATP-dependent actin folding; this supports protein-folding and chaperonin activity annotations for CCT5 as a TRiC/CCT subunit.</div>
+
+                        <div class="finding-text">"The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose action is required for folding the cytoskeletal proteins actin and tubulin"</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link">
                             PMID:19536198
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding pathways in the cell.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The chaperone interactome study is useful context for CCT contacts but reports indirect TAP-tag interactions rather than a specific molecular activity.</div>
+
+                        <div class="finding-text">"It should be emphasized that the interactions presented are indirect TAP-tag based interactions and not direct binary interactions."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/37968396" target="_blank" class="term-link">
                             PMID:37968396
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The social and structural architecture of the yeast protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/CCT5/CCT5-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for CCT5</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The Falcon report was reviewed and synthesized into the CCT5 curation, including core-function framing, family/PANTHER context, and evidence limitations.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> How does the high-ATP-affinity Cct5 subunit shape client progression through the yeast TRiC/CCT ATPase cycle?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P40413" data-a="Q: How does the high-ATP-affinity Cct5 subunit shape ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Compare ATPase-cycle reporters, client folding assays, and viability for targeted CCT5 ATP-pocket alleles in yeast, separating assembled-complex abundance from kinetic effects.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Cct5 ATP binding/hydrolysis helps set the timing of TRiC/CCT chamber closure for actin and tubulin clients.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: site-directed mutagenesis with chaperonin folding and ATPase assays</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P40413" data-a="EXPERIMENT: Compare ATPase-cycle reporters, client folding ass..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(CCT5-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P40413" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-04T10:06:00.865548'<br />
+end_time: '2026-05-04T10:25:00.852286'<br />
+duration_seconds: 1139.99<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: yeast<br />
+  gene_id: CCT5<br />
+  gene_symbol: CCT5<br />
+  uniprot_accession: P40413<br />
+  protein_description: 'RecName: Full=T-complex protein 1 subunit epsilon; Short=TCP-1-epsilon;<br />
+    AltName: Full=CCT-epsilon;'<br />
+  gene_info: Name=CCT5; Synonyms=TCP5; OrderedLocusNames=YJR064W; ORFNames=J1752;<br />
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).<br />
+  protein_family: Belongs to the TCP-1 chaperonin family. .<br />
+  protein_domains: Chap_CCT_epsi. (IPR012718); Chaperone_TCP-1. (IPR017998); Chaperonin_TCP-1_CS.<br />
+    (IPR002194); Cpn60/GroEL/TCP-1. (IPR002423); GroEL-like_apical_dom_sf. (IPR027409)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 37</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P40413</li>
+<li><strong>Protein Description:</strong> RecName: Full=T-complex protein 1 subunit epsilon; Short=TCP-1-epsilon; AltName: Full=CCT-epsilon;</li>
+<li><strong>Gene Information:</strong> Name=CCT5; Synonyms=TCP5; OrderedLocusNames=YJR064W; ORFNames=J1752;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the TCP-1 chaperonin family. .</li>
+<li><strong>Key Domains:</strong> Chap_CCT_epsi. (IPR012718); Chaperone_TCP-1. (IPR017998); Chaperonin_TCP-1_CS. (IPR002194); Cpn60/GroEL/TCP-1. (IPR002423); GroEL-like_apical_dom_sf. (IPR027409)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "CCT5" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'CCT5' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>CCT5</strong> (gene ID: CCT5, UniProt: P40413) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P40413</li>
+<li><strong>Protein Description:</strong> RecName: Full=T-complex protein 1 subunit epsilon; Short=TCP-1-epsilon; AltName: Full=CCT-epsilon;</li>
+<li><strong>Gene Information:</strong> Name=CCT5; Synonyms=TCP5; OrderedLocusNames=YJR064W; ORFNames=J1752;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the TCP-1 chaperonin family. .</li>
+<li><strong>Key Domains:</strong> Chap_CCT_epsi. (IPR012718); Chaperone_TCP-1. (IPR017998); Chaperonin_TCP-1_CS. (IPR002194); Cpn60/GroEL/TCP-1. (IPR002423); GroEL-like_apical_dom_sf. (IPR027409)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "CCT5" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'CCT5' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>CCT5</strong> (gene ID: CCT5, UniProt: P40413) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="research-report-functional-annotation-of-cct5-uniprot-p40413-in-saccharomyces-cerevisiae-s288c">Research Report: Functional Annotation of <strong>CCT5</strong> (UniProt <strong>P40413</strong>) in <em>Saccharomyces cerevisiae</em> (S288c)</h1>
+<h2 id="executive-summary">Executive summary</h2>
+<p><em>CCT5</em> (ORF <strong>YJR064W</strong>, synonym <strong>TCP5</strong>) encodes the <strong>epsilon subunit of the cytosolic group II chaperonin TRiC/CCT</strong> (also called the TCP‑1 ring complex). CCT5 is not an enzyme with a unique small-molecule substrate; rather, it is an ATP-binding/ATPase chaperonin subunit that contributes to an essential hetero-oligomeric folding machine that supports eukaryotic proteostasis, with strongest evidence for folding/biogenesis of <strong>actin</strong> and <strong>tubulin</strong> and for broad roles in assembly of WD40/propeller proteins and other complexes. Yeast genetic and structural studies implicate ATPase-competent CCT5 as critical for viability and for the ATP-driven conformational cycle of the TRiC/CCT chamber. Recent 2023–2024 cryo-EM work in the field (mostly in mammalian TRiC, plus yeast mechanistic cryo-EM studies) refined models for how the ATPase cycle drives substrate translocation and how co-chaperones (prefoldin, phosducin-like proteins) control substrate delivery and chamber occupancy—mechanistic context directly relevant to interpreting yeast CCT5’s function as part of TRiC/CCT. (stoldt1996reviewthecct pages 1-2, grantham2020themolecularchaperone pages 1-2, kelly2020structuralandfunctionala pages 42-48, liu2023pathwayandmechanism pages 1-2, junsun2024astructuralvista pages 1-2)</p>
+<h2 id="1-target-verification-critical-identity-disambiguation">1. Target verification (critical identity disambiguation)</h2>
+<h3 id="11-verified-geneprotein-identity">1.1 Verified gene/protein identity</h3>
+<p>The literature and yeast-specific reviews identify the <em>S. cerevisiae</em> epsilon subunit of the CCT/TRiC chaperonin as <strong>CCT5</strong> (historical names include <strong>Cctε</strong>, <strong>TCP1E/TCP5</strong>) and explicitly map it to <strong>ORF YJR064W</strong> in S288c. (Publication date: <strong>1996-05</strong>; URL: https://doi.org/10.1002/(sici)1097-0061(199605)12:6&lt;523::aid-yea962&gt;3.0.co;2-c) (stoldt1996reviewthecct pages 1-2)</p>
+<h3 id="12-avoiding-symbol-ambiguity">1.2 Avoiding symbol ambiguity</h3>
+<p>The symbol <strong>CCT5</strong> is also used for orthologous TRiC/CCT subunit 5 proteins in animals, where variants are associated with disease (e.g., hereditary sensory neuropathy). Such papers inform conserved structure/function of CCT5-family proteins but are not yeast-specific functional genetics and should not be conflated with <em>S. cerevisiae</em> phenotypes. (pereira2017structureofthe pages 1-2, kelly2020structuralandfunctionala pages 23-28)</p>
+<h2 id="2-key-concepts-and-definitions-current-understanding">2. Key concepts and definitions (current understanding)</h2>
+<h3 id="21-triccct-a-eukaryotic-group-ii-chaperonin">2.1 TRiC/CCT: a eukaryotic group II chaperonin</h3>
+<p>TRiC/CCT is a <strong>group II chaperonin</strong> localized to the <strong>eukaryotic cytosol</strong>, consisting of <strong>two stacked rings</strong> with <strong>eight distinct paralogous subunits per ring</strong> (CCT1–CCT8; CCT5 is the epsilon/“subunit 5” paralog). The complex couples ATP binding/hydrolysis to large conformational changes that close a built-in lid over a central folding cavity (unlike bacterial GroEL, which requires GroES). (ghozlan2022thetrickybusiness pages 1-2, kabir2011functionalsubunitsof pages 1-2, kelly2020structuralandfunctionala pages 14-18)</p>
+<h3 id="22-what-cct5-does-at-the-molecular-level">2.2 What CCT5 “does” at the molecular level</h3>
+<p>CCT5 is best defined as a <strong>structural and catalytic component</strong> (ATPase + substrate-interaction surface) of TRiC/CCT rather than a standalone enzyme. TRiC/CCT’s strongest obligate substrates are <strong>actin and tubulin</strong>, which require TRiC/CCT to reach native conformations/assembly-competent states; CCT5 contributes one of the eight distinct apical-domain surfaces that form the composite substrate-binding environment within the chamber. (grantham2020themolecularchaperone pages 1-2, willison2018thesubstratespecificity pages 1-2)</p>
+<h3 id="23-conserved-domain-architecture">2.3 Conserved domain architecture</h3>
+<p>CCT5-family subunits have a canonical chaperonin architecture with <strong>equatorial</strong> (ATP binding and ring contacts), <strong>intermediate</strong> (hinge/transmission), and <strong>apical</strong> (substrate recognition/lid) domains. The ATP-binding region is relatively conserved across paralogs, whereas apical domains are more divergent and contribute to subunit-specific substrate recognition properties. (ghozlan2022thetrickybusiness pages 1-2, pereira2017structureofthe pages 1-2)</p>
+<h2 id="3-yeast-specific-functional-annotation-of-cct5">3. Yeast-specific functional annotation of CCT5</h2>
+<h3 id="31-complex-membership-subunit-arrangement-and-chamber-electrostatics">3.1 Complex membership, subunit arrangement, and chamber electrostatics</h3>
+<p>Yeast TRiC/CCT structural work places subunits in a defined ring order and groups them into electrostatic “hemispheres” within the chamber; CCT5 sits in the <strong>CCT2 hemisphere</strong> alongside CCT4 and CCT2, contributing to a positively charged partition of the folding environment. (kelly2020structuralandfunctional pages 35-42)</p>
+<h3 id="32-atpase-asymmetry-and-subunit-specific-conformational-role-of-cct5">3.2 ATPase asymmetry and subunit-specific conformational role of CCT5</h3>
+<p>In yeast structural/functional analyses, CCT5 belongs to a <strong>high ATP-affinity</strong> set of subunits (CCT1/2/4/5), with CCT5 (and CCT4) described as having the <strong>highest ATP affinities</strong> in one model. CCT5’s apical domain undergoes substantial nucleotide-linked motion (reported as ~<strong>14° rotation</strong> toward the folding cavity upon nucleotide binding), and CCT5 is among the subunits showing larger conformational changes than others in the ring. (kelly2020structuralandfunctionala pages 42-48)</p>
+<h3 id="33-essentiality-and-viability-relevant-mutations">3.3 Essentiality and viability-relevant mutations</h3>
+<p>Yeast-focused synthesis indicates that all eight CCT genes are essential and that even relatively small perturbations in ATP-binding motifs/ATPase kinetics can cause severe growth and morphology defects. (willison2018thesubstratespecificity pages 2-3)</p>
+<p>More directly subunit-linked evidence indicates that mutating the P-loop ATP-binding motif (GDGTT→AAAAA) in high-affinity subunits leads to <strong>lethal phenotypes in yeast</strong>, implicating ATPase competence of high-affinity subunits including <strong>CCT5</strong> as critical for viability. (kelly2020structuralandfunctionala pages 42-48)</p>
+<h3 id="34-biological-processes-and-pathway-context-inferred-from-yeast-ccttric-biology">3.4 Biological processes and pathway context inferred from yeast CCT/TRiC biology</h3>
+<p>Because CCT5 functions as an obligate TRiC/CCT subunit, yeast process annotations are best supported at the complex level:</p>
+<ul>
+<li><strong>Actin and microtubule assembly / cytoskeletal organization</strong>: Yeast conditional mutant studies link the Cct complex to in vivo assembly of <strong>microtubules and actin</strong>, consistent with conserved TRiC/CCT roles in actin and tubulin folding. (1996-05; URL above) (stoldt1996reviewthecct pages 1-2)</li>
+<li><strong>Genetic interactions with cytoskeletal alleles</strong>: Allele-specific synthetic interactions between CCT subunit mutants and actin/tubulin alleles (e.g., inviability of a cct1-1 tub2-402 double mutant) support close functional coupling between CCT and cytoskeletal components. (stoldt1996reviewthecct pages 5-6)</li>
+<li><strong>Cell cycle regulation via folding of APC/C activators</strong>: A yeast CCT interactome/functional synthesis indicates that WD40/propeller proteins and specific cell-cycle regulators such as APC activators <strong>Cdc20p and Cdh1p</strong> are obligate CCT substrates in yeast. (willison2018thesubstratespecificity pages 1-2)</li>
+<li><strong>Growth/nutrient signaling linkage (TOR pathway)</strong>: Expert synthesis highlights TRiC/CCT’s functional linkage to TOR signaling in yeast, including growth defects when CCT activity is reduced and altered phosphorylation of TOR pathway outputs (S6K/S6). (kelly2020structuralandfunctionalb pages 23-28)</li>
+</ul>
+<h3 id="35-subcellular-localization">3.5 Subcellular localization</h3>
+<p>CCT5 acts primarily in the <strong>cytosol</strong> as part of the cytosolic TRiC/CCT folding machine. Current evidence in the retrieved set supports this cytosolic role; no strong evidence was retrieved for a stable organellar or secreted localization for yeast CCT5. (kabir2011functionalsubunitsof pages 1-2, kelly2020structuralandfunctionala pages 14-18)</p>
+<h2 id="4-recent-developments-prioritizing-20232024">4. Recent developments (prioritizing 2023–2024)</h2>
+<p>Recent high-resolution structural and mechanistic work has focused on TRiC/CCT’s ATP-driven cycle and co-chaperone coordination; while much of this is performed on mammalian TRiC, the mechanisms are widely treated as conserved and provide direct interpretive context for yeast subunit roles (including CCT5).</p>
+<h3 id="41-2023-cryo-em-delineation-of-tubulin-folding-pathway-along-the-atpase-cycle">4.1 2023: Cryo-EM delineation of tubulin folding pathway along the ATPase cycle</h3>
+<p>A 2023 cryo-EM + XL-MS study captured multiple TRiC states with endogenously engaged tubulin and quantified state occupancies. Key reported quantitative findings include open-state classification with <strong>61.6% empty</strong> and <strong>38.4% tubulin-like density</strong>, and a trapped population with <strong>27.2% both-rings-closed</strong> under ATP-AlFx. The work describes gradual substrate translocation/stabilization during ring closure and a near-native tubulin captured in the closed chamber; notably, the tubulin I domain is reported to associate more loosely with the <strong>CCT2 hemisphere subunits (CCT7/5/2/4)</strong>—the same hemisphere that includes yeast CCT5. (Publication date: <strong>2023-05</strong>; URL: https://doi.org/10.1038/s42003-023-04915-x) (liu2023pathwayandmechanism pages 1-2, liu2023pathwayandmechanism pages 6-7)</p>
+<h3 id="42-2024-structural-mechanism-for-phlp2atric-coordination-and-prefoldin-displacement">4.2 2024: Structural mechanism for PhLP2A–TRiC coordination and prefoldin displacement</h3>
+<p>A 2024 <em>Nature Communications</em> cryo-EM/biochemical study resolved how <strong>PhLP2A</strong> binds open TRiC, how an N-terminal helix engages <strong>CCT3/CCT4</strong> apical domains to displace prefoldin, and how ATP-induced closure rearranges PhLP2A contacts. The authors reiterate that TRiC facilitates folding of ~<strong>10%</strong> of the eukaryotic proteome and show a mechanistic model in which co-chaperones and substrates can segregate into opposing chambers during the folding cycle. (Publication date: <strong>2024-02</strong>; URL: https://doi.org/10.1038/s41467-024-45242-x) (junsun2024astructuralvista pages 1-2)</p>
+<p><strong>Visual evidence</strong>: the paper includes a labeled cryo-EM view of the TRiC ring with subunits <strong>CCT1–CCT8</strong> annotated, supporting the defined subunit arrangement that underpins any subunit-specific annotation. (junsun2024astructuralvista media 0880aeaf)</p>
+<h3 id="43-yeast-focused-mechanistic-cryo-em-ring-opening-intermediates-context">4.3 Yeast-focused mechanistic cryo-EM: ring opening intermediates (context)</h3>
+<p>A yeast TRiC cryo-EM study of ADP-bound ensembles reports a stepwise ring-opening model in which outward leaning involves consecutive subunits including <strong>CCT6/8/7/5</strong>, placing CCT5 on a mechanically relevant trajectory during nucleotide-dependent reopening and (putative) substrate release. (Publication: <strong>2025</strong>; URL: https://doi.org/10.1017/qrd.2024.17) (jin2025theconformationallandscape pages 1-2)</p>
+<h2 id="5-current-applications-and-real-world-implementations">5. Current applications and real-world implementations</h2>
+<p>Although yeast CCT5 itself is primarily a basic-science target, TRiC/CCT research has translational applications; yeast is often the model for mechanistic/functional dissection.</p>
+<h3 id="51-therapeutic-targeting-and-chemical-modulation-of-triccct">5.1 Therapeutic targeting and chemical modulation of TRiC/CCT</h3>
+<p>Expert syntheses describe TRiC/CCT as a potential <strong>therapeutic target</strong> in cancer and proteostasis-related diseases. Examples discussed include a TRiC-inhibiting peptide (<strong>CT20p</strong>) tested in cancer cell line contexts and small molecules/lipids reported to modulate TRiC-mediated folding (e.g., clemastine; 1-deoxydihydroceramide), as well as modulation by stress-response-linked factors (e.g., HSF1A). These applications are complex-level rather than yeast-CCT5-specific but rely on understanding subunit-specific assembly/ATPase features (including those involving CCT5). (kelly2020structuralandfunctionala pages 23-28, shen2025proteinfoldingby pages 5-7)</p>
+<h3 id="52-proteostasis-engineering-and-mechanistic-tool-development-in-yeast">5.2 Proteostasis engineering and mechanistic tool development in yeast</h3>
+<p>Yeast serves as an engineering and discovery platform for TRiC/CCT structure-function studies, including strategies for subunit identification in cryo-EM maps by endogenous tagging approaches. Such methods enable subunit-resolved mechanistic annotation of components like CCT5 without overexpression artifacts. (Publication date: <strong>2018-02</strong>; URL: https://doi.org/10.1038/s41598-017-18962-y) (context: subunit identification strategy applied to TRiC; CCT5 used as tagged subunit) (from retrieved paper list; not directly evidenced in snippets beyond abstract)</p>
+<h2 id="6-statistics-and-quantitative-data-relevant-to-yeast-cct5-annotation">6. Statistics and quantitative data relevant to yeast CCT5 annotation</h2>
+<ul>
+<li><strong>Proteome fraction</strong>: TRiC/CCT is widely described as folding roughly <strong>~10% of cytosolic proteins</strong>. (junsun2024astructuralvista pages 1-2, liu2023pathwayandmechanism pages 1-2)</li>
+<li><strong>Yeast transcript estimate for CCT5</strong>: A yeast-focused synthesis reports an estimated <strong>CCT5 mRNA copy number ~2.24 per cell</strong> (derived from global transcript counts at 30°C) and notes low variance among CCT subunits in abundance. (Publication date: <strong>2018-06</strong>; URL: https://doi.org/10.1098/rstb.2017.0192) (willison2018thesubstratespecificity pages 7-8)</li>
+<li><strong>Yeast interactome scale</strong>: The yeast CCT interactome is summarized as roughly <strong>~300 members</strong>, with many being cofactors/effectors rather than direct folding substrates, indicating extensive pathway connectivity beyond actin/tubulin. (willison2018thesubstratespecificity pages 2-3)</li>
+</ul>
+<h2 id="7-interpretation-and-expert-analysis-what-is-well-supported-vs-uncertain-for-yeast-cct5">7. Interpretation and expert analysis (what is well-supported vs. uncertain for yeast CCT5)</h2>
+<h3 id="71-high-confidence-statements-supported-directly">7.1 High-confidence statements (supported directly)</h3>
+<ul>
+<li>CCT5 is the <em>S. cerevisiae</em> <strong>TRiC/CCT epsilon subunit</strong> encoded by <strong>YJR064W</strong>. (stoldt1996reviewthecct pages 1-2)</li>
+<li>CCT5 participates in a <strong>cytosolic</strong> group II chaperonin complex essential for folding/biogenesis of <strong>actin and tubulin</strong> (complex-level function with strong yeast linkage). (stoldt1996reviewthecct pages 1-2, willison2018thesubstratespecificity pages 1-2)</li>
+<li>Yeast structural/functional analyses place CCT5 in a <strong>high ATP-affinity hemisphere</strong> and show <strong>large nucleotide-linked conformational change</strong>; yeast viability depends on ATPase-competent high-affinity subunits including CCT5 (P-loop mutant lethality). (kelly2020structuralandfunctionala pages 42-48)</li>
+</ul>
+<h3 id="72-medium-confidenceinference-statements">7.2 Medium-confidence/inference statements</h3>
+<ul>
+<li><strong>Subunit-specific substrate recognition</strong>: Reviews emphasize that divergence in apical domains across the eight subunits confers substrate selectivity, implying that CCT5 contributes unique binding determinants. However, the retrieved yeast literature did not provide a CCT5-only substrate list; most substrate specificity is attributed to the assembled chamber interface. (willison2018thesubstratespecificity pages 1-2, ghozlan2022thetrickybusiness pages 1-2)</li>
+</ul>
+<h3 id="73-not-resolved-in-the-retrieved-corpus">7.3 Not resolved in the retrieved corpus</h3>
+<ul>
+<li>A dedicated, yeast-only experimental characterization of CCT5-specific phenotypes (e.g., temperature-sensitive <em>cct5</em> alleles) was not retrieved here; available yeast phenotypes in the evidence largely pertain to the TRiC/CCT complex broadly or to other subunits. Accordingly, CCT5-specific phenotype statements above are restricted to ATP-binding motif perturbations and subunit-resolved structural dynamics. (kelly2020structuralandfunctionala pages 42-48, willison2018thesubstratespecificity pages 2-3)</li>
+</ul>
+<h2 id="summary-table">Summary table</h2>
+<table>
+<thead>
+<tr>
+<th>Topic</th>
+<th>Key points</th>
+<th>Best recent/authoritative source (with year)</th>
+<th>Evidence/notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Target identity verification</td>
+<td><strong>CCT5</strong> in this report refers to the <strong>Saccharomyces cerevisiae</strong> gene/product encoded by <strong>ORF YJR064W</strong>; it is the <strong>T-complex protein 1 subunit epsilon (CCT/TRiC subunit ε)</strong>, also called <strong>TCP5/TCP1E/Cctε</strong> in older nomenclature.</td>
+<td>Stoldt et al., <em>Yeast</em> (1996); Grantham, <em>Front. Genet.</em> (2020)</td>
+<td>Yeast review explicitly maps the epsilon subunit to <strong>YJR064W</strong> and lists historical synonyms; later reviews place CCT5 among the eight paralogous CCT/TRiC subunits, helping distinguish it from metazoan CCT5 orthologs with disease literature that should not be conflated with yeast annotation. (stoldt1996reviewthecct pages 1-2, grantham2020themolecularchaperone pages 1-2)</td>
+</tr>
+<tr>
+<td>Complex membership</td>
+<td>CCT5 is one of the <strong>8 distinct subunits per ring</strong> of the eukaryotic <strong>group II cytosolic chaperonin TRiC/CCT</strong>, forming a <strong>double-ring complex</strong>. In yeast structural work, subunits occupy a defined order within each ring.</td>
+<td>Jin et al., <em>Subcell. Biochem.</em> (2020); Kelly (2020)</td>
+<td>Reviews and structural studies agree that TRiC/CCT is a hetero-oligomeric, barrel-shaped chaperonin with two stacked rings; yeast cryo-EM resolves a defined subunit order and places CCT5 in the ring architecture rather than as a standalone enzyme. (kelly2020structuralandfunctionala pages 14-18, kelly2020structuralandfunctional pages 35-42)</td>
+</tr>
+<tr>
+<td>Protein family / definition</td>
+<td>CCT5 belongs to the <strong>TCP-1/CCT chaperonin family</strong>, i.e. <strong>group II chaperonins</strong> specialized for ATP-dependent folding of difficult cytosolic proteins in eukaryotes.</td>
+<td>Ghozlan et al., <em>Front. Cell Dev. Biol.</em> (2022); Kabir et al. (2011)</td>
+<td>Family-level features match UniProt/domain expectations: eukaryotic cytosolic localization, ATP-dependent conformational cycle, and function within the hetero-oligomeric CCT machine. (ghozlan2022thetrickybusiness pages 1-2, kabir2011functionalsubunitsof pages 1-2)</td>
+</tr>
+<tr>
+<td>Domain architecture</td>
+<td>Like other CCT subunits, CCT5 has the canonical <strong>three-domain chaperonin architecture</strong>: <strong>equatorial</strong> domain (ATP binding, ring contacts), <strong>intermediate</strong> domain (hinge/transmission), and <strong>apical</strong> domain (substrate/lid functions).</td>
+<td>Pereira et al., <em>Sci. Rep.</em> (2017); Kelly (2020)</td>
+<td>These structural features are conserved across CCT5 orthologs and are consistent with the supplied InterPro/domain annotations. The equatorial ATP-binding region is the most conserved; the apical region contributes to subunit-specific substrate recognition. (pereira2017structureofthe pages 1-2, kelly2020structuralandfunctionala pages 14-18)</td>
+</tr>
+<tr>
+<td>Cellular localization</td>
+<td>The biologically relevant localization of CCT5 is <strong>cytosolic</strong>, as a constituent of the <strong>cytosolic TRiC/CCT chaperonin</strong>.</td>
+<td>Kabir et al. (2011); Ghozlan et al. (2022)</td>
+<td>Available evidence supports cytosolic localization at the complex level; no strong evidence from the retrieved set supports a stable extracellular or organellar role for yeast CCT5. (kabir2011functionalsubunitsof pages 1-2, ghozlan2022thetrickybusiness pages 1-2)</td>
+</tr>
+<tr>
+<td>Primary molecular function</td>
+<td>CCT5 is <strong>not a classical metabolic enzyme</strong> with a unique small-molecule substrate; instead, it contributes one ATPase/substrate-binding module to the <strong>ATP-driven folding chamber</strong> of TRiC/CCT. Its function is to help fold cytosolic proteins and maintain proteostasis.</td>
+<td>Grantham, <em>Front. Genet.</em> (2020); Ghozlan et al., <em>Front. Cell Dev. Biol.</em> (2022)</td>
+<td>Reviews emphasize that TRiC/CCT folds obligate clients such as <strong>actin and tubulin</strong>, and likely assists a restricted but important set of additional proteins; CCT5 contributes to this machine as a structurally specialized subunit. (grantham2020themolecularchaperone pages 1-2, ghozlan2022thetrickybusiness pages 1-2)</td>
+</tr>
+<tr>
+<td>Core substrates / pathway context</td>
+<td>At the complex level, TRiC/CCT is best established for folding <strong>actin</strong> and <strong>tubulin</strong> and participates more broadly in <strong>cytosolic proteostasis</strong>, including assembly/folding of some complex or aggregation-prone proteins.</td>
+<td>Stoldt et al., <em>Yeast</em> (1996); Willison, <em>Phil. Trans. R. Soc. B</em> (2018)</td>
+<td>Yeast and broader eukaryotic studies converge on actin/tubulin as canonical obligate clients. For yeast CCT5 specifically, evidence is mostly <strong>subunit-in-complex</strong> rather than substrate specificity assigned to the isolated subunit. (stoldt1996reviewthecct pages 2-4, stoldt1996reviewthecct pages 1-2, willison2018thesubstratespecificity pages 7-8)</td>
+</tr>
+<tr>
+<td>Yeast-specific biological processes</td>
+<td>In yeast, the Cct complex is required for <strong>microtubule and actin assembly/organization</strong>, linking CCT5 indirectly to cytoskeletal biogenesis, cell growth, and proteostasis.</td>
+<td>Stoldt et al., <em>Yeast</em> (1996)</td>
+<td>Conditional-mutant studies in <em>S. cerevisiae</em> showed Cct requirement for in vivo assembly of microtubules and actin; the excerpted evidence is stronger for the complex than for CCT5 alone. (stoldt1996reviewthecct pages 2-4, stoldt1996reviewthecct pages 1-2)</td>
+</tr>
+<tr>
+<td>Subunit-specific structural role of CCT5</td>
+<td>Yeast cryo-EM and biochemical analyses identify CCT5 as a <strong>high-ATP-affinity</strong> subunit whose <strong>apical domain undergoes substantial nucleotide-linked movement</strong>; it contributes to the positively charged <strong>CCT2 hemisphere</strong> of the chamber.</td>
+<td>Kelly (2020)</td>
+<td>CCT5 shows ~<strong>14° apical-domain rotation</strong> on nucleotide binding and is grouped among subunits with larger conformational changes; CCT5/CCT4 are highlighted as having the <strong>highest ATP affinities</strong> in one yeast analysis. (kelly2020structuralandfunctional pages 42-48, kelly2020structuralandfunctionala pages 42-48, kelly2020structuralandfunctional pages 35-42)</td>
+</tr>
+<tr>
+<td>Essentiality / genetic evidence in yeast</td>
+<td>The overall CCT machine is essential, and reviews note that the <strong>eight subunits are products of essential genes in yeast</strong>; yeast mutational data further show that disrupting ATP-binding P-loop residues in high-affinity subunits, including CCT5, is <strong>lethal</strong>.</td>
+<td>Grantham, <em>Front. Genet.</em> (2020); Kelly (2020)</td>
+<td>The strongest retrieved CCT5-specific genetic statement is that alanine substitution of the P-loop motif in high-affinity subunits causes <strong>lethal phenotypes</strong> in yeast, implicating CCT5 ATPase competence in viability. (grantham2020themolecularchaperone pages 1-2, kelly2020structuralandfunctional pages 42-48, kelly2020structuralandfunctionala pages 42-48)</td>
+</tr>
+<tr>
+<td>Assembly importance</td>
+<td>Evidence from structural/biochemical work suggests <strong>CCT5 may be particularly important for TRiC assembly</strong>, though this is not yet a universally canonical annotation in basic yeast databases.</td>
+<td>Kelly (2020)</td>
+<td>The retrieved structural dissertation/review material explicitly states that analyses suggested <strong>CCT5 is the most important subunit for assembly of TRiC</strong>; this is best treated as a strong mechanistic proposal rather than settled textbook fact. (kelly2020structuralandfunctionalb pages 23-28)</td>
+</tr>
+<tr>
+<td>Quantitative/statistical data</td>
+<td>CCT/TRiC is estimated to assist folding of roughly <strong>~10% of cytosolic proteins</strong>. In one yeast-focused synthesis, <strong>CCT5 mRNA</strong> abundance was estimated at about <strong>2.24 copies/cell</strong>, and CCT subunits showed <strong>low variance</strong> in abundance across the complex.</td>
+<td>Park et al., <em>Nat. Commun.</em> (2024) for ~10%; Willison, <em>Phil. Trans. R. Soc. B</em> (2018) for yeast abundance synthesis</td>
+<td>The ~10% figure is widely repeated across structural reviews. The yeast quantitative synthesis indicates coordinated expression of CCT subunits and places actin/tubulin/CCT near central abundance and half-life distributions. (junsun2024astructuralvista pages 1-2, liu2023pathwayandmechanism pages 1-2, willison2018thesubstratespecificity pages 7-8)</td>
+</tr>
+<tr>
+<td>Co-chaperone network</td>
+<td>TRiC/CCT functions with <strong>prefoldin (PFD)</strong> and <strong>phosducin-like proteins (PhLPs)</strong>; these co-chaperones help deliver or stabilize substrates and regulate the folding cycle.</td>
+<td>Gestaut et al., <em>Cell</em> (2019); Park et al., <em>Nat. Commun.</em> (2024)</td>
+<td>This network is directly relevant to functional annotation because CCT5 acts within a multi-component folding pathway rather than alone. Disruption of PFD–TRiC interaction causes widespread aggregation in yeast, illustrating pathway-level importance. (junsun2024astructuralvista pages 1-2, kelly2020structuralandfunctionalb pages 23-28, kelly2020structuralandfunctionala pages 23-28)</td>
+</tr>
+<tr>
+<td>2023 development: substrate-folding mechanism</td>
+<td>Recent cryo-EM work mapped the <strong>ATPase-cycle-dependent pathway of tubulin folding</strong> by TRiC/CCT, showing gradual substrate translocation/stabilization and a near-native tubulin state in the closed chamber.</td>
+<td>Liu et al., <em>Commun. Biol.</em> (2023)</td>
+<td>Quantitative details include open-state classes with <strong>61.6% empty</strong> and <strong>38.4% tubulin-like density</strong>, a <strong>3.1 Å</strong> open-state map, and <strong>27.2%</strong> both-rings-closed population under ATP-AlFx conditions. Though from human TRiC, these findings strongly inform conserved mechanism relevant to yeast CCT5 annotation. (liu2023pathwayandmechanism pages 6-7, liu2023pathwayandmechanism pages 1-2)</td>
+</tr>
+<tr>
+<td>2024 development: co-chaperone mechanism</td>
+<td>New structural work resolved how <strong>PhLP2A</strong> and <strong>prefoldin</strong> interact with open/closed TRiC and showed ATP-driven rearrangements that coordinate substrate handling.</td>
+<td>Park et al., <em>Nat. Commun.</em> (2024)</td>
+<td>PhLP2A binds open TRiC through polyvalent contacts, can displace PFD via CCT3/4 contacts, and rearranges during closure; these studies refine current understanding of how subunits such as CCT5 participate in a regulated cochaperone-assisted folding cycle. (junsun2024astructuralvista pages 1-2, junsun2024astructuralvista media 0880aeaf)</td>
+</tr>
+<tr>
+<td>Expert interpretation / real-world relevance</td>
+<td>Authoritative reviews frame TRiC/CCT as a central <strong>proteostasis hub</strong> and a candidate <strong>therapeutic target</strong> in aggregation diseases, cancer, and viral infection. Yeast remains an important mechanistic model for defining subunit function and proteostasis defects.</td>
+<td>Ghozlan et al. (2022); Grantham (2020); Shen &amp; Willardson (2025)</td>
+<td>These application-oriented insights are mostly complex-level rather than yeast-CCT5-specific, but they explain why subunit-resolved annotation matters: altered CCT subunits affect assembly, substrate folding, and disease-linked proteostasis pathways. (grantham2020themolecularchaperone pages 1-2, ghozlan2022thetrickybusiness pages 1-2, shen2025proteinfoldingby pages 5-7)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes verified identity, function, localization, and mechanistic evidence for Saccharomyces cerevisiae CCT5/YJR064W, emphasizing what is directly supported for the yeast subunit versus what is inferred from the TRiC/CCT complex. It also highlights recent 2023-2024 developments that refine the current mechanistic annotation of CCT5 within TRiC.</em></p>
+<h2 id="key-figures-visual-evidence">Key figures (visual evidence)</h2>
+<ul>
+<li>Labeled TRiC subunit arrangement and PhLP2A-bound open-state structure (useful for orienting where CCT5 sits in the ring and how cochaperones engage the complex). (junsun2024astructuralvista media 0880aeaf)</li>
+<li>Comparative schematics of prefoldin and PhLP2A interactions with TRiC (relevant to understanding co-chaperone regulated folding pathways). (junsun2024astructuralvista media 774d2963, junsun2024astructuralvista media e727d38e)</li>
+</ul>
+<h2 id="references-urls-and-publication-dates-from-evidence">References (URLs and publication dates from evidence)</h2>
+<ul>
+<li>Stoldt V. et al. “Review: The Cct eukaryotic chaperonin subunits of <em>Saccharomyces cerevisiae</em> and other yeasts.” <em>Yeast</em> <strong>1996-05</strong>. https://doi.org/10.1002/(sici)1097-0061(199605)12:6&lt;523::aid-yea962&gt;3.0.co;2-c (stoldt1996reviewthecct pages 1-2)</li>
+<li>Willison K.R. “The substrate specificity of eukaryotic cytosolic chaperonin CCT.” <em>Phil. Trans. R. Soc. B</em> <strong>2018-06</strong>. https://doi.org/10.1098/rstb.2017.0192 (willison2018thesubstratespecificity pages 7-8, willison2018thesubstratespecificity pages 2-3, willison2018thesubstratespecificity pages 1-2)</li>
+<li>Grantham J. “The Molecular Chaperone CCT/TRiC: An Essential Component of Proteostasis and a Potential Modulator of Protein Aggregation.” <em>Front. Genet.</em> <strong>2020-03</strong>. https://doi.org/10.3389/fgene.2020.00172 (grantham2020themolecularchaperone pages 1-2)</li>
+<li>Liu C. et al. “Pathway and mechanism of tubulin folding mediated by TRiC/CCT along its ATPase cycle revealed using cryo-EM.” <em>Communications Biology</em> <strong>2023-05</strong>. https://doi.org/10.1038/s42003-023-04915-x (liu2023pathwayandmechanism pages 1-2, liu2023pathwayandmechanism pages 6-7)</li>
+<li>Park J. et al. “A structural vista of phosducin-like PhLP2A–chaperonin TRiC cooperation during the ATP-driven folding cycle.” <em>Nature Communications</em> <strong>2024-02</strong>. https://doi.org/10.1038/s41467-024-45242-x (junsun2024astructuralvista pages 1-2, junsun2024astructuralvista media 0880aeaf)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(stoldt1996reviewthecct pages 1-2): Volker Stoldt, Felicitas Rademacher, Verena Kehren, Joachim F. Ernst, David A. Pearce, and Fred Sherman. Review: the cct eukaryotic chaperonin subunits of saccharomyces cerevisiae and other yeasts. Yeast, 12:523-529, May 1996. URL: https://doi.org/10.1002/(sici)1097-0061(199605)12:6&lt;523::aid-yea962&gt;3.0.co;2-c, doi:10.1002/(sici)1097-0061(199605)12:6&lt;523::aid-yea962&gt;3.0.co;2-c. This article has 153 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(grantham2020themolecularchaperone pages 1-2): Julie Grantham. The molecular chaperone cct/tric: an essential component of proteostasis and a potential modulator of protein aggregation. Frontiers in Genetics, Mar 2020. URL: https://doi.org/10.3389/fgene.2020.00172, doi:10.3389/fgene.2020.00172. This article has 139 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kelly2020structuralandfunctionala pages 42-48): J Kelly. Structural and functional characterisation of the group ii chaperonin cct/tric. Unknown journal, 2020.</p>
+</li>
+<li>
+<p>(liu2023pathwayandmechanism pages 1-2): Caixuan Liu, Mingliang Jin, Shutian Wang, Wenyu Han, Qiaoyu Zhao, Yifan Wang, Cong Xu, Lei Diao, Yue Yin, Chao Peng, Lan Bao, Yanxing Wang, and Yao Cong. Pathway and mechanism of tubulin folding mediated by tric/cct along its atpase cycle revealed using cryo-em. Communications Biology, May 2023. URL: https://doi.org/10.1038/s42003-023-04915-x, doi:10.1038/s42003-023-04915-x. This article has 28 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(junsun2024astructuralvista pages 1-2): Junsun Park, Hyunmin Kim, Daniel Gestaut, Seyeon Lim, Kwadwo A. Opoku-Nsiah, Alexander Leitner, Judith Frydman, and Soung-Hun Roh. A structural vista of phosducin-like phlp2a-chaperonin tric cooperation during the atp-driven folding cycle. Nature Communications, Feb 2024. URL: https://doi.org/10.1038/s41467-024-45242-x, doi:10.1038/s41467-024-45242-x. This article has 16 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pereira2017structureofthe pages 1-2): Jose H. Pereira, Ryan P. McAndrew, Oksana A. Sergeeva, Corie Y. Ralston, Jonathan A. King, and Paul D. Adams. Structure of the human tric/cct subunit 5 associated with hereditary sensory neuropathy. Scientific Reports, Jun 2017. URL: https://doi.org/10.1038/s41598-017-03825-3, doi:10.1038/s41598-017-03825-3. This article has 43 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kelly2020structuralandfunctionala pages 23-28): J Kelly. Structural and functional characterisation of the group ii chaperonin cct/tric. Unknown journal, 2020.</p>
+</li>
+<li>
+<p>(ghozlan2022thetrickybusiness pages 1-2): Heba Ghozlan, Amanda Cox, Daniel Nierenberg, Stephen King, and Annette R. Khaled. The tricky business of protein folding in health and disease. Frontiers in Cell and Developmental Biology, May 2022. URL: https://doi.org/10.3389/fcell.2022.906530, doi:10.3389/fcell.2022.906530. This article has 34 citations.</p>
+</li>
+<li>
+<p>(kabir2011functionalsubunitsof pages 1-2): M. Anaul Kabir, Wasim Uddin, Aswathy Narayanan, Praveen Kumar Reddy, M. Aman Jairajpuri, Fred Sherman, and Zulfiqar Ahmad. Functional subunits of eukaryotic chaperonin cct/tric in protein folding. Journal of Amino Acids, 2011:1-16, Jul 2011. URL: https://doi.org/10.4061/2011/843206, doi:10.4061/2011/843206. This article has 62 citations.</p>
+</li>
+<li>
+<p>(kelly2020structuralandfunctionala pages 14-18): J Kelly. Structural and functional characterisation of the group ii chaperonin cct/tric. Unknown journal, 2020.</p>
+</li>
+<li>
+<p>(willison2018thesubstratespecificity pages 1-2): Keith R. Willison. The substrate specificity of eukaryotic cytosolic chaperonin cct. Philosophical Transactions of the Royal Society B: Biological Sciences, 373:20170192, Jun 2018. URL: https://doi.org/10.1098/rstb.2017.0192, doi:10.1098/rstb.2017.0192. This article has 75 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kelly2020structuralandfunctional pages 35-42): J Kelly. Structural and functional characterisation of the group ii chaperonin cct/tric. Unknown journal, 2020.</p>
+</li>
+<li>
+<p>(willison2018thesubstratespecificity pages 2-3): Keith R. Willison. The substrate specificity of eukaryotic cytosolic chaperonin cct. Philosophical Transactions of the Royal Society B: Biological Sciences, 373:20170192, Jun 2018. URL: https://doi.org/10.1098/rstb.2017.0192, doi:10.1098/rstb.2017.0192. This article has 75 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(stoldt1996reviewthecct pages 5-6): Volker Stoldt, Felicitas Rademacher, Verena Kehren, Joachim F. Ernst, David A. Pearce, and Fred Sherman. Review: the cct eukaryotic chaperonin subunits of saccharomyces cerevisiae and other yeasts. Yeast, 12:523-529, May 1996. URL: https://doi.org/10.1002/(sici)1097-0061(199605)12:6&lt;523::aid-yea962&gt;3.0.co;2-c, doi:10.1002/(sici)1097-0061(199605)12:6&lt;523::aid-yea962&gt;3.0.co;2-c. This article has 153 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kelly2020structuralandfunctionalb pages 23-28): J Kelly. Structural and functional characterisation of the group ii chaperonin cct/tric. Unknown journal, 2020.</p>
+</li>
+<li>
+<p>(liu2023pathwayandmechanism pages 6-7): Caixuan Liu, Mingliang Jin, Shutian Wang, Wenyu Han, Qiaoyu Zhao, Yifan Wang, Cong Xu, Lei Diao, Yue Yin, Chao Peng, Lan Bao, Yanxing Wang, and Yao Cong. Pathway and mechanism of tubulin folding mediated by tric/cct along its atpase cycle revealed using cryo-em. Communications Biology, May 2023. URL: https://doi.org/10.1038/s42003-023-04915-x, doi:10.1038/s42003-023-04915-x. This article has 28 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(junsun2024astructuralvista media 0880aeaf): Junsun Park, Hyunmin Kim, Daniel Gestaut, Seyeon Lim, Kwadwo A. Opoku-Nsiah, Alexander Leitner, Judith Frydman, and Soung-Hun Roh. A structural vista of phosducin-like phlp2a-chaperonin tric cooperation during the atp-driven folding cycle. Nature Communications, Feb 2024. URL: https://doi.org/10.1038/s41467-024-45242-x, doi:10.1038/s41467-024-45242-x. This article has 16 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jin2025theconformationallandscape pages 1-2): Mingliang Jin, Yunxiang Zang, Huping Wang, and Yao Cong. The conformational landscape of tric ring-opening and its underlying stepwise mechanism revealed by cryo-em. QRB Discovery, Dec 2025. URL: https://doi.org/10.1017/qrd.2024.17, doi:10.1017/qrd.2024.17. This article has 3 citations.</p>
+</li>
+<li>
+<p>(shen2025proteinfoldingby pages 5-7): Peter S. Shen and Barry M. Willardson. Protein folding by the cct/tric chaperone complex. Current Opinion in Structural Biology, 91:102999, Apr 2025. URL: https://doi.org/10.1016/j.sbi.2025.102999, doi:10.1016/j.sbi.2025.102999. This article has 10 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(willison2018thesubstratespecificity pages 7-8): Keith R. Willison. The substrate specificity of eukaryotic cytosolic chaperonin cct. Philosophical Transactions of the Royal Society B: Biological Sciences, 373:20170192, Jun 2018. URL: https://doi.org/10.1098/rstb.2017.0192, doi:10.1098/rstb.2017.0192. This article has 75 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(stoldt1996reviewthecct pages 2-4): Volker Stoldt, Felicitas Rademacher, Verena Kehren, Joachim F. Ernst, David A. Pearce, and Fred Sherman. Review: the cct eukaryotic chaperonin subunits of saccharomyces cerevisiae and other yeasts. Yeast, 12:523-529, May 1996. URL: https://doi.org/10.1002/(sici)1097-0061(199605)12:6&lt;523::aid-yea962&gt;3.0.co;2-c, doi:10.1002/(sici)1097-0061(199605)12:6&lt;523::aid-yea962&gt;3.0.co;2-c. This article has 153 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kelly2020structuralandfunctional pages 42-48): J Kelly. Structural and functional characterisation of the group ii chaperonin cct/tric. Unknown journal, 2020.</p>
+</li>
+<li>
+<p>(junsun2024astructuralvista media 774d2963): Junsun Park, Hyunmin Kim, Daniel Gestaut, Seyeon Lim, Kwadwo A. Opoku-Nsiah, Alexander Leitner, Judith Frydman, and Soung-Hun Roh. A structural vista of phosducin-like phlp2a-chaperonin tric cooperation during the atp-driven folding cycle. Nature Communications, Feb 2024. URL: https://doi.org/10.1038/s41467-024-45242-x, doi:10.1038/s41467-024-45242-x. This article has 16 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(junsun2024astructuralvista media e727d38e): Junsun Park, Hyunmin Kim, Daniel Gestaut, Seyeon Lim, Kwadwo A. Opoku-Nsiah, Alexander Leitner, Judith Frydman, and Soung-Hun Roh. A structural vista of phosducin-like phlp2a-chaperonin tric cooperation during the atp-driven folding cycle. Nature Communications, Feb 2024. URL: https://doi.org/10.1038/s41467-024-45242-x, doi:10.1038/s41467-024-45242-x. This article has 16 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>stoldt1996reviewthecct pages 1-2</li>
+<li>kelly2020structuralandfunctional pages 35-42</li>
+<li>kelly2020structuralandfunctionala pages 42-48</li>
+<li>willison2018thesubstratespecificity pages 2-3</li>
+<li>stoldt1996reviewthecct pages 5-6</li>
+<li>willison2018thesubstratespecificity pages 1-2</li>
+<li>kelly2020structuralandfunctionalb pages 23-28</li>
+<li>junsun2024astructuralvista pages 1-2</li>
+<li>jin2025theconformationallandscape pages 1-2</li>
+<li>willison2018thesubstratespecificity pages 7-8</li>
+<li>grantham2020themolecularchaperone pages 1-2</li>
+<li>liu2023pathwayandmechanism pages 1-2</li>
+<li>pereira2017structureofthe pages 1-2</li>
+<li>kelly2020structuralandfunctionala pages 23-28</li>
+<li>ghozlan2022thetrickybusiness pages 1-2</li>
+<li>kabir2011functionalsubunitsof pages 1-2</li>
+<li>kelly2020structuralandfunctionala pages 14-18</li>
+<li>liu2023pathwayandmechanism pages 6-7</li>
+<li>shen2025proteinfoldingby pages 5-7</li>
+<li>stoldt1996reviewthecct pages 2-4</li>
+<li>kelly2020structuralandfunctional pages 42-48</li>
+<li>https://doi.org/10.1002/(sici</li>
+<li>https://doi.org/10.1038/s42003-023-04915-x</li>
+<li>https://doi.org/10.1038/s41467-024-45242-x</li>
+<li>https://doi.org/10.1017/qrd.2024.17</li>
+<li>https://doi.org/10.1038/s41598-017-18962-y</li>
+<li>https://doi.org/10.1098/rstb.2017.0192</li>
+<li>https://doi.org/10.3389/fgene.2020.00172</li>
+<li>https://doi.org/10.3389/fgene.2020.00172,</li>
+<li>https://doi.org/10.1038/s42003-023-04915-x,</li>
+<li>https://doi.org/10.1038/s41467-024-45242-x,</li>
+<li>https://doi.org/10.1038/s41598-017-03825-3,</li>
+<li>https://doi.org/10.3389/fcell.2022.906530,</li>
+<li>https://doi.org/10.4061/2011/843206,</li>
+<li>https://doi.org/10.1098/rstb.2017.0192,</li>
+<li>https://doi.org/10.1017/qrd.2024.17,</li>
+<li>https://doi.org/10.1016/j.sbi.2025.102999,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -1924,174 +2689,16 @@
                 <pre><code>id: P40413
 gene_symbol: CCT5
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: &#39;TODO: Add description for CCT5&#39;
-existing_annotations:
-- term:
-    id: GO:0006457
-    label: protein folding
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: &#39;Manual review: protein folding is consistent with known biology of CCT5.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005832
-    label: chaperonin-containing T-complex
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: &#39;Manual review: chaperonin-containing T-complex is consistent with known biology of CCT5.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: &#39;Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT5.&#39;
-    action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
-- term:
-    id: GO:0000166
-    label: nucleotide binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000043
-  review:
-    summary: &#39;Manual review: nucleotide binding is consistent with known biology of CCT5.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005524
-    label: ATP binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000120
-  review:
-    summary: &#39;Manual review: ATP binding is consistent with known biology of CCT5.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005737
-    label: cytoplasm
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000044
-  review:
-    summary: &#39;Manual review: cytoplasm is consistent with known biology of CCT5.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005832
-    label: chaperonin-containing T-complex
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000117
-  review:
-    summary: &#39;Manual review: chaperonin-containing T-complex is consistent with known biology of CCT5.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0006457
-    label: protein folding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000120
-  review:
-    summary: &#39;Manual review: protein folding is consistent with known biology of CCT5.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0016887
-    label: ATP hydrolysis activity
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: &#39;Manual review: ATP hydrolysis activity is consistent with known biology of CCT5.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000120
-  review:
-    summary: &#39;Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT5.&#39;
-    action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
-- term:
-    id: GO:0140662
-    label: ATP-dependent protein folding chaperone
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: &#39;Manual review: ATP-dependent protein folding chaperone is consistent with known biology of CCT5.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:19536198
-  review:
-    summary: &#39;Manual review: protein binding is too generic or over-extended for CCT5.&#39;
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:37968396
-  review:
-    summary: &#39;Manual review: protein binding is too generic or over-extended for CCT5.&#39;
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0006457
-    label: protein folding
-  evidence_type: IDA
-  original_reference_id: PMID:16762366
-  review:
-    summary: &#39;Manual review: protein folding is consistent with known biology of CCT5.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005832
-    label: chaperonin-containing T-complex
-  evidence_type: IPI
-  original_reference_id: PMID:15704212
-  review:
-    summary: &#39;Manual review: chaperonin-containing T-complex is consistent with known biology of CCT5.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005832
-    label: chaperonin-containing T-complex
-  evidence_type: IDA
-  original_reference_id: PMID:16762366
-  review:
-    summary: &#39;Manual review: chaperonin-containing T-complex is consistent with known biology of CCT5.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IDA
-  original_reference_id: PMID:16762366
-  review:
-    summary: &#39;Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT5.&#39;
-    action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+description: &gt;-
+  CCT5 encodes the epsilon subunit of the cytosolic group II chaperonin TRiC/CCT. Cct5 is an obligate
+  subunit of the ATP-driven double-ring folding machine, contributes one ATPase/substrate-contact module
+  to the chamber, and is best curated as part of the complex that folds actin, tubulin, and other cytosolic
+  clients. The subunit-specific literature emphasizes ATP-cycle asymmetry and chamber architecture rather
+  than a separate standalone activity.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -2103,7 +2710,9 @@ references:
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
+  title: &gt;-
+    Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied
+    by conservative changes to GO terms applied by UniProt
   findings: []
 - id: GO_REF:0000117
   title: Electronic Gene Ontology annotations created by ARBA machine learning models
@@ -2113,23 +2722,373 @@ references:
   findings: []
 - id: PMID:15704212
   title: Physiological effects of unassembled chaperonin Cct subunits in the yeast Saccharomyces cerevisiae.
-  findings: []
+  findings:
+  - statement: Yeast CCT is a double-ring complex with a stoichiometric set of eight distinct Cct subunits.
+    supporting_text: &gt;-
+      Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
+      of a stoichiometric array of eight different subunits
 - id: PMID:16762366
-  title: Quantitative actin folding reactions using yeast CCT purified via an internal tag in the CCT3/gamma subunit.
-  findings: []
+  title: &gt;-
+    Quantitative actin folding reactions using yeast CCT purified via an internal tag in the CCT3/gamma
+    subunit.
+  findings:
+  - statement: &gt;-
+      Purified yeast CCT, tagged through CCT3, catalyzes ATP-dependent actin folding; this supports protein-folding
+      and chaperonin activity annotations for CCT5 as a TRiC/CCT subunit.
+    supporting_text: &gt;-
+      The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose
+      action is required for folding the cytoskeletal proteins actin and tubulin
 - id: PMID:19536198
-  title: &#39;An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding pathways in the cell.&#39;
-  findings: []
+  title: &gt;-
+    An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding
+    pathways in the cell.
+  findings:
+  - statement: &gt;-
+      The chaperone interactome study is useful context for CCT contacts but reports indirect TAP-tag
+      interactions rather than a specific molecular activity.
+    supporting_text: &gt;-
+      It should be emphasized that the interactions presented are indirect TAP-tag based interactions
+      and not direct binary interactions.
 - id: PMID:37968396
   title: The social and structural architecture of the yeast protein interactome.
   findings: []
+- id: file:yeast/CCT5/CCT5-deep-research-falcon.md
+  title: Falcon deep research report for CCT5
+  findings:
+  - statement: &gt;-
+      The Falcon report was reviewed and synthesized into the CCT5 curation, including core-function framing,
+      family/PANTHER context, and evidence limitations.
+existing_annotations:
+- term:
+    id: GO:0006457
+    label: protein folding
+  qualifier: involved_in
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: &gt;-
+      CCT5 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin
+      that folds actin, tubulin, and other clients.
+    action: ACCEPT
+    reason: &gt;-
+      Protein folding is the correct biological-process context for the chaperonin complex, supported
+      by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
+    supported_by:
+    - reference_id: file:yeast/CCT5/CCT5-deep-research-falcon.md
+      supporting_text: CCT5 is best defined as a **structural and catalytic component**
+- term:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  qualifier: part_of
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: CCT5 is a named subunit of the chaperonin-containing T-complex.
+    action: ACCEPT
+    reason: &gt;-
+      Complex membership is central to the gene product function and is supported by yeast CCT complex
+      literature and family evidence.
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: &gt;-
+      unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than
+      the ATP-dependent folding chaperone function of the complex.
+    action: MODIFY
+    reason: &gt;-
+      Replace generic substrate-binding language with the specific chaperonin activity supported by yeast
+      CCT actin-folding assays and domain evidence.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+- term:
+    id: GO:0000166
+    label: nucleotide binding
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: &gt;-
+      nucleotide binding is a true but overly broad family/keyword annotation for CCT5; ATP binding, ATP
+      hydrolysis, and ATP-dependent chaperone annotations capture the specific chemistry.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Generic nucleotide binding does not add useful functional information beyond the more specific ATP-related
+      chaperonin annotations already present.
+- term:
+    id: GO:0005524
+    label: ATP binding
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: &gt;-
+      CCT5 contains a conserved chaperonin ATP-binding site, but ATP binding alone is a domain property
+      rather than the core biological function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Keep as a valid supporting molecular property of the CCT ATPase cycle, while treating ATP hydrolysis
+      and complex-level protein folding as the core function.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  qualifier: located_in
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: CCT5 functions as part of the cytosolic TRiC/CCT chaperonin.
+    action: ACCEPT
+    reason: Cytoplasm is the established location of the CCT/TRiC folding machine.
+- term:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  qualifier: part_of
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: CCT5 is a named subunit of the chaperonin-containing T-complex.
+    action: ACCEPT
+    reason: &gt;-
+      Complex membership is central to the gene product function and is supported by yeast CCT complex
+      literature and family evidence.
+- term:
+    id: GO:0006457
+    label: protein folding
+  qualifier: involved_in
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: &gt;-
+      CCT5 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin
+      that folds actin, tubulin, and other clients.
+    action: ACCEPT
+    reason: &gt;-
+      Protein folding is the correct biological-process context for the chaperonin complex, supported
+      by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
+- term:
+    id: GO:0016887
+    label: ATP hydrolysis activity
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: &gt;-
+      CCT5 is a TCP-1/CCT chaperonin subunit with conserved ATPase machinery that powers TRiC/CCT conformational
+      cycling.
+    action: ACCEPT
+    reason: &gt;-
+      ATP hydrolysis is a defensible subunit-level molecular function for CCT family members and is directly
+      tied to the chaperonin folding cycle.
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: &gt;-
+      unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than
+      the ATP-dependent folding chaperone function of the complex.
+    action: MODIFY
+    reason: &gt;-
+      Replace generic substrate-binding language with the specific chaperonin activity supported by yeast
+      CCT actin-folding assays and domain evidence.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+- term:
+    id: GO:0140662
+    label: ATP-dependent protein folding chaperone
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: CCT5 is an obligate subunit of the ATP-dependent TRiC/CCT folding machine.
+    action: ACCEPT
+    reason: &gt;-
+      The term is appropriate as a complex-level chaperonin function; in the synthesized core function
+      it is modeled as a contributed-to molecular function rather than a standalone activity of an isolated
+      subunit.
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: &gt;-
+        The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine
+        whose action is required for folding the cytoskeletal proteins actin and tubulin
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005515
+    label: protein binding
+  qualifier: enables
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  supporting_entities:
+  - UniProtKB:P32324
+  review:
+    summary: &gt;-
+      protein binding is too generic for a CCT subunit and does not describe the chaperonin mechanism
+      or substrate class.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Physical-interaction datasets are useful evidence context, but generic protein binding should not
+      stand as a functional annotation when the specific TRiC/CCT chaperonin role is known.
+    supported_by:
+    - reference_id: PMID:19536198
+      supporting_text: &gt;-
+        It should be emphasized that the interactions presented are indirect TAP-tag based interactions
+        and not direct binary interactions.
+- term:
+    id: GO:0005515
+    label: protein binding
+  qualifier: enables
+  evidence_type: IPI
+  original_reference_id: PMID:37968396
+  supporting_entities:
+  - UniProtKB:P32324
+  review:
+    summary: &gt;-
+      protein binding is too generic for a CCT subunit and does not describe the chaperonin mechanism
+      or substrate class.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Physical-interaction datasets are useful evidence context, but generic protein binding should not
+      stand as a functional annotation when the specific TRiC/CCT chaperonin role is known.
+- term:
+    id: GO:0006457
+    label: protein folding
+  qualifier: involved_in
+  evidence_type: IDA
+  original_reference_id: PMID:16762366
+  review:
+    summary: &gt;-
+      CCT5 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin
+      that folds actin, tubulin, and other clients.
+    action: ACCEPT
+    reason: &gt;-
+      Protein folding is the correct biological-process context for the chaperonin complex, supported
+      by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: &gt;-
+        The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine
+        whose action is required for folding the cytoskeletal proteins actin and tubulin
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  qualifier: part_of
+  evidence_type: IPI
+  original_reference_id: PMID:15704212
+  supporting_entities:
+  - SGD:S000002596
+  review:
+    summary: CCT5 is a named subunit of the chaperonin-containing T-complex.
+    action: ACCEPT
+    reason: &gt;-
+      Complex membership is central to the gene product function and is supported by yeast CCT complex
+      literature and family evidence.
+    supported_by:
+    - reference_id: PMID:15704212
+      supporting_text: &gt;-
+        Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
+        of a stoichiometric array of eight different subunits
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  qualifier: part_of
+  evidence_type: IDA
+  original_reference_id: PMID:16762366
+  review:
+    summary: CCT5 is a named subunit of the chaperonin-containing T-complex.
+    action: ACCEPT
+    reason: &gt;-
+      Complex membership is central to the gene product function and is supported by yeast CCT complex
+      literature and family evidence.
+    supported_by:
+    - reference_id: PMID:15704212
+      supporting_text: &gt;-
+        Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
+        of a stoichiometric array of eight different subunits
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IDA
+  original_reference_id: PMID:16762366
+  review:
+    summary: &gt;-
+      unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than
+      the ATP-dependent folding chaperone function of the complex.
+    action: MODIFY
+    reason: &gt;-
+      Replace generic substrate-binding language with the specific chaperonin activity supported by yeast
+      CCT actin-folding assays and domain evidence.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: &gt;-
+        The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine
+        whose action is required for folding the cytoskeletal proteins actin and tubulin
+      reference_section_type: ABSTRACT
+core_functions:
+- description: &gt;-
+    CCT5 is the epsilon subunit of the cytosolic TRiC/CCT chaperonin. The subunit contributes ATPase and
+    substrate-contact surfaces to the hetero-oligomeric double-ring complex, whose ATP-dependent conformational
+    cycle folds actin, tubulin, and other cytosolic client proteins. The synthesized function is modeled
+    as subunit ATP hydrolysis contributing to the complex-level ATP-dependent protein folding chaperone
+    activity.
+  molecular_function:
+    id: GO:0016887
+    label: ATP hydrolysis activity
+  contributes_to_molecular_function:
+    id: GO:0140662
+    label: ATP-dependent protein folding chaperone
+  directly_involved_in:
+  - id: GO:0006457
+    label: protein folding
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+  in_complex:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  supported_by:
+  - reference_id: PMID:16762366
+    supporting_text: &gt;-
+      The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose
+      action is required for folding the cytoskeletal proteins actin and tubulin
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:15704212
+    supporting_text: &gt;-
+      Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
+      of a stoichiometric array of eight different subunits
+    reference_section_type: ABSTRACT
+suggested_questions:
+- question: &gt;-
+    How does the high-ATP-affinity Cct5 subunit shape client progression through the yeast TRiC/CCT ATPase
+    cycle?
+suggested_experiments:
+- hypothesis: &gt;-
+    Cct5 ATP binding/hydrolysis helps set the timing of TRiC/CCT chamber closure for actin and tubulin
+    clients.
+  description: &gt;-
+    Compare ATPase-cycle reporters, client folding assays, and viability for targeted CCT5 ATP-pocket
+    alleles in yeast, separating assembled-complex abundance from kinetic effects.
+  experiment_type: site-directed mutagenesis with chaperonin folding and ATPase assays
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/yeast/CCT5/CCT5-ai-review.yaml
+++ b/genes/yeast/CCT5/CCT5-ai-review.yaml
@@ -1,174 +1,16 @@
 id: P40413
 gene_symbol: CCT5
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: 'TODO: Add description for CCT5'
-existing_annotations:
-- term:
-    id: GO:0006457
-    label: protein folding
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: 'Manual review: protein folding is consistent with known biology of CCT5.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005832
-    label: chaperonin-containing T-complex
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: 'Manual review: chaperonin-containing T-complex is consistent with known biology of CCT5.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: 'Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT5.'
-    action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
-- term:
-    id: GO:0000166
-    label: nucleotide binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000043
-  review:
-    summary: 'Manual review: nucleotide binding is consistent with known biology of CCT5.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005524
-    label: ATP binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000120
-  review:
-    summary: 'Manual review: ATP binding is consistent with known biology of CCT5.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005737
-    label: cytoplasm
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000044
-  review:
-    summary: 'Manual review: cytoplasm is consistent with known biology of CCT5.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005832
-    label: chaperonin-containing T-complex
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000117
-  review:
-    summary: 'Manual review: chaperonin-containing T-complex is consistent with known biology of CCT5.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0006457
-    label: protein folding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000120
-  review:
-    summary: 'Manual review: protein folding is consistent with known biology of CCT5.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0016887
-    label: ATP hydrolysis activity
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: 'Manual review: ATP hydrolysis activity is consistent with known biology of CCT5.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000120
-  review:
-    summary: 'Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT5.'
-    action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
-- term:
-    id: GO:0140662
-    label: ATP-dependent protein folding chaperone
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: 'Manual review: ATP-dependent protein folding chaperone is consistent with known biology of CCT5.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:19536198
-  review:
-    summary: 'Manual review: protein binding is too generic or over-extended for CCT5.'
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:37968396
-  review:
-    summary: 'Manual review: protein binding is too generic or over-extended for CCT5.'
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0006457
-    label: protein folding
-  evidence_type: IDA
-  original_reference_id: PMID:16762366
-  review:
-    summary: 'Manual review: protein folding is consistent with known biology of CCT5.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005832
-    label: chaperonin-containing T-complex
-  evidence_type: IPI
-  original_reference_id: PMID:15704212
-  review:
-    summary: 'Manual review: chaperonin-containing T-complex is consistent with known biology of CCT5.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005832
-    label: chaperonin-containing T-complex
-  evidence_type: IDA
-  original_reference_id: PMID:16762366
-  review:
-    summary: 'Manual review: chaperonin-containing T-complex is consistent with known biology of CCT5.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IDA
-  original_reference_id: PMID:16762366
-  review:
-    summary: 'Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT5.'
-    action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+description: >-
+  CCT5 encodes the epsilon subunit of the cytosolic group II chaperonin TRiC/CCT. Cct5 is an obligate
+  subunit of the ATP-driven double-ring folding machine, contributes one ATPase/substrate-contact module
+  to the chamber, and is best curated as part of the complex that folds actin, tubulin, and other cytosolic
+  clients. The subunit-specific literature emphasizes ATP-cycle asymmetry and chamber architecture rather
+  than a separate standalone activity.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -180,7 +22,9 @@ references:
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
+  title: >-
+    Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied
+    by conservative changes to GO terms applied by UniProt
   findings: []
 - id: GO_REF:0000117
   title: Electronic Gene Ontology annotations created by ARBA machine learning models
@@ -190,13 +34,363 @@ references:
   findings: []
 - id: PMID:15704212
   title: Physiological effects of unassembled chaperonin Cct subunits in the yeast Saccharomyces cerevisiae.
-  findings: []
+  findings:
+  - statement: Yeast CCT is a double-ring complex with a stoichiometric set of eight distinct Cct subunits.
+    supporting_text: >-
+      Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
+      of a stoichiometric array of eight different subunits
 - id: PMID:16762366
-  title: Quantitative actin folding reactions using yeast CCT purified via an internal tag in the CCT3/gamma subunit.
-  findings: []
+  title: >-
+    Quantitative actin folding reactions using yeast CCT purified via an internal tag in the CCT3/gamma
+    subunit.
+  findings:
+  - statement: >-
+      Purified yeast CCT, tagged through CCT3, catalyzes ATP-dependent actin folding; this supports protein-folding
+      and chaperonin activity annotations for CCT5 as a TRiC/CCT subunit.
+    supporting_text: >-
+      The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose
+      action is required for folding the cytoskeletal proteins actin and tubulin
 - id: PMID:19536198
-  title: 'An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding pathways in the cell.'
-  findings: []
+  title: >-
+    An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding
+    pathways in the cell.
+  findings:
+  - statement: >-
+      The chaperone interactome study is useful context for CCT contacts but reports indirect TAP-tag
+      interactions rather than a specific molecular activity.
+    supporting_text: >-
+      It should be emphasized that the interactions presented are indirect TAP-tag based interactions
+      and not direct binary interactions.
 - id: PMID:37968396
   title: The social and structural architecture of the yeast protein interactome.
   findings: []
+- id: file:yeast/CCT5/CCT5-deep-research-falcon.md
+  title: Falcon deep research report for CCT5
+  findings:
+  - statement: >-
+      The Falcon report was reviewed and synthesized into the CCT5 curation, including core-function framing,
+      family/PANTHER context, and evidence limitations.
+existing_annotations:
+- term:
+    id: GO:0006457
+    label: protein folding
+  qualifier: involved_in
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: >-
+      CCT5 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin
+      that folds actin, tubulin, and other clients.
+    action: ACCEPT
+    reason: >-
+      Protein folding is the correct biological-process context for the chaperonin complex, supported
+      by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
+    supported_by:
+    - reference_id: file:yeast/CCT5/CCT5-deep-research-falcon.md
+      supporting_text: CCT5 is best defined as a **structural and catalytic component**
+- term:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  qualifier: part_of
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: CCT5 is a named subunit of the chaperonin-containing T-complex.
+    action: ACCEPT
+    reason: >-
+      Complex membership is central to the gene product function and is supported by yeast CCT complex
+      literature and family evidence.
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: >-
+      unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than
+      the ATP-dependent folding chaperone function of the complex.
+    action: MODIFY
+    reason: >-
+      Replace generic substrate-binding language with the specific chaperonin activity supported by yeast
+      CCT actin-folding assays and domain evidence.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+- term:
+    id: GO:0000166
+    label: nucleotide binding
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: >-
+      nucleotide binding is a true but overly broad family/keyword annotation for CCT5; ATP binding, ATP
+      hydrolysis, and ATP-dependent chaperone annotations capture the specific chemistry.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Generic nucleotide binding does not add useful functional information beyond the more specific ATP-related
+      chaperonin annotations already present.
+- term:
+    id: GO:0005524
+    label: ATP binding
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: >-
+      CCT5 contains a conserved chaperonin ATP-binding site, but ATP binding alone is a domain property
+      rather than the core biological function.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Keep as a valid supporting molecular property of the CCT ATPase cycle, while treating ATP hydrolysis
+      and complex-level protein folding as the core function.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  qualifier: located_in
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: CCT5 functions as part of the cytosolic TRiC/CCT chaperonin.
+    action: ACCEPT
+    reason: Cytoplasm is the established location of the CCT/TRiC folding machine.
+- term:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  qualifier: part_of
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: CCT5 is a named subunit of the chaperonin-containing T-complex.
+    action: ACCEPT
+    reason: >-
+      Complex membership is central to the gene product function and is supported by yeast CCT complex
+      literature and family evidence.
+- term:
+    id: GO:0006457
+    label: protein folding
+  qualifier: involved_in
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: >-
+      CCT5 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin
+      that folds actin, tubulin, and other clients.
+    action: ACCEPT
+    reason: >-
+      Protein folding is the correct biological-process context for the chaperonin complex, supported
+      by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
+- term:
+    id: GO:0016887
+    label: ATP hydrolysis activity
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: >-
+      CCT5 is a TCP-1/CCT chaperonin subunit with conserved ATPase machinery that powers TRiC/CCT conformational
+      cycling.
+    action: ACCEPT
+    reason: >-
+      ATP hydrolysis is a defensible subunit-level molecular function for CCT family members and is directly
+      tied to the chaperonin folding cycle.
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: >-
+      unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than
+      the ATP-dependent folding chaperone function of the complex.
+    action: MODIFY
+    reason: >-
+      Replace generic substrate-binding language with the specific chaperonin activity supported by yeast
+      CCT actin-folding assays and domain evidence.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+- term:
+    id: GO:0140662
+    label: ATP-dependent protein folding chaperone
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: CCT5 is an obligate subunit of the ATP-dependent TRiC/CCT folding machine.
+    action: ACCEPT
+    reason: >-
+      The term is appropriate as a complex-level chaperonin function; in the synthesized core function
+      it is modeled as a contributed-to molecular function rather than a standalone activity of an isolated
+      subunit.
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: >-
+        The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine
+        whose action is required for folding the cytoskeletal proteins actin and tubulin
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005515
+    label: protein binding
+  qualifier: enables
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  supporting_entities:
+  - UniProtKB:P32324
+  review:
+    summary: >-
+      protein binding is too generic for a CCT subunit and does not describe the chaperonin mechanism
+      or substrate class.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Physical-interaction datasets are useful evidence context, but generic protein binding should not
+      stand as a functional annotation when the specific TRiC/CCT chaperonin role is known.
+    supported_by:
+    - reference_id: PMID:19536198
+      supporting_text: >-
+        It should be emphasized that the interactions presented are indirect TAP-tag based interactions
+        and not direct binary interactions.
+- term:
+    id: GO:0005515
+    label: protein binding
+  qualifier: enables
+  evidence_type: IPI
+  original_reference_id: PMID:37968396
+  supporting_entities:
+  - UniProtKB:P32324
+  review:
+    summary: >-
+      protein binding is too generic for a CCT subunit and does not describe the chaperonin mechanism
+      or substrate class.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Physical-interaction datasets are useful evidence context, but generic protein binding should not
+      stand as a functional annotation when the specific TRiC/CCT chaperonin role is known.
+- term:
+    id: GO:0006457
+    label: protein folding
+  qualifier: involved_in
+  evidence_type: IDA
+  original_reference_id: PMID:16762366
+  review:
+    summary: >-
+      CCT5 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin
+      that folds actin, tubulin, and other clients.
+    action: ACCEPT
+    reason: >-
+      Protein folding is the correct biological-process context for the chaperonin complex, supported
+      by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: >-
+        The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine
+        whose action is required for folding the cytoskeletal proteins actin and tubulin
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  qualifier: part_of
+  evidence_type: IPI
+  original_reference_id: PMID:15704212
+  supporting_entities:
+  - SGD:S000002596
+  review:
+    summary: CCT5 is a named subunit of the chaperonin-containing T-complex.
+    action: ACCEPT
+    reason: >-
+      Complex membership is central to the gene product function and is supported by yeast CCT complex
+      literature and family evidence.
+    supported_by:
+    - reference_id: PMID:15704212
+      supporting_text: >-
+        Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
+        of a stoichiometric array of eight different subunits
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  qualifier: part_of
+  evidence_type: IDA
+  original_reference_id: PMID:16762366
+  review:
+    summary: CCT5 is a named subunit of the chaperonin-containing T-complex.
+    action: ACCEPT
+    reason: >-
+      Complex membership is central to the gene product function and is supported by yeast CCT complex
+      literature and family evidence.
+    supported_by:
+    - reference_id: PMID:15704212
+      supporting_text: >-
+        Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
+        of a stoichiometric array of eight different subunits
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IDA
+  original_reference_id: PMID:16762366
+  review:
+    summary: >-
+      unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than
+      the ATP-dependent folding chaperone function of the complex.
+    action: MODIFY
+    reason: >-
+      Replace generic substrate-binding language with the specific chaperonin activity supported by yeast
+      CCT actin-folding assays and domain evidence.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: >-
+        The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine
+        whose action is required for folding the cytoskeletal proteins actin and tubulin
+      reference_section_type: ABSTRACT
+core_functions:
+- description: >-
+    CCT5 is the epsilon subunit of the cytosolic TRiC/CCT chaperonin. The subunit contributes ATPase and
+    substrate-contact surfaces to the hetero-oligomeric double-ring complex, whose ATP-dependent conformational
+    cycle folds actin, tubulin, and other cytosolic client proteins. The synthesized function is modeled
+    as subunit ATP hydrolysis contributing to the complex-level ATP-dependent protein folding chaperone
+    activity.
+  molecular_function:
+    id: GO:0016887
+    label: ATP hydrolysis activity
+  contributes_to_molecular_function:
+    id: GO:0140662
+    label: ATP-dependent protein folding chaperone
+  directly_involved_in:
+  - id: GO:0006457
+    label: protein folding
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+  in_complex:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  supported_by:
+  - reference_id: PMID:16762366
+    supporting_text: >-
+      The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose
+      action is required for folding the cytoskeletal proteins actin and tubulin
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:15704212
+    supporting_text: >-
+      Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
+      of a stoichiometric array of eight different subunits
+    reference_section_type: ABSTRACT
+suggested_questions:
+- question: >-
+    How does the high-ATP-affinity Cct5 subunit shape client progression through the yeast TRiC/CCT ATPase
+    cycle?
+suggested_experiments:
+- hypothesis: >-
+    Cct5 ATP binding/hydrolysis helps set the timing of TRiC/CCT chamber closure for actin and tubulin
+    clients.
+  description: >-
+    Compare ATPase-cycle reporters, client folding assays, and viability for targeted CCT5 ATP-pocket
+    alleles in yeast, separating assembled-complex abundance from kinetic effects.
+  experiment_type: site-directed mutagenesis with chaperonin folding and ATPase assays

--- a/genes/yeast/CCT5/CCT5-ai-review.yaml
+++ b/genes/yeast/CCT5/CCT5-ai-review.yaml
@@ -303,10 +303,10 @@ existing_annotations:
       Complex membership is central to the gene product function and is supported by yeast CCT complex
       literature and family evidence.
     supported_by:
-    - reference_id: PMID:15704212
+    - reference_id: PMID:16762366
       supporting_text: >-
-        Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
-        of a stoichiometric array of eight different subunits
+        The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine
+        whose action is required for folding the cytoskeletal proteins actin and tubulin
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005832

--- a/genes/yeast/CCT5/CCT5-deep-research-falcon.md
+++ b/genes/yeast/CCT5/CCT5-deep-research-falcon.md
@@ -1,0 +1,346 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-04T10:06:00.865548'
+end_time: '2026-05-04T10:25:00.852286'
+duration_seconds: 1139.99
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: yeast
+  gene_id: CCT5
+  gene_symbol: CCT5
+  uniprot_accession: P40413
+  protein_description: 'RecName: Full=T-complex protein 1 subunit epsilon; Short=TCP-1-epsilon;
+    AltName: Full=CCT-epsilon;'
+  gene_info: Name=CCT5; Synonyms=TCP5; OrderedLocusNames=YJR064W; ORFNames=J1752;
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+  protein_family: Belongs to the TCP-1 chaperonin family. .
+  protein_domains: Chap_CCT_epsi. (IPR012718); Chaperone_TCP-1. (IPR017998); Chaperonin_TCP-1_CS.
+    (IPR002194); Cpn60/GroEL/TCP-1. (IPR002423); GroEL-like_apical_dom_sf. (IPR027409)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 37
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P40413
+- **Protein Description:** RecName: Full=T-complex protein 1 subunit epsilon; Short=TCP-1-epsilon; AltName: Full=CCT-epsilon;
+- **Gene Information:** Name=CCT5; Synonyms=TCP5; OrderedLocusNames=YJR064W; ORFNames=J1752;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the TCP-1 chaperonin family. .
+- **Key Domains:** Chap_CCT_epsi. (IPR012718); Chaperone_TCP-1. (IPR017998); Chaperonin_TCP-1_CS. (IPR002194); Cpn60/GroEL/TCP-1. (IPR002423); GroEL-like_apical_dom_sf. (IPR027409)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "CCT5" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'CCT5' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **CCT5** (gene ID: CCT5, UniProt: P40413) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P40413
+- **Protein Description:** RecName: Full=T-complex protein 1 subunit epsilon; Short=TCP-1-epsilon; AltName: Full=CCT-epsilon;
+- **Gene Information:** Name=CCT5; Synonyms=TCP5; OrderedLocusNames=YJR064W; ORFNames=J1752;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the TCP-1 chaperonin family. .
+- **Key Domains:** Chap_CCT_epsi. (IPR012718); Chaperone_TCP-1. (IPR017998); Chaperonin_TCP-1_CS. (IPR002194); Cpn60/GroEL/TCP-1. (IPR002423); GroEL-like_apical_dom_sf. (IPR027409)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "CCT5" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'CCT5' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **CCT5** (gene ID: CCT5, UniProt: P40413) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+# Research Report: Functional Annotation of **CCT5** (UniProt **P40413**) in *Saccharomyces cerevisiae* (S288c)
+
+## Executive summary
+*CCT5* (ORF **YJR064W**, synonym **TCP5**) encodes the **epsilon subunit of the cytosolic group II chaperonin TRiC/CCT** (also called the TCP‑1 ring complex). CCT5 is not an enzyme with a unique small-molecule substrate; rather, it is an ATP-binding/ATPase chaperonin subunit that contributes to an essential hetero-oligomeric folding machine that supports eukaryotic proteostasis, with strongest evidence for folding/biogenesis of **actin** and **tubulin** and for broad roles in assembly of WD40/propeller proteins and other complexes. Yeast genetic and structural studies implicate ATPase-competent CCT5 as critical for viability and for the ATP-driven conformational cycle of the TRiC/CCT chamber. Recent 2023–2024 cryo-EM work in the field (mostly in mammalian TRiC, plus yeast mechanistic cryo-EM studies) refined models for how the ATPase cycle drives substrate translocation and how co-chaperones (prefoldin, phosducin-like proteins) control substrate delivery and chamber occupancy—mechanistic context directly relevant to interpreting yeast CCT5’s function as part of TRiC/CCT. (stoldt1996reviewthecct pages 1-2, grantham2020themolecularchaperone pages 1-2, kelly2020structuralandfunctionala pages 42-48, liu2023pathwayandmechanism pages 1-2, junsun2024astructuralvista pages 1-2)
+
+## 1. Target verification (critical identity disambiguation)
+### 1.1 Verified gene/protein identity
+The literature and yeast-specific reviews identify the *S. cerevisiae* epsilon subunit of the CCT/TRiC chaperonin as **CCT5** (historical names include **Cctε**, **TCP1E/TCP5**) and explicitly map it to **ORF YJR064W** in S288c. (Publication date: **1996-05**; URL: https://doi.org/10.1002/(sici)1097-0061(199605)12:6<523::aid-yea962>3.0.co;2-c) (stoldt1996reviewthecct pages 1-2)
+
+### 1.2 Avoiding symbol ambiguity
+The symbol **CCT5** is also used for orthologous TRiC/CCT subunit 5 proteins in animals, where variants are associated with disease (e.g., hereditary sensory neuropathy). Such papers inform conserved structure/function of CCT5-family proteins but are not yeast-specific functional genetics and should not be conflated with *S. cerevisiae* phenotypes. (pereira2017structureofthe pages 1-2, kelly2020structuralandfunctionala pages 23-28)
+
+## 2. Key concepts and definitions (current understanding)
+### 2.1 TRiC/CCT: a eukaryotic group II chaperonin
+TRiC/CCT is a **group II chaperonin** localized to the **eukaryotic cytosol**, consisting of **two stacked rings** with **eight distinct paralogous subunits per ring** (CCT1–CCT8; CCT5 is the epsilon/“subunit 5” paralog). The complex couples ATP binding/hydrolysis to large conformational changes that close a built-in lid over a central folding cavity (unlike bacterial GroEL, which requires GroES). (ghozlan2022thetrickybusiness pages 1-2, kabir2011functionalsubunitsof pages 1-2, kelly2020structuralandfunctionala pages 14-18)
+
+### 2.2 What CCT5 “does” at the molecular level
+CCT5 is best defined as a **structural and catalytic component** (ATPase + substrate-interaction surface) of TRiC/CCT rather than a standalone enzyme. TRiC/CCT’s strongest obligate substrates are **actin and tubulin**, which require TRiC/CCT to reach native conformations/assembly-competent states; CCT5 contributes one of the eight distinct apical-domain surfaces that form the composite substrate-binding environment within the chamber. (grantham2020themolecularchaperone pages 1-2, willison2018thesubstratespecificity pages 1-2)
+
+### 2.3 Conserved domain architecture
+CCT5-family subunits have a canonical chaperonin architecture with **equatorial** (ATP binding and ring contacts), **intermediate** (hinge/transmission), and **apical** (substrate recognition/lid) domains. The ATP-binding region is relatively conserved across paralogs, whereas apical domains are more divergent and contribute to subunit-specific substrate recognition properties. (ghozlan2022thetrickybusiness pages 1-2, pereira2017structureofthe pages 1-2)
+
+## 3. Yeast-specific functional annotation of CCT5
+### 3.1 Complex membership, subunit arrangement, and chamber electrostatics
+Yeast TRiC/CCT structural work places subunits in a defined ring order and groups them into electrostatic “hemispheres” within the chamber; CCT5 sits in the **CCT2 hemisphere** alongside CCT4 and CCT2, contributing to a positively charged partition of the folding environment. (kelly2020structuralandfunctional pages 35-42)
+
+### 3.2 ATPase asymmetry and subunit-specific conformational role of CCT5
+In yeast structural/functional analyses, CCT5 belongs to a **high ATP-affinity** set of subunits (CCT1/2/4/5), with CCT5 (and CCT4) described as having the **highest ATP affinities** in one model. CCT5’s apical domain undergoes substantial nucleotide-linked motion (reported as ~**14° rotation** toward the folding cavity upon nucleotide binding), and CCT5 is among the subunits showing larger conformational changes than others in the ring. (kelly2020structuralandfunctionala pages 42-48)
+
+### 3.3 Essentiality and viability-relevant mutations
+Yeast-focused synthesis indicates that all eight CCT genes are essential and that even relatively small perturbations in ATP-binding motifs/ATPase kinetics can cause severe growth and morphology defects. (willison2018thesubstratespecificity pages 2-3)
+
+More directly subunit-linked evidence indicates that mutating the P-loop ATP-binding motif (GDGTT→AAAAA) in high-affinity subunits leads to **lethal phenotypes in yeast**, implicating ATPase competence of high-affinity subunits including **CCT5** as critical for viability. (kelly2020structuralandfunctionala pages 42-48)
+
+### 3.4 Biological processes and pathway context inferred from yeast CCT/TRiC biology
+Because CCT5 functions as an obligate TRiC/CCT subunit, yeast process annotations are best supported at the complex level:
+
+- **Actin and microtubule assembly / cytoskeletal organization**: Yeast conditional mutant studies link the Cct complex to in vivo assembly of **microtubules and actin**, consistent with conserved TRiC/CCT roles in actin and tubulin folding. (1996-05; URL above) (stoldt1996reviewthecct pages 1-2)
+- **Genetic interactions with cytoskeletal alleles**: Allele-specific synthetic interactions between CCT subunit mutants and actin/tubulin alleles (e.g., inviability of a cct1-1 tub2-402 double mutant) support close functional coupling between CCT and cytoskeletal components. (stoldt1996reviewthecct pages 5-6)
+- **Cell cycle regulation via folding of APC/C activators**: A yeast CCT interactome/functional synthesis indicates that WD40/propeller proteins and specific cell-cycle regulators such as APC activators **Cdc20p and Cdh1p** are obligate CCT substrates in yeast. (willison2018thesubstratespecificity pages 1-2)
+- **Growth/nutrient signaling linkage (TOR pathway)**: Expert synthesis highlights TRiC/CCT’s functional linkage to TOR signaling in yeast, including growth defects when CCT activity is reduced and altered phosphorylation of TOR pathway outputs (S6K/S6). (kelly2020structuralandfunctionalb pages 23-28)
+
+### 3.5 Subcellular localization
+CCT5 acts primarily in the **cytosol** as part of the cytosolic TRiC/CCT folding machine. Current evidence in the retrieved set supports this cytosolic role; no strong evidence was retrieved for a stable organellar or secreted localization for yeast CCT5. (kabir2011functionalsubunitsof pages 1-2, kelly2020structuralandfunctionala pages 14-18)
+
+## 4. Recent developments (prioritizing 2023–2024)
+Recent high-resolution structural and mechanistic work has focused on TRiC/CCT’s ATP-driven cycle and co-chaperone coordination; while much of this is performed on mammalian TRiC, the mechanisms are widely treated as conserved and provide direct interpretive context for yeast subunit roles (including CCT5).
+
+### 4.1 2023: Cryo-EM delineation of tubulin folding pathway along the ATPase cycle
+A 2023 cryo-EM + XL-MS study captured multiple TRiC states with endogenously engaged tubulin and quantified state occupancies. Key reported quantitative findings include open-state classification with **61.6% empty** and **38.4% tubulin-like density**, and a trapped population with **27.2% both-rings-closed** under ATP-AlFx. The work describes gradual substrate translocation/stabilization during ring closure and a near-native tubulin captured in the closed chamber; notably, the tubulin I domain is reported to associate more loosely with the **CCT2 hemisphere subunits (CCT7/5/2/4)**—the same hemisphere that includes yeast CCT5. (Publication date: **2023-05**; URL: https://doi.org/10.1038/s42003-023-04915-x) (liu2023pathwayandmechanism pages 1-2, liu2023pathwayandmechanism pages 6-7)
+
+### 4.2 2024: Structural mechanism for PhLP2A–TRiC coordination and prefoldin displacement
+A 2024 *Nature Communications* cryo-EM/biochemical study resolved how **PhLP2A** binds open TRiC, how an N-terminal helix engages **CCT3/CCT4** apical domains to displace prefoldin, and how ATP-induced closure rearranges PhLP2A contacts. The authors reiterate that TRiC facilitates folding of ~**10%** of the eukaryotic proteome and show a mechanistic model in which co-chaperones and substrates can segregate into opposing chambers during the folding cycle. (Publication date: **2024-02**; URL: https://doi.org/10.1038/s41467-024-45242-x) (junsun2024astructuralvista pages 1-2)
+
+**Visual evidence**: the paper includes a labeled cryo-EM view of the TRiC ring with subunits **CCT1–CCT8** annotated, supporting the defined subunit arrangement that underpins any subunit-specific annotation. (junsun2024astructuralvista media 0880aeaf)
+
+### 4.3 Yeast-focused mechanistic cryo-EM: ring opening intermediates (context)
+A yeast TRiC cryo-EM study of ADP-bound ensembles reports a stepwise ring-opening model in which outward leaning involves consecutive subunits including **CCT6/8/7/5**, placing CCT5 on a mechanically relevant trajectory during nucleotide-dependent reopening and (putative) substrate release. (Publication: **2025**; URL: https://doi.org/10.1017/qrd.2024.17) (jin2025theconformationallandscape pages 1-2)
+
+## 5. Current applications and real-world implementations
+Although yeast CCT5 itself is primarily a basic-science target, TRiC/CCT research has translational applications; yeast is often the model for mechanistic/functional dissection.
+
+### 5.1 Therapeutic targeting and chemical modulation of TRiC/CCT
+Expert syntheses describe TRiC/CCT as a potential **therapeutic target** in cancer and proteostasis-related diseases. Examples discussed include a TRiC-inhibiting peptide (**CT20p**) tested in cancer cell line contexts and small molecules/lipids reported to modulate TRiC-mediated folding (e.g., clemastine; 1-deoxydihydroceramide), as well as modulation by stress-response-linked factors (e.g., HSF1A). These applications are complex-level rather than yeast-CCT5-specific but rely on understanding subunit-specific assembly/ATPase features (including those involving CCT5). (kelly2020structuralandfunctionala pages 23-28, shen2025proteinfoldingby pages 5-7)
+
+### 5.2 Proteostasis engineering and mechanistic tool development in yeast
+Yeast serves as an engineering and discovery platform for TRiC/CCT structure-function studies, including strategies for subunit identification in cryo-EM maps by endogenous tagging approaches. Such methods enable subunit-resolved mechanistic annotation of components like CCT5 without overexpression artifacts. (Publication date: **2018-02**; URL: https://doi.org/10.1038/s41598-017-18962-y) (context: subunit identification strategy applied to TRiC; CCT5 used as tagged subunit) (from retrieved paper list; not directly evidenced in snippets beyond abstract)
+
+## 6. Statistics and quantitative data relevant to yeast CCT5 annotation
+- **Proteome fraction**: TRiC/CCT is widely described as folding roughly **~10% of cytosolic proteins**. (junsun2024astructuralvista pages 1-2, liu2023pathwayandmechanism pages 1-2)
+- **Yeast transcript estimate for CCT5**: A yeast-focused synthesis reports an estimated **CCT5 mRNA copy number ~2.24 per cell** (derived from global transcript counts at 30°C) and notes low variance among CCT subunits in abundance. (Publication date: **2018-06**; URL: https://doi.org/10.1098/rstb.2017.0192) (willison2018thesubstratespecificity pages 7-8)
+- **Yeast interactome scale**: The yeast CCT interactome is summarized as roughly **~300 members**, with many being cofactors/effectors rather than direct folding substrates, indicating extensive pathway connectivity beyond actin/tubulin. (willison2018thesubstratespecificity pages 2-3)
+
+## 7. Interpretation and expert analysis (what is well-supported vs. uncertain for yeast CCT5)
+### 7.1 High-confidence statements (supported directly)
+- CCT5 is the *S. cerevisiae* **TRiC/CCT epsilon subunit** encoded by **YJR064W**. (stoldt1996reviewthecct pages 1-2)
+- CCT5 participates in a **cytosolic** group II chaperonin complex essential for folding/biogenesis of **actin and tubulin** (complex-level function with strong yeast linkage). (stoldt1996reviewthecct pages 1-2, willison2018thesubstratespecificity pages 1-2)
+- Yeast structural/functional analyses place CCT5 in a **high ATP-affinity hemisphere** and show **large nucleotide-linked conformational change**; yeast viability depends on ATPase-competent high-affinity subunits including CCT5 (P-loop mutant lethality). (kelly2020structuralandfunctionala pages 42-48)
+
+### 7.2 Medium-confidence/inference statements
+- **Subunit-specific substrate recognition**: Reviews emphasize that divergence in apical domains across the eight subunits confers substrate selectivity, implying that CCT5 contributes unique binding determinants. However, the retrieved yeast literature did not provide a CCT5-only substrate list; most substrate specificity is attributed to the assembled chamber interface. (willison2018thesubstratespecificity pages 1-2, ghozlan2022thetrickybusiness pages 1-2)
+
+### 7.3 Not resolved in the retrieved corpus
+- A dedicated, yeast-only experimental characterization of CCT5-specific phenotypes (e.g., temperature-sensitive *cct5* alleles) was not retrieved here; available yeast phenotypes in the evidence largely pertain to the TRiC/CCT complex broadly or to other subunits. Accordingly, CCT5-specific phenotype statements above are restricted to ATP-binding motif perturbations and subunit-resolved structural dynamics. (kelly2020structuralandfunctionala pages 42-48, willison2018thesubstratespecificity pages 2-3)
+
+## Summary table
+| Topic | Key points | Best recent/authoritative source (with year) | Evidence/notes |
+|---|---|---|---|
+| Target identity verification | **CCT5** in this report refers to the **Saccharomyces cerevisiae** gene/product encoded by **ORF YJR064W**; it is the **T-complex protein 1 subunit epsilon (CCT/TRiC subunit ε)**, also called **TCP5/TCP1E/Cctε** in older nomenclature. | Stoldt et al., *Yeast* (1996); Grantham, *Front. Genet.* (2020) | Yeast review explicitly maps the epsilon subunit to **YJR064W** and lists historical synonyms; later reviews place CCT5 among the eight paralogous CCT/TRiC subunits, helping distinguish it from metazoan CCT5 orthologs with disease literature that should not be conflated with yeast annotation. (stoldt1996reviewthecct pages 1-2, grantham2020themolecularchaperone pages 1-2) |
+| Complex membership | CCT5 is one of the **8 distinct subunits per ring** of the eukaryotic **group II cytosolic chaperonin TRiC/CCT**, forming a **double-ring complex**. In yeast structural work, subunits occupy a defined order within each ring. | Jin et al., *Subcell. Biochem.* (2020); Kelly (2020) | Reviews and structural studies agree that TRiC/CCT is a hetero-oligomeric, barrel-shaped chaperonin with two stacked rings; yeast cryo-EM resolves a defined subunit order and places CCT5 in the ring architecture rather than as a standalone enzyme. (kelly2020structuralandfunctionala pages 14-18, kelly2020structuralandfunctional pages 35-42) |
+| Protein family / definition | CCT5 belongs to the **TCP-1/CCT chaperonin family**, i.e. **group II chaperonins** specialized for ATP-dependent folding of difficult cytosolic proteins in eukaryotes. | Ghozlan et al., *Front. Cell Dev. Biol.* (2022); Kabir et al. (2011) | Family-level features match UniProt/domain expectations: eukaryotic cytosolic localization, ATP-dependent conformational cycle, and function within the hetero-oligomeric CCT machine. (ghozlan2022thetrickybusiness pages 1-2, kabir2011functionalsubunitsof pages 1-2) |
+| Domain architecture | Like other CCT subunits, CCT5 has the canonical **three-domain chaperonin architecture**: **equatorial** domain (ATP binding, ring contacts), **intermediate** domain (hinge/transmission), and **apical** domain (substrate/lid functions). | Pereira et al., *Sci. Rep.* (2017); Kelly (2020) | These structural features are conserved across CCT5 orthologs and are consistent with the supplied InterPro/domain annotations. The equatorial ATP-binding region is the most conserved; the apical region contributes to subunit-specific substrate recognition. (pereira2017structureofthe pages 1-2, kelly2020structuralandfunctionala pages 14-18) |
+| Cellular localization | The biologically relevant localization of CCT5 is **cytosolic**, as a constituent of the **cytosolic TRiC/CCT chaperonin**. | Kabir et al. (2011); Ghozlan et al. (2022) | Available evidence supports cytosolic localization at the complex level; no strong evidence from the retrieved set supports a stable extracellular or organellar role for yeast CCT5. (kabir2011functionalsubunitsof pages 1-2, ghozlan2022thetrickybusiness pages 1-2) |
+| Primary molecular function | CCT5 is **not a classical metabolic enzyme** with a unique small-molecule substrate; instead, it contributes one ATPase/substrate-binding module to the **ATP-driven folding chamber** of TRiC/CCT. Its function is to help fold cytosolic proteins and maintain proteostasis. | Grantham, *Front. Genet.* (2020); Ghozlan et al., *Front. Cell Dev. Biol.* (2022) | Reviews emphasize that TRiC/CCT folds obligate clients such as **actin and tubulin**, and likely assists a restricted but important set of additional proteins; CCT5 contributes to this machine as a structurally specialized subunit. (grantham2020themolecularchaperone pages 1-2, ghozlan2022thetrickybusiness pages 1-2) |
+| Core substrates / pathway context | At the complex level, TRiC/CCT is best established for folding **actin** and **tubulin** and participates more broadly in **cytosolic proteostasis**, including assembly/folding of some complex or aggregation-prone proteins. | Stoldt et al., *Yeast* (1996); Willison, *Phil. Trans. R. Soc. B* (2018) | Yeast and broader eukaryotic studies converge on actin/tubulin as canonical obligate clients. For yeast CCT5 specifically, evidence is mostly **subunit-in-complex** rather than substrate specificity assigned to the isolated subunit. (stoldt1996reviewthecct pages 2-4, stoldt1996reviewthecct pages 1-2, willison2018thesubstratespecificity pages 7-8) |
+| Yeast-specific biological processes | In yeast, the Cct complex is required for **microtubule and actin assembly/organization**, linking CCT5 indirectly to cytoskeletal biogenesis, cell growth, and proteostasis. | Stoldt et al., *Yeast* (1996) | Conditional-mutant studies in *S. cerevisiae* showed Cct requirement for in vivo assembly of microtubules and actin; the excerpted evidence is stronger for the complex than for CCT5 alone. (stoldt1996reviewthecct pages 2-4, stoldt1996reviewthecct pages 1-2) |
+| Subunit-specific structural role of CCT5 | Yeast cryo-EM and biochemical analyses identify CCT5 as a **high-ATP-affinity** subunit whose **apical domain undergoes substantial nucleotide-linked movement**; it contributes to the positively charged **CCT2 hemisphere** of the chamber. | Kelly (2020) | CCT5 shows ~**14° apical-domain rotation** on nucleotide binding and is grouped among subunits with larger conformational changes; CCT5/CCT4 are highlighted as having the **highest ATP affinities** in one yeast analysis. (kelly2020structuralandfunctional pages 42-48, kelly2020structuralandfunctionala pages 42-48, kelly2020structuralandfunctional pages 35-42) |
+| Essentiality / genetic evidence in yeast | The overall CCT machine is essential, and reviews note that the **eight subunits are products of essential genes in yeast**; yeast mutational data further show that disrupting ATP-binding P-loop residues in high-affinity subunits, including CCT5, is **lethal**. | Grantham, *Front. Genet.* (2020); Kelly (2020) | The strongest retrieved CCT5-specific genetic statement is that alanine substitution of the P-loop motif in high-affinity subunits causes **lethal phenotypes** in yeast, implicating CCT5 ATPase competence in viability. (grantham2020themolecularchaperone pages 1-2, kelly2020structuralandfunctional pages 42-48, kelly2020structuralandfunctionala pages 42-48) |
+| Assembly importance | Evidence from structural/biochemical work suggests **CCT5 may be particularly important for TRiC assembly**, though this is not yet a universally canonical annotation in basic yeast databases. | Kelly (2020) | The retrieved structural dissertation/review material explicitly states that analyses suggested **CCT5 is the most important subunit for assembly of TRiC**; this is best treated as a strong mechanistic proposal rather than settled textbook fact. (kelly2020structuralandfunctionalb pages 23-28) |
+| Quantitative/statistical data | CCT/TRiC is estimated to assist folding of roughly **~10% of cytosolic proteins**. In one yeast-focused synthesis, **CCT5 mRNA** abundance was estimated at about **2.24 copies/cell**, and CCT subunits showed **low variance** in abundance across the complex. | Park et al., *Nat. Commun.* (2024) for ~10%; Willison, *Phil. Trans. R. Soc. B* (2018) for yeast abundance synthesis | The ~10% figure is widely repeated across structural reviews. The yeast quantitative synthesis indicates coordinated expression of CCT subunits and places actin/tubulin/CCT near central abundance and half-life distributions. (junsun2024astructuralvista pages 1-2, liu2023pathwayandmechanism pages 1-2, willison2018thesubstratespecificity pages 7-8) |
+| Co-chaperone network | TRiC/CCT functions with **prefoldin (PFD)** and **phosducin-like proteins (PhLPs)**; these co-chaperones help deliver or stabilize substrates and regulate the folding cycle. | Gestaut et al., *Cell* (2019); Park et al., *Nat. Commun.* (2024) | This network is directly relevant to functional annotation because CCT5 acts within a multi-component folding pathway rather than alone. Disruption of PFD–TRiC interaction causes widespread aggregation in yeast, illustrating pathway-level importance. (junsun2024astructuralvista pages 1-2, kelly2020structuralandfunctionalb pages 23-28, kelly2020structuralandfunctionala pages 23-28) |
+| 2023 development: substrate-folding mechanism | Recent cryo-EM work mapped the **ATPase-cycle-dependent pathway of tubulin folding** by TRiC/CCT, showing gradual substrate translocation/stabilization and a near-native tubulin state in the closed chamber. | Liu et al., *Commun. Biol.* (2023) | Quantitative details include open-state classes with **61.6% empty** and **38.4% tubulin-like density**, a **3.1 Å** open-state map, and **27.2%** both-rings-closed population under ATP-AlFx conditions. Though from human TRiC, these findings strongly inform conserved mechanism relevant to yeast CCT5 annotation. (liu2023pathwayandmechanism pages 6-7, liu2023pathwayandmechanism pages 1-2) |
+| 2024 development: co-chaperone mechanism | New structural work resolved how **PhLP2A** and **prefoldin** interact with open/closed TRiC and showed ATP-driven rearrangements that coordinate substrate handling. | Park et al., *Nat. Commun.* (2024) | PhLP2A binds open TRiC through polyvalent contacts, can displace PFD via CCT3/4 contacts, and rearranges during closure; these studies refine current understanding of how subunits such as CCT5 participate in a regulated cochaperone-assisted folding cycle. (junsun2024astructuralvista pages 1-2, junsun2024astructuralvista media 0880aeaf) |
+| Expert interpretation / real-world relevance | Authoritative reviews frame TRiC/CCT as a central **proteostasis hub** and a candidate **therapeutic target** in aggregation diseases, cancer, and viral infection. Yeast remains an important mechanistic model for defining subunit function and proteostasis defects. | Ghozlan et al. (2022); Grantham (2020); Shen & Willardson (2025) | These application-oriented insights are mostly complex-level rather than yeast-CCT5-specific, but they explain why subunit-resolved annotation matters: altered CCT subunits affect assembly, substrate folding, and disease-linked proteostasis pathways. (grantham2020themolecularchaperone pages 1-2, ghozlan2022thetrickybusiness pages 1-2, shen2025proteinfoldingby pages 5-7) |
+
+
+*Table: This table summarizes verified identity, function, localization, and mechanistic evidence for Saccharomyces cerevisiae CCT5/YJR064W, emphasizing what is directly supported for the yeast subunit versus what is inferred from the TRiC/CCT complex. It also highlights recent 2023-2024 developments that refine the current mechanistic annotation of CCT5 within TRiC.*
+
+## Key figures (visual evidence)
+- Labeled TRiC subunit arrangement and PhLP2A-bound open-state structure (useful for orienting where CCT5 sits in the ring and how cochaperones engage the complex). (junsun2024astructuralvista media 0880aeaf)
+- Comparative schematics of prefoldin and PhLP2A interactions with TRiC (relevant to understanding co-chaperone regulated folding pathways). (junsun2024astructuralvista media 774d2963, junsun2024astructuralvista media e727d38e)
+
+## References (URLs and publication dates from evidence)
+- Stoldt V. et al. “Review: The Cct eukaryotic chaperonin subunits of *Saccharomyces cerevisiae* and other yeasts.” *Yeast* **1996-05**. https://doi.org/10.1002/(sici)1097-0061(199605)12:6<523::aid-yea962>3.0.co;2-c (stoldt1996reviewthecct pages 1-2)
+- Willison K.R. “The substrate specificity of eukaryotic cytosolic chaperonin CCT.” *Phil. Trans. R. Soc. B* **2018-06**. https://doi.org/10.1098/rstb.2017.0192 (willison2018thesubstratespecificity pages 7-8, willison2018thesubstratespecificity pages 2-3, willison2018thesubstratespecificity pages 1-2)
+- Grantham J. “The Molecular Chaperone CCT/TRiC: An Essential Component of Proteostasis and a Potential Modulator of Protein Aggregation.” *Front. Genet.* **2020-03**. https://doi.org/10.3389/fgene.2020.00172 (grantham2020themolecularchaperone pages 1-2)
+- Liu C. et al. “Pathway and mechanism of tubulin folding mediated by TRiC/CCT along its ATPase cycle revealed using cryo-EM.” *Communications Biology* **2023-05**. https://doi.org/10.1038/s42003-023-04915-x (liu2023pathwayandmechanism pages 1-2, liu2023pathwayandmechanism pages 6-7)
+- Park J. et al. “A structural vista of phosducin-like PhLP2A–chaperonin TRiC cooperation during the ATP-driven folding cycle.” *Nature Communications* **2024-02**. https://doi.org/10.1038/s41467-024-45242-x (junsun2024astructuralvista pages 1-2, junsun2024astructuralvista media 0880aeaf)
+
+
+References
+
+1. (stoldt1996reviewthecct pages 1-2): Volker Stoldt, Felicitas Rademacher, Verena Kehren, Joachim F. Ernst, David A. Pearce, and Fred Sherman. Review: the cct eukaryotic chaperonin subunits of saccharomyces cerevisiae and other yeasts. Yeast, 12:523-529, May 1996. URL: https://doi.org/10.1002/(sici)1097-0061(199605)12:6<523::aid-yea962>3.0.co;2-c, doi:10.1002/(sici)1097-0061(199605)12:6<523::aid-yea962>3.0.co;2-c. This article has 153 citations and is from a peer-reviewed journal.
+
+2. (grantham2020themolecularchaperone pages 1-2): Julie Grantham. The molecular chaperone cct/tric: an essential component of proteostasis and a potential modulator of protein aggregation. Frontiers in Genetics, Mar 2020. URL: https://doi.org/10.3389/fgene.2020.00172, doi:10.3389/fgene.2020.00172. This article has 139 citations and is from a peer-reviewed journal.
+
+3. (kelly2020structuralandfunctionala pages 42-48): J Kelly. Structural and functional characterisation of the group ii chaperonin cct/tric. Unknown journal, 2020.
+
+4. (liu2023pathwayandmechanism pages 1-2): Caixuan Liu, Mingliang Jin, Shutian Wang, Wenyu Han, Qiaoyu Zhao, Yifan Wang, Cong Xu, Lei Diao, Yue Yin, Chao Peng, Lan Bao, Yanxing Wang, and Yao Cong. Pathway and mechanism of tubulin folding mediated by tric/cct along its atpase cycle revealed using cryo-em. Communications Biology, May 2023. URL: https://doi.org/10.1038/s42003-023-04915-x, doi:10.1038/s42003-023-04915-x. This article has 28 citations and is from a peer-reviewed journal.
+
+5. (junsun2024astructuralvista pages 1-2): Junsun Park, Hyunmin Kim, Daniel Gestaut, Seyeon Lim, Kwadwo A. Opoku-Nsiah, Alexander Leitner, Judith Frydman, and Soung-Hun Roh. A structural vista of phosducin-like phlp2a-chaperonin tric cooperation during the atp-driven folding cycle. Nature Communications, Feb 2024. URL: https://doi.org/10.1038/s41467-024-45242-x, doi:10.1038/s41467-024-45242-x. This article has 16 citations and is from a highest quality peer-reviewed journal.
+
+6. (pereira2017structureofthe pages 1-2): Jose H. Pereira, Ryan P. McAndrew, Oksana A. Sergeeva, Corie Y. Ralston, Jonathan A. King, and Paul D. Adams. Structure of the human tric/cct subunit 5 associated with hereditary sensory neuropathy. Scientific Reports, Jun 2017. URL: https://doi.org/10.1038/s41598-017-03825-3, doi:10.1038/s41598-017-03825-3. This article has 43 citations and is from a peer-reviewed journal.
+
+7. (kelly2020structuralandfunctionala pages 23-28): J Kelly. Structural and functional characterisation of the group ii chaperonin cct/tric. Unknown journal, 2020.
+
+8. (ghozlan2022thetrickybusiness pages 1-2): Heba Ghozlan, Amanda Cox, Daniel Nierenberg, Stephen King, and Annette R. Khaled. The tricky business of protein folding in health and disease. Frontiers in Cell and Developmental Biology, May 2022. URL: https://doi.org/10.3389/fcell.2022.906530, doi:10.3389/fcell.2022.906530. This article has 34 citations.
+
+9. (kabir2011functionalsubunitsof pages 1-2): M. Anaul Kabir, Wasim Uddin, Aswathy Narayanan, Praveen Kumar Reddy, M. Aman Jairajpuri, Fred Sherman, and Zulfiqar Ahmad. Functional subunits of eukaryotic chaperonin cct/tric in protein folding. Journal of Amino Acids, 2011:1-16, Jul 2011. URL: https://doi.org/10.4061/2011/843206, doi:10.4061/2011/843206. This article has 62 citations.
+
+10. (kelly2020structuralandfunctionala pages 14-18): J Kelly. Structural and functional characterisation of the group ii chaperonin cct/tric. Unknown journal, 2020.
+
+11. (willison2018thesubstratespecificity pages 1-2): Keith R. Willison. The substrate specificity of eukaryotic cytosolic chaperonin cct. Philosophical Transactions of the Royal Society B: Biological Sciences, 373:20170192, Jun 2018. URL: https://doi.org/10.1098/rstb.2017.0192, doi:10.1098/rstb.2017.0192. This article has 75 citations and is from a domain leading peer-reviewed journal.
+
+12. (kelly2020structuralandfunctional pages 35-42): J Kelly. Structural and functional characterisation of the group ii chaperonin cct/tric. Unknown journal, 2020.
+
+13. (willison2018thesubstratespecificity pages 2-3): Keith R. Willison. The substrate specificity of eukaryotic cytosolic chaperonin cct. Philosophical Transactions of the Royal Society B: Biological Sciences, 373:20170192, Jun 2018. URL: https://doi.org/10.1098/rstb.2017.0192, doi:10.1098/rstb.2017.0192. This article has 75 citations and is from a domain leading peer-reviewed journal.
+
+14. (stoldt1996reviewthecct pages 5-6): Volker Stoldt, Felicitas Rademacher, Verena Kehren, Joachim F. Ernst, David A. Pearce, and Fred Sherman. Review: the cct eukaryotic chaperonin subunits of saccharomyces cerevisiae and other yeasts. Yeast, 12:523-529, May 1996. URL: https://doi.org/10.1002/(sici)1097-0061(199605)12:6<523::aid-yea962>3.0.co;2-c, doi:10.1002/(sici)1097-0061(199605)12:6<523::aid-yea962>3.0.co;2-c. This article has 153 citations and is from a peer-reviewed journal.
+
+15. (kelly2020structuralandfunctionalb pages 23-28): J Kelly. Structural and functional characterisation of the group ii chaperonin cct/tric. Unknown journal, 2020.
+
+16. (liu2023pathwayandmechanism pages 6-7): Caixuan Liu, Mingliang Jin, Shutian Wang, Wenyu Han, Qiaoyu Zhao, Yifan Wang, Cong Xu, Lei Diao, Yue Yin, Chao Peng, Lan Bao, Yanxing Wang, and Yao Cong. Pathway and mechanism of tubulin folding mediated by tric/cct along its atpase cycle revealed using cryo-em. Communications Biology, May 2023. URL: https://doi.org/10.1038/s42003-023-04915-x, doi:10.1038/s42003-023-04915-x. This article has 28 citations and is from a peer-reviewed journal.
+
+17. (junsun2024astructuralvista media 0880aeaf): Junsun Park, Hyunmin Kim, Daniel Gestaut, Seyeon Lim, Kwadwo A. Opoku-Nsiah, Alexander Leitner, Judith Frydman, and Soung-Hun Roh. A structural vista of phosducin-like phlp2a-chaperonin tric cooperation during the atp-driven folding cycle. Nature Communications, Feb 2024. URL: https://doi.org/10.1038/s41467-024-45242-x, doi:10.1038/s41467-024-45242-x. This article has 16 citations and is from a highest quality peer-reviewed journal.
+
+18. (jin2025theconformationallandscape pages 1-2): Mingliang Jin, Yunxiang Zang, Huping Wang, and Yao Cong. The conformational landscape of tric ring-opening and its underlying stepwise mechanism revealed by cryo-em. QRB Discovery, Dec 2025. URL: https://doi.org/10.1017/qrd.2024.17, doi:10.1017/qrd.2024.17. This article has 3 citations.
+
+19. (shen2025proteinfoldingby pages 5-7): Peter S. Shen and Barry M. Willardson. Protein folding by the cct/tric chaperone complex. Current Opinion in Structural Biology, 91:102999, Apr 2025. URL: https://doi.org/10.1016/j.sbi.2025.102999, doi:10.1016/j.sbi.2025.102999. This article has 10 citations and is from a peer-reviewed journal.
+
+20. (willison2018thesubstratespecificity pages 7-8): Keith R. Willison. The substrate specificity of eukaryotic cytosolic chaperonin cct. Philosophical Transactions of the Royal Society B: Biological Sciences, 373:20170192, Jun 2018. URL: https://doi.org/10.1098/rstb.2017.0192, doi:10.1098/rstb.2017.0192. This article has 75 citations and is from a domain leading peer-reviewed journal.
+
+21. (stoldt1996reviewthecct pages 2-4): Volker Stoldt, Felicitas Rademacher, Verena Kehren, Joachim F. Ernst, David A. Pearce, and Fred Sherman. Review: the cct eukaryotic chaperonin subunits of saccharomyces cerevisiae and other yeasts. Yeast, 12:523-529, May 1996. URL: https://doi.org/10.1002/(sici)1097-0061(199605)12:6<523::aid-yea962>3.0.co;2-c, doi:10.1002/(sici)1097-0061(199605)12:6<523::aid-yea962>3.0.co;2-c. This article has 153 citations and is from a peer-reviewed journal.
+
+22. (kelly2020structuralandfunctional pages 42-48): J Kelly. Structural and functional characterisation of the group ii chaperonin cct/tric. Unknown journal, 2020.
+
+23. (junsun2024astructuralvista media 774d2963): Junsun Park, Hyunmin Kim, Daniel Gestaut, Seyeon Lim, Kwadwo A. Opoku-Nsiah, Alexander Leitner, Judith Frydman, and Soung-Hun Roh. A structural vista of phosducin-like phlp2a-chaperonin tric cooperation during the atp-driven folding cycle. Nature Communications, Feb 2024. URL: https://doi.org/10.1038/s41467-024-45242-x, doi:10.1038/s41467-024-45242-x. This article has 16 citations and is from a highest quality peer-reviewed journal.
+
+24. (junsun2024astructuralvista media e727d38e): Junsun Park, Hyunmin Kim, Daniel Gestaut, Seyeon Lim, Kwadwo A. Opoku-Nsiah, Alexander Leitner, Judith Frydman, and Soung-Hun Roh. A structural vista of phosducin-like phlp2a-chaperonin tric cooperation during the atp-driven folding cycle. Nature Communications, Feb 2024. URL: https://doi.org/10.1038/s41467-024-45242-x, doi:10.1038/s41467-024-45242-x. This article has 16 citations and is from a highest quality peer-reviewed journal.
+
+## Citations
+
+1. stoldt1996reviewthecct pages 1-2
+2. kelly2020structuralandfunctional pages 35-42
+3. kelly2020structuralandfunctionala pages 42-48
+4. willison2018thesubstratespecificity pages 2-3
+5. stoldt1996reviewthecct pages 5-6
+6. willison2018thesubstratespecificity pages 1-2
+7. kelly2020structuralandfunctionalb pages 23-28
+8. junsun2024astructuralvista pages 1-2
+9. jin2025theconformationallandscape pages 1-2
+10. willison2018thesubstratespecificity pages 7-8
+11. grantham2020themolecularchaperone pages 1-2
+12. liu2023pathwayandmechanism pages 1-2
+13. pereira2017structureofthe pages 1-2
+14. kelly2020structuralandfunctionala pages 23-28
+15. ghozlan2022thetrickybusiness pages 1-2
+16. kabir2011functionalsubunitsof pages 1-2
+17. kelly2020structuralandfunctionala pages 14-18
+18. liu2023pathwayandmechanism pages 6-7
+19. shen2025proteinfoldingby pages 5-7
+20. stoldt1996reviewthecct pages 2-4
+21. kelly2020structuralandfunctional pages 42-48
+22. https://doi.org/10.1002/(sici
+23. https://doi.org/10.1038/s42003-023-04915-x
+24. https://doi.org/10.1038/s41467-024-45242-x
+25. https://doi.org/10.1017/qrd.2024.17
+26. https://doi.org/10.1038/s41598-017-18962-y
+27. https://doi.org/10.1098/rstb.2017.0192
+28. https://doi.org/10.3389/fgene.2020.00172
+29. https://doi.org/10.3389/fgene.2020.00172,
+30. https://doi.org/10.1038/s42003-023-04915-x,
+31. https://doi.org/10.1038/s41467-024-45242-x,
+32. https://doi.org/10.1038/s41598-017-03825-3,
+33. https://doi.org/10.3389/fcell.2022.906530,
+34. https://doi.org/10.4061/2011/843206,
+35. https://doi.org/10.1098/rstb.2017.0192,
+36. https://doi.org/10.1017/qrd.2024.17,
+37. https://doi.org/10.1016/j.sbi.2025.102999,

--- a/genes/yeast/CCT6/CCT6-ai-review.html
+++ b/genes/yeast/CCT6/CCT6-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>CCT6</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P39079" target="_blank" class="term-link">
                         P39079
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Saccharomyces cerevisiae</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,24 +728,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="P39079" data-a="DESCRIPTION: TODO: Add description for CCT6..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="P39079" data-a="DESCRIPTION: CCT6 encodes the zeta subunit of the cytosolic gro..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TODO: Add description for CCT6</p>
+        <p>CCT6 encodes the zeta subunit of the cytosolic group II chaperonin TRiC/CCT. Cct6 contributes to the ATP-driven chaperonin chamber that folds actin, tubulin, and other cytosolic clients, and yeast genetics also shows that excess unassembled Cct6 can suppress diverse conditional phenotypes in an ATP-motif-dependent state. Its core GO function is therefore the TRiC/CCT chaperonin role, with unassembled-subunit phenotypes treated as contextual rather than separate core annotations.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,46 +795,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein folding is consistent with known biology of CCT6.
+                            <strong>Summary:</strong> CCT6 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin that folds actin, tubulin, and other clients.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Protein folding is the correct biological-process context for the chaperonin complex, supported by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/CCT6/CCT6-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">a structural/ATPase subunit of the TRiC/CCT chaperonin</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005832" target="_blank" class="term-link">
                                     GO:0005832
                                 </a>
                             </span>
                             <span class="term-label">chaperonin-containing T-complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -846,46 +862,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: chaperonin-containing T-complex is consistent with known biology of CCT6.
+                            <strong>Summary:</strong> CCT6 is a named subunit of the chaperonin-containing T-complex.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Complex membership is central to the gene product function and is supported by yeast CCT complex literature and family evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -897,159 +913,159 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT6.
+                            <strong>Summary:</strong> unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than the ATP-dependent folding chaperone function of the complex.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
+                            <strong>Reason:</strong> Replace generic substrate-binding language with the specific chaperonin activity supported by yeast CCT actin-folding assays and domain evidence.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
+                                    ATP-dependent protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000166" target="_blank" class="term-link">
                                     GO:0000166
                                 </a>
                             </span>
                             <span class="term-label">nucleotide binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P39079" data-a="GO:0000166" data-r="GO_REF:0000043" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P39079" data-a="GO:0000166" data-r="GO_REF:0000043" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: nucleotide binding is consistent with known biology of CCT6.
+                            <strong>Summary:</strong> nucleotide binding is a true but overly broad family/keyword annotation for CCT6; ATP binding, ATP hydrolysis, and ATP-dependent chaperone annotations capture the specific chemistry.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Generic nucleotide binding does not add useful functional information beyond the more specific ATP-related chaperonin annotations already present.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
                                     GO:0005524
                                 </a>
                             </span>
                             <span class="term-label">ATP binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P39079" data-a="GO:0005524" data-r="GO_REF:0000120" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P39079" data-a="GO:0005524" data-r="GO_REF:0000120" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ATP binding is consistent with known biology of CCT6.
+                            <strong>Summary:</strong> CCT6 contains a conserved chaperonin ATP-binding site, but ATP binding alone is a domain property rather than the core biological function.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Keep as a valid supporting molecular property of the CCT ATPase cycle, while treating ATP hydrolysis and complex-level protein folding as the core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1061,46 +1077,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cytoplasm is consistent with known biology of CCT6.
+                            <strong>Summary:</strong> CCT6 functions as part of the cytosolic TRiC/CCT chaperonin.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Cytoplasm is the established location of the CCT/TRiC folding machine.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005832" target="_blank" class="term-link">
                                     GO:0005832
                                 </a>
                             </span>
                             <span class="term-label">chaperonin-containing T-complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1112,46 +1128,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: chaperonin-containing T-complex is consistent with known biology of CCT6.
+                            <strong>Summary:</strong> CCT6 is a named subunit of the chaperonin-containing T-complex.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Complex membership is central to the gene product function and is supported by yeast CCT complex literature and family evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1163,46 +1179,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein folding is consistent with known biology of CCT6.
+                            <strong>Summary:</strong> CCT6 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin that folds actin, tubulin, and other clients.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Protein folding is the correct biological-process context for the chaperonin complex, supported by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1214,46 +1230,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ATP hydrolysis activity is consistent with known biology of CCT6.
+                            <strong>Summary:</strong> CCT6 is a TCP-1/CCT chaperonin subunit with conserved ATPase machinery that powers TRiC/CCT conformational cycling.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> ATP hydrolysis is a defensible subunit-level molecular function for CCT family members and is directly tied to the chaperonin folding cycle.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1265,57 +1281,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT6.
+                            <strong>Summary:</strong> unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than the ATP-dependent folding chaperone function of the complex.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
+                            <strong>Reason:</strong> Replace generic substrate-binding language with the specific chaperonin activity supported by yeast CCT actin-folding assays and domain evidence.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
+                                    ATP-dependent protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
                                     GO:0140662
                                 </a>
                             </span>
                             <span class="term-label">ATP-dependent protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1327,57 +1343,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ATP-dependent protein folding chaperone is consistent with known biology of CCT6.
+                            <strong>Summary:</strong> CCT6 is an obligate subunit of the ATP-dependent TRiC/CCT folding machine.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The term is appropriate as a complex-level chaperonin function; in the synthesized core function it is modeled as a contributed-to molecular function rather than a standalone activity of an isolated subunit.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose action is required for folding the cytoskeletal proteins actin and tubulin</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16554755" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16554755
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Global landscape of protein complexes in the yeast Saccharom...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1389,57 +1423,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for CCT6.
+                            <strong>Summary:</strong> protein binding is too generic for a CCT subunit and does not describe the chaperonin mechanism or substrate class.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Physical-interaction datasets are useful evidence context, but generic protein binding should not stand as a functional annotation when the specific TRiC/CCT chaperonin role is known.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19536198
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An atlas of chaperone-protein interactions in Saccharomyces ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1451,57 +1485,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for CCT6.
+                            <strong>Summary:</strong> protein binding is too generic for a CCT subunit and does not describe the chaperonin mechanism or substrate class.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Physical-interaction datasets are useful evidence context, but generic protein binding should not stand as a functional annotation when the specific TRiC/CCT chaperonin role is known.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link">
+                                        PMID:19536198
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">It should be emphasized that the interactions presented are indirect TAP-tag based interactions and not direct binary interactions.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/37968396" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:37968396
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The social and structural architecture of the yeast protein ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1513,57 +1565,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for CCT6.
+                            <strong>Summary:</strong> protein binding is too generic for a CCT subunit and does not describe the chaperonin mechanism or substrate class.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Physical-interaction datasets are useful evidence context, but generic protein binding should not stand as a functional annotation when the specific TRiC/CCT chaperonin role is known.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16762366
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Quantitative actin folding reactions using yeast CCT purifie...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1575,57 +1627,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein folding is consistent with known biology of CCT6.
+                            <strong>Summary:</strong> CCT6 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin that folds actin, tubulin, and other clients.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Protein folding is the correct biological-process context for the chaperonin complex, supported by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose action is required for folding the cytoskeletal proteins actin and tubulin</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005832" target="_blank" class="term-link">
                                     GO:0005832
                                 </a>
                             </span>
                             <span class="term-label">chaperonin-containing T-complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16762366
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Quantitative actin folding reactions using yeast CCT purifie...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1637,57 +1707,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: chaperonin-containing T-complex is consistent with known biology of CCT6.
+                            <strong>Summary:</strong> CCT6 is a named subunit of the chaperonin-containing T-complex.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Complex membership is central to the gene product function and is supported by yeast CCT complex literature and family evidence.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15704212" target="_blank" class="term-link">
+                                        PMID:15704212
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed of a stoichiometric array of eight different subunits</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16762366
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Quantitative actin folding reactions using yeast CCT purifie...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1699,220 +1787,914 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT6.
+                            <strong>Summary:</strong> unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than the ATP-dependent folding chaperone function of the complex.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
+                            <strong>Reason:</strong> Replace generic substrate-binding language with the specific chaperonin activity supported by yeast CCT actin-folding assays and domain evidence.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
+                                    ATP-dependent protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose action is required for folding the cytoskeletal proteins actin and tubulin</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>CCT6 is the zeta subunit of the cytosolic TRiC/CCT chaperonin. The subunit contributes ATPase and substrate-contact surfaces to the hetero-oligomeric double-ring complex, whose ATP-dependent conformational cycle folds actin, tubulin, and other cytosolic client proteins. The synthesized function is modeled as subunit ATP hydrolysis contributing to the complex-level ATP-dependent protein folding chaperone activity.</h3>
+                <span class="vote-buttons" data-g="P39079" data-a="FUNCTION: CCT6 is the zeta subunit of the cytosolic TRiC/CCT..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
+                            ATP hydrolysis activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                protein folding
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005832" target="_blank" class="term-link">
+                            chaperonin-containing T-complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                PMID:16762366
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose action is required for folding the cytoskeletal proteins actin and tubulin</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15704212" target="_blank" class="term-link">
+                                PMID:15704212
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed of a stoichiometric array of eight different subunits</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16554755" target="_blank" class="term-link">
                             PMID:16554755
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Global landscape of protein complexes in the yeast Saccharomyces cerevisiae.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
                             PMID:16762366
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Quantitative actin folding reactions using yeast CCT purified via an internal tag in the CCT3/gamma subunit.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Purified yeast CCT, tagged through CCT3, catalyzes ATP-dependent actin folding; this supports protein-folding and chaperonin activity annotations for CCT6 as a TRiC/CCT subunit.</div>
+
+                        <div class="finding-text">"The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose action is required for folding the cytoskeletal proteins actin and tubulin"</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link">
                             PMID:19536198
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding pathways in the cell.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The chaperone interactome study is useful context for CCT contacts but reports indirect TAP-tag interactions rather than a specific molecular activity.</div>
+
+                        <div class="finding-text">"It should be emphasized that the interactions presented are indirect TAP-tag based interactions and not direct binary interactions."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/37968396" target="_blank" class="term-link">
                             PMID:37968396
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The social and structural architecture of the yeast protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/CCT6/CCT6-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for CCT6</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The Falcon report was reviewed and synthesized into the CCT6 curation, including core-function framing, family/PANTHER context, and evidence limitations.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which physiological effects of CCT6 overexpression are caused by unassembled Cct6p versus altered flux through assembled TRiC/CCT?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P39079" data-a="Q: Which physiological effects of CCT6 overexpression..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Measure assembled TRiC/CCT, free Cct6p, and candidate client interactions across CCT6 overexpression and ATP-motif mutant backgrounds that differ in suppression but retain viability.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Unassembled Cct6p suppresses selected conditional phenotypes by sequestering or buffering client proteins independently of increasing assembled TRiC/CCT.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: native complex profiling with affinity purification and genetic suppression assays</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P39079" data-a="EXPERIMENT: Measure assembled TRiC/CCT, free Cct6p, and candid..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(CCT6-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P39079" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-04T10:05:59.072300'<br />
+end_time: '2026-05-04T10:18:37.086732'<br />
+duration_seconds: 758.01<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: yeast<br />
+  gene_id: CCT6<br />
+  gene_symbol: CCT6<br />
+  uniprot_accession: P39079<br />
+  protein_description: 'RecName: Full=T-complex protein 1 subunit zeta; Short=TCP-1-zeta;<br />
+    AltName: Full=CCT-zeta;'<br />
+  gene_info: Name=CCT6; Synonyms=TCP20, TCP6; OrderedLocusNames=YDR188W; ORFNames=YD9395.21;<br />
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).<br />
+  protein_family: Belongs to the TCP-1 chaperonin family. .<br />
+  protein_domains: Chap_CCT_zeta. (IPR012722); Chaperone_TCP-1. (IPR017998); Chaperonin_TCP-1_CS.<br />
+    (IPR002194); Cpn60/GroEL/TCP-1. (IPR002423); GroEL-like_apical_dom_sf. (IPR027409)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 39</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P39079</li>
+<li><strong>Protein Description:</strong> RecName: Full=T-complex protein 1 subunit zeta; Short=TCP-1-zeta; AltName: Full=CCT-zeta;</li>
+<li><strong>Gene Information:</strong> Name=CCT6; Synonyms=TCP20, TCP6; OrderedLocusNames=YDR188W; ORFNames=YD9395.21;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the TCP-1 chaperonin family. .</li>
+<li><strong>Key Domains:</strong> Chap_CCT_zeta. (IPR012722); Chaperone_TCP-1. (IPR017998); Chaperonin_TCP-1_CS. (IPR002194); Cpn60/GroEL/TCP-1. (IPR002423); GroEL-like_apical_dom_sf. (IPR027409)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "CCT6" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'CCT6' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>CCT6</strong> (gene ID: CCT6, UniProt: P39079) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P39079</li>
+<li><strong>Protein Description:</strong> RecName: Full=T-complex protein 1 subunit zeta; Short=TCP-1-zeta; AltName: Full=CCT-zeta;</li>
+<li><strong>Gene Information:</strong> Name=CCT6; Synonyms=TCP20, TCP6; OrderedLocusNames=YDR188W; ORFNames=YD9395.21;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the TCP-1 chaperonin family. .</li>
+<li><strong>Key Domains:</strong> Chap_CCT_zeta. (IPR012722); Chaperone_TCP-1. (IPR017998); Chaperonin_TCP-1_CS. (IPR002194); Cpn60/GroEL/TCP-1. (IPR002423); GroEL-like_apical_dom_sf. (IPR027409)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "CCT6" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'CCT6' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>CCT6</strong> (gene ID: CCT6, UniProt: P39079) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="research-report-cct6-ydr188w-uniprot-p39079-in-saccharomyces-cerevisiae-s288c">Research report: <strong>CCT6 (YDR188W; UniProt P39079)</strong> in <em>Saccharomyces cerevisiae</em> (S288c)</h1>
+<h2 id="executive-summary">Executive summary</h2>
+<p>CCT6 (YDR188W; UniProt P39079) encodes <strong>T-complex protein 1 subunit zeta (Cct6p; also called CCT-ζ)</strong>, one of eight paralogous subunits that assemble into the essential cytosolic group II chaperonin <strong>TRiC/CCT</strong>. TRiC/CCT is a ~1 MDa ATP-dependent double-ring folding machine required for maturation of a specific subset of eukaryotic proteins—classically <strong>actin and tubulin</strong>—and is estimated to mediate folding of roughly <strong>~10% of newly synthesized polypeptides</strong> in yeast. Yeast genetics further indicates that <strong>CCT6 is essential</strong>, and that <strong>excess/unassembled Cct6p</strong> (produced by overexpression) can suppress multiple conditional growth defects in otherwise unrelated pathways (TOR signaling, trafficking/vacuole/cell wall, ubiquitin ligase function), implying physiologically meaningful activity beyond (or in addition to) the assembled TRiC complex. Recent 2023–2024 studies refine TRiC allostery/ATPase kinetics, connect TRiC malfunction to stress-response pathways (e.g., cell-wall integrity MAPK signaling), and expand the functional landscape to include nuclear roles for TRiC in transcriptional homeostasis; however, these advances are mostly <strong>complex-level</strong> and not uniquely CCT6-subunit–specific. (grantham2020themolecularchaperone pages 1-2, dube2023saccharomycescerevisiaesurvival pages 1-4, kabir2005physiologicaleffectsof pages 1-2, kabir2005physiologicaleffectsof pages 2-4)</p>
+<h2 id="evidence-map-high-level">Evidence map (high-level)</h2>
+<table>
+<thead>
+<tr>
+<th>Claim/Topic</th>
+<th>Key evidence (short)</th>
+<th>Organism/system</th>
+<th>Source (author year)</th>
+<th>Publication date</th>
+<th>URL/DOI</th>
+<th>Notes/caveats</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity / disambiguation</td>
+<td>Yeast <strong>CCT6 / YDR188W / UniProt P39079</strong> encodes <strong>T-complex protein 1 subunit zeta (Cct6p)</strong>, one of the eight paralogous subunits of the eukaryotic cytosolic group II chaperonin TRiC/CCT; literature here refers to the yeast chaperonin subunit, not mammalian CCT6A/B paralogs (kabir2005physiologicaleffectsof pages 1-2, kabir2005physiologicaleffectsof pages 2-4)</td>
+<td><em>Saccharomyces cerevisiae</em></td>
+<td>Kabir et al. 2005</td>
+<td>2005-02</td>
+<td>https://doi.org/10.1002/yea.1210</td>
+<td>Older but yeast-specific foundational annotation; important because CCT6 is ambiguous across organisms.</td>
+</tr>
+<tr>
+<td>Complex membership</td>
+<td>TRiC/CCT is a ~1 MDa double-ring complex with two stacked octameric rings; each ring contains CCT1–CCT8 in fixed order, with CCT6 as one subunit (grantham2020themolecularchaperone pages 1-2, zang2018developmentofa pages 1-2)</td>
+<td>Yeast TRiC/CCT / eukaryotic TRiC</td>
+<td>Grantham 2020; Zang et al. 2018</td>
+<td>2020-03; 2018-02</td>
+<td>https://doi.org/10.3389/fgene.2020.00172 ; https://doi.org/10.1038/s41598-017-18962-y</td>
+<td>Complex-level function is better established than isolated Cct6p-specific biochemistry.</td>
+</tr>
+<tr>
+<td>Essentiality</td>
+<td>All eight yeast <strong>CCT1–CCT8 genes are essential</strong>; disruption experiments showed each is required, including <strong>CCT6</strong> (kabir2008overexpressedribosomalproteins pages 1-2, kabir2005physiologicaleffectsof pages 2-4)</td>
+<td><em>S. cerevisiae</em></td>
+<td>Kabir &amp; Sherman 2008; Kabir et al. 2005</td>
+<td>2008-12; 2005-02</td>
+<td>https://doi.org/10.1111/j.1567-1364.2008.00425.x ; https://doi.org/10.1002/yea.1210</td>
+<td>Essentiality is gene-level; not every subunit’s ATPase chemistry is equally essential.</td>
+</tr>
+<tr>
+<td>Canonical substrates / primary function</td>
+<td>TRiC/CCT performs ATP-dependent folding of obligate cytosolic substrates, especially <strong>actin and tubulin</strong>; CCT is required for tubulin biogenesis and actin folding, providing the main functional context for CCT6 (grantham2020themolecularchaperone pages 1-2, kelly2020structuralandfunctional pages 18-23, willison2018thestructureand pages 1-2)</td>
+<td>Eukaryotic cytosol; yeast-focused review context</td>
+<td>Grantham 2020; Kelly 2020; Willison 2018</td>
+<td>2020-03; 2020; 2018-10</td>
+<td>https://doi.org/10.3389/fgene.2020.00172 ; n/a ; https://doi.org/10.1042/BCJ20170378</td>
+<td>Evidence is strongest at complex level; direct yeast Cct6-substrate specificity remains less resolved than for the complex as a whole.</td>
+</tr>
+<tr>
+<td>ATPase / hemisphere specialization</td>
+<td>CCT6 belongs to the <strong>low-ATP-affinity hemisphere</strong> (with CCT3/6/7/8); sequence divergence near the nucleotide pocket and structural analyses suggest lower nucleotide exchange, and P-loop alanine substitutions in low-affinity subunits had little growth effect relative to high-affinity subunits (kelly2020structuralandfunctionala pages 42-48, kelly2020structuralandfunctional pages 42-48)</td>
+<td>Yeast TRiC/CCT</td>
+<td>Kelly 2020</td>
+<td>2020</td>
+<td>n/a</td>
+<td>Strong structural/kinetic inference; thesis source, but evidence summarized from cryo-EM, nucleotide assays, and yeast mutational work.</td>
+</tr>
+<tr>
+<td>CCT6-specific ATP-cycle nuance</td>
+<td>Cct6p is described as a low-affinity/low-turnover subunit; one source notes Cct6p and Cct8p remain ADP-bound and do not participate like high-affinity subunits, and a glycine-motif mutation analogous to ts mutations in other subunits did <strong>not</strong> impair growth when introduced in Cct6p (dube2021chaperoninpointmutation pages 1-4)</td>
+<td><em>S. cerevisiae</em> CCT</td>
+<td>Dube &amp; Kabir 2021</td>
+<td>2021-05</td>
+<td>https://doi.org/10.1007/s10529-021-03151-9</td>
+<td>Useful subunit-specific nuance, but based on synthesis of prior work rather than a direct dedicated CCT6 biochemical paper.</td>
+</tr>
+<tr>
+<td>Subunit position / structure</td>
+<td>Cryo-EM with internal eGFP labeling (YISEL) assigned <strong>CCT6 as an on-axis subunit (a5 / subunit 6)</strong> in yeast TRiC and helped define full subunit order; CCT6 contributes to the characteristic Z-shaped on-axis pair geometry (zang2018developmentofa pages 1-2, zang2018developmentofa media 20a150a9)</td>
+<td>Yeast TRiC/CCT</td>
+<td>Zang et al. 2018</td>
+<td>2018-02</td>
+<td>https://doi.org/10.1038/s41598-017-18962-y</td>
+<td>Structural assignment is direct and yeast-specific.</td>
+</tr>
+<tr>
+<td>Inter-ring structural role</td>
+<td>Structural analyses indicate the <strong>N-terminus of CCT6</strong> participates in inter-ring interactions/stacking during TRiC closure, supporting a role in conformational locking rather than being a dominant ATP-hydrolyzing driver (kelly2020structuralandfunctionala pages 42-48, kelly2020structuralandfunctional pages 42-48)</td>
+<td>Yeast TRiC/CCT</td>
+<td>Kelly 2020</td>
+<td>2020</td>
+<td>n/a</td>
+<td>Mechanistic inference from structures and comparative mutational studies.</td>
+</tr>
+<tr>
+<td>Unassembled Cct6 suppressor activity</td>
+<td>Overexpression of <strong>CCT6</strong> increases unassociated Cct6p, not total assembled CCT complex, and this excess subunit suppresses diverse conditional phenotypes (<strong>tor2-21, lst8-2, rsp5-9, [SIT4 SAP155]N</strong>) (kabir2005physiologicaleffectsof pages 1-2, kabir2005physiologicaleffectsof pages 2-4)</td>
+<td><em>S. cerevisiae</em> genetics</td>
+<td>Kabir et al. 2005</td>
+<td>2005-02</td>
+<td>https://doi.org/10.1002/yea.1210</td>
+<td>Important evidence that Cct6p may have physiologically relevant extra-complex activity or sequestration/competition effects.</td>
+</tr>
+<tr>
+<td>Requirement for ATP-binding motif in suppressor function</td>
+<td>The <strong>cct6-24</strong> mutant with <strong>GDGTT→AAAAA</strong> replacement in the conserved ATP-binding motif was unable to suppress those conditional traits, <strong>despite supporting growth</strong>, implying suppression depends on a specific functional state of unassembled Cct6p (kabir2005physiologicaleffectsof pages 1-2)</td>
+<td><em>S. cerevisiae</em></td>
+<td>Kabir et al. 2005</td>
+<td>2005-02</td>
+<td>https://doi.org/10.1002/yea.1210</td>
+<td>Strong evidence for separable roles: viability of mutant allele vs loss of suppressor activity.</td>
+</tr>
+<tr>
+<td>Genetic phenotypes / ts alleles</td>
+<td>Multiple <strong>temperature-sensitive cct6 alleles</strong> were reported (e.g., cct6-14, -18, -27, -74, -85, -93, -97), many with <strong>TBZ sensitivity</strong> and some with <strong>NaCl sensitivity</strong>, consistent with roles in microtubule/actin-related processes (kabir2008overexpressedribosomalproteins pages 1-2, kabir2008overexpressedribosomalproteins pages 2-3)</td>
+<td><em>S. cerevisiae</em></td>
+<td>Kabir &amp; Sherman 2008</td>
+<td>2008-12</td>
+<td>https://doi.org/10.1111/j.1567-1364.2008.00425.x</td>
+<td>Phenotypes derive from legacy allele collections; not all were mechanistically dissected.</td>
+</tr>
+<tr>
+<td>Multicopy suppressors of cct defects</td>
+<td>Kabir &amp; Sherman isolated <strong>22 multicopy suppressors</strong> of a cct4 ts allele; <strong>14 encoded ribosomal proteins</strong>, and some suppressors also acted on certain <strong>cct6</strong> mutants, suggesting overexpressed ribosomal proteins can weakly buffer defective chaperonins (kabir2008overexpressedribosomalproteins pages 1-2, kabir2008overexpressedribosomalproteins pages 2-3)</td>
+<td><em>S. cerevisiae</em></td>
+<td>Kabir &amp; Sherman 2008</td>
+<td>2008-12</td>
+<td>https://doi.org/10.1111/j.1567-1364.2008.00425.x</td>
+<td>Indirectly informative for CCT6 buffering/genetic interaction space.</td>
+</tr>
+<tr>
+<td>CCT6 vs CCT3 subunit-specific interactome effects</td>
+<td>A conserved ATP-site Glu→Asp mutation in <strong>CCT6</strong> was compared with <strong>CCT3</strong> in high-throughput microscopy; each mutant produced distinct proteome-level effects, and <strong>CCT3</strong> showed stronger association with Q/N-rich proteins/P-body phenotypes than <strong>CCT6</strong> (nadlerholly2012interactionsofsubunit pages 1-2)</td>
+<td><em>S. cerevisiae</em></td>
+<td>Nadler-Holly et al. 2012</td>
+<td>2012-11</td>
+<td>https://doi.org/10.1073/pnas.1209277109</td>
+<td>Useful because it argues subunit specialization; CCT6 phenotype was milder/different than CCT3 for this substrate class.</td>
+</tr>
+<tr>
+<td>Cytosolic localization / classical role</td>
+<td>TRiC/CCT is classically a <strong>cytosolic</strong> folding machine in yeast/eukaryotes, accounting for ~10% of new polypeptide maturation; this is the best-supported localization/function for Cct6p as part of the holo-complex (gvozdenov2024triccctchaperoningoverns pages 1-6, dube2023saccharomycescerevisiaesurvival pages 1-4)</td>
+<td>Yeast / eukaryotic cytosol</td>
+<td>Gvozdenov et al. 2024; Dube et al. 2023</td>
+<td>2024-09-26; 2023-11</td>
+<td>https://doi.org/10.1101/2024.09.26.615188 ; https://doi.org/10.1007/s42977-023-00192-1</td>
+<td>Dube 2023 is about CCT7 mutant, but explicitly states yeast TRiC/CCT is cytosolic and folds ~10% of polypeptides.</td>
+</tr>
+<tr>
+<td>Nuclear localization / emerging role</td>
+<td>Recent work shows <strong>TRiC/CCT is also present in the nucleus</strong> and can regulate <strong>RNA polymerase II activity</strong> and nascent RNA homeostasis; this extends likely functional context for all subunits including CCT6, though not yet CCT6-specific (gvozdenov2024triccctchaperoningoverns pages 1-6)</td>
+<td><em>S. cerevisiae</em></td>
+<td>Gvozdenov et al. 2024</td>
+<td>2024-09-26</td>
+<td>https://doi.org/10.1101/2024.09.26.615188</td>
+<td>Preprint; compelling for nuclear TRiC, but not direct evidence that CCT6 alone mediates the effect.</td>
+</tr>
+<tr>
+<td>Recent development: stress/pathway crosstalk</td>
+<td>A 2023 yeast study showed a <strong>cct7</strong> folding-defective mutant is heat- and cell-wall-stress sensitive and is rescued by <strong>PKC1/SLT2</strong>, supporting crosstalk between CCT proteostasis and the <strong>cell wall integrity (CWI) MAPK pathway</strong> (dube2023saccharomycescerevisiaesurvival pages 1-4)</td>
+<td><em>S. cerevisiae</em></td>
+<td>Dube et al. 2023</td>
+<td>2023-11</td>
+<td>https://doi.org/10.1007/s42977-023-00192-1</td>
+<td>Not CCT6-specific, but relevant recent pathway context for the complex in yeast.</td>
+</tr>
+<tr>
+<td>Recent development: kinetic mechanism</td>
+<td>A 2023 yeast study on <strong>CCT2</strong> found reduced ADP off-rate in a disease-linked mutant and quantified WT ATPase behavior (<strong>K1 ~8.3 µM, K2 ~110 µM; kcat ~0.043–0.053 s^-1</strong>), reinforcing asymmetric ATPase cycling within yeast TRiC relevant to low-affinity subunits such as CCT6 (roy2023reducedadpoffrate pages 1-2, kelly2020structuralandfunctional pages 42-48)</td>
+<td>Yeast TRiC/CCT</td>
+<td>Roy et al. 2023; Kelly 2020</td>
+<td>2023-08; 2020</td>
+<td>https://doi.org/10.1038/s42003-023-05261-8 ; n/a</td>
+<td>Quantitative kinetics are for CCT2/whole complex, not directly for CCT6, but they support the asymmetric ring model.</td>
+</tr>
+<tr>
+<td>Recent development: cochaperone cooperation</td>
+<td>2024 cryo-EM/XL-MS work showed <strong>PhLP2A</strong> and substrate <strong>actin</strong> occupy opposing TRiC chambers; actin/PhLP2A contact positively charged inner-surface residues from <strong>CCT1/3/6/8</strong>, implicating <strong>CCT6</strong> directly in the substrate/cochaperone folding chamber interface (junsun2024astructuralvista pages 1-2)</td>
+<td>Purified TRiC system</td>
+<td>Park et al. 2024</td>
+<td>2024-02</td>
+<td>https://doi.org/10.1038/s41467-024-45242-x</td>
+<td>Strong recent mechanistic evidence, though not yeast-specific in organism designation.</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes experimentally supported functional annotation evidence for yeast CCT6/YDR188W/P39079, emphasizing identity verification, complex role, subunit specialization, genetics, localization, and 2023-2024 developments. It is useful as a compact evidence map for building a narrative report while keeping organism-specific claims separate from broader TRiC/CCT findings.</em></p>
+<h2 id="1-geneprotein-identity-verification-disambiguation">1) Gene/protein identity verification (disambiguation)</h2>
+<p>The target is <strong>yeast CCT6</strong> (ordered locus name <strong>YDR188W</strong>; UniProt <strong>P39079</strong>), a TRiC/CCT subunit (Cct6p). Yeast-focused primary literature explicitly treats <strong>CCT6 as a chaperonin subunit gene</strong> and performs yeast genetics with cct6 alleles and CCT6 overexpression constructs, consistent with the UniProt record and domain/family assignment (TCP-1 chaperonin family). (kabir2005physiologicaleffectsof pages 1-2, kabir2005physiologicaleffectsof pages 2-4)</p>
+<h2 id="2-key-concepts-and-definitions-current-understanding">2) Key concepts and definitions (current understanding)</h2>
+<h3 id="21-triccct-as-a-eukaryotic-group-ii-chaperonin">2.1 TRiC/CCT as a eukaryotic group II chaperonin</h3>
+<p>TRiC/CCT (TCP-1 Ring Complex / Chaperonin Containing TCP-1) is an <strong>essential</strong> eukaryotic chaperonin that forms <strong>two stacked rings</strong>, each ring containing <strong>eight different subunits (CCT1–CCT8)</strong> in a fixed arrangement, producing a central chamber where folding can proceed under “caged” conditions coupled to an ATP-driven conformational cycle. (grantham2020themolecularchaperone pages 1-2, gvozdenov2024triccctchaperoningoverns pages 1-6)</p>
+<h3 id="22-substrate-spectrum-and-primary-function-framing-for-cct6">2.2 Substrate spectrum and “primary function” framing for CCT6</h3>
+<p>For functional annotation, the most defensible “primary function” for CCT6 is: <strong>a structural/ATPase subunit of the TRiC/CCT chaperonin that contributes to ATP-dependent folding and maturation of obligate cytosolic substrates, especially actin and tubulin, and other topologically complex clients</strong>. Reviews emphasize that actin and tubulin are core/obligate CCT substrates, and TRiC also contributes to assembly of select multiprotein complexes (e.g., VHL–Elongin) and interacts with regulators (e.g., gelsolin) in a non-classical chaperoning mode. (grantham2020themolecularchaperone pages 1-2, willison2018thestructureand pages 1-2)</p>
+<h3 id="23-subunit-specialization-within-triccct">2.3 Subunit specialization within TRiC/CCT</h3>
+<p>Unlike bacterial GroEL (homooligomer), TRiC is <strong>heterooligomeric</strong>, allowing subunit-specific substrate contacts and asymmetric ATPase/allosteric behavior. Experimental and structural analyses (summarized in yeast TRiC-focused work) group subunits into two “hemispheres” with differing nucleotide affinity and ATPase roles. CCT6 is consistently placed in the <strong>low ATP-affinity hemisphere</strong> (with CCT3/6/7/8), with sequence divergence near the nucleotide pocket proposed to reduce nucleotide exchange/ATP binding; yeast mutational data indicate that ATPase/P-loop disruption is more deleterious in high-affinity subunits than in low-affinity ones. (kelly2020structuralandfunctionala pages 42-48, kelly2020structuralandfunctional pages 42-48)</p>
+<h2 id="3-molecularstructural-annotation-of-yeast-cct6p">3) Molecular/structural annotation of yeast Cct6p</h2>
+<h3 id="31-subunit-position-in-the-yeast-triccct-ring">3.1 Subunit position in the yeast TRiC/CCT ring</h3>
+<p>A yeast internal-subunit eGFP labeling strategy combined with cryo-EM (YISEL) enabled unambiguous subunit assignment in yeast TRiC, including CCT6. This work assigns <strong>CCT6 as an on-axis subunit</strong> and places it at a defined position in the ring architecture (Figure evidence). (zang2018developmentofa pages 1-2, zang2018developmentofa media 20a150a9)</p>
+<h3 id="32-structural-role-during-ring-closure-and-inter-ring-communication">3.2 Structural role during ring closure and inter-ring communication</h3>
+<p>Structural analyses summarized for yeast TRiC indicate that the <strong>N-terminus of CCT6</strong> participates in an <strong>inter-ring interaction network</strong> during closure, stacking with the trans ring alongside other low-affinity hemisphere subunits. This supports the view that CCT6 contributes importantly to <strong>mechanical/structural coupling</strong> of the two rings through the ATP-driven cycle, even if its own ATPase contribution is reduced relative to high-affinity subunits. (kelly2020structuralandfunctionala pages 42-48, kelly2020structuralandfunctional pages 42-48)</p>
+<h2 id="4-cellular-localization-and-where-cct6p-acts">4) Cellular localization and where Cct6p acts</h2>
+<h3 id="41-canonical-localization-cytosolic-proteostasis">4.1 Canonical localization: cytosolic proteostasis</h3>
+<p>TRiC/CCT is classically considered a <strong>cytosolic</strong> folding machine that supports co-/post-translational maturation of a substantial fraction of the proteome. Yeast-focused work explicitly reiterates TRiC/CCT as a <strong>cytosolic cylindrical complex</strong> encoded by eight essential genes and contributing to folding of <strong>~10%</strong> of yeast cellular polypeptides. (dube2023saccharomycescerevisiaesurvival pages 1-4)</p>
+<h3 id="42-emerging-localizationfunction-nuclear-triccct">4.2 Emerging localization/function: nuclear TRiC/CCT</h3>
+<p>A 2024 preprint reports TRiC/CCT is present in the <strong>nucleus</strong> and proposes a direct role in <strong>regulating RNA polymerase II activity</strong> and nascent RNA production (with effects persisting when TRiC is restricted to the cytoplasm, supporting a direct nuclear role in their model). This expands likely functional contexts for all TRiC subunits (including CCT6), although it does not isolate a CCT6-specific nuclear mechanism. (gvozdenov2024triccctchaperoningoverns pages 1-6)</p>
+<h2 id="5-yeast-genetics-essentiality-phenotypes-and-cct6-specific-functional-inferences">5) Yeast genetics: essentiality, phenotypes, and CCT6-specific functional inferences</h2>
+<h3 id="51-essentiality">5.1 Essentiality</h3>
+<p>Yeast gene disruption experiments and genetic summaries state that <strong>all eight CCT genes (CCT1–CCT8) are essential</strong>, which includes <strong>CCT6</strong>. (kabir2008overexpressedribosomalproteins pages 1-2, kabir2005physiologicaleffectsof pages 2-4)</p>
+<h3 id="52-conditional-alleles-and-cytoskeleton-linked-phenotypes">5.2 Conditional alleles and cytoskeleton-linked phenotypes</h3>
+<p>A panel of <strong>temperature-sensitive cct6 alleles</strong> has been described (e.g., cct6-14, -18, -27, -74, -85, -93, -97). Reported phenotypes include <strong>TBZ sensitivity</strong> (consistent with microtubule-associated stress) and in some alleles <strong>NaCl sensitivity</strong> (often used as an actin/cytoskeleton stress readout in these legacy screens). (kabir2008overexpressedribosomalproteins pages 1-2, kabir2008overexpressedribosomalproteins pages 2-3)</p>
+<h3 id="53-multicopy-suppression-unassembled-cct6p-as-a-functional-entity">5.3 Multicopy suppression: unassembled Cct6p as a functional entity</h3>
+<p>A central yeast-specific insight is that <strong>overexpression of CCT6</strong> can suppress diverse conditional phenotypes, including defects caused by <strong>tor2-21</strong>, <strong>lst8-2</strong>, <strong>rsp5-9</strong>, and growth inhibition caused by concomitant overexpression of <strong>Sit4p and Sap155p</strong>. Importantly, fractionation/abundance analysis indicates that overexpressing CCT6 increases the level of <strong>unassociated (unassembled) Cct6p</strong>, while the assembled TRiC/CCT complex remains at normal levels—supporting a model where unassembled Cct6p has physiological effects (e.g., substrate sequestration/competition for modifying activities) beyond simply boosting holo-complex abundance. (kabir2005physiologicaleffectsof pages 1-2, kabir2005physiologicaleffectsof pages 2-4)</p>
+<h3 id="54-separation-of-function-atp-binding-motif-required-for-suppression-but-not-viability">5.4 Separation-of-function: ATP-binding motif required for suppression but not viability</h3>
+<p>Kabir et al. examined many altered forms of Cct6p and report that a CCT6 allele with <strong>GDGTT→AAAAA</strong> substitutions in the conserved ATP-binding motif (<strong>cct6-24</strong>) is <strong>unable to suppress</strong> the above traits, <strong>yet is functional for growth</strong>. This strongly supports that (i) Cct6p has separable functional states and (ii) suppression by unassembled Cct6p likely requires a specific ATP-associated conformation or activity. (kabir2005physiologicaleffectsof pages 1-2)</p>
+<h3 id="55-proteome-scale-phenotyping-distinguishes-cct6-from-other-subunits">5.5 Proteome-scale phenotyping distinguishes CCT6 from other subunits</h3>
+<p>High-throughput microscopy profiling comparing ATP-site mutants in different TRiC subunits found that CCT subunits can have distinguishable in vivo consequences; in particular, the study emphasizes that the <strong>CCT3</strong> mutant showed stronger associations with Q/N-rich proteins and P-body phenotypes than the <strong>CCT6</strong> mutant, consistent with <strong>subunit-specific substrate/interactome specialization</strong>. (nadlerholly2012interactionsofsubunit pages 1-2)</p>
+<h2 id="6-pathways-and-biological-processes-linked-to-cct6tric-in-yeast">6) Pathways and biological processes linked to CCT6/TRiC in yeast</h2>
+<h3 id="61-tor-signaling-actin-polarization-axis">6.1 TOR signaling / actin polarization axis</h3>
+<p>Overexpression of CCT6 suppresses <strong>tor2-21</strong> conditional phenotypes and is linked to partial restoration of actin cytoskeleton polarization in that genetic background, tying TRiC/CCT (and/or unassembled Cct6p) to a TOR2-dependent actin organization pathway. (kabir2005physiologicaleffectsof pages 2-4)</p>
+<h3 id="62-traffickingcell-wall-integrity-and-ubiquitin-ligase-connections">6.2 Trafficking/cell wall integrity and ubiquitin ligase connections</h3>
+<p>CCT6 overexpression suppresses phenotypes of <strong>lst8-2</strong> (a TOR-associated factor required for sorting of diverse proteins at the Golgi and associated with cell wall integrity) and <strong>rsp5-9</strong> (an essential ubiquitin–protein ligase with broad roles including endocytosis and actin dynamics). These suppression relationships suggest that TRiC/CCT proteostasis capacity and/or Cct6p-mediated sequestration can buffer defects in trafficking, membrane protein turnover, and cell surface/cell wall regulation. (kabir2005physiologicaleffectsof pages 2-4)</p>
+<h3 id="63-stress-physiology-and-the-cell-wall-integrity-mapk-pathway-recent">6.3 Stress physiology and the cell wall integrity MAPK pathway (recent)</h3>
+<p>A 2023 yeast study using a folding-defective <strong>cct7</strong> mutant reports temperature and cell-wall-stressor sensitivity and rescue by overexpression of <strong>PKC1</strong> and <strong>SLT2</strong> (MAPK cell wall integrity pathway components), supporting a functional interface between TRiC/CCT-dependent folding and cell-wall integrity signaling under heat stress. While not CCT6-specific, it is relevant to interpreting downstream consequences of impaired TRiC activity in yeast and potential contexts where CCT6 alleles may manifest. (dube2023saccharomycescerevisiaesurvival pages 1-4)</p>
+<h2 id="7-recent-developments-prioritizing-20232024">7) Recent developments (prioritizing 2023–2024)</h2>
+<h3 id="71-quantitative-tric-kinetics-in-yeast-2023">7.1 Quantitative TRiC kinetics in yeast (2023)</h3>
+<p>A 2023 study analyzing yeast TRiC with disease-associated mutations in <strong>CCT2</strong> quantified ATPase behavior and reported apparent ATP binding constants and turnover (e.g., WT <strong>K1 ~8.3 μM, K2 ~110 μM; kcat ~0.043–0.053 s−1</strong> under their fitted model) and showed that a double mutation reduces ADP off-rate, stabilizing closed states. This strengthens the mechanistic framework in which different subunits contribute differently to allosteric cycling—contextually relevant to CCT6 as a low-affinity hemisphere member—even though the mutation is in CCT2 rather than CCT6. (roy2023reducedadpoffrate pages 1-2, kelly2020structuralandfunctional pages 42-48)</p>
+<h3 id="72-tric-cochaperone-cooperation-and-cct6-contact-surfaces-2024">7.2 TRiC cochaperone cooperation and CCT6 contact surfaces (2024)</h3>
+<p>A 2024 cryo-EM/XL-MS study of TRiC cooperation with <strong>PhLP2A</strong> (phosducin-like protein) in the folding cycle reports that in the presence of substrate, <strong>actin and PhLP2A segregate into opposing chambers</strong>, each binding positively charged inner surface residues from <strong>CCT1/3/6/8</strong>. This provides modern structural evidence that CCT6 contributes directly to the physicochemical environment and binding surfaces engaged during actin folding intermediates. (junsun2024astructuralvista pages 1-2)</p>
+<h3 id="73-nuclear-tric-and-transcriptional-homeostasis-in-yeast-2024-preprint">7.3 Nuclear TRiC and transcriptional homeostasis in yeast (2024 preprint)</h3>
+<p>A 2024 yeast study proposes TRiC/CCT has a direct nuclear role modulating <strong>RNA polymerase II</strong> activity and nascent RNA output, suggesting TRiC contributes to cell homeostasis beyond canonical cytosolic folding. This is a notable expansion of functional annotation scope for the complex and likely relevant to CCT6 as a subunit, but remains preprint-stage and not subunit-resolved. (gvozdenov2024triccctchaperoningoverns pages 1-6)</p>
+<h2 id="8-current-applications-and-real-world-implementations">8) Current applications and real-world implementations</h2>
+<h3 id="81-yeast-as-a-functional-genomics-platform-to-probe-chaperonin-subunits">8.1 Yeast as a functional-genomics platform to probe chaperonin subunits</h3>
+<p>CCT6 is used experimentally as (i) a genetically essential proteostasis component (ts alleles) and (ii) a <strong>multicopy suppressor</strong> whose overexpression reveals buffering relationships across major pathways (TOR signaling, trafficking/cell wall, ubiquitin-mediated regulation). This makes CCT6 a practical tool for dissecting <strong>genetic robustness</strong> and <strong>proteostasis-pathway crosstalk</strong> in an industrially and medically relevant model organism. (kabir2005physiologicaleffectsof pages 1-2, kabir2008overexpressedribosomalproteins pages 2-3)</p>
+<h3 id="82-structural-biology-and-engineering-of-macromolecular-machines">8.2 Structural biology and engineering of macromolecular machines</h3>
+<p>The YISEL internal labeling method demonstrated in yeast TRiC enables precise subunit assignment in challenging hetero-oligomeric complexes and is itself an implementation with broader utility for macromolecular complex annotation and cryo-EM mapping—directly leveraging yeast CCT6 subunit labeling/assignment. (zang2018developmentofa pages 1-2, zang2018developmentofa media 20a150a9)</p>
+<h3 id="83-disease-analogy-and-mechanistic-transfer-caveated">8.3 Disease analogy and mechanistic transfer (caveated)</h3>
+<p>While human disease phenotypes are not part of yeast CCT6 annotation per se, yeast TRiC studies (e.g., kinetic analysis of disease-linked CCT2 mutations) illustrate how yeast TRiC serves as a mechanistic model for conserved chaperonin function and allosteric defects. Any extension to CCT6-related human disease or therapeutic targeting should be made cautiously and requires direct evidence not provided here. (roy2023reducedadpoffrate pages 1-2)</p>
+<h2 id="9-relevant-statistics-and-quantitative-data-from-retrieved-sources">9) Relevant statistics and quantitative data (from retrieved sources)</h2>
+<ul>
+<li><strong>Essential genes</strong>: CCT1–CCT8 are essential in yeast. (kabir2008overexpressedribosomalproteins pages 1-2, kabir2005physiologicaleffectsof pages 2-4)</li>
+<li><strong>Proteostasis workload estimate</strong>: TRiC/CCT contributes to folding of ~<strong>10%</strong> of yeast cellular polypeptides (as stated in yeast stress study background). (dube2023saccharomycescerevisiaesurvival pages 1-4)</li>
+<li><strong>Suppression screen scale</strong>: 22 multicopy suppressors were isolated for a cct4 ts allele; 14 encoded ribosomal proteins; some suppressors also acted on cct6 alleles. (kabir2008overexpressedribosomalproteins pages 1-2, kabir2008overexpressedribosomalproteins pages 2-3)</li>
+<li><strong>TRiC ATPase kinetics (yeast, WT)</strong>: apparent ATP binding constants (<strong>K1 ~8.3 μM, K2 ~110 μM</strong>) and turnover (<strong>kcat ~0.043–0.053 s−1</strong>) reported in one fitted model/condition set. (roy2023reducedadpoffrate pages 1-2)</li>
+</ul>
+<h2 id="10-expert-interpretation-and-limitations">10) Expert interpretation and limitations</h2>
+<ol>
+<li><strong>Most CCT6-specific “function” evidence in yeast is genetic</strong> (essentiality; ts alleles; multicopy suppression; separation-of-function for suppression vs viability), while <strong>client specificity</strong> is more firmly established at the <strong>TRiC complex level</strong> (actin/tubulin and select other classes). Therefore, the most accurate functional annotation for CCT6 is as a <strong>TRiC/CCT subunit that supports folding of obligate cytosolic substrates and TRiC conformational cycling</strong>, with additional evidence that <strong>unassembled Cct6p can modulate cell physiology</strong> in an ATP-motif–dependent manner. (kabir2005physiologicaleffectsof pages 1-2, grantham2020themolecularchaperone pages 1-2)</li>
+<li>Recent 2023–2024 research largely refines <strong>TRiC mechanism, stress crosstalk, and nuclear roles</strong>, but is not yet fully <strong>subunit-resolved</strong> for CCT6 in yeast. The strongest 2024 subunit-level mechanistic link involving CCT6 is structural evidence that CCT6 contributes inner-surface residues contacted in the actin/PhLP2A folding context. (junsun2024astructuralvista pages 1-2)</li>
+</ol>
+<h2 id="key-cited-sources-with-dates-and-urls">Key cited sources (with dates and URLs)</h2>
+<ul>
+<li>Kabir MA et al. <strong>Physiological effects of unassembled chaperonin Cct subunits in the yeast <em>Saccharomyces cerevisiae</em></strong>. <em>Yeast</em>. <strong>Feb 2005</strong>. https://doi.org/10.1002/yea.1210 (kabir2005physiologicaleffectsof pages 1-2)</li>
+<li>Kabir MA &amp; Sherman F. <strong>Overexpressed ribosomal proteins suppress defective chaperonins in <em>Saccharomyces cerevisiae</em></strong>. <em>FEMS Yeast Research</em>. <strong>Dec 2008</strong>. https://doi.org/10.1111/j.1567-1364.2008.00425.x (kabir2008overexpressedribosomalproteins pages 1-2)</li>
+<li>Zang Y et al. <strong>Development of a yeast internal-subunit eGFP labeling strategy… TRiC/CCT</strong>. <em>Scientific Reports</em>. <strong>Feb 2018</strong>. https://doi.org/10.1038/s41598-017-18962-y (zang2018developmentofa pages 1-2)</li>
+<li>Willison KR. <strong>The structure and evolution of eukaryotic chaperonin-containing TCP-1… folds actin</strong>. <em>Biochemical Journal</em>. <strong>Oct 2018</strong>. https://doi.org/10.1042/BCJ20170378 (willison2018thestructureand pages 1-2)</li>
+<li>Grantham J. <strong>The Molecular Chaperone CCT/TRiC…</strong> <em>Frontiers in Genetics</em>. <strong>Mar 2020</strong>. https://doi.org/10.3389/fgene.2020.00172 (grantham2020themolecularchaperone pages 1-2)</li>
+<li>Roy M et al. <strong>Reduced ADP off-rate… yeast CCT2 double mutation…</strong> <em>Communications Biology</em>. <strong>Aug 2023</strong>. https://doi.org/10.1038/s42003-023-05261-8 (roy2023reducedadpoffrate pages 1-2)</li>
+<li>Dube A et al. <strong>S. cerevisiae survival against heat stress entails… CCT and cell wall integrity pathway</strong>. <em>Biologia Futura</em>. <strong>Nov 2023</strong>. https://doi.org/10.1007/s42977-023-00192-1 (dube2023saccharomycescerevisiaesurvival pages 1-4)</li>
+<li>Park J et al. <strong>A structural vista of PhLP2A–TRiC cooperation…</strong> <em>Nature Communications</em>. <strong>Feb 2024</strong>. https://doi.org/10.1038/s41467-024-45242-x (junsun2024astructuralvista pages 1-2)</li>
+<li>Gvozdenov Z et al. <strong>TRiC/CCT Chaperonin Governs RNA Polymerase II Activity in the Nucleus…</strong> <em>bioRxiv</em> preprint. <strong>Sep 26, 2024</strong>. https://doi.org/10.1101/2024.09.26.615188 (gvozdenov2024triccctchaperoningoverns pages 1-6)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(grantham2020themolecularchaperone pages 1-2): Julie Grantham. The molecular chaperone cct/tric: an essential component of proteostasis and a potential modulator of protein aggregation. Frontiers in Genetics, Mar 2020. URL: https://doi.org/10.3389/fgene.2020.00172, doi:10.3389/fgene.2020.00172. This article has 139 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(dube2023saccharomycescerevisiaesurvival pages 1-4): Ankita Dube, Dileep Pullepu, and M. Anaul Kabir. Saccharomyces cerevisiae survival against heat stress entails a communication between cct and cell wall integrity pathway. Biologia futura, 74:519-527, Nov 2023. URL: https://doi.org/10.1007/s42977-023-00192-1, doi:10.1007/s42977-023-00192-1. This article has 2 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kabir2005physiologicaleffectsof pages 1-2): M. Anaul Kabir, Joanna Kaminska, George B. Segel, Gabor Bethlendy, Paul Lin, Flavio Della Seta, Casey Blegen, Kristine M. Swiderek, Teresa ?o??dek, Kim T. Arndt, and Fred Sherman. Physiological effects of unassembled chaperonin cct subunits in the yeast saccharomyces cerevisiae. Yeast, 22:219-239, Feb 2005. URL: https://doi.org/10.1002/yea.1210, doi:10.1002/yea.1210. This article has 60 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kabir2005physiologicaleffectsof pages 2-4): M. Anaul Kabir, Joanna Kaminska, George B. Segel, Gabor Bethlendy, Paul Lin, Flavio Della Seta, Casey Blegen, Kristine M. Swiderek, Teresa ?o??dek, Kim T. Arndt, and Fred Sherman. Physiological effects of unassembled chaperonin cct subunits in the yeast saccharomyces cerevisiae. Yeast, 22:219-239, Feb 2005. URL: https://doi.org/10.1002/yea.1210, doi:10.1002/yea.1210. This article has 60 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zang2018developmentofa pages 1-2): Yunxiang Zang, Huping Wang, Zhicheng Cui, Mingliang Jin, Caixuan Liu, Wenyu Han, Yanxing Wang, and Yao Cong. Development of a yeast internal-subunit egfp labeling strategy and its application in subunit identification in eukaryotic group ii chaperonin tric/cct. Scientific Reports, Feb 2018. URL: https://doi.org/10.1038/s41598-017-18962-y, doi:10.1038/s41598-017-18962-y. This article has 22 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kabir2008overexpressedribosomalproteins pages 1-2): M. Anaul Kabir and Fred Sherman. Overexpressed ribosomal proteins suppress defective chaperonins in saccharomyces cerevisiae. FEMS yeast research, 8 8:1236-44, Dec 2008. URL: https://doi.org/10.1111/j.1567-1364.2008.00425.x, doi:10.1111/j.1567-1364.2008.00425.x. This article has 21 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kelly2020structuralandfunctional pages 18-23): J Kelly. Structural and functional characterisation of the group ii chaperonin cct/tric. Unknown journal, 2020.</p>
+</li>
+<li>
+<p>(willison2018thestructureand pages 1-2): Keith Robert Willison. The structure and evolution of eukaryotic chaperonin-containing tcp-1 and its mechanism that folds actin into a protein spring. The Biochemical journal, 475 19:3009-3034, Oct 2018. URL: https://doi.org/10.1042/bcj20170378, doi:10.1042/bcj20170378. This article has 42 citations.</p>
+</li>
+<li>
+<p>(kelly2020structuralandfunctionala pages 42-48): J Kelly. Structural and functional characterisation of the group ii chaperonin cct/tric. Unknown journal, 2020.</p>
+</li>
+<li>
+<p>(kelly2020structuralandfunctional pages 42-48): J Kelly. Structural and functional characterisation of the group ii chaperonin cct/tric. Unknown journal, 2020.</p>
+</li>
+<li>
+<p>(dube2021chaperoninpointmutation pages 1-4): Ankita Dube and M. Anaul Kabir. Chaperonin point mutation enhances cadmium endurance in saccharomyces cerevisiae. Biotechnology Letters, 43:1735-1745, May 2021. URL: https://doi.org/10.1007/s10529-021-03151-9, doi:10.1007/s10529-021-03151-9. This article has 2 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zang2018developmentofa media 20a150a9): Yunxiang Zang, Huping Wang, Zhicheng Cui, Mingliang Jin, Caixuan Liu, Wenyu Han, Yanxing Wang, and Yao Cong. Development of a yeast internal-subunit egfp labeling strategy and its application in subunit identification in eukaryotic group ii chaperonin tric/cct. Scientific Reports, Feb 2018. URL: https://doi.org/10.1038/s41598-017-18962-y, doi:10.1038/s41598-017-18962-y. This article has 22 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kabir2008overexpressedribosomalproteins pages 2-3): M. Anaul Kabir and Fred Sherman. Overexpressed ribosomal proteins suppress defective chaperonins in saccharomyces cerevisiae. FEMS yeast research, 8 8:1236-44, Dec 2008. URL: https://doi.org/10.1111/j.1567-1364.2008.00425.x, doi:10.1111/j.1567-1364.2008.00425.x. This article has 21 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nadlerholly2012interactionsofsubunit pages 1-2): Michal Nadler-Holly, Michal Breker, Ranit Gruber, Ariel Azia, Melissa Gymrek, Miriam Eisenstein, Keith R. Willison, Maya Schuldiner, and Amnon Horovitz. Interactions of subunit cct3 in the yeast chaperonin cct/tric with q/n-rich proteins revealed by high-throughput microscopy analysis. Proceedings of the National Academy of Sciences, 109:18833-18838, Oct 2012. URL: https://doi.org/10.1073/pnas.1209277109, doi:10.1073/pnas.1209277109. This article has 52 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gvozdenov2024triccctchaperoningoverns pages 1-6): Zlata Gvozdenov, Audrey Yi Tyan Peng, Anusmita Biswas, Zeno Barcutean, Daniel Gestaut, Judith Frydman, Kevin Struhl, and Brian C. Freeman. Tric/cct chaperonin governs rna polymerase ii activity in the nucleus to support rna homeostasis. bioRxiv, Sep 2024. URL: https://doi.org/10.1101/2024.09.26.615188, doi:10.1101/2024.09.26.615188. This article has 3 citations.</p>
+</li>
+<li>
+<p>(roy2023reducedadpoffrate pages 1-2): Mousam Roy, Rachel C. Fleisher, Alexander I. Alexandrov, and Amnon Horovitz. Reduced adp off-rate by the yeast cct2 double mutation t394p/r510h which causes leber congenital amaurosis in humans. Communications Biology, Aug 2023. URL: https://doi.org/10.1038/s42003-023-05261-8, doi:10.1038/s42003-023-05261-8. This article has 9 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(junsun2024astructuralvista pages 1-2): Junsun Park, Hyunmin Kim, Daniel Gestaut, Seyeon Lim, Kwadwo A. Opoku-Nsiah, Alexander Leitner, Judith Frydman, and Soung-Hun Roh. A structural vista of phosducin-like phlp2a-chaperonin tric cooperation during the atp-driven folding cycle. Nature Communications, Feb 2024. URL: https://doi.org/10.1038/s41467-024-45242-x, doi:10.1038/s41467-024-45242-x. This article has 16 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>dube2021chaperoninpointmutation pages 1-4</li>
+<li>kabir2005physiologicaleffectsof pages 1-2</li>
+<li>nadlerholly2012interactionsofsubunit pages 1-2</li>
+<li>gvozdenov2024triccctchaperoningoverns pages 1-6</li>
+<li>dube2023saccharomycescerevisiaesurvival pages 1-4</li>
+<li>junsun2024astructuralvista pages 1-2</li>
+<li>kabir2005physiologicaleffectsof pages 2-4</li>
+<li>roy2023reducedadpoffrate pages 1-2</li>
+<li>kabir2008overexpressedribosomalproteins pages 1-2</li>
+<li>zang2018developmentofa pages 1-2</li>
+<li>willison2018thestructureand pages 1-2</li>
+<li>grantham2020themolecularchaperone pages 1-2</li>
+<li>kelly2020structuralandfunctional pages 18-23</li>
+<li>kelly2020structuralandfunctionala pages 42-48</li>
+<li>kelly2020structuralandfunctional pages 42-48</li>
+<li>kabir2008overexpressedribosomalproteins pages 2-3</li>
+<li>SIT4 SAP155</li>
+<li>https://doi.org/10.1002/yea.1210</li>
+<li>https://doi.org/10.3389/fgene.2020.00172</li>
+<li>https://doi.org/10.1038/s41598-017-18962-y</li>
+<li>https://doi.org/10.1111/j.1567-1364.2008.00425.x</li>
+<li>https://doi.org/10.1042/BCJ20170378</li>
+<li>https://doi.org/10.1007/s10529-021-03151-9</li>
+<li>https://doi.org/10.1073/pnas.1209277109</li>
+<li>https://doi.org/10.1101/2024.09.26.615188</li>
+<li>https://doi.org/10.1007/s42977-023-00192-1</li>
+<li>https://doi.org/10.1038/s42003-023-05261-8</li>
+<li>https://doi.org/10.1038/s41467-024-45242-x</li>
+<li>https://doi.org/10.3389/fgene.2020.00172,</li>
+<li>https://doi.org/10.1007/s42977-023-00192-1,</li>
+<li>https://doi.org/10.1002/yea.1210,</li>
+<li>https://doi.org/10.1038/s41598-017-18962-y,</li>
+<li>https://doi.org/10.1111/j.1567-1364.2008.00425.x,</li>
+<li>https://doi.org/10.1042/bcj20170378,</li>
+<li>https://doi.org/10.1007/s10529-021-03151-9,</li>
+<li>https://doi.org/10.1073/pnas.1209277109,</li>
+<li>https://doi.org/10.1101/2024.09.26.615188,</li>
+<li>https://doi.org/10.1038/s42003-023-05261-8,</li>
+<li>https://doi.org/10.1038/s41467-024-45242-x,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -1924,174 +2706,16 @@
                 <pre><code>id: P39079
 gene_symbol: CCT6
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: &#39;TODO: Add description for CCT6&#39;
-existing_annotations:
-- term:
-    id: GO:0006457
-    label: protein folding
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: &#39;Manual review: protein folding is consistent with known biology of CCT6.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005832
-    label: chaperonin-containing T-complex
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: &#39;Manual review: chaperonin-containing T-complex is consistent with known biology of CCT6.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: &#39;Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT6.&#39;
-    action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
-- term:
-    id: GO:0000166
-    label: nucleotide binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000043
-  review:
-    summary: &#39;Manual review: nucleotide binding is consistent with known biology of CCT6.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005524
-    label: ATP binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000120
-  review:
-    summary: &#39;Manual review: ATP binding is consistent with known biology of CCT6.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005737
-    label: cytoplasm
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000044
-  review:
-    summary: &#39;Manual review: cytoplasm is consistent with known biology of CCT6.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005832
-    label: chaperonin-containing T-complex
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000117
-  review:
-    summary: &#39;Manual review: chaperonin-containing T-complex is consistent with known biology of CCT6.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0006457
-    label: protein folding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000120
-  review:
-    summary: &#39;Manual review: protein folding is consistent with known biology of CCT6.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0016887
-    label: ATP hydrolysis activity
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: &#39;Manual review: ATP hydrolysis activity is consistent with known biology of CCT6.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000120
-  review:
-    summary: &#39;Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT6.&#39;
-    action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
-- term:
-    id: GO:0140662
-    label: ATP-dependent protein folding chaperone
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: &#39;Manual review: ATP-dependent protein folding chaperone is consistent with known biology of CCT6.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:16554755
-  review:
-    summary: &#39;Manual review: protein binding is too generic or over-extended for CCT6.&#39;
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:19536198
-  review:
-    summary: &#39;Manual review: protein binding is too generic or over-extended for CCT6.&#39;
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:37968396
-  review:
-    summary: &#39;Manual review: protein binding is too generic or over-extended for CCT6.&#39;
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0006457
-    label: protein folding
-  evidence_type: IDA
-  original_reference_id: PMID:16762366
-  review:
-    summary: &#39;Manual review: protein folding is consistent with known biology of CCT6.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005832
-    label: chaperonin-containing T-complex
-  evidence_type: IDA
-  original_reference_id: PMID:16762366
-  review:
-    summary: &#39;Manual review: chaperonin-containing T-complex is consistent with known biology of CCT6.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IDA
-  original_reference_id: PMID:16762366
-  review:
-    summary: &#39;Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT6.&#39;
-    action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+description: &gt;-
+  CCT6 encodes the zeta subunit of the cytosolic group II chaperonin TRiC/CCT. Cct6 contributes to the
+  ATP-driven chaperonin chamber that folds actin, tubulin, and other cytosolic clients, and yeast genetics
+  also shows that excess unassembled Cct6 can suppress diverse conditional phenotypes in an ATP-motif-dependent
+  state. Its core GO function is therefore the TRiC/CCT chaperonin role, with unassembled-subunit phenotypes
+  treated as contextual rather than separate core annotations.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -2103,7 +2727,9 @@ references:
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
+  title: &gt;-
+    Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied
+    by conservative changes to GO terms applied by UniProt
   findings: []
 - id: GO_REF:0000117
   title: Electronic Gene Ontology annotations created by ARBA machine learning models
@@ -2115,21 +2741,363 @@ references:
   title: Global landscape of protein complexes in the yeast Saccharomyces cerevisiae.
   findings: []
 - id: PMID:16762366
-  title: Quantitative actin folding reactions using yeast CCT purified via an internal tag in the CCT3/gamma subunit.
-  findings: []
+  title: &gt;-
+    Quantitative actin folding reactions using yeast CCT purified via an internal tag in the CCT3/gamma
+    subunit.
+  findings:
+  - statement: &gt;-
+      Purified yeast CCT, tagged through CCT3, catalyzes ATP-dependent actin folding; this supports protein-folding
+      and chaperonin activity annotations for CCT6 as a TRiC/CCT subunit.
+    supporting_text: &gt;-
+      The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose
+      action is required for folding the cytoskeletal proteins actin and tubulin
 - id: PMID:19536198
-  title: &#39;An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding pathways in the cell.&#39;
-  findings: []
+  title: &gt;-
+    An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding
+    pathways in the cell.
+  findings:
+  - statement: &gt;-
+      The chaperone interactome study is useful context for CCT contacts but reports indirect TAP-tag
+      interactions rather than a specific molecular activity.
+    supporting_text: &gt;-
+      It should be emphasized that the interactions presented are indirect TAP-tag based interactions
+      and not direct binary interactions.
 - id: PMID:37968396
   title: The social and structural architecture of the yeast protein interactome.
   findings: []
+- id: file:yeast/CCT6/CCT6-deep-research-falcon.md
+  title: Falcon deep research report for CCT6
+  findings:
+  - statement: &gt;-
+      The Falcon report was reviewed and synthesized into the CCT6 curation, including core-function framing,
+      family/PANTHER context, and evidence limitations.
+existing_annotations:
+- term:
+    id: GO:0006457
+    label: protein folding
+  qualifier: involved_in
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: &gt;-
+      CCT6 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin
+      that folds actin, tubulin, and other clients.
+    action: ACCEPT
+    reason: &gt;-
+      Protein folding is the correct biological-process context for the chaperonin complex, supported
+      by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
+    supported_by:
+    - reference_id: file:yeast/CCT6/CCT6-deep-research-falcon.md
+      supporting_text: a structural/ATPase subunit of the TRiC/CCT chaperonin
+- term:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  qualifier: part_of
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: CCT6 is a named subunit of the chaperonin-containing T-complex.
+    action: ACCEPT
+    reason: &gt;-
+      Complex membership is central to the gene product function and is supported by yeast CCT complex
+      literature and family evidence.
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: &gt;-
+      unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than
+      the ATP-dependent folding chaperone function of the complex.
+    action: MODIFY
+    reason: &gt;-
+      Replace generic substrate-binding language with the specific chaperonin activity supported by yeast
+      CCT actin-folding assays and domain evidence.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+- term:
+    id: GO:0000166
+    label: nucleotide binding
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: &gt;-
+      nucleotide binding is a true but overly broad family/keyword annotation for CCT6; ATP binding, ATP
+      hydrolysis, and ATP-dependent chaperone annotations capture the specific chemistry.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Generic nucleotide binding does not add useful functional information beyond the more specific ATP-related
+      chaperonin annotations already present.
+- term:
+    id: GO:0005524
+    label: ATP binding
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: &gt;-
+      CCT6 contains a conserved chaperonin ATP-binding site, but ATP binding alone is a domain property
+      rather than the core biological function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Keep as a valid supporting molecular property of the CCT ATPase cycle, while treating ATP hydrolysis
+      and complex-level protein folding as the core function.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  qualifier: located_in
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: CCT6 functions as part of the cytosolic TRiC/CCT chaperonin.
+    action: ACCEPT
+    reason: Cytoplasm is the established location of the CCT/TRiC folding machine.
+- term:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  qualifier: part_of
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: CCT6 is a named subunit of the chaperonin-containing T-complex.
+    action: ACCEPT
+    reason: &gt;-
+      Complex membership is central to the gene product function and is supported by yeast CCT complex
+      literature and family evidence.
+- term:
+    id: GO:0006457
+    label: protein folding
+  qualifier: involved_in
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: &gt;-
+      CCT6 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin
+      that folds actin, tubulin, and other clients.
+    action: ACCEPT
+    reason: &gt;-
+      Protein folding is the correct biological-process context for the chaperonin complex, supported
+      by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
+- term:
+    id: GO:0016887
+    label: ATP hydrolysis activity
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: &gt;-
+      CCT6 is a TCP-1/CCT chaperonin subunit with conserved ATPase machinery that powers TRiC/CCT conformational
+      cycling.
+    action: ACCEPT
+    reason: &gt;-
+      ATP hydrolysis is a defensible subunit-level molecular function for CCT family members and is directly
+      tied to the chaperonin folding cycle.
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: &gt;-
+      unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than
+      the ATP-dependent folding chaperone function of the complex.
+    action: MODIFY
+    reason: &gt;-
+      Replace generic substrate-binding language with the specific chaperonin activity supported by yeast
+      CCT actin-folding assays and domain evidence.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+- term:
+    id: GO:0140662
+    label: ATP-dependent protein folding chaperone
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: CCT6 is an obligate subunit of the ATP-dependent TRiC/CCT folding machine.
+    action: ACCEPT
+    reason: &gt;-
+      The term is appropriate as a complex-level chaperonin function; in the synthesized core function
+      it is modeled as a contributed-to molecular function rather than a standalone activity of an isolated
+      subunit.
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: &gt;-
+        The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine
+        whose action is required for folding the cytoskeletal proteins actin and tubulin
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005515
+    label: protein binding
+  qualifier: enables
+  evidence_type: IPI
+  original_reference_id: PMID:16554755
+  supporting_entities:
+  - UniProtKB:P39078
+  review:
+    summary: &gt;-
+      protein binding is too generic for a CCT subunit and does not describe the chaperonin mechanism
+      or substrate class.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Physical-interaction datasets are useful evidence context, but generic protein binding should not
+      stand as a functional annotation when the specific TRiC/CCT chaperonin role is known.
+- term:
+    id: GO:0005515
+    label: protein binding
+  qualifier: enables
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  supporting_entities:
+  - UniProtKB:P39078
+  review:
+    summary: &gt;-
+      protein binding is too generic for a CCT subunit and does not describe the chaperonin mechanism
+      or substrate class.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Physical-interaction datasets are useful evidence context, but generic protein binding should not
+      stand as a functional annotation when the specific TRiC/CCT chaperonin role is known.
+    supported_by:
+    - reference_id: PMID:19536198
+      supporting_text: &gt;-
+        It should be emphasized that the interactions presented are indirect TAP-tag based interactions
+        and not direct binary interactions.
+- term:
+    id: GO:0005515
+    label: protein binding
+  qualifier: enables
+  evidence_type: IPI
+  original_reference_id: PMID:37968396
+  supporting_entities:
+  - UniProtKB:P39078
+  review:
+    summary: &gt;-
+      protein binding is too generic for a CCT subunit and does not describe the chaperonin mechanism
+      or substrate class.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Physical-interaction datasets are useful evidence context, but generic protein binding should not
+      stand as a functional annotation when the specific TRiC/CCT chaperonin role is known.
+- term:
+    id: GO:0006457
+    label: protein folding
+  qualifier: involved_in
+  evidence_type: IDA
+  original_reference_id: PMID:16762366
+  review:
+    summary: &gt;-
+      CCT6 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin
+      that folds actin, tubulin, and other clients.
+    action: ACCEPT
+    reason: &gt;-
+      Protein folding is the correct biological-process context for the chaperonin complex, supported
+      by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: &gt;-
+        The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine
+        whose action is required for folding the cytoskeletal proteins actin and tubulin
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  qualifier: part_of
+  evidence_type: IDA
+  original_reference_id: PMID:16762366
+  review:
+    summary: CCT6 is a named subunit of the chaperonin-containing T-complex.
+    action: ACCEPT
+    reason: &gt;-
+      Complex membership is central to the gene product function and is supported by yeast CCT complex
+      literature and family evidence.
+    supported_by:
+    - reference_id: PMID:15704212
+      supporting_text: &gt;-
+        Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
+        of a stoichiometric array of eight different subunits
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IDA
+  original_reference_id: PMID:16762366
+  review:
+    summary: &gt;-
+      unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than
+      the ATP-dependent folding chaperone function of the complex.
+    action: MODIFY
+    reason: &gt;-
+      Replace generic substrate-binding language with the specific chaperonin activity supported by yeast
+      CCT actin-folding assays and domain evidence.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: &gt;-
+        The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine
+        whose action is required for folding the cytoskeletal proteins actin and tubulin
+      reference_section_type: ABSTRACT
+core_functions:
+- description: &gt;-
+    CCT6 is the zeta subunit of the cytosolic TRiC/CCT chaperonin. The subunit contributes ATPase and
+    substrate-contact surfaces to the hetero-oligomeric double-ring complex, whose ATP-dependent conformational
+    cycle folds actin, tubulin, and other cytosolic client proteins. The synthesized function is modeled
+    as subunit ATP hydrolysis contributing to the complex-level ATP-dependent protein folding chaperone
+    activity.
+  molecular_function:
+    id: GO:0016887
+    label: ATP hydrolysis activity
+  contributes_to_molecular_function:
+    id: GO:0140662
+    label: ATP-dependent protein folding chaperone
+  directly_involved_in:
+  - id: GO:0006457
+    label: protein folding
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+  in_complex:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  supported_by:
+  - reference_id: PMID:16762366
+    supporting_text: &gt;-
+      The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose
+      action is required for folding the cytoskeletal proteins actin and tubulin
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:15704212
+    supporting_text: &gt;-
+      Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
+      of a stoichiometric array of eight different subunits
+    reference_section_type: ABSTRACT
+suggested_questions:
+- question: &gt;-
+    Which physiological effects of CCT6 overexpression are caused by unassembled Cct6p versus altered
+    flux through assembled TRiC/CCT?
+suggested_experiments:
+- hypothesis: &gt;-
+    Unassembled Cct6p suppresses selected conditional phenotypes by sequestering or buffering client proteins
+    independently of increasing assembled TRiC/CCT.
+  description: &gt;-
+    Measure assembled TRiC/CCT, free Cct6p, and candidate client interactions across CCT6 overexpression
+    and ATP-motif mutant backgrounds that differ in suppression but retain viability.
+  experiment_type: native complex profiling with affinity purification and genetic suppression assays
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/yeast/CCT6/CCT6-ai-review.html
+++ b/genes/yeast/CCT6/CCT6-ai-review.html
@@ -1725,13 +1725,13 @@
                             <div class="support-item">
                                 <span class="support-ref">
 
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15704212" target="_blank" class="term-link">
-                                        PMID:15704212
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
                                     </a>
 
                                 </span>
 
-                                <div class="support-text">Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed of a stoichiometric array of eight different subunits</div>
+                                <div class="support-text">The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose action is required for folding the cytoskeletal proteins actin and tubulin</div>
 
                             </div>
 
@@ -2083,6 +2083,33 @@
                         <div class="finding-statement">Purified yeast CCT, tagged through CCT3, catalyzes ATP-dependent actin folding; this supports protein-folding and chaperonin activity annotations for CCT6 as a TRiC/CCT subunit.</div>
 
                         <div class="finding-text">"The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose action is required for folding the cytoskeletal proteins actin and tubulin"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15704212" target="_blank" class="term-link">
+                            PMID:15704212
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Physiological effects of unassembled chaperonin Cct subunits in the yeast Saccharomyces cerevisiae.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Yeast CCT is a double-ring complex with a stoichiometric set of eight distinct Cct subunits.</div>
+
+                        <div class="finding-text">"Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed of a stoichiometric array of eight different subunits"</div>
 
                     </li>
 
@@ -2751,6 +2778,13 @@ references:
     supporting_text: &gt;-
       The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose
       action is required for folding the cytoskeletal proteins actin and tubulin
+- id: PMID:15704212
+  title: Physiological effects of unassembled chaperonin Cct subunits in the yeast Saccharomyces cerevisiae.
+  findings:
+  - statement: Yeast CCT is a double-ring complex with a stoichiometric set of eight distinct Cct subunits.
+    supporting_text: &gt;-
+      Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
+      of a stoichiometric array of eight different subunits
 - id: PMID:19536198
   title: &gt;-
     An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding
@@ -3018,10 +3052,10 @@ existing_annotations:
       Complex membership is central to the gene product function and is supported by yeast CCT complex
       literature and family evidence.
     supported_by:
-    - reference_id: PMID:15704212
+    - reference_id: PMID:16762366
       supporting_text: &gt;-
-        Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
-        of a stoichiometric array of eight different subunits
+        The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine
+        whose action is required for folding the cytoskeletal proteins actin and tubulin
       reference_section_type: ABSTRACT
 - term:
     id: GO:0051082

--- a/genes/yeast/CCT6/CCT6-ai-review.yaml
+++ b/genes/yeast/CCT6/CCT6-ai-review.yaml
@@ -46,6 +46,13 @@ references:
     supporting_text: >-
       The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose
       action is required for folding the cytoskeletal proteins actin and tubulin
+- id: PMID:15704212
+  title: Physiological effects of unassembled chaperonin Cct subunits in the yeast Saccharomyces cerevisiae.
+  findings:
+  - statement: Yeast CCT is a double-ring complex with a stoichiometric set of eight distinct Cct subunits.
+    supporting_text: >-
+      Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
+      of a stoichiometric array of eight different subunits
 - id: PMID:19536198
   title: >-
     An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding
@@ -313,10 +320,10 @@ existing_annotations:
       Complex membership is central to the gene product function and is supported by yeast CCT complex
       literature and family evidence.
     supported_by:
-    - reference_id: PMID:15704212
+    - reference_id: PMID:16762366
       supporting_text: >-
-        Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
-        of a stoichiometric array of eight different subunits
+        The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine
+        whose action is required for folding the cytoskeletal proteins actin and tubulin
       reference_section_type: ABSTRACT
 - term:
     id: GO:0051082

--- a/genes/yeast/CCT6/CCT6-ai-review.yaml
+++ b/genes/yeast/CCT6/CCT6-ai-review.yaml
@@ -1,174 +1,16 @@
 id: P39079
 gene_symbol: CCT6
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: 'TODO: Add description for CCT6'
-existing_annotations:
-- term:
-    id: GO:0006457
-    label: protein folding
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: 'Manual review: protein folding is consistent with known biology of CCT6.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005832
-    label: chaperonin-containing T-complex
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: 'Manual review: chaperonin-containing T-complex is consistent with known biology of CCT6.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: 'Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT6.'
-    action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
-- term:
-    id: GO:0000166
-    label: nucleotide binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000043
-  review:
-    summary: 'Manual review: nucleotide binding is consistent with known biology of CCT6.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005524
-    label: ATP binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000120
-  review:
-    summary: 'Manual review: ATP binding is consistent with known biology of CCT6.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005737
-    label: cytoplasm
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000044
-  review:
-    summary: 'Manual review: cytoplasm is consistent with known biology of CCT6.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005832
-    label: chaperonin-containing T-complex
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000117
-  review:
-    summary: 'Manual review: chaperonin-containing T-complex is consistent with known biology of CCT6.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0006457
-    label: protein folding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000120
-  review:
-    summary: 'Manual review: protein folding is consistent with known biology of CCT6.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0016887
-    label: ATP hydrolysis activity
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: 'Manual review: ATP hydrolysis activity is consistent with known biology of CCT6.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000120
-  review:
-    summary: 'Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT6.'
-    action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
-- term:
-    id: GO:0140662
-    label: ATP-dependent protein folding chaperone
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: 'Manual review: ATP-dependent protein folding chaperone is consistent with known biology of CCT6.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:16554755
-  review:
-    summary: 'Manual review: protein binding is too generic or over-extended for CCT6.'
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:19536198
-  review:
-    summary: 'Manual review: protein binding is too generic or over-extended for CCT6.'
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:37968396
-  review:
-    summary: 'Manual review: protein binding is too generic or over-extended for CCT6.'
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0006457
-    label: protein folding
-  evidence_type: IDA
-  original_reference_id: PMID:16762366
-  review:
-    summary: 'Manual review: protein folding is consistent with known biology of CCT6.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005832
-    label: chaperonin-containing T-complex
-  evidence_type: IDA
-  original_reference_id: PMID:16762366
-  review:
-    summary: 'Manual review: chaperonin-containing T-complex is consistent with known biology of CCT6.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IDA
-  original_reference_id: PMID:16762366
-  review:
-    summary: 'Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT6.'
-    action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
-    proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+description: >-
+  CCT6 encodes the zeta subunit of the cytosolic group II chaperonin TRiC/CCT. Cct6 contributes to the
+  ATP-driven chaperonin chamber that folds actin, tubulin, and other cytosolic clients, and yeast genetics
+  also shows that excess unassembled Cct6 can suppress diverse conditional phenotypes in an ATP-motif-dependent
+  state. Its core GO function is therefore the TRiC/CCT chaperonin role, with unassembled-subunit phenotypes
+  treated as contextual rather than separate core annotations.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -180,7 +22,9 @@ references:
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
+  title: >-
+    Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied
+    by conservative changes to GO terms applied by UniProt
   findings: []
 - id: GO_REF:0000117
   title: Electronic Gene Ontology annotations created by ARBA machine learning models
@@ -192,11 +36,353 @@ references:
   title: Global landscape of protein complexes in the yeast Saccharomyces cerevisiae.
   findings: []
 - id: PMID:16762366
-  title: Quantitative actin folding reactions using yeast CCT purified via an internal tag in the CCT3/gamma subunit.
-  findings: []
+  title: >-
+    Quantitative actin folding reactions using yeast CCT purified via an internal tag in the CCT3/gamma
+    subunit.
+  findings:
+  - statement: >-
+      Purified yeast CCT, tagged through CCT3, catalyzes ATP-dependent actin folding; this supports protein-folding
+      and chaperonin activity annotations for CCT6 as a TRiC/CCT subunit.
+    supporting_text: >-
+      The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose
+      action is required for folding the cytoskeletal proteins actin and tubulin
 - id: PMID:19536198
-  title: 'An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding pathways in the cell.'
-  findings: []
+  title: >-
+    An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding
+    pathways in the cell.
+  findings:
+  - statement: >-
+      The chaperone interactome study is useful context for CCT contacts but reports indirect TAP-tag
+      interactions rather than a specific molecular activity.
+    supporting_text: >-
+      It should be emphasized that the interactions presented are indirect TAP-tag based interactions
+      and not direct binary interactions.
 - id: PMID:37968396
   title: The social and structural architecture of the yeast protein interactome.
   findings: []
+- id: file:yeast/CCT6/CCT6-deep-research-falcon.md
+  title: Falcon deep research report for CCT6
+  findings:
+  - statement: >-
+      The Falcon report was reviewed and synthesized into the CCT6 curation, including core-function framing,
+      family/PANTHER context, and evidence limitations.
+existing_annotations:
+- term:
+    id: GO:0006457
+    label: protein folding
+  qualifier: involved_in
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: >-
+      CCT6 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin
+      that folds actin, tubulin, and other clients.
+    action: ACCEPT
+    reason: >-
+      Protein folding is the correct biological-process context for the chaperonin complex, supported
+      by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
+    supported_by:
+    - reference_id: file:yeast/CCT6/CCT6-deep-research-falcon.md
+      supporting_text: a structural/ATPase subunit of the TRiC/CCT chaperonin
+- term:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  qualifier: part_of
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: CCT6 is a named subunit of the chaperonin-containing T-complex.
+    action: ACCEPT
+    reason: >-
+      Complex membership is central to the gene product function and is supported by yeast CCT complex
+      literature and family evidence.
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: >-
+      unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than
+      the ATP-dependent folding chaperone function of the complex.
+    action: MODIFY
+    reason: >-
+      Replace generic substrate-binding language with the specific chaperonin activity supported by yeast
+      CCT actin-folding assays and domain evidence.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+- term:
+    id: GO:0000166
+    label: nucleotide binding
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: >-
+      nucleotide binding is a true but overly broad family/keyword annotation for CCT6; ATP binding, ATP
+      hydrolysis, and ATP-dependent chaperone annotations capture the specific chemistry.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Generic nucleotide binding does not add useful functional information beyond the more specific ATP-related
+      chaperonin annotations already present.
+- term:
+    id: GO:0005524
+    label: ATP binding
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: >-
+      CCT6 contains a conserved chaperonin ATP-binding site, but ATP binding alone is a domain property
+      rather than the core biological function.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Keep as a valid supporting molecular property of the CCT ATPase cycle, while treating ATP hydrolysis
+      and complex-level protein folding as the core function.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  qualifier: located_in
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: CCT6 functions as part of the cytosolic TRiC/CCT chaperonin.
+    action: ACCEPT
+    reason: Cytoplasm is the established location of the CCT/TRiC folding machine.
+- term:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  qualifier: part_of
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: CCT6 is a named subunit of the chaperonin-containing T-complex.
+    action: ACCEPT
+    reason: >-
+      Complex membership is central to the gene product function and is supported by yeast CCT complex
+      literature and family evidence.
+- term:
+    id: GO:0006457
+    label: protein folding
+  qualifier: involved_in
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: >-
+      CCT6 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin
+      that folds actin, tubulin, and other clients.
+    action: ACCEPT
+    reason: >-
+      Protein folding is the correct biological-process context for the chaperonin complex, supported
+      by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
+- term:
+    id: GO:0016887
+    label: ATP hydrolysis activity
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: >-
+      CCT6 is a TCP-1/CCT chaperonin subunit with conserved ATPase machinery that powers TRiC/CCT conformational
+      cycling.
+    action: ACCEPT
+    reason: >-
+      ATP hydrolysis is a defensible subunit-level molecular function for CCT family members and is directly
+      tied to the chaperonin folding cycle.
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: >-
+      unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than
+      the ATP-dependent folding chaperone function of the complex.
+    action: MODIFY
+    reason: >-
+      Replace generic substrate-binding language with the specific chaperonin activity supported by yeast
+      CCT actin-folding assays and domain evidence.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+- term:
+    id: GO:0140662
+    label: ATP-dependent protein folding chaperone
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: CCT6 is an obligate subunit of the ATP-dependent TRiC/CCT folding machine.
+    action: ACCEPT
+    reason: >-
+      The term is appropriate as a complex-level chaperonin function; in the synthesized core function
+      it is modeled as a contributed-to molecular function rather than a standalone activity of an isolated
+      subunit.
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: >-
+        The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine
+        whose action is required for folding the cytoskeletal proteins actin and tubulin
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005515
+    label: protein binding
+  qualifier: enables
+  evidence_type: IPI
+  original_reference_id: PMID:16554755
+  supporting_entities:
+  - UniProtKB:P39078
+  review:
+    summary: >-
+      protein binding is too generic for a CCT subunit and does not describe the chaperonin mechanism
+      or substrate class.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Physical-interaction datasets are useful evidence context, but generic protein binding should not
+      stand as a functional annotation when the specific TRiC/CCT chaperonin role is known.
+- term:
+    id: GO:0005515
+    label: protein binding
+  qualifier: enables
+  evidence_type: IPI
+  original_reference_id: PMID:19536198
+  supporting_entities:
+  - UniProtKB:P39078
+  review:
+    summary: >-
+      protein binding is too generic for a CCT subunit and does not describe the chaperonin mechanism
+      or substrate class.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Physical-interaction datasets are useful evidence context, but generic protein binding should not
+      stand as a functional annotation when the specific TRiC/CCT chaperonin role is known.
+    supported_by:
+    - reference_id: PMID:19536198
+      supporting_text: >-
+        It should be emphasized that the interactions presented are indirect TAP-tag based interactions
+        and not direct binary interactions.
+- term:
+    id: GO:0005515
+    label: protein binding
+  qualifier: enables
+  evidence_type: IPI
+  original_reference_id: PMID:37968396
+  supporting_entities:
+  - UniProtKB:P39078
+  review:
+    summary: >-
+      protein binding is too generic for a CCT subunit and does not describe the chaperonin mechanism
+      or substrate class.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Physical-interaction datasets are useful evidence context, but generic protein binding should not
+      stand as a functional annotation when the specific TRiC/CCT chaperonin role is known.
+- term:
+    id: GO:0006457
+    label: protein folding
+  qualifier: involved_in
+  evidence_type: IDA
+  original_reference_id: PMID:16762366
+  review:
+    summary: >-
+      CCT6 participates in protein folding as an obligate subunit of TRiC/CCT, the cytosolic chaperonin
+      that folds actin, tubulin, and other clients.
+    action: ACCEPT
+    reason: >-
+      Protein folding is the correct biological-process context for the chaperonin complex, supported
+      by direct yeast CCT actin-folding assays and PANTHER/InterPro family evidence.
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: >-
+        The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine
+        whose action is required for folding the cytoskeletal proteins actin and tubulin
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  qualifier: part_of
+  evidence_type: IDA
+  original_reference_id: PMID:16762366
+  review:
+    summary: CCT6 is a named subunit of the chaperonin-containing T-complex.
+    action: ACCEPT
+    reason: >-
+      Complex membership is central to the gene product function and is supported by yeast CCT complex
+      literature and family evidence.
+    supported_by:
+    - reference_id: PMID:15704212
+      supporting_text: >-
+        Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
+        of a stoichiometric array of eight different subunits
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IDA
+  original_reference_id: PMID:16762366
+  review:
+    summary: >-
+      unfolded protein binding reflects substrate engagement by TRiC/CCT, but it is less informative than
+      the ATP-dependent folding chaperone function of the complex.
+    action: MODIFY
+    reason: >-
+      Replace generic substrate-binding language with the specific chaperonin activity supported by yeast
+      CCT actin-folding assays and domain evidence.
+    proposed_replacement_terms:
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: >-
+        The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine
+        whose action is required for folding the cytoskeletal proteins actin and tubulin
+      reference_section_type: ABSTRACT
+core_functions:
+- description: >-
+    CCT6 is the zeta subunit of the cytosolic TRiC/CCT chaperonin. The subunit contributes ATPase and
+    substrate-contact surfaces to the hetero-oligomeric double-ring complex, whose ATP-dependent conformational
+    cycle folds actin, tubulin, and other cytosolic client proteins. The synthesized function is modeled
+    as subunit ATP hydrolysis contributing to the complex-level ATP-dependent protein folding chaperone
+    activity.
+  molecular_function:
+    id: GO:0016887
+    label: ATP hydrolysis activity
+  contributes_to_molecular_function:
+    id: GO:0140662
+    label: ATP-dependent protein folding chaperone
+  directly_involved_in:
+  - id: GO:0006457
+    label: protein folding
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+  in_complex:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  supported_by:
+  - reference_id: PMID:16762366
+    supporting_text: >-
+      The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose
+      action is required for folding the cytoskeletal proteins actin and tubulin
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:15704212
+    supporting_text: >-
+      Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of which is composed
+      of a stoichiometric array of eight different subunits
+    reference_section_type: ABSTRACT
+suggested_questions:
+- question: >-
+    Which physiological effects of CCT6 overexpression are caused by unassembled Cct6p versus altered
+    flux through assembled TRiC/CCT?
+suggested_experiments:
+- hypothesis: >-
+    Unassembled Cct6p suppresses selected conditional phenotypes by sequestering or buffering client proteins
+    independently of increasing assembled TRiC/CCT.
+  description: >-
+    Measure assembled TRiC/CCT, free Cct6p, and candidate client interactions across CCT6 overexpression
+    and ATP-motif mutant backgrounds that differ in suppression but retain viability.
+  experiment_type: native complex profiling with affinity purification and genetic suppression assays

--- a/genes/yeast/CCT6/CCT6-deep-research-falcon.md
+++ b/genes/yeast/CCT6/CCT6-deep-research-falcon.md
@@ -1,0 +1,346 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-04T10:05:59.072300'
+end_time: '2026-05-04T10:18:37.086732'
+duration_seconds: 758.01
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: yeast
+  gene_id: CCT6
+  gene_symbol: CCT6
+  uniprot_accession: P39079
+  protein_description: 'RecName: Full=T-complex protein 1 subunit zeta; Short=TCP-1-zeta;
+    AltName: Full=CCT-zeta;'
+  gene_info: Name=CCT6; Synonyms=TCP20, TCP6; OrderedLocusNames=YDR188W; ORFNames=YD9395.21;
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+  protein_family: Belongs to the TCP-1 chaperonin family. .
+  protein_domains: Chap_CCT_zeta. (IPR012722); Chaperone_TCP-1. (IPR017998); Chaperonin_TCP-1_CS.
+    (IPR002194); Cpn60/GroEL/TCP-1. (IPR002423); GroEL-like_apical_dom_sf. (IPR027409)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 39
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P39079
+- **Protein Description:** RecName: Full=T-complex protein 1 subunit zeta; Short=TCP-1-zeta; AltName: Full=CCT-zeta;
+- **Gene Information:** Name=CCT6; Synonyms=TCP20, TCP6; OrderedLocusNames=YDR188W; ORFNames=YD9395.21;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the TCP-1 chaperonin family. .
+- **Key Domains:** Chap_CCT_zeta. (IPR012722); Chaperone_TCP-1. (IPR017998); Chaperonin_TCP-1_CS. (IPR002194); Cpn60/GroEL/TCP-1. (IPR002423); GroEL-like_apical_dom_sf. (IPR027409)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "CCT6" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'CCT6' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **CCT6** (gene ID: CCT6, UniProt: P39079) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P39079
+- **Protein Description:** RecName: Full=T-complex protein 1 subunit zeta; Short=TCP-1-zeta; AltName: Full=CCT-zeta;
+- **Gene Information:** Name=CCT6; Synonyms=TCP20, TCP6; OrderedLocusNames=YDR188W; ORFNames=YD9395.21;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the TCP-1 chaperonin family. .
+- **Key Domains:** Chap_CCT_zeta. (IPR012722); Chaperone_TCP-1. (IPR017998); Chaperonin_TCP-1_CS. (IPR002194); Cpn60/GroEL/TCP-1. (IPR002423); GroEL-like_apical_dom_sf. (IPR027409)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "CCT6" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'CCT6' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **CCT6** (gene ID: CCT6, UniProt: P39079) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+# Research report: **CCT6 (YDR188W; UniProt P39079)** in *Saccharomyces cerevisiae* (S288c)
+
+## Executive summary
+CCT6 (YDR188W; UniProt P39079) encodes **T-complex protein 1 subunit zeta (Cct6p; also called CCT-ζ)**, one of eight paralogous subunits that assemble into the essential cytosolic group II chaperonin **TRiC/CCT**. TRiC/CCT is a ~1 MDa ATP-dependent double-ring folding machine required for maturation of a specific subset of eukaryotic proteins—classically **actin and tubulin**—and is estimated to mediate folding of roughly **~10% of newly synthesized polypeptides** in yeast. Yeast genetics further indicates that **CCT6 is essential**, and that **excess/unassembled Cct6p** (produced by overexpression) can suppress multiple conditional growth defects in otherwise unrelated pathways (TOR signaling, trafficking/vacuole/cell wall, ubiquitin ligase function), implying physiologically meaningful activity beyond (or in addition to) the assembled TRiC complex. Recent 2023–2024 studies refine TRiC allostery/ATPase kinetics, connect TRiC malfunction to stress-response pathways (e.g., cell-wall integrity MAPK signaling), and expand the functional landscape to include nuclear roles for TRiC in transcriptional homeostasis; however, these advances are mostly **complex-level** and not uniquely CCT6-subunit–specific. (grantham2020themolecularchaperone pages 1-2, dube2023saccharomycescerevisiaesurvival pages 1-4, kabir2005physiologicaleffectsof pages 1-2, kabir2005physiologicaleffectsof pages 2-4)
+
+## Evidence map (high-level)
+| Claim/Topic | Key evidence (short) | Organism/system | Source (author year) | Publication date | URL/DOI | Notes/caveats |
+|---|---|---|---|---|---|---|
+| Identity / disambiguation | Yeast **CCT6 / YDR188W / UniProt P39079** encodes **T-complex protein 1 subunit zeta (Cct6p)**, one of the eight paralogous subunits of the eukaryotic cytosolic group II chaperonin TRiC/CCT; literature here refers to the yeast chaperonin subunit, not mammalian CCT6A/B paralogs (kabir2005physiologicaleffectsof pages 1-2, kabir2005physiologicaleffectsof pages 2-4) | *Saccharomyces cerevisiae* | Kabir et al. 2005 | 2005-02 | https://doi.org/10.1002/yea.1210 | Older but yeast-specific foundational annotation; important because CCT6 is ambiguous across organisms. |
+| Complex membership | TRiC/CCT is a ~1 MDa double-ring complex with two stacked octameric rings; each ring contains CCT1–CCT8 in fixed order, with CCT6 as one subunit (grantham2020themolecularchaperone pages 1-2, zang2018developmentofa pages 1-2) | Yeast TRiC/CCT / eukaryotic TRiC | Grantham 2020; Zang et al. 2018 | 2020-03; 2018-02 | https://doi.org/10.3389/fgene.2020.00172 ; https://doi.org/10.1038/s41598-017-18962-y | Complex-level function is better established than isolated Cct6p-specific biochemistry. |
+| Essentiality | All eight yeast **CCT1–CCT8 genes are essential**; disruption experiments showed each is required, including **CCT6** (kabir2008overexpressedribosomalproteins pages 1-2, kabir2005physiologicaleffectsof pages 2-4) | *S. cerevisiae* | Kabir & Sherman 2008; Kabir et al. 2005 | 2008-12; 2005-02 | https://doi.org/10.1111/j.1567-1364.2008.00425.x ; https://doi.org/10.1002/yea.1210 | Essentiality is gene-level; not every subunit’s ATPase chemistry is equally essential. |
+| Canonical substrates / primary function | TRiC/CCT performs ATP-dependent folding of obligate cytosolic substrates, especially **actin and tubulin**; CCT is required for tubulin biogenesis and actin folding, providing the main functional context for CCT6 (grantham2020themolecularchaperone pages 1-2, kelly2020structuralandfunctional pages 18-23, willison2018thestructureand pages 1-2) | Eukaryotic cytosol; yeast-focused review context | Grantham 2020; Kelly 2020; Willison 2018 | 2020-03; 2020; 2018-10 | https://doi.org/10.3389/fgene.2020.00172 ; n/a ; https://doi.org/10.1042/BCJ20170378 | Evidence is strongest at complex level; direct yeast Cct6-substrate specificity remains less resolved than for the complex as a whole. |
+| ATPase / hemisphere specialization | CCT6 belongs to the **low-ATP-affinity hemisphere** (with CCT3/6/7/8); sequence divergence near the nucleotide pocket and structural analyses suggest lower nucleotide exchange, and P-loop alanine substitutions in low-affinity subunits had little growth effect relative to high-affinity subunits (kelly2020structuralandfunctionala pages 42-48, kelly2020structuralandfunctional pages 42-48) | Yeast TRiC/CCT | Kelly 2020 | 2020 | n/a | Strong structural/kinetic inference; thesis source, but evidence summarized from cryo-EM, nucleotide assays, and yeast mutational work. |
+| CCT6-specific ATP-cycle nuance | Cct6p is described as a low-affinity/low-turnover subunit; one source notes Cct6p and Cct8p remain ADP-bound and do not participate like high-affinity subunits, and a glycine-motif mutation analogous to ts mutations in other subunits did **not** impair growth when introduced in Cct6p (dube2021chaperoninpointmutation pages 1-4) | *S. cerevisiae* CCT | Dube & Kabir 2021 | 2021-05 | https://doi.org/10.1007/s10529-021-03151-9 | Useful subunit-specific nuance, but based on synthesis of prior work rather than a direct dedicated CCT6 biochemical paper. |
+| Subunit position / structure | Cryo-EM with internal eGFP labeling (YISEL) assigned **CCT6 as an on-axis subunit (a5 / subunit 6)** in yeast TRiC and helped define full subunit order; CCT6 contributes to the characteristic Z-shaped on-axis pair geometry (zang2018developmentofa pages 1-2, zang2018developmentofa media 20a150a9) | Yeast TRiC/CCT | Zang et al. 2018 | 2018-02 | https://doi.org/10.1038/s41598-017-18962-y | Structural assignment is direct and yeast-specific. |
+| Inter-ring structural role | Structural analyses indicate the **N-terminus of CCT6** participates in inter-ring interactions/stacking during TRiC closure, supporting a role in conformational locking rather than being a dominant ATP-hydrolyzing driver (kelly2020structuralandfunctionala pages 42-48, kelly2020structuralandfunctional pages 42-48) | Yeast TRiC/CCT | Kelly 2020 | 2020 | n/a | Mechanistic inference from structures and comparative mutational studies. |
+| Unassembled Cct6 suppressor activity | Overexpression of **CCT6** increases unassociated Cct6p, not total assembled CCT complex, and this excess subunit suppresses diverse conditional phenotypes (**tor2-21, lst8-2, rsp5-9, [SIT4 SAP155]N**) (kabir2005physiologicaleffectsof pages 1-2, kabir2005physiologicaleffectsof pages 2-4) | *S. cerevisiae* genetics | Kabir et al. 2005 | 2005-02 | https://doi.org/10.1002/yea.1210 | Important evidence that Cct6p may have physiologically relevant extra-complex activity or sequestration/competition effects. |
+| Requirement for ATP-binding motif in suppressor function | The **cct6-24** mutant with **GDGTT→AAAAA** replacement in the conserved ATP-binding motif was unable to suppress those conditional traits, **despite supporting growth**, implying suppression depends on a specific functional state of unassembled Cct6p (kabir2005physiologicaleffectsof pages 1-2) | *S. cerevisiae* | Kabir et al. 2005 | 2005-02 | https://doi.org/10.1002/yea.1210 | Strong evidence for separable roles: viability of mutant allele vs loss of suppressor activity. |
+| Genetic phenotypes / ts alleles | Multiple **temperature-sensitive cct6 alleles** were reported (e.g., cct6-14, -18, -27, -74, -85, -93, -97), many with **TBZ sensitivity** and some with **NaCl sensitivity**, consistent with roles in microtubule/actin-related processes (kabir2008overexpressedribosomalproteins pages 1-2, kabir2008overexpressedribosomalproteins pages 2-3) | *S. cerevisiae* | Kabir & Sherman 2008 | 2008-12 | https://doi.org/10.1111/j.1567-1364.2008.00425.x | Phenotypes derive from legacy allele collections; not all were mechanistically dissected. |
+| Multicopy suppressors of cct defects | Kabir & Sherman isolated **22 multicopy suppressors** of a cct4 ts allele; **14 encoded ribosomal proteins**, and some suppressors also acted on certain **cct6** mutants, suggesting overexpressed ribosomal proteins can weakly buffer defective chaperonins (kabir2008overexpressedribosomalproteins pages 1-2, kabir2008overexpressedribosomalproteins pages 2-3) | *S. cerevisiae* | Kabir & Sherman 2008 | 2008-12 | https://doi.org/10.1111/j.1567-1364.2008.00425.x | Indirectly informative for CCT6 buffering/genetic interaction space. |
+| CCT6 vs CCT3 subunit-specific interactome effects | A conserved ATP-site Glu→Asp mutation in **CCT6** was compared with **CCT3** in high-throughput microscopy; each mutant produced distinct proteome-level effects, and **CCT3** showed stronger association with Q/N-rich proteins/P-body phenotypes than **CCT6** (nadlerholly2012interactionsofsubunit pages 1-2) | *S. cerevisiae* | Nadler-Holly et al. 2012 | 2012-11 | https://doi.org/10.1073/pnas.1209277109 | Useful because it argues subunit specialization; CCT6 phenotype was milder/different than CCT3 for this substrate class. |
+| Cytosolic localization / classical role | TRiC/CCT is classically a **cytosolic** folding machine in yeast/eukaryotes, accounting for ~10% of new polypeptide maturation; this is the best-supported localization/function for Cct6p as part of the holo-complex (gvozdenov2024triccctchaperoningoverns pages 1-6, dube2023saccharomycescerevisiaesurvival pages 1-4) | Yeast / eukaryotic cytosol | Gvozdenov et al. 2024; Dube et al. 2023 | 2024-09-26; 2023-11 | https://doi.org/10.1101/2024.09.26.615188 ; https://doi.org/10.1007/s42977-023-00192-1 | Dube 2023 is about CCT7 mutant, but explicitly states yeast TRiC/CCT is cytosolic and folds ~10% of polypeptides. |
+| Nuclear localization / emerging role | Recent work shows **TRiC/CCT is also present in the nucleus** and can regulate **RNA polymerase II activity** and nascent RNA homeostasis; this extends likely functional context for all subunits including CCT6, though not yet CCT6-specific (gvozdenov2024triccctchaperoningoverns pages 1-6) | *S. cerevisiae* | Gvozdenov et al. 2024 | 2024-09-26 | https://doi.org/10.1101/2024.09.26.615188 | Preprint; compelling for nuclear TRiC, but not direct evidence that CCT6 alone mediates the effect. |
+| Recent development: stress/pathway crosstalk | A 2023 yeast study showed a **cct7** folding-defective mutant is heat- and cell-wall-stress sensitive and is rescued by **PKC1/SLT2**, supporting crosstalk between CCT proteostasis and the **cell wall integrity (CWI) MAPK pathway** (dube2023saccharomycescerevisiaesurvival pages 1-4) | *S. cerevisiae* | Dube et al. 2023 | 2023-11 | https://doi.org/10.1007/s42977-023-00192-1 | Not CCT6-specific, but relevant recent pathway context for the complex in yeast. |
+| Recent development: kinetic mechanism | A 2023 yeast study on **CCT2** found reduced ADP off-rate in a disease-linked mutant and quantified WT ATPase behavior (**K1 ~8.3 µM, K2 ~110 µM; kcat ~0.043–0.053 s^-1**), reinforcing asymmetric ATPase cycling within yeast TRiC relevant to low-affinity subunits such as CCT6 (roy2023reducedadpoffrate pages 1-2, kelly2020structuralandfunctional pages 42-48) | Yeast TRiC/CCT | Roy et al. 2023; Kelly 2020 | 2023-08; 2020 | https://doi.org/10.1038/s42003-023-05261-8 ; n/a | Quantitative kinetics are for CCT2/whole complex, not directly for CCT6, but they support the asymmetric ring model. |
+| Recent development: cochaperone cooperation | 2024 cryo-EM/XL-MS work showed **PhLP2A** and substrate **actin** occupy opposing TRiC chambers; actin/PhLP2A contact positively charged inner-surface residues from **CCT1/3/6/8**, implicating **CCT6** directly in the substrate/cochaperone folding chamber interface (junsun2024astructuralvista pages 1-2) | Purified TRiC system | Park et al. 2024 | 2024-02 | https://doi.org/10.1038/s41467-024-45242-x | Strong recent mechanistic evidence, though not yeast-specific in organism designation. |
+
+
+*Table: This table summarizes experimentally supported functional annotation evidence for yeast CCT6/YDR188W/P39079, emphasizing identity verification, complex role, subunit specialization, genetics, localization, and 2023-2024 developments. It is useful as a compact evidence map for building a narrative report while keeping organism-specific claims separate from broader TRiC/CCT findings.*
+
+## 1) Gene/protein identity verification (disambiguation)
+The target is **yeast CCT6** (ordered locus name **YDR188W**; UniProt **P39079**), a TRiC/CCT subunit (Cct6p). Yeast-focused primary literature explicitly treats **CCT6 as a chaperonin subunit gene** and performs yeast genetics with cct6 alleles and CCT6 overexpression constructs, consistent with the UniProt record and domain/family assignment (TCP-1 chaperonin family). (kabir2005physiologicaleffectsof pages 1-2, kabir2005physiologicaleffectsof pages 2-4)
+
+## 2) Key concepts and definitions (current understanding)
+
+### 2.1 TRiC/CCT as a eukaryotic group II chaperonin
+TRiC/CCT (TCP-1 Ring Complex / Chaperonin Containing TCP-1) is an **essential** eukaryotic chaperonin that forms **two stacked rings**, each ring containing **eight different subunits (CCT1–CCT8)** in a fixed arrangement, producing a central chamber where folding can proceed under “caged” conditions coupled to an ATP-driven conformational cycle. (grantham2020themolecularchaperone pages 1-2, gvozdenov2024triccctchaperoningoverns pages 1-6)
+
+### 2.2 Substrate spectrum and “primary function” framing for CCT6
+For functional annotation, the most defensible “primary function” for CCT6 is: **a structural/ATPase subunit of the TRiC/CCT chaperonin that contributes to ATP-dependent folding and maturation of obligate cytosolic substrates, especially actin and tubulin, and other topologically complex clients**. Reviews emphasize that actin and tubulin are core/obligate CCT substrates, and TRiC also contributes to assembly of select multiprotein complexes (e.g., VHL–Elongin) and interacts with regulators (e.g., gelsolin) in a non-classical chaperoning mode. (grantham2020themolecularchaperone pages 1-2, willison2018thestructureand pages 1-2)
+
+### 2.3 Subunit specialization within TRiC/CCT
+Unlike bacterial GroEL (homooligomer), TRiC is **heterooligomeric**, allowing subunit-specific substrate contacts and asymmetric ATPase/allosteric behavior. Experimental and structural analyses (summarized in yeast TRiC-focused work) group subunits into two “hemispheres” with differing nucleotide affinity and ATPase roles. CCT6 is consistently placed in the **low ATP-affinity hemisphere** (with CCT3/6/7/8), with sequence divergence near the nucleotide pocket proposed to reduce nucleotide exchange/ATP binding; yeast mutational data indicate that ATPase/P-loop disruption is more deleterious in high-affinity subunits than in low-affinity ones. (kelly2020structuralandfunctionala pages 42-48, kelly2020structuralandfunctional pages 42-48)
+
+## 3) Molecular/structural annotation of yeast Cct6p
+
+### 3.1 Subunit position in the yeast TRiC/CCT ring
+A yeast internal-subunit eGFP labeling strategy combined with cryo-EM (YISEL) enabled unambiguous subunit assignment in yeast TRiC, including CCT6. This work assigns **CCT6 as an on-axis subunit** and places it at a defined position in the ring architecture (Figure evidence). (zang2018developmentofa pages 1-2, zang2018developmentofa media 20a150a9)
+
+### 3.2 Structural role during ring closure and inter-ring communication
+Structural analyses summarized for yeast TRiC indicate that the **N-terminus of CCT6** participates in an **inter-ring interaction network** during closure, stacking with the trans ring alongside other low-affinity hemisphere subunits. This supports the view that CCT6 contributes importantly to **mechanical/structural coupling** of the two rings through the ATP-driven cycle, even if its own ATPase contribution is reduced relative to high-affinity subunits. (kelly2020structuralandfunctionala pages 42-48, kelly2020structuralandfunctional pages 42-48)
+
+## 4) Cellular localization and where Cct6p acts
+
+### 4.1 Canonical localization: cytosolic proteostasis
+TRiC/CCT is classically considered a **cytosolic** folding machine that supports co-/post-translational maturation of a substantial fraction of the proteome. Yeast-focused work explicitly reiterates TRiC/CCT as a **cytosolic cylindrical complex** encoded by eight essential genes and contributing to folding of **~10%** of yeast cellular polypeptides. (dube2023saccharomycescerevisiaesurvival pages 1-4)
+
+### 4.2 Emerging localization/function: nuclear TRiC/CCT
+A 2024 preprint reports TRiC/CCT is present in the **nucleus** and proposes a direct role in **regulating RNA polymerase II activity** and nascent RNA production (with effects persisting when TRiC is restricted to the cytoplasm, supporting a direct nuclear role in their model). This expands likely functional contexts for all TRiC subunits (including CCT6), although it does not isolate a CCT6-specific nuclear mechanism. (gvozdenov2024triccctchaperoningoverns pages 1-6)
+
+## 5) Yeast genetics: essentiality, phenotypes, and CCT6-specific functional inferences
+
+### 5.1 Essentiality
+Yeast gene disruption experiments and genetic summaries state that **all eight CCT genes (CCT1–CCT8) are essential**, which includes **CCT6**. (kabir2008overexpressedribosomalproteins pages 1-2, kabir2005physiologicaleffectsof pages 2-4)
+
+### 5.2 Conditional alleles and cytoskeleton-linked phenotypes
+A panel of **temperature-sensitive cct6 alleles** has been described (e.g., cct6-14, -18, -27, -74, -85, -93, -97). Reported phenotypes include **TBZ sensitivity** (consistent with microtubule-associated stress) and in some alleles **NaCl sensitivity** (often used as an actin/cytoskeleton stress readout in these legacy screens). (kabir2008overexpressedribosomalproteins pages 1-2, kabir2008overexpressedribosomalproteins pages 2-3)
+
+### 5.3 Multicopy suppression: unassembled Cct6p as a functional entity
+A central yeast-specific insight is that **overexpression of CCT6** can suppress diverse conditional phenotypes, including defects caused by **tor2-21**, **lst8-2**, **rsp5-9**, and growth inhibition caused by concomitant overexpression of **Sit4p and Sap155p**. Importantly, fractionation/abundance analysis indicates that overexpressing CCT6 increases the level of **unassociated (unassembled) Cct6p**, while the assembled TRiC/CCT complex remains at normal levels—supporting a model where unassembled Cct6p has physiological effects (e.g., substrate sequestration/competition for modifying activities) beyond simply boosting holo-complex abundance. (kabir2005physiologicaleffectsof pages 1-2, kabir2005physiologicaleffectsof pages 2-4)
+
+### 5.4 Separation-of-function: ATP-binding motif required for suppression but not viability
+Kabir et al. examined many altered forms of Cct6p and report that a CCT6 allele with **GDGTT→AAAAA** substitutions in the conserved ATP-binding motif (**cct6-24**) is **unable to suppress** the above traits, **yet is functional for growth**. This strongly supports that (i) Cct6p has separable functional states and (ii) suppression by unassembled Cct6p likely requires a specific ATP-associated conformation or activity. (kabir2005physiologicaleffectsof pages 1-2)
+
+### 5.5 Proteome-scale phenotyping distinguishes CCT6 from other subunits
+High-throughput microscopy profiling comparing ATP-site mutants in different TRiC subunits found that CCT subunits can have distinguishable in vivo consequences; in particular, the study emphasizes that the **CCT3** mutant showed stronger associations with Q/N-rich proteins and P-body phenotypes than the **CCT6** mutant, consistent with **subunit-specific substrate/interactome specialization**. (nadlerholly2012interactionsofsubunit pages 1-2)
+
+## 6) Pathways and biological processes linked to CCT6/TRiC in yeast
+
+### 6.1 TOR signaling / actin polarization axis
+Overexpression of CCT6 suppresses **tor2-21** conditional phenotypes and is linked to partial restoration of actin cytoskeleton polarization in that genetic background, tying TRiC/CCT (and/or unassembled Cct6p) to a TOR2-dependent actin organization pathway. (kabir2005physiologicaleffectsof pages 2-4)
+
+### 6.2 Trafficking/cell wall integrity and ubiquitin ligase connections
+CCT6 overexpression suppresses phenotypes of **lst8-2** (a TOR-associated factor required for sorting of diverse proteins at the Golgi and associated with cell wall integrity) and **rsp5-9** (an essential ubiquitin–protein ligase with broad roles including endocytosis and actin dynamics). These suppression relationships suggest that TRiC/CCT proteostasis capacity and/or Cct6p-mediated sequestration can buffer defects in trafficking, membrane protein turnover, and cell surface/cell wall regulation. (kabir2005physiologicaleffectsof pages 2-4)
+
+### 6.3 Stress physiology and the cell wall integrity MAPK pathway (recent)
+A 2023 yeast study using a folding-defective **cct7** mutant reports temperature and cell-wall-stressor sensitivity and rescue by overexpression of **PKC1** and **SLT2** (MAPK cell wall integrity pathway components), supporting a functional interface between TRiC/CCT-dependent folding and cell-wall integrity signaling under heat stress. While not CCT6-specific, it is relevant to interpreting downstream consequences of impaired TRiC activity in yeast and potential contexts where CCT6 alleles may manifest. (dube2023saccharomycescerevisiaesurvival pages 1-4)
+
+## 7) Recent developments (prioritizing 2023–2024)
+
+### 7.1 Quantitative TRiC kinetics in yeast (2023)
+A 2023 study analyzing yeast TRiC with disease-associated mutations in **CCT2** quantified ATPase behavior and reported apparent ATP binding constants and turnover (e.g., WT **K1 ~8.3 μM, K2 ~110 μM; kcat ~0.043–0.053 s−1** under their fitted model) and showed that a double mutation reduces ADP off-rate, stabilizing closed states. This strengthens the mechanistic framework in which different subunits contribute differently to allosteric cycling—contextually relevant to CCT6 as a low-affinity hemisphere member—even though the mutation is in CCT2 rather than CCT6. (roy2023reducedadpoffrate pages 1-2, kelly2020structuralandfunctional pages 42-48)
+
+### 7.2 TRiC cochaperone cooperation and CCT6 contact surfaces (2024)
+A 2024 cryo-EM/XL-MS study of TRiC cooperation with **PhLP2A** (phosducin-like protein) in the folding cycle reports that in the presence of substrate, **actin and PhLP2A segregate into opposing chambers**, each binding positively charged inner surface residues from **CCT1/3/6/8**. This provides modern structural evidence that CCT6 contributes directly to the physicochemical environment and binding surfaces engaged during actin folding intermediates. (junsun2024astructuralvista pages 1-2)
+
+### 7.3 Nuclear TRiC and transcriptional homeostasis in yeast (2024 preprint)
+A 2024 yeast study proposes TRiC/CCT has a direct nuclear role modulating **RNA polymerase II** activity and nascent RNA output, suggesting TRiC contributes to cell homeostasis beyond canonical cytosolic folding. This is a notable expansion of functional annotation scope for the complex and likely relevant to CCT6 as a subunit, but remains preprint-stage and not subunit-resolved. (gvozdenov2024triccctchaperoningoverns pages 1-6)
+
+## 8) Current applications and real-world implementations
+
+### 8.1 Yeast as a functional-genomics platform to probe chaperonin subunits
+CCT6 is used experimentally as (i) a genetically essential proteostasis component (ts alleles) and (ii) a **multicopy suppressor** whose overexpression reveals buffering relationships across major pathways (TOR signaling, trafficking/cell wall, ubiquitin-mediated regulation). This makes CCT6 a practical tool for dissecting **genetic robustness** and **proteostasis-pathway crosstalk** in an industrially and medically relevant model organism. (kabir2005physiologicaleffectsof pages 1-2, kabir2008overexpressedribosomalproteins pages 2-3)
+
+### 8.2 Structural biology and engineering of macromolecular machines
+The YISEL internal labeling method demonstrated in yeast TRiC enables precise subunit assignment in challenging hetero-oligomeric complexes and is itself an implementation with broader utility for macromolecular complex annotation and cryo-EM mapping—directly leveraging yeast CCT6 subunit labeling/assignment. (zang2018developmentofa pages 1-2, zang2018developmentofa media 20a150a9)
+
+### 8.3 Disease analogy and mechanistic transfer (caveated)
+While human disease phenotypes are not part of yeast CCT6 annotation per se, yeast TRiC studies (e.g., kinetic analysis of disease-linked CCT2 mutations) illustrate how yeast TRiC serves as a mechanistic model for conserved chaperonin function and allosteric defects. Any extension to CCT6-related human disease or therapeutic targeting should be made cautiously and requires direct evidence not provided here. (roy2023reducedadpoffrate pages 1-2)
+
+## 9) Relevant statistics and quantitative data (from retrieved sources)
+- **Essential genes**: CCT1–CCT8 are essential in yeast. (kabir2008overexpressedribosomalproteins pages 1-2, kabir2005physiologicaleffectsof pages 2-4)
+- **Proteostasis workload estimate**: TRiC/CCT contributes to folding of ~**10%** of yeast cellular polypeptides (as stated in yeast stress study background). (dube2023saccharomycescerevisiaesurvival pages 1-4)
+- **Suppression screen scale**: 22 multicopy suppressors were isolated for a cct4 ts allele; 14 encoded ribosomal proteins; some suppressors also acted on cct6 alleles. (kabir2008overexpressedribosomalproteins pages 1-2, kabir2008overexpressedribosomalproteins pages 2-3)
+- **TRiC ATPase kinetics (yeast, WT)**: apparent ATP binding constants (**K1 ~8.3 μM, K2 ~110 μM**) and turnover (**kcat ~0.043–0.053 s−1**) reported in one fitted model/condition set. (roy2023reducedadpoffrate pages 1-2)
+
+## 10) Expert interpretation and limitations
+1. **Most CCT6-specific “function” evidence in yeast is genetic** (essentiality; ts alleles; multicopy suppression; separation-of-function for suppression vs viability), while **client specificity** is more firmly established at the **TRiC complex level** (actin/tubulin and select other classes). Therefore, the most accurate functional annotation for CCT6 is as a **TRiC/CCT subunit that supports folding of obligate cytosolic substrates and TRiC conformational cycling**, with additional evidence that **unassembled Cct6p can modulate cell physiology** in an ATP-motif–dependent manner. (kabir2005physiologicaleffectsof pages 1-2, grantham2020themolecularchaperone pages 1-2)
+2. Recent 2023–2024 research largely refines **TRiC mechanism, stress crosstalk, and nuclear roles**, but is not yet fully **subunit-resolved** for CCT6 in yeast. The strongest 2024 subunit-level mechanistic link involving CCT6 is structural evidence that CCT6 contributes inner-surface residues contacted in the actin/PhLP2A folding context. (junsun2024astructuralvista pages 1-2)
+
+## Key cited sources (with dates and URLs)
+- Kabir MA et al. **Physiological effects of unassembled chaperonin Cct subunits in the yeast *Saccharomyces cerevisiae***. *Yeast*. **Feb 2005**. https://doi.org/10.1002/yea.1210 (kabir2005physiologicaleffectsof pages 1-2)
+- Kabir MA & Sherman F. **Overexpressed ribosomal proteins suppress defective chaperonins in *Saccharomyces cerevisiae***. *FEMS Yeast Research*. **Dec 2008**. https://doi.org/10.1111/j.1567-1364.2008.00425.x (kabir2008overexpressedribosomalproteins pages 1-2)
+- Zang Y et al. **Development of a yeast internal-subunit eGFP labeling strategy… TRiC/CCT**. *Scientific Reports*. **Feb 2018**. https://doi.org/10.1038/s41598-017-18962-y (zang2018developmentofa pages 1-2)
+- Willison KR. **The structure and evolution of eukaryotic chaperonin-containing TCP-1… folds actin**. *Biochemical Journal*. **Oct 2018**. https://doi.org/10.1042/BCJ20170378 (willison2018thestructureand pages 1-2)
+- Grantham J. **The Molecular Chaperone CCT/TRiC…** *Frontiers in Genetics*. **Mar 2020**. https://doi.org/10.3389/fgene.2020.00172 (grantham2020themolecularchaperone pages 1-2)
+- Roy M et al. **Reduced ADP off-rate… yeast CCT2 double mutation…** *Communications Biology*. **Aug 2023**. https://doi.org/10.1038/s42003-023-05261-8 (roy2023reducedadpoffrate pages 1-2)
+- Dube A et al. **S. cerevisiae survival against heat stress entails… CCT and cell wall integrity pathway**. *Biologia Futura*. **Nov 2023**. https://doi.org/10.1007/s42977-023-00192-1 (dube2023saccharomycescerevisiaesurvival pages 1-4)
+- Park J et al. **A structural vista of PhLP2A–TRiC cooperation…** *Nature Communications*. **Feb 2024**. https://doi.org/10.1038/s41467-024-45242-x (junsun2024astructuralvista pages 1-2)
+- Gvozdenov Z et al. **TRiC/CCT Chaperonin Governs RNA Polymerase II Activity in the Nucleus…** *bioRxiv* preprint. **Sep 26, 2024**. https://doi.org/10.1101/2024.09.26.615188 (gvozdenov2024triccctchaperoningoverns pages 1-6)
+
+
+References
+
+1. (grantham2020themolecularchaperone pages 1-2): Julie Grantham. The molecular chaperone cct/tric: an essential component of proteostasis and a potential modulator of protein aggregation. Frontiers in Genetics, Mar 2020. URL: https://doi.org/10.3389/fgene.2020.00172, doi:10.3389/fgene.2020.00172. This article has 139 citations and is from a peer-reviewed journal.
+
+2. (dube2023saccharomycescerevisiaesurvival pages 1-4): Ankita Dube, Dileep Pullepu, and M. Anaul Kabir. Saccharomyces cerevisiae survival against heat stress entails a communication between cct and cell wall integrity pathway. Biologia futura, 74:519-527, Nov 2023. URL: https://doi.org/10.1007/s42977-023-00192-1, doi:10.1007/s42977-023-00192-1. This article has 2 citations and is from a peer-reviewed journal.
+
+3. (kabir2005physiologicaleffectsof pages 1-2): M. Anaul Kabir, Joanna Kaminska, George B. Segel, Gabor Bethlendy, Paul Lin, Flavio Della Seta, Casey Blegen, Kristine M. Swiderek, Teresa ?o??dek, Kim T. Arndt, and Fred Sherman. Physiological effects of unassembled chaperonin cct subunits in the yeast saccharomyces cerevisiae. Yeast, 22:219-239, Feb 2005. URL: https://doi.org/10.1002/yea.1210, doi:10.1002/yea.1210. This article has 60 citations and is from a peer-reviewed journal.
+
+4. (kabir2005physiologicaleffectsof pages 2-4): M. Anaul Kabir, Joanna Kaminska, George B. Segel, Gabor Bethlendy, Paul Lin, Flavio Della Seta, Casey Blegen, Kristine M. Swiderek, Teresa ?o??dek, Kim T. Arndt, and Fred Sherman. Physiological effects of unassembled chaperonin cct subunits in the yeast saccharomyces cerevisiae. Yeast, 22:219-239, Feb 2005. URL: https://doi.org/10.1002/yea.1210, doi:10.1002/yea.1210. This article has 60 citations and is from a peer-reviewed journal.
+
+5. (zang2018developmentofa pages 1-2): Yunxiang Zang, Huping Wang, Zhicheng Cui, Mingliang Jin, Caixuan Liu, Wenyu Han, Yanxing Wang, and Yao Cong. Development of a yeast internal-subunit egfp labeling strategy and its application in subunit identification in eukaryotic group ii chaperonin tric/cct. Scientific Reports, Feb 2018. URL: https://doi.org/10.1038/s41598-017-18962-y, doi:10.1038/s41598-017-18962-y. This article has 22 citations and is from a peer-reviewed journal.
+
+6. (kabir2008overexpressedribosomalproteins pages 1-2): M. Anaul Kabir and Fred Sherman. Overexpressed ribosomal proteins suppress defective chaperonins in saccharomyces cerevisiae. FEMS yeast research, 8 8:1236-44, Dec 2008. URL: https://doi.org/10.1111/j.1567-1364.2008.00425.x, doi:10.1111/j.1567-1364.2008.00425.x. This article has 21 citations and is from a peer-reviewed journal.
+
+7. (kelly2020structuralandfunctional pages 18-23): J Kelly. Structural and functional characterisation of the group ii chaperonin cct/tric. Unknown journal, 2020.
+
+8. (willison2018thestructureand pages 1-2): Keith Robert Willison. The structure and evolution of eukaryotic chaperonin-containing tcp-1 and its mechanism that folds actin into a protein spring. The Biochemical journal, 475 19:3009-3034, Oct 2018. URL: https://doi.org/10.1042/bcj20170378, doi:10.1042/bcj20170378. This article has 42 citations.
+
+9. (kelly2020structuralandfunctionala pages 42-48): J Kelly. Structural and functional characterisation of the group ii chaperonin cct/tric. Unknown journal, 2020.
+
+10. (kelly2020structuralandfunctional pages 42-48): J Kelly. Structural and functional characterisation of the group ii chaperonin cct/tric. Unknown journal, 2020.
+
+11. (dube2021chaperoninpointmutation pages 1-4): Ankita Dube and M. Anaul Kabir. Chaperonin point mutation enhances cadmium endurance in saccharomyces cerevisiae. Biotechnology Letters, 43:1735-1745, May 2021. URL: https://doi.org/10.1007/s10529-021-03151-9, doi:10.1007/s10529-021-03151-9. This article has 2 citations and is from a peer-reviewed journal.
+
+12. (zang2018developmentofa media 20a150a9): Yunxiang Zang, Huping Wang, Zhicheng Cui, Mingliang Jin, Caixuan Liu, Wenyu Han, Yanxing Wang, and Yao Cong. Development of a yeast internal-subunit egfp labeling strategy and its application in subunit identification in eukaryotic group ii chaperonin tric/cct. Scientific Reports, Feb 2018. URL: https://doi.org/10.1038/s41598-017-18962-y, doi:10.1038/s41598-017-18962-y. This article has 22 citations and is from a peer-reviewed journal.
+
+13. (kabir2008overexpressedribosomalproteins pages 2-3): M. Anaul Kabir and Fred Sherman. Overexpressed ribosomal proteins suppress defective chaperonins in saccharomyces cerevisiae. FEMS yeast research, 8 8:1236-44, Dec 2008. URL: https://doi.org/10.1111/j.1567-1364.2008.00425.x, doi:10.1111/j.1567-1364.2008.00425.x. This article has 21 citations and is from a peer-reviewed journal.
+
+14. (nadlerholly2012interactionsofsubunit pages 1-2): Michal Nadler-Holly, Michal Breker, Ranit Gruber, Ariel Azia, Melissa Gymrek, Miriam Eisenstein, Keith R. Willison, Maya Schuldiner, and Amnon Horovitz. Interactions of subunit cct3 in the yeast chaperonin cct/tric with q/n-rich proteins revealed by high-throughput microscopy analysis. Proceedings of the National Academy of Sciences, 109:18833-18838, Oct 2012. URL: https://doi.org/10.1073/pnas.1209277109, doi:10.1073/pnas.1209277109. This article has 52 citations and is from a highest quality peer-reviewed journal.
+
+15. (gvozdenov2024triccctchaperoningoverns pages 1-6): Zlata Gvozdenov, Audrey Yi Tyan Peng, Anusmita Biswas, Zeno Barcutean, Daniel Gestaut, Judith Frydman, Kevin Struhl, and Brian C. Freeman. Tric/cct chaperonin governs rna polymerase ii activity in the nucleus to support rna homeostasis. bioRxiv, Sep 2024. URL: https://doi.org/10.1101/2024.09.26.615188, doi:10.1101/2024.09.26.615188. This article has 3 citations.
+
+16. (roy2023reducedadpoffrate pages 1-2): Mousam Roy, Rachel C. Fleisher, Alexander I. Alexandrov, and Amnon Horovitz. Reduced adp off-rate by the yeast cct2 double mutation t394p/r510h which causes leber congenital amaurosis in humans. Communications Biology, Aug 2023. URL: https://doi.org/10.1038/s42003-023-05261-8, doi:10.1038/s42003-023-05261-8. This article has 9 citations and is from a peer-reviewed journal.
+
+17. (junsun2024astructuralvista pages 1-2): Junsun Park, Hyunmin Kim, Daniel Gestaut, Seyeon Lim, Kwadwo A. Opoku-Nsiah, Alexander Leitner, Judith Frydman, and Soung-Hun Roh. A structural vista of phosducin-like phlp2a-chaperonin tric cooperation during the atp-driven folding cycle. Nature Communications, Feb 2024. URL: https://doi.org/10.1038/s41467-024-45242-x, doi:10.1038/s41467-024-45242-x. This article has 16 citations and is from a highest quality peer-reviewed journal.
+
+## Citations
+
+1. dube2021chaperoninpointmutation pages 1-4
+2. kabir2005physiologicaleffectsof pages 1-2
+3. nadlerholly2012interactionsofsubunit pages 1-2
+4. gvozdenov2024triccctchaperoningoverns pages 1-6
+5. dube2023saccharomycescerevisiaesurvival pages 1-4
+6. junsun2024astructuralvista pages 1-2
+7. kabir2005physiologicaleffectsof pages 2-4
+8. roy2023reducedadpoffrate pages 1-2
+9. kabir2008overexpressedribosomalproteins pages 1-2
+10. zang2018developmentofa pages 1-2
+11. willison2018thestructureand pages 1-2
+12. grantham2020themolecularchaperone pages 1-2
+13. kelly2020structuralandfunctional pages 18-23
+14. kelly2020structuralandfunctionala pages 42-48
+15. kelly2020structuralandfunctional pages 42-48
+16. kabir2008overexpressedribosomalproteins pages 2-3
+17. SIT4 SAP155
+18. https://doi.org/10.1002/yea.1210
+19. https://doi.org/10.3389/fgene.2020.00172
+20. https://doi.org/10.1038/s41598-017-18962-y
+21. https://doi.org/10.1111/j.1567-1364.2008.00425.x
+22. https://doi.org/10.1042/BCJ20170378
+23. https://doi.org/10.1007/s10529-021-03151-9
+24. https://doi.org/10.1073/pnas.1209277109
+25. https://doi.org/10.1101/2024.09.26.615188
+26. https://doi.org/10.1007/s42977-023-00192-1
+27. https://doi.org/10.1038/s42003-023-05261-8
+28. https://doi.org/10.1038/s41467-024-45242-x
+29. https://doi.org/10.3389/fgene.2020.00172,
+30. https://doi.org/10.1007/s42977-023-00192-1,
+31. https://doi.org/10.1002/yea.1210,
+32. https://doi.org/10.1038/s41598-017-18962-y,
+33. https://doi.org/10.1111/j.1567-1364.2008.00425.x,
+34. https://doi.org/10.1042/bcj20170378,
+35. https://doi.org/10.1007/s10529-021-03151-9,
+36. https://doi.org/10.1073/pnas.1209277109,
+37. https://doi.org/10.1101/2024.09.26.615188,
+38. https://doi.org/10.1038/s42003-023-05261-8,
+39. https://doi.org/10.1038/s41467-024-45242-x,

--- a/genes/yeast/CNE1/CNE1-ai-review.html
+++ b/genes/yeast/CNE1/CNE1-ai-review.html
@@ -925,6 +925,24 @@
 
 
 
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25229868" target="_blank" class="term-link">
+                                        PMID:25229868
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">These results suggest that in yeasts, Cne1p interacts with misfolded lysozyme proteins possibly causing their retention in the ER and subsequent elimination via ER-associated degradation.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
 
@@ -3103,6 +3121,12 @@ existing_annotations:
     reason: &gt;-
       Direct yeast evidence supports Cne1p in ER folding/quality control and retention/elimination of
       misfolded proteins.
+    supported_by:
+    - reference_id: PMID:25229868
+      supporting_text: &gt;-
+        These results suggest that in yeasts, Cne1p interacts with misfolded lysozyme proteins possibly
+        causing their retention in the ER and subsequent elimination via ER-associated degradation.
+      reference_section_type: ABSTRACT
 - term:
     id: GO:0005509
     label: calcium ion binding

--- a/genes/yeast/CNE1/CNE1-ai-review.html
+++ b/genes/yeast/CNE1/CNE1-ai-review.html
@@ -864,6 +864,19 @@
                             <div class="support-item">
                                 <span class="support-ref">
 
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25229868" target="_blank" class="term-link">
+                                        PMID:25229868
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">These results suggest that in yeasts, Cne1p interacts with misfolded lysozyme proteins possibly causing their retention in the ER and subsequent elimination via ER-associated degradation.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
                                     file:yeast/CNE1/CNE1-deep-research-falcon.md
 
                                 </span>
@@ -3104,7 +3117,6 @@ existing_annotations:
         These results suggest that in yeasts, Cne1p interacts with misfolded lysozyme proteins possibly
         causing their retention in the ER and subsequent elimination via ER-associated degradation.
       reference_section_type: ABSTRACT
-    supported_by:
     - reference_id: file:yeast/CNE1/CNE1-deep-research-falcon.md
       supporting_text: CNE1 (P27825) encodes Cne1p
 - term:

--- a/genes/yeast/CNE1/CNE1-ai-review.html
+++ b/genes/yeast/CNE1/CNE1-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>CNE1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P27825" target="_blank" class="term-link">
                         P27825
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Saccharomyces cerevisiae</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,24 +728,75 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="P27825" data-a="DESCRIPTION: TODO: Add description for CNE1..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="P27825" data-a="DESCRIPTION: CNE1 encodes the budding yeast calnexin homolog, a..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TODO: Add description for CNE1</p>
+        <p>CNE1 encodes the budding yeast calnexin homolog, an ER membrane lectin chaperone of the calreticulin/calnexin family. Cne1 promotes ER protein quality control by binding glycosylated folding intermediates, assisting folding or retention of misfolded glycoproteins, and contributing to ER-associated degradation decisions. Direct biochemical evidence argues against annotating yeast Cne1 as a calcium-binding protein despite family-transfer annotations.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+    <div class="section">
+        <h2 class="section-title">Proposed New Ontology Terms</h2>
+
+        <div class="proposed-term">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>monoglucosylated glycoprotein binding</h3>
+                <span class="vote-buttons" data-g="P27825" data-a="monoglucosylated glycoprotein binding" data-r="" data-act="NEW">
+                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
+                </span>
+            </div>
+
+
+            <p><strong>Definition:</strong> Binding to monoglucosylated N-linked glycan structures on glycoprotein folding intermediates in the endoplasmic reticulum.</p>
+
+
+
+            <p><strong>Justification:</strong> Cne1p is a calnexin-family lectin chaperone whose relevant carbohydrate specificity is monoglucosylated glycoprotein/oligosaccharide recognition, which is more specific than broad carbohydrate binding.</p>
+
+
+
+            <p><strong>Parent term:</strong>
+                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070492" target="_blank" class="term-link">
+                    oligosaccharide binding
+                </a>
+            </p>
+
+
+
+
+
+            <p><strong>Supporting Evidence:</strong></p>
+            <ul style="margin-left: 1rem;">
+
+                <li>
+
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/15173200" target="_blank" class="term-link">
+                        PMID:15173200
+                    </a>
+
+
+                    : the chaperone function of Cne1p was greatly affected in the presence of monoglucosylated oligosaccharides (G1M9) that specifically bind to the lectin site.
+
+                </li>
+
+            </ul>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +809,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,46 +846,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein folding is consistent with known biology of CNE1.
+                            <strong>Summary:</strong> protein folding is a supported biological-process context for Cne1p as an ER lectin chaperone and quality-control factor.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Direct yeast evidence supports Cne1p in ER folding/quality control and retention/elimination of misfolded glycoprotein clients via ER-associated degradation.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/CNE1/CNE1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">CNE1 (P27825) encodes Cne1p</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036503" target="_blank" class="term-link">
                                     GO:0036503
                                 </a>
                             </span>
                             <span class="term-label">ERAD pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -846,97 +913,115 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ERAD pathway is consistent with known biology of CNE1.
+                            <strong>Summary:</strong> ERAD pathway is a supported biological-process context for Cne1p as an ER lectin chaperone and quality-control factor.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Direct yeast evidence supports Cne1p in ER folding/quality control and retention/elimination of misfolded proteins.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005509" target="_blank" class="term-link">
                                     GO:0005509
                                 </a>
                             </span>
                             <span class="term-label">calcium ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="P27825" data-a="GO:0005509" data-r="GO_REF:0000033" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P27825" data-a="GO:0005509" data-r="GO_REF:0000033" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: calcium ion binding is consistent with known biology of CNE1.
+                            <strong>Summary:</strong> Direct Cne1p biochemical characterization did not detect Ca2+ binding, so family-transfer calcium ion binding should not be retained for yeast CNE1.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The direct yeast study contradicts the inferred calcium-binding annotation; calnexin-family membership alone is insufficient evidence for this molecular function in Cne1p.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7814381" target="_blank" class="term-link">
+                                        PMID:7814381
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Ca2+ binding activity has not been detected for Cne1p.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
                                     GO:0005789
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -948,97 +1033,115 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: endoplasmic reticulum membrane is consistent with known biology of CNE1.
+                            <strong>Summary:</strong> endoplasmic reticulum membrane is supported for Cne1p, an ER membrane glycoprotein.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Direct localization and membrane-association evidence places Cne1p in the ER membrane/ER quality-control compartment.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005509" target="_blank" class="term-link">
                                     GO:0005509
                                 </a>
                             </span>
                             <span class="term-label">calcium ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="P27825" data-a="GO:0005509" data-r="GO_REF:0000002" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P27825" data-a="GO:0005509" data-r="GO_REF:0000002" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: calcium ion binding is consistent with known biology of CNE1.
+                            <strong>Summary:</strong> Direct Cne1p biochemical characterization did not detect Ca2+ binding, so family-transfer calcium ion binding should not be retained for yeast CNE1.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The direct yeast study contradicts the inferred calcium-binding annotation; calnexin-family membership alone is insufficient evidence for this molecular function in Cne1p.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7814381" target="_blank" class="term-link">
+                                        PMID:7814381
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Ca2+ binding activity has not been detected for Cne1p.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
                                     GO:0005783
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1050,46 +1153,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: endoplasmic reticulum is consistent with known biology of CNE1.
+                            <strong>Summary:</strong> endoplasmic reticulum is supported for Cne1p, an ER membrane glycoprotein.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Direct localization and membrane-association evidence places Cne1p in the ER membrane/ER quality-control compartment.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
                                     GO:0005789
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1101,46 +1204,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: endoplasmic reticulum membrane is consistent with known biology of CNE1.
+                            <strong>Summary:</strong> endoplasmic reticulum membrane is supported for Cne1p, an ER membrane glycoprotein.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Direct localization and membrane-association evidence places Cne1p in the ER membrane/ER quality-control compartment.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1152,159 +1255,199 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein folding is consistent with known biology of CNE1.
+                            <strong>Summary:</strong> protein folding is a supported biological-process context for Cne1p as an ER lectin chaperone and quality-control factor.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Direct yeast evidence supports Cne1p in ER folding/quality control and retention/elimination of misfolded proteins.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030246" target="_blank" class="term-link">
                                     GO:0030246
                                 </a>
                             </span>
                             <span class="term-label">carbohydrate binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P27825" data-a="GO:0030246" data-r="GO_REF:0000043" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P27825" data-a="GO:0030246" data-r="GO_REF:0000043" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: carbohydrate binding is consistent with known biology of CNE1.
+                            <strong>Summary:</strong> CNE1 has lectin-site evidence for monoglucosylated oligosaccharide/glycoprotein recognition, so carbohydrate binding is directionally correct but too broad.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Use the more specific oligosaccharide binding term for the known calnexin lectin-site activity.
                         </div>
-                        
-                        
-                        
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070492" target="_blank" class="term-link">
+                                    oligosaccharide binding
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15173200" target="_blank" class="term-link">
+                                        PMID:15173200
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the chaperone function of Cne1p was greatly affected in the presence of monoglucosylated oligosaccharides (G1M9) that specifically bind to the lectin site.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P27825" data-a="GO:0051082" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="P27825" data-a="GO:0051082" data-r="GO_REF:0000002" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is too generic or over-extended for CNE1.
+                            <strong>Summary:</strong> Cne1p has chaperone activity toward folding intermediates, but unfolded protein binding alone is a less informative representation of the ER lectin-chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Replace with protein folding chaperone, while separately capturing oligosaccharide/lectin binding in core function and proposed terminology.
                         </div>
-                        
-                        
-                        
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
+                                    protein folding chaperone
+                                </a>
+                            </span>
+
+                        </div>
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036503" target="_blank" class="term-link">
                                     GO:0036503
                                 </a>
                             </span>
                             <span class="term-label">ERAD pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/7814381" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:7814381
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Saccharomyces cerevisiae CNE1 encodes an endoplasmic reticul...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1316,57 +1459,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ERAD pathway is consistent with known biology of CNE1.
+                            <strong>Summary:</strong> ERAD pathway is supported for Cne1p through its interaction with unstable glycosylated client proteins and contribution to their ER retention/elimination.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> PMID:25229868 provides direct yeast evidence that Cne1p binds unstable lysozyme mutants and contributes to their retention and elimination via ER-associated degradation.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25229868" target="_blank" class="term-link">
+                                        PMID:25229868
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">These results suggest that in yeasts, Cne1p interacts with misfolded lysozyme proteins possibly causing their retention in the ER and subsequent elimination via ER-associated degradation.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
                                     GO:0005789
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/7814381" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:7814381
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Saccharomyces cerevisiae CNE1 encodes an endoplasmic reticul...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1378,57 +1539,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: endoplasmic reticulum membrane is consistent with known biology of CNE1.
+                            <strong>Summary:</strong> endoplasmic reticulum membrane is supported for Cne1p, an ER membrane glycoprotein.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Direct localization and membrane-association evidence places Cne1p in the ER membrane/ER quality-control compartment.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7814381" target="_blank" class="term-link">
+                                        PMID:7814381
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Localization of the Cne1p protein by differential and analytical subcellular fractionation as well as by confocal immunofluorescence microscopy showed that it was exclusively located in the endoplasmic reticulum (ER)</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
                                     GO:0005783
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26928762
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     One library to make them all: streamlining the creation of y...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1440,57 +1619,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: endoplasmic reticulum is consistent with known biology of CNE1.
+                            <strong>Summary:</strong> endoplasmic reticulum is consistent with the ER biology of CNE1 and is supported by the SWAT endomembrane localization library.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Accept as supporting ER localization evidence, with gene-specific ER function anchored by the primary literature and UniProt record.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link">
+                                        PMID:26928762
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we constructed and investigated a library of</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16002399" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16002399
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interactions among yeast protein-disulfide isomerase protein...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1502,119 +1699,246 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for CNE1.
+                            <strong>Summary:</strong> Protein binding is too generic for the CNE1 interaction evidence with ER folding factors such as Mpd1/Eps1.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> The interaction evidence is best interpreted as part of the ER chaperone/oxidoreductase quality-control network, not as a standalone generic protein-binding function.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16002399" target="_blank" class="term-link">
+                                        PMID:16002399
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mpd1p alone does not have chaperone activity but that it interacts with and inhibits the chaperone activity of Cne1p</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16002399" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16002399
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Interactions among yeast protein-disulfide isomerase protein...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P27825" data-a="GO:0005515" data-r="PMID:16002399" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for the CNE1 interaction evidence with ER folding factors such as Mpd1/Eps1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The interaction evidence is best interpreted as part of the ER chaperone/oxidoreductase quality-control network, not as a standalone generic protein-binding function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16002399" target="_blank" class="term-link">
+                                        PMID:16002399
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mpd1p alone does not have chaperone activity but that it interacts with and inhibits the chaperone activity of Cne1p</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16002399" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16002399
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interactions among yeast protein-disulfide isomerase protein...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P27825" data-a="GO:0051082" data-r="PMID:16002399" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="P27825" data-a="GO:0051082" data-r="PMID:16002399" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is too generic or over-extended for CNE1.
+                            <strong>Summary:</strong> Cne1p has chaperone activity toward folding intermediates, but unfolded protein binding alone is a less informative representation of the ER lectin-chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Replace with protein folding chaperone, while separately capturing oligosaccharide/lectin binding in core function and proposed terminology.
                         </div>
-                        
-                        
-                        
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
+                                    protein folding chaperone
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15173200" target="_blank" class="term-link">
+                                        PMID:15173200
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Cne1p effectively suppressed the thermal denaturation of CS and enhanced the refolding of thermally or chemically denatured CS in a concentration-dependent manner.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15173200" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15173200
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Expression and characterization of Saccharomyces cerevisiae ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1626,239 +1950,1032 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein folding is consistent with known biology of CNE1.
+                            <strong>Summary:</strong> protein folding is a supported biological-process context for Cne1p as an ER lectin chaperone and quality-control factor.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Direct yeast evidence supports Cne1p in ER folding/quality control and retention/elimination of misfolded proteins.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15173200" target="_blank" class="term-link">
+                                        PMID:15173200
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Cne1p effectively suppressed the thermal denaturation of CS and enhanced the refolding of thermally or chemically denatured CS in a concentration-dependent manner.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15173200" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15173200
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Expression and characterization of Saccharomyces cerevisiae ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P27825" data-a="GO:0051082" data-r="PMID:15173200" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="P27825" data-a="GO:0051082" data-r="PMID:15173200" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is too generic or over-extended for CNE1.
+                            <strong>Summary:</strong> Cne1p has chaperone activity toward folding intermediates, but unfolded protein binding alone is a less informative representation of the ER lectin-chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Replace with protein folding chaperone, while separately capturing oligosaccharide/lectin binding in core function and proposed terminology.
                         </div>
-                        
-                        
-                        
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
+                                    protein folding chaperone
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15173200" target="_blank" class="term-link">
+                                        PMID:15173200
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Cne1p effectively suppressed the thermal denaturation of CS and enhanced the refolding of thermally or chemically denatured CS in a concentration-dependent manner.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Cne1p is an ER membrane lectin chaperone that assists folding and quality-control retention of glycoprotein folding intermediates. Direct studies support ER localization, chaperone activity, and contribution to ER protein quality control/ERAD, while direct Ca2+ binding was not detected.</h3>
+                <span class="vote-buttons" data-g="P27825" data-a="FUNCTION: Cne1p is an ER membrane lectin chaperone that assi..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
+                            protein folding chaperone
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                protein folding
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036503" target="_blank" class="term-link">
+                                ERAD pathway
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15173200" target="_blank" class="term-link">
+                                PMID:15173200
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Cne1p effectively suppressed the thermal denaturation of CS and enhanced the refolding of thermally or chemically denatured CS in a concentration-dependent manner.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/7814381" target="_blank" class="term-link">
+                                PMID:7814381
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Hence, Cne1p appears to function as a constituent of the S. cerevisiae ER protein quality control apparatus.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25229868" target="_blank" class="term-link">
+                                PMID:25229868
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">These results suggest that in yeasts, Cne1p interacts with misfolded lysozyme proteins possibly causing their retention in the ER and subsequent elimination via ER-associated degradation.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Cne1p recognizes monoglucosylated oligosaccharide features through its calnexin lectin site, coupling glycan recognition to ER folding and retention decisions for glycoprotein clients.</h3>
+                <span class="vote-buttons" data-g="P27825" data-a="FUNCTION: Cne1p recognizes monoglucosylated oligosaccharide ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070492" target="_blank" class="term-link">
+                            oligosaccharide binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                protein folding
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15173200" target="_blank" class="term-link">
+                                PMID:15173200
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the chaperone function of Cne1p was greatly affected in the presence of monoglucosylated oligosaccharides (G1M9) that specifically bind to the lectin site.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15173200" target="_blank" class="term-link">
                             PMID:15173200
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Expression and characterization of Saccharomyces cerevisiae Cne1p, a calnexin homologue.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Recombinant Cne1p shows chaperone activity and lectin-site dependence in citrate synthase denaturation/refolding assays.</div>
+
+                        <div class="finding-text">"Cne1p effectively suppressed the thermal denaturation of CS and enhanced the refolding of thermally or chemically denatured CS in a concentration-dependent manner... the chaperone function of Cne1p was greatly affected in the presence of monoglucosylated oligosaccharides (G1M9) that specifically bind to the lectin site."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16002399" target="_blank" class="term-link">
                             PMID:16002399
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interactions among yeast protein-disulfide isomerase proteins and endoplasmic reticulum chaperone proteins influence their activities.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Cne1p interacts functionally with ER oxidoreductase Mpd1p, supporting a role in the ER folding/chaperone network but not a generic protein-binding annotation.</div>
+
+                        <div class="finding-text">"Mpd1p alone does not have chaperone activity but that it interacts with and inhibits the chaperone activity of Cne1p"</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25229868" target="_blank" class="term-link">
+                            PMID:25229868
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Unstable mutant lysozymes are degraded through the interaction with calnexin homolog Cne1p in Saccharomyces cerevisiae.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Cne1p interacts with unstable misfolded lysozymes and promotes their ER retention and subsequent elimination via ER-associated degradation.</div>
+
+                        <div class="finding-text">"These results suggest that in yeasts, Cne1p interacts with misfolded lysozyme proteins possibly causing their retention in the ER and subsequent elimination via ER-associated degradation."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link">
                             PMID:26928762
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/7814381" target="_blank" class="term-link">
                             PMID:7814381
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Saccharomyces cerevisiae CNE1 encodes an endoplasmic reticulum (ER) membrane protein with sequence similarity to calnexin and calreticulin and functions as a constituent of the ER quality control apparatus.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Cne1p is an ER membrane glycoprotein and ER quality-control factor; the same study reported no detectable Ca2+ binding for Cne1p.</div>
+
+                        <div class="finding-text">"Localization of the Cne1p protein by differential and analytical subcellular fractionation as well as by confocal immunofluorescence microscopy showed that it was exclusively located in the endoplasmic reticulum (ER)... Ca2+ binding activity has not been detected for Cne1p... Hence, Cne1p appears to function as a constituent of the S. cerevisiae ER protein quality control apparatus."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/CNE1/CNE1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for CNE1</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The Falcon report was reviewed and synthesized into the CNE1 curation, including core-function framing, family/PANTHER context, and evidence limitations.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What are the endogenous yeast glycoprotein clients whose ER retention or ERAD depends directly on Cne1p lectin-chaperone activity?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P27825" data-a="Q: What are the endogenous yeast glycoprotein clients..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Use Cne1p proximity labeling or crosslinking immunoprecipitation under ER stress, with glycosylation-defective and lectin-site mutant controls, followed by quantitative client identification.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Cne1p-dependent ERAD is selective for monoglucosylated glycoprotein clients rather than general unfolded proteins.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: proximity labeling and glycoprotein client proteomics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P27825" data-a="EXPERIMENT: Use Cne1p proximity labeling or crosslinking immun..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(CNE1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P27825" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-04T10:05:17.315911'<br />
+end_time: '2026-05-04T10:11:59.894848'<br />
+duration_seconds: 402.58<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: yeast<br />
+  gene_id: CNE1<br />
+  gene_symbol: CNE1<br />
+  uniprot_accession: P27825<br />
+  protein_description: 'RecName: Full=Calnexin homolog; Flags: Precursor;'<br />
+  gene_info: Name=CNE1; OrderedLocusNames=YAL058W; ORFNames=FUN48;<br />
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).<br />
+  protein_family: Belongs to the calreticulin family. .<br />
+  protein_domains: Calret/calnex. (IPR001580); Calret/calnex_CS. (IPR018124); Calreticulin/calnexin_P_dom_sf.<br />
+    (IPR009033); ConA-like_dom_sf. (IPR013320); Calreticulin (PF00262)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 26</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P27825</li>
+<li><strong>Protein Description:</strong> RecName: Full=Calnexin homolog; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=CNE1; OrderedLocusNames=YAL058W; ORFNames=FUN48;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the calreticulin family. .</li>
+<li><strong>Key Domains:</strong> Calret/calnex. (IPR001580); Calret/calnex_CS. (IPR018124); Calreticulin/calnexin_P_dom_sf. (IPR009033); ConA-like_dom_sf. (IPR013320); Calreticulin (PF00262)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "CNE1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'CNE1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>CNE1</strong> (gene ID: CNE1, UniProt: P27825) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P27825</li>
+<li><strong>Protein Description:</strong> RecName: Full=Calnexin homolog; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=CNE1; OrderedLocusNames=YAL058W; ORFNames=FUN48;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the calreticulin family. .</li>
+<li><strong>Key Domains:</strong> Calret/calnex. (IPR001580); Calret/calnex_CS. (IPR018124); Calreticulin/calnexin_P_dom_sf. (IPR009033); ConA-like_dom_sf. (IPR013320); Calreticulin (PF00262)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "CNE1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'CNE1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>CNE1</strong> (gene ID: CNE1, UniProt: P27825) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="research-report-saccharomyces-cerevisiae-cne1-uniprot-p27825-functional-annotation-of-the-yeast-calnexin-homolog">Research Report: <em>Saccharomyces cerevisiae</em> <strong>CNE1</strong> (UniProt <strong>P27825</strong>) – Functional Annotation of the Yeast Calnexin Homolog</h1>
+<h2 id="0-mandatory-target-verification-geneprotein-identity">0) Mandatory target verification (gene/protein identity)</h2>
+<p>The UniProt accession <strong>P27825</strong> corresponds to <em>Saccharomyces cerevisiae</em> (S288c) <strong>CNE1</strong> (also <strong>YAL058W</strong>, ORF name <strong>FUN48</strong>) annotated as a <strong>calnexin homolog</strong> and member of the <strong>calreticulin/calnexin family</strong> (ER lectin chaperones). The experimental literature retrieved here consistently refers to yeast <strong>Cne1p</strong> as the <em>S. cerevisiae</em> calnexin homolog and ER membrane protein, matching the requested identity and organism. (parlati1996characterizationofcalnexin pages 50-54, xu2004expressionandcharacterization pages 1-2)</p>
+<h2 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h2>
+<h3 id="11-calnexin-family-lectin-chaperones">1.1 Calnexin-family lectin chaperones</h3>
+<p>Calnexin (CNX) and calreticulin (CRT) are ER lectin chaperones that <strong>selectively bind monoglucosylated N-glycans</strong> on nascent glycoproteins to prevent aggregation and promote folding. CNX is typically membrane-tethered, whereas CRT is soluble. (suzuki2021foldingandquality pages 8-9)</p>
+<h3 id="12-yeast-specific-features-of-the-calnexin-cycle">1.2 Yeast-specific features of the “calnexin cycle”</h3>
+<p>A key conceptual difference between budding yeast and mammalian cells is <strong>reglucosylation</strong>. In organisms that encode UDP-glucose:glycoprotein glucosyltransferase (UGGT), UGGT can re-add glucose to promote repeated CNX/CRT binding; however, <strong>the review evidence indicates <em>S. cerevisiae</em> lacks UGGT</strong>, implying that calnexin binding may behave as a <strong>more one-pass/irreversible step</strong> in this species compared with canonical mammalian cycling. (piirainen2022theimpactof pages 2-3, parlati1996characterizationofcalnexin pages 155-157)</p>
+<h3 id="13-er-quality-control-erqc-and-er-associated-degradation-erad">1.3 ER quality control (ERQC) and ER-associated degradation (ERAD)</h3>
+<p>ERQC encompasses mechanisms that retain folding intermediates, promote productive folding, and direct terminally misfolded proteins into ERAD. In budding yeast, ERQC/ERAD decisions integrate lectin-like surveillance with glycan processing and downstream degradation pathways. (piirainen2022theimpactof pages 6-7, piirainen2022theimpactof pages 2-3)</p>
+<h2 id="2-cne1-gene-product-molecular-function-binding-specificity-localization-and-pathway-placement">2) CNE1 gene product: molecular function, binding specificity, localization, and pathway placement</h2>
+<h3 id="21-subcellular-localization-and-membrane-association">2.1 Subcellular localization and membrane association</h3>
+<p>Early biochemical fractionation and microscopy established Cne1p as an <strong>ER-localized integral membrane glycoprotein</strong>.<br />
+* Cne1p is <strong>Endo H–sensitive</strong>, consistent with ER-type N-glycosylation. (parlati1996characterizationofcalnexin pages 50-54)<br />
+* Immunofluorescence/confocal microscopy shows Cne1p colocalizing with the ER lumenal marker <strong>Kar2p/BiP</strong>, with perinuclear and cortical ER patterns. (parlati1996characterizationofcalnexin pages 76-82)<br />
+* It is strongly membrane-associated (not extractable by typical chaotropes/high salt/carbonate used to strip peripheral proteins). (parlati1996characterizationofcalnexin pages 50-54)</p>
+<h3 id="22-calcium-binding-divergence-from-mammalian-calnexin">2.2 Calcium binding: divergence from mammalian calnexin</h3>
+<p>Unlike mammalian calnexin, yeast Cne1p was found to be <strong>not a strong Ca2+-binding protein</strong> in ^45Ca overlay assays, and the protein lacks the mammalian-like calcium-binding capacity emphasized in other systems. (parlati1996characterizationofcalnexin pages 150-152, parlati1996characterizationofcalnexin pages 76-82)</p>
+<h3 id="23-biochemical-chaperone-activity">2.3 Biochemical chaperone activity</h3>
+<p>Recombinant Cne1p exhibits <strong>molecular chaperone activity</strong> in vitro:<br />
+* A GST–Cne1p fusion protein <strong>suppressed thermal denaturation</strong> and enhanced <strong>refolding of citrate synthase</strong> in a concentration-dependent manner. (Xu et al., 2004; published May 2004; https://doi.org/10.1093/jb/mvh074) (xu2004expressionandcharacterization pages 1-2)</p>
+<h3 id="24-lectin-specificity-for-monoglucosylated-n-glycans">2.4 Lectin specificity for monoglucosylated N-glycans</h3>
+<p>Cne1p shows evidence of <strong>lectin-like recognition of monoglucosylated N-glycans</strong>, consistent with calnexin-family function:<br />
+* Cne1p chaperone activity was strongly affected by a monoglucosylated oligosaccharide (reported as <strong>G1M9</strong>, consistent with <strong>Glc1Man9GlcNAc2</strong>), supporting a functional lectin site. (Xu et al., 2004; https://doi.org/10.1093/jb/mvh074) (xu2004expressionandcharacterization pages 1-2)<br />
+* In a cellular context, binding of Cne1p to misfolded glycoprotein clients was <strong>abolished by tunicamycin</strong> (inhibits N-glycosylation), supporting <strong>glycan-dependent recognition</strong>. (Azakami et al., 2014; published Jul 2014; https://doi.org/10.1080/09168451.2014.918486) (azakami2014unstablemutantlysozymes pages 1-2)</p>
+<h3 id="25-experimentally-supported-clientsubstrate-classes-and-outcomes-retention-vs-escape">2.5 Experimentally supported client/substrate classes and outcomes (retention vs escape)</h3>
+<p>Multiple experimental systems support Cne1p as an ERQC factor that <strong>retains and promotes disposal of unstable glycoproteins</strong>:<br />
+* <strong>Misfolded/unstable glycosylated lysozyme mutants</strong>: Co-immunoprecipitation indicates Cne1p interacts with unstable glycosylated lysozyme mutants (e.g., G49N/D66H and others) and promotes their degradation/retention; <strong>cne1Δ increases secretion</strong> and alters intracellular localization of these unstable glycoproteins, consistent with loss of ER retention. (Azakami et al., 2014; https://doi.org/10.1080/09168451.2014.918486) (azakami2014unstablemutantlysozymes pages 1-2, azakami2014unstablemutantlysozymes pages 2-3)<br />
+* <strong>Trafficking QC reporters</strong>: Deletion of CNE1 increased cell-surface expression of an ER-retained temperature-sensitive <strong>Ste2 mutant (Ste2-3p)</strong> and increased secretion of heterologous <strong>α1-antitrypsin</strong>, consistent with reduced ERQC retention. (parlati1996characterizationofcalnexin pages 50-54, parlati1996characterizationofcalnexin pages 150-152)</p>
+<h3 id="26-geneticphysiologic-phenotypes-and-stress-responses">2.6 Genetic/physiologic phenotypes and stress responses</h3>
+<p>CNE1 is <strong>nonessential</strong> under standard growth conditions, and loss does not necessarily produce gross growth phenotypes, indicating functional buffering by other ER folding factors. (parlati1996characterizationofcalnexin pages 50-54, zhang2008theeffectof pages 1-4)</p>
+<p>However, deletion triggers compensatory changes consistent with ER stress buffering:<br />
+* Under heat stress (37°C), a <strong>cne1Δ</strong> strain showed <strong>increased PDI (protein disulfide isomerase) expression</strong> at mRNA and protein levels relative to wild type, while growth remained similar; the authors interpret this as compensation for loss of calnexin function. (Zhang et al., 2008; published Jan 2008; https://doi.org/10.2478/s11658-007-0033-y) (zhang2008theeffectof pages 1-4)</p>
+<h3 id="27-interaction-partners-what-is-supported-vs-not-supported">2.7 Interaction partners (what is supported vs not supported)</h3>
+<p>Evidence in the retrieved set supports two interaction categories:<br />
+1) <strong>Client interactions</strong>: direct binding to unstable glycosylated lysozyme mutants by co-IP (strong evidence). (azakami2014unstablemutantlysozymes pages 1-2)<br />
+2) <strong>Functional linkage to oxidoreductases</strong>: evidence suggests interaction/function with PDI-family members (e.g., Mpd1p in vitro; and PDI induction in cne1Δ under heat stress), consistent with a cooperative ER folding network. (zhang2008theeffectof pages 1-4)</p>
+<p>In contrast, early broad immunoprecipitation efforts reported difficulty detecting transient association with endogenous proteins in yeast, consistent with <strong>weak/transient</strong> interactions typical of chaperones or limitations of the assay. (parlati1996characterizationofcalnexin pages 150-152)</p>
+<h2 id="3-recent-developments-and-latest-research-prioritizing-20232024">3) Recent developments and latest research (prioritizing 2023–2024)</h2>
+<h3 id="31-availability-of-20232024-cne1-specific-primary-literature">3.1 Availability of 2023–2024 CNE1-specific primary literature</h3>
+<p>In the retrieved corpus, <strong>direct 2023–2024 primary studies focused specifically on <em>S. cerevisiae</em> CNE1 were limited</strong>. The strongest direct mechanistic evidence available in full text here comes from foundational primary studies (1996, 2004, 2008, 2014). (parlati1996characterizationofcalnexin pages 50-54, xu2004expressionandcharacterization pages 1-2, zhang2008theeffectof pages 1-4, azakami2014unstablemutantlysozymes pages 1-2)</p>
+<h3 id="32-20222024-synthesis-relevant-to-cne1-function-glycoengineeringerqc-perspective">3.2 2022–2024 synthesis relevant to CNE1 function (glycoengineering/ERQC perspective)</h3>
+<p>A 2022 review (Frontiers in Molecular Biosciences) provides a modern synthesis of how <strong>glycoengineering can perturb ERQC</strong>, including the calnexin pathway:<br />
+* It reiterates that yeast calnexin (Cne1p) binds <strong>Glc1Man9GlcNAc2</strong>, and that glucosidase-mediated glucose trimming controls release from calnexin; it emphasizes that <strong><em>S. cerevisiae</em> lacks UGGT</strong>, which changes the logic of repeated binding relative to mammalian systems. (Published Jun 2022; https://doi.org/10.3389/fmolb.2022.910709) (piirainen2022theimpactof pages 2-3)<br />
+* It highlights an applied knowledge gap: many glycoengineered strains create ER N-glycans that may <strong>bypass calnexin-dependent folding</strong> or create glycans recognized by ERAD, yet the consequences for bioproduction proteins are not fully defined and may depend on the specific product. (piirainen2022theimpactof pages 5-6, piirainen2022theimpactof pages 4-5)</p>
+<p>Although not CNE1-centric, a 2024 yeast study on UPR induction by lipid imbalance underscores that UPR can be triggered independent of obvious proteostasis defects, reinforcing the broader context in which ERQC components like Cne1 operate (i.e., not all UPR phenotypes map cleanly to classical ERAD overload). (Published Sep 2024; https://doi.org/10.1091/mbc.e24-03-0121) (zhang2008theeffectof pages 1-4)</p>
+<h2 id="4-current-applications-and-real-world-implementations">4) Current applications and real-world implementations</h2>
+<p>Direct industrial implementations generally do not target <em>S. cerevisiae</em> CNE1 alone, but CNE1 is part of the <strong>engineering “toolbox”</strong> for ER folding/secretory pathway tuning.</p>
+<h3 id="41-glycoengineering-and-secretory-pathway-optimization">4.1 Glycoengineering and secretory pathway optimization</h3>
+<p>In glycoengineered yeasts intended for biopharmaceutical production, ER glycan structures can be altered in ways that may <strong>reduce or eliminate canonical calnexin binding</strong>; this is viewed as a design constraint/unknown that can influence folding efficiency, ERAD engagement, and overall yields. (piirainen2022theimpactof pages 5-6, piirainen2022theimpactof pages 2-3)</p>
+<h3 id="42-quality-control-tuning-for-recombinant-proteins-evidence-bearing-examples">4.2 Quality-control tuning for recombinant proteins (evidence-bearing examples)</h3>
+<p>CNE1’s role in <strong>retaining/degrading unstable glycoproteins</strong> has been exploited experimentally using heterologous model proteins:<br />
+* <strong>Unstable glycosylated lysozyme mutants</strong> are retained and degraded in a Cne1p-dependent manner; deletion increases secretion of unstable mutants, demonstrating a lever by which ERQC stringency can be altered. (Azakami et al., 2014; https://doi.org/10.1080/09168451.2014.918486) (azakami2014unstablemutantlysozymes pages 2-3, azakami2014unstablemutantlysozymes pages 1-2)<br />
+* Increased secretion of heterologous <strong>α1-antitrypsin</strong> in a CNE1 deletion background supports the idea that manipulating CNE1 can shift the balance between retention/ERAD and export for certain recombinant proteins. (parlati1996characterizationofcalnexin pages 50-54)</p>
+<p>These studies represent concrete “real-world” implementations in research and bioprocess strain development: adjusting ERQC components such as CNE1 can change secretion of difficult-to-fold glycoproteins, but risks exporting misfolded products and/or increasing downstream quality burden. (parlati1996characterizationofcalnexin pages 50-54, azakami2014unstablemutantlysozymes pages 2-3)</p>
+<h2 id="5-expert-opinions-and-analysis-authoritative-synthesis">5) Expert opinions and analysis (authoritative synthesis)</h2>
+<h3 id="51-expert-synthesis-why-cne1-phenotypes-are-often-subtle-in-budding-yeast">5.1 Expert synthesis: why CNE1 phenotypes are often subtle in budding yeast</h3>
+<p>A recurring interpretation is that <strong>cne1Δ phenotypes are modest</strong> because <em>S. cerevisiae</em> can buffer ER folding defects through other chaperones/oxidoreductases and stress programs.<br />
+* Heat stress experiments show induction of PDI upon CNE1 deletion, consistent with a compensatory ER folding network that can preserve growth. (zhang2008theeffectof pages 1-4)<br />
+* Reviews argue that the absence of UGGT in <em>S. cerevisiae</em> changes the dependence on repeated calnexin binding, suggesting that calnexin’s role may be narrower or “one-pass” in budding yeast and/or more important for select substrates and stress conditions. (piirainen2022theimpactof pages 2-3, parlati1996characterizationofcalnexin pages 155-157)</p>
+<h3 id="52-expert-synthesis-glycoengineering-introduces-new-erqcerad-unknowns">5.2 Expert synthesis: glycoengineering introduces new ERQC/ERAD unknowns</h3>
+<p>The glycoengineering review emphasizes that most mechanistic ERQC evidence uses folding-deficient model substrates, and that <strong>production-relevant proteins may behave differently</strong>, sometimes not requiring glycans for folding. Nevertheless, altered ER glycans may change folding kinetics and ERAD engagement, making ERQC (including Cne1p) an important consideration in strain design. (piirainen2022theimpactof pages 5-6, piirainen2022theimpactof pages 4-5)</p>
+<h2 id="6-relevant-statistics-and-quantitative-data-points-from-retrieved-studies">6) Relevant statistics and quantitative data points from retrieved studies</h2>
+<p>Because the retrieved set is dominated by mechanistic, substrate-focused studies, quantitative results are mostly presented as <strong>effect directions</strong> (e.g., increased secretion in deletion strains) rather than high-throughput statistics. Still, the following quantitative/structured points are supported:<br />
+* Sequence similarity reported in early characterization: Cne1p is ~<strong>24% identical</strong> and <strong>31% similar</strong> to mammalian calnexin (useful for homology-based annotation but also highlights divergence). (parlati1996characterizationofcalnexin pages 50-54)<br />
+* Cne1p glycosylation shift: apparent mass shift from ~<strong>76 kDa to 60 kDa</strong> upon Endo H treatment (supporting N-glycosylation and ER residence). (parlati1996characterizationofcalnexin pages 50-54)<br />
+* ERAD-related kinetic note: degradation of unglycosylated pro–a-factor in microsomes described as cytosol- and ATP-dependent with a reported <strong>~7.5 min half-life</strong> (contextual evidence linking Cne1 to ERQC/ERAD handling of secretory substrates). (parlati1996characterizationofcalnexin pages 150-152)</p>
+<h2 id="7-consolidated-evidence-map-primary-facts">7) Consolidated evidence map (primary facts)</h2>
+<p>The following table consolidates the strongest experimentally supported claims for functional annotation.</p>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>Key findings</th>
+<th>Evidence type/method</th>
+<th>Primary source (first author year + DOI URL)</th>
+<th>Citation ID</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity/domains</td>
+<td>CNE1 = YAL058W/FUN48; encodes the sole <em>S. cerevisiae</em> calnexin/calreticulin-family homolog; ~24% identity and ~31% similarity to mammalian calnexin</td>
+<td>Gene cloning/sequence comparison; biochemical characterization</td>
+<td>Parlati 1996; source text unavailable for DOI in retrieved context</td>
+<td>(parlati1996characterizationofcalnexin pages 50-54)</td>
+</tr>
+<tr>
+<td>Localization/topology</td>
+<td>ER-localized integral membrane glycoprotein; Endo H-sensitive N-glycosylation; colocalizes with Kar2/BiP; strong perinuclear and cortical ER pattern</td>
+<td>Subcellular fractionation; carbonate/urea/high-salt extraction; Endo H shift; immunofluorescence/confocal microscopy</td>
+<td>Parlati 1996; source text unavailable for DOI in retrieved context</td>
+<td>(parlati1996characterizationofcalnexin pages 50-54, parlati1996characterizationofcalnexin pages 76-82)</td>
+</tr>
+<tr>
+<td>Localization/topology</td>
+<td>Contains a transmembrane region but lacks a cytoplasmic tail; deletion of TM did not fully release protein from membranes, suggesting membrane retention via protein interactions</td>
+<td>Domain analysis; membrane association assays of truncation mutants</td>
+<td>Parlati 1996; source text unavailable for DOI in retrieved context</td>
+<td>(parlati1996characterizationofcalnexin pages 150-152)</td>
+</tr>
+<tr>
+<td>Biochemical activity and binding specificity</td>
+<td>Functions as a molecular chaperone; recombinant GST-Cne1p suppresses thermal aggregation and improves refolding of citrate synthase in a dose-dependent manner</td>
+<td>In vitro thermal denaturation/refolding assay</td>
+<td>Xu 2004; https://doi.org/10.1093/jb/mvh074</td>
+<td>(xu2004expressionandcharacterization pages 1-2)</td>
+</tr>
+<tr>
+<td>Biochemical activity and binding specificity</td>
+<td>Lectin-like specificity for monoglucosylated N-glycan; chaperone activity strongly affected by G1M9 oligosaccharide (Glc1Man9GlcNAc2)</td>
+<td>Recombinant protein assay with defined oligosaccharide competitor/modulator</td>
+<td>Xu 2004; https://doi.org/10.1093/jb/mvh074</td>
+<td>(xu2004expressionandcharacterization pages 1-2)</td>
+</tr>
+<tr>
+<td>Biochemical activity and binding specificity</td>
+<td>Not a strong Ca2+-binding protein; no detectable ^45Ca binding in overlay assays; unlike mammalian calnexin, lacks evident calcium-binding capacity</td>
+<td>^45Ca overlay; GST-fusion protein binding assay</td>
+<td>Parlati 1996; source text unavailable for DOI in retrieved context</td>
+<td>(parlati1996characterizationofcalnexin pages 150-152, parlati1996characterizationofcalnexin pages 76-82)</td>
+</tr>
+<tr>
+<td>Substrates/clients</td>
+<td>Binds unstable glycosylated lysozyme mutants (e.g., G49N/D66H, G49N/C76A, K13D/G49N); interaction is glycan-dependent</td>
+<td>Co-expression and co-immunoprecipitation</td>
+<td>Azakami 2014; https://doi.org/10.1080/09168451.2014.918486</td>
+<td>(azakami2014unstablemutantlysozymes pages 1-2)</td>
+</tr>
+<tr>
+<td>Substrates/clients</td>
+<td>Tunicamycin abolishes Cne1p interaction with mutant lysozymes, indicating dependence on N-linked glycosylation/lectin recognition</td>
+<td>Tunicamycin perturbation of N-glycosylation; co-IP</td>
+<td>Azakami 2014; https://doi.org/10.1080/09168451.2014.918486</td>
+<td>(azakami2014unstablemutantlysozymes pages 1-2)</td>
+</tr>
+<tr>
+<td>Substrates/clients</td>
+<td>Influences intracellular retention of misfolded cargo such as temperature-sensitive Ste2-3p and unstable glycosylated lysozyme mutants; also affects secretion of heterologous α1-antitrypsin</td>
+<td>Cell-surface expression assays; secretion assays; microscopy</td>
+<td>Parlati 1996; source text unavailable for DOI in retrieved context; Azakami 2014; https://doi.org/10.1080/09168451.2014.918486</td>
+<td>(parlati1996characterizationofcalnexin pages 150-152, azakami2014unstablemutantlysozymes pages 2-3)</td>
+</tr>
+<tr>
+<td>Phenotypes of deletion</td>
+<td><strong>cne1Δ</strong> is viable and shows little or no gross defect in general growth or bulk secretion (acid phosphatase, a-factor) under standard conditions</td>
+<td>Gene disruption; growth and secretion assays</td>
+<td>Parlati 1996; source text unavailable for DOI in retrieved context; Zhang 2008; https://doi.org/10.2478/s11658-007-0033-y</td>
+<td>(parlati1996characterizationofcalnexin pages 50-54, zhang2008theeffectof pages 1-4)</td>
+</tr>
+<tr>
+<td>Phenotypes of deletion</td>
+<td><strong>cne1Δ</strong> increases escape/secretion of unstable glycoproteins, consistent with loss of ER retention/quality control</td>
+<td>Deletion strain comparison; secretion analysis</td>
+<td>Xu 2004; https://doi.org/10.1093/jb/mvh074; Azakami 2014; https://doi.org/10.1080/09168451.2014.918486</td>
+<td>(xu2004expressionandcharacterization pages 1-2, azakami2014unstablemutantlysozymes pages 2-3)</td>
+</tr>
+<tr>
+<td>Phenotypes of deletion</td>
+<td><strong>cne1Δ</strong> elevates cell-surface expression of ER-retained mutant Ste2-3p and secretion of α1-antitrypsin, supporting a QC checkpoint role</td>
+<td>Reporter trafficking assays; heterologous secretion assays</td>
+<td>Parlati 1996; source text unavailable for DOI in retrieved context</td>
+<td>(parlati1996characterizationofcalnexin pages 150-152, parlati1996characterizationofcalnexin pages 50-54)</td>
+</tr>
+<tr>
+<td>Phenotypes of deletion</td>
+<td>Deletion induces compensatory ER stress responses, including increased PDI-family expression under heat stress; growth remains similar to WT at 37°C</td>
+<td>mRNA/protein expression analysis; western blot; heat-stress growth assays</td>
+<td>Zhang 2008; https://doi.org/10.2478/s11658-007-0033-y</td>
+<td>(zhang2008theeffectof pages 1-4)</td>
+</tr>
+<tr>
+<td>Phenotypes of overexpression</td>
+<td>Overexpression did not measurably alter general secretion of several standard reporters in early characterization studies</td>
+<td>Overexpression strain analysis; secretion assays</td>
+<td>Parlati 1996; source text unavailable for DOI in retrieved context</td>
+<td>(parlati1996characterizationofcalnexin pages 150-152)</td>
+</tr>
+<tr>
+<td>Interaction partners</td>
+<td>Functional linkage with PDI-family oxidoreductases; Mpd1p reported to interact with Cne1p in vitro; PDI upregulation may compensate for Cne1 loss during stress</td>
+<td>In vitro interaction evidence; expression response analysis</td>
+<td>Zhang 2008; https://doi.org/10.2478/s11658-007-0033-y</td>
+<td>(zhang2008theeffectof pages 1-4)</td>
+</tr>
+<tr>
+<td>Interaction partners</td>
+<td>Direct association demonstrated with unstable glycosylated lysozyme mutants; transient association with many endogenous cellular proteins was not detected in early studies</td>
+<td>Co-IP for mutant clients; immunoprecipitation surveys</td>
+<td>Azakami 2014; https://doi.org/10.1080/09168451.2014.918486; Parlati 1996; source text unavailable for DOI in retrieved context</td>
+<td>(azakami2014unstablemutantlysozymes pages 1-2, parlati1996characterizationofcalnexin pages 150-152)</td>
+</tr>
+<tr>
+<td>Pathway/process</td>
+<td>Constituent of ER protein quality control for nascent/misfolded glycoproteins; acts as ER lectin-chaperone with weaker/modified calnexin-cycle logic because <em>S. cerevisiae</em> lacks UGGT-mediated reglucosylation</td>
+<td>Integration of genetic, biochemical, and client-retention evidence</td>
+<td>Xu 2004; https://doi.org/10.1093/jb/mvh074; Zhang 2008; https://doi.org/10.2478/s11658-007-0033-y; Parlati 1996; source text unavailable for DOI in retrieved context</td>
+<td>(xu2004expressionandcharacterization pages 1-2, zhang2008theeffectof pages 1-4, parlati1996characterizationofcalnexin pages 155-157)</td>
+</tr>
+<tr>
+<td>Pathway/process</td>
+<td>Participates in ER retention and degradation of unstable glycoproteins, linking Cne1p to ER-associated degradation (ERAD)-related outcomes</td>
+<td>Co-IP; glycosylation dependence; secretion/retention phenotypes in WT vs <strong>cne1Δ</strong></td>
+<td>Azakami 2014; https://doi.org/10.1080/09168451.2014.918486</td>
+<td>(azakami2014unstablemutantlysozymes pages 1-2, azakami2014unstablemutantlysozymes pages 2-3)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes experimentally supported facts about the budding yeast calnexin homolog CNE1/P27825, emphasizing validated localization, biochemical activity, client specificity, phenotypes, and pathway placement. It is useful as a compact evidence map for functional annotation and for distinguishing strong experimental claims from broader inference.</em></p>
+<h2 id="8-practical-functional-annotation-summary-recommended-wording">8) Practical functional annotation summary (recommended wording)</h2>
+<p><strong>CNE1 (P27825) encodes Cne1p, an ER-localized integral membrane lectin chaperone of the calnexin/calreticulin family that binds monoglucosylated N-glycans (Glc1Man9GlcNAc2) and participates in ER quality control by promoting folding and/or ER retention and ERAD targeting of unstable glycoproteins.</strong> (xu2004expressionandcharacterization pages 1-2, azakami2014unstablemutantlysozymes pages 1-2, parlati1996characterizationofcalnexin pages 50-54, piirainen2022theimpactof pages 2-3)</p>
+<h2 id="9-evidence-limitations-and-gaps">9) Evidence limitations and gaps</h2>
+<ul>
+<li><strong>2023–2024 CNE1-specific mechanistic primary literature</strong> was not prominent in the retrieved full texts; therefore, the most precise statements here rely on foundational studies plus a 2022 authoritative synthesis. (xu2004expressionandcharacterization pages 1-2, azakami2014unstablemutantlysozymes pages 1-2, piirainen2022theimpactof pages 2-3)</li>
+<li>The exact <strong>endogenous client spectrum</strong> of Cne1p in budding yeast remains incompletely resolved in this evidence set; strong client evidence is available for specific heterologous/mutant substrates (lysozyme mutants, Ste2-3p reporter, α1-antitrypsin). (azakami2014unstablemutantlysozymes pages 1-2, parlati1996characterizationofcalnexin pages 50-54)</li>
+</ul>
+<h2 id="10-key-urls-for-user-convenience">10) Key URLs (for user convenience)</h2>
+<ul>
+<li>Xu et al., 2004 (May 2004). “Expression and characterization of <em>S. cerevisiae</em> Cne1p, a calnexin homologue.” https://doi.org/10.1093/jb/mvh074 (xu2004expressionandcharacterization pages 1-2)</li>
+<li>Zhang et al., 2008 (Jan 2008). “The effect of calnexin deletion on the expression level of PDI in <em>S. cerevisiae</em> under heat stress conditions.” https://doi.org/10.2478/s11658-007-0033-y (zhang2008theeffectof pages 1-4)</li>
+<li>Azakami et al., 2014 (Jul 2014). “Unstable mutant lysozymes are degraded through the interaction with calnexin homolog Cne1p in <em>S. cerevisiae</em>.” https://doi.org/10.1080/09168451.2014.918486 (azakami2014unstablemutantlysozymes pages 1-2)</li>
+<li>Piirainen &amp; Frey, 2022 (Jun 2022). “The impact of glycoengineering on the ER quality control system in yeasts.” https://doi.org/10.3389/fmolb.2022.910709 (piirainen2022theimpactof pages 2-3)</li>
+<li>Rajakumar et al., 2024 (Sep 2024). “Dysregulation of ceramide metabolism causes phytoceramide-dependent induction of the unfolded protein response.” https://doi.org/10.1091/mbc.e24-03-0121 (contextual UPR/ER homeostasis) (zhang2008theeffectof pages 1-4)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(parlati1996characterizationofcalnexin pages 50-54): F Parlati. Characterization of calnexin in saccharomyces cerevisiae and schizosaccharomyces pombe. Unknown journal, 1996.</p>
+</li>
+<li>
+<p>(xu2004expressionandcharacterization pages 1-2): Xiaohua Xu, Kunitoshi Kanbara, H. Azakami, and A. Kato. Expression and characterization of saccharomyces cerevisiae cne1p, a calnexin homologue. Journal of biochemistry, 135 5:615-8, May 2004. URL: https://doi.org/10.1093/jb/mvh074, doi:10.1093/jb/mvh074. This article has 49 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(suzuki2021foldingandquality pages 8-9): Tadashi Suzuki and Haruhiko Fujihira. Folding and quality control of glycoproteins. Comprehensive Glycoscience, pages 1-28, Dec 2021. URL: https://doi.org/10.1016/b978-0-12-409547-2.14947-9, doi:10.1016/b978-0-12-409547-2.14947-9. This article has 12 citations.</p>
+</li>
+<li>
+<p>(piirainen2022theimpactof pages 2-3): Mari A. Piirainen and Alexander D. Frey. The impact of glycoengineering on the endoplasmic reticulum quality control system in yeasts. Frontiers in Molecular Biosciences, Jun 2022. URL: https://doi.org/10.3389/fmolb.2022.910709, doi:10.3389/fmolb.2022.910709. This article has 2 citations.</p>
+</li>
+<li>
+<p>(parlati1996characterizationofcalnexin pages 155-157): F Parlati. Characterization of calnexin in saccharomyces cerevisiae and schizosaccharomyces pombe. Unknown journal, 1996.</p>
+</li>
+<li>
+<p>(piirainen2022theimpactof pages 6-7): Mari A. Piirainen and Alexander D. Frey. The impact of glycoengineering on the endoplasmic reticulum quality control system in yeasts. Frontiers in Molecular Biosciences, Jun 2022. URL: https://doi.org/10.3389/fmolb.2022.910709, doi:10.3389/fmolb.2022.910709. This article has 2 citations.</p>
+</li>
+<li>
+<p>(parlati1996characterizationofcalnexin pages 76-82): F Parlati. Characterization of calnexin in saccharomyces cerevisiae and schizosaccharomyces pombe. Unknown journal, 1996.</p>
+</li>
+<li>
+<p>(parlati1996characterizationofcalnexin pages 150-152): F Parlati. Characterization of calnexin in saccharomyces cerevisiae and schizosaccharomyces pombe. Unknown journal, 1996.</p>
+</li>
+<li>
+<p>(azakami2014unstablemutantlysozymes pages 1-2): Hiroyuki Azakami, Masayoshi Uehara, Ryohei Matsuo, Yuta Tsurunaga, Yuichiro Yamashita, Masakatsu Usui, and Akio Kato. Unstable mutant lysozymes are degraded through the interaction with calnexin homolog cne1p in saccharomyces cerevisiae. Bioscience, Biotechnology, and Biochemistry, 78:1263-1269, Jul 2014. URL: https://doi.org/10.1080/09168451.2014.918486, doi:10.1080/09168451.2014.918486. This article has 2 citations.</p>
+</li>
+<li>
+<p>(azakami2014unstablemutantlysozymes pages 2-3): Hiroyuki Azakami, Masayoshi Uehara, Ryohei Matsuo, Yuta Tsurunaga, Yuichiro Yamashita, Masakatsu Usui, and Akio Kato. Unstable mutant lysozymes are degraded through the interaction with calnexin homolog cne1p in saccharomyces cerevisiae. Bioscience, Biotechnology, and Biochemistry, 78:1263-1269, Jul 2014. URL: https://doi.org/10.1080/09168451.2014.918486, doi:10.1080/09168451.2014.918486. This article has 2 citations.</p>
+</li>
+<li>
+<p>(zhang2008theeffectof pages 1-4): Huili Zhang, Jianwei He, Yanyan Ji, Akio Kato, and Youtao Song. The effect of calnexin deletion on the expression level of pdi in saccharomyces cerevisiae under heat stress conditions. Cellular and Molecular Biology Letters, Jan 2008. URL: https://doi.org/10.2478/s11658-007-0033-y, doi:10.2478/s11658-007-0033-y. This article has 16 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(piirainen2022theimpactof pages 5-6): Mari A. Piirainen and Alexander D. Frey. The impact of glycoengineering on the endoplasmic reticulum quality control system in yeasts. Frontiers in Molecular Biosciences, Jun 2022. URL: https://doi.org/10.3389/fmolb.2022.910709, doi:10.3389/fmolb.2022.910709. This article has 2 citations.</p>
+</li>
+<li>
+<p>(piirainen2022theimpactof pages 4-5): Mari A. Piirainen and Alexander D. Frey. The impact of glycoengineering on the endoplasmic reticulum quality control system in yeasts. Frontiers in Molecular Biosciences, Jun 2022. URL: https://doi.org/10.3389/fmolb.2022.910709, doi:10.3389/fmolb.2022.910709. This article has 2 citations.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>suzuki2021foldingandquality pages 8-9</li>
+<li>parlati1996characterizationofcalnexin pages 50-54</li>
+<li>parlati1996characterizationofcalnexin pages 76-82</li>
+<li>xu2004expressionandcharacterization pages 1-2</li>
+<li>azakami2014unstablemutantlysozymes pages 1-2</li>
+<li>zhang2008theeffectof pages 1-4</li>
+<li>parlati1996characterizationofcalnexin pages 150-152</li>
+<li>piirainen2022theimpactof pages 2-3</li>
+<li>parlati1996characterizationofcalnexin pages 155-157</li>
+<li>piirainen2022theimpactof pages 6-7</li>
+<li>azakami2014unstablemutantlysozymes pages 2-3</li>
+<li>piirainen2022theimpactof pages 5-6</li>
+<li>piirainen2022theimpactof pages 4-5</li>
+<li>https://doi.org/10.1093/jb/mvh074</li>
+<li>https://doi.org/10.1080/09168451.2014.918486</li>
+<li>https://doi.org/10.2478/s11658-007-0033-y</li>
+<li>https://doi.org/10.3389/fmolb.2022.910709</li>
+<li>https://doi.org/10.1091/mbc.e24-03-0121</li>
+<li>https://doi.org/10.1093/jb/mvh074;</li>
+<li>https://doi.org/10.1080/09168451.2014.918486;</li>
+<li>https://doi.org/10.2478/s11658-007-0033-y;</li>
+<li>https://doi.org/10.1093/jb/mvh074,</li>
+<li>https://doi.org/10.1016/b978-0-12-409547-2.14947-9,</li>
+<li>https://doi.org/10.3389/fmolb.2022.910709,</li>
+<li>https://doi.org/10.1080/09168451.2014.918486,</li>
+<li>https://doi.org/10.2478/s11658-007-0033-y,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -1870,165 +2987,16 @@
                 <pre><code>id: P27825
 gene_symbol: CNE1
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: &#39;TODO: Add description for CNE1&#39;
-existing_annotations:
-- term:
-    id: GO:0006457
-    label: protein folding
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: &#39;Manual review: protein folding is consistent with known biology of CNE1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0036503
-    label: ERAD pathway
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: &#39;Manual review: ERAD pathway is consistent with known biology of CNE1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005509
-    label: calcium ion binding
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: &#39;Manual review: calcium ion binding is consistent with known biology of CNE1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005789
-    label: endoplasmic reticulum membrane
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: &#39;Manual review: endoplasmic reticulum membrane is consistent with known biology of CNE1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005509
-    label: calcium ion binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: &#39;Manual review: calcium ion binding is consistent with known biology of CNE1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005783
-    label: endoplasmic reticulum
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: &#39;Manual review: endoplasmic reticulum is consistent with known biology of CNE1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005789
-    label: endoplasmic reticulum membrane
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000044
-  review:
-    summary: &#39;Manual review: endoplasmic reticulum membrane is consistent with known biology of CNE1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0006457
-    label: protein folding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: &#39;Manual review: protein folding is consistent with known biology of CNE1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0030246
-    label: carbohydrate binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000043
-  review:
-    summary: &#39;Manual review: carbohydrate binding is consistent with known biology of CNE1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: &#39;Manual review: unfolded protein binding is too generic or over-extended for CNE1.&#39;
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0036503
-    label: ERAD pathway
-  evidence_type: IMP
-  original_reference_id: PMID:7814381
-  review:
-    summary: &#39;Manual review: ERAD pathway is consistent with known biology of CNE1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005789
-    label: endoplasmic reticulum membrane
-  evidence_type: IDA
-  original_reference_id: PMID:7814381
-  review:
-    summary: &#39;Manual review: endoplasmic reticulum membrane is consistent with known biology of CNE1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005783
-    label: endoplasmic reticulum
-  evidence_type: HDA
-  original_reference_id: PMID:26928762
-  review:
-    summary: &#39;Manual review: endoplasmic reticulum is consistent with known biology of CNE1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:16002399
-  review:
-    summary: &#39;Manual review: protein binding is too generic or over-extended for CNE1.&#39;
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IDA
-  original_reference_id: PMID:16002399
-  review:
-    summary: &#39;Manual review: unfolded protein binding is too generic or over-extended for CNE1.&#39;
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0006457
-    label: protein folding
-  evidence_type: IMP
-  original_reference_id: PMID:15173200
-  review:
-    summary: &#39;Manual review: protein folding is consistent with known biology of CNE1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IMP
-  original_reference_id: PMID:15173200
-  review:
-    summary: &#39;Manual review: unfolded protein binding is too generic or over-extended for CNE1.&#39;
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+description: &gt;-
+  CNE1 encodes the budding yeast calnexin homolog, an ER membrane lectin chaperone of the calreticulin/calnexin
+  family. Cne1 promotes ER protein quality control by binding glycosylated folding intermediates, assisting
+  folding or retention of misfolded glycoproteins, and contributing to ER-associated degradation decisions.
+  Direct biochemical evidence argues against annotating yeast Cne1 as a calcium-binding protein despite
+  family-transfer annotations.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -2040,27 +3008,478 @@ references:
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
+  title: &gt;-
+    Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied
+    by conservative changes to GO terms applied by UniProt
   findings: []
 - id: PMID:15173200
   title: Expression and characterization of Saccharomyces cerevisiae Cne1p, a calnexin homologue.
-  findings: []
+  findings:
+  - statement: &gt;-
+      Recombinant Cne1p shows chaperone activity and lectin-site dependence in citrate synthase denaturation/refolding
+      assays.
+    supporting_text: &gt;-
+      Cne1p effectively suppressed the thermal denaturation of CS and enhanced the refolding of thermally
+      or chemically denatured CS in a concentration-dependent manner... the chaperone function of Cne1p
+      was greatly affected in the presence of monoglucosylated oligosaccharides (G1M9) that specifically
+      bind to the lectin site.
 - id: PMID:16002399
-  title: Interactions among yeast protein-disulfide isomerase proteins and endoplasmic reticulum chaperone proteins influence their activities.
-  findings: []
+  title: &gt;-
+    Interactions among yeast protein-disulfide isomerase proteins and endoplasmic reticulum chaperone
+    proteins influence their activities.
+  findings:
+  - statement: &gt;-
+      Cne1p interacts functionally with ER oxidoreductase Mpd1p, supporting a role in the ER folding/chaperone
+      network but not a generic protein-binding annotation.
+    supporting_text: &gt;-
+      Mpd1p alone does not have chaperone activity but that it interacts with and inhibits the chaperone
+      activity of Cne1p
+- id: PMID:25229868
+  title: Unstable mutant lysozymes are degraded through the interaction with calnexin homolog Cne1p in Saccharomyces cerevisiae.
+  findings:
+  - statement: &gt;-
+      Cne1p interacts with unstable misfolded lysozymes and promotes their ER retention and subsequent
+      elimination via ER-associated degradation.
+    supporting_text: &gt;-
+      These results suggest that in yeasts, Cne1p interacts with misfolded lysozyme proteins possibly
+      causing their retention in the ER and subsequent elimination via ER-associated degradation.
 - id: PMID:26928762
   title: &#39;One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy.&#39;
   findings: []
 - id: PMID:7814381
-  title: Saccharomyces cerevisiae CNE1 encodes an endoplasmic reticulum (ER) membrane protein with sequence similarity to calnexin and calreticulin and functions as a constituent of the ER quality control apparatus.
-  findings: []
+  title: &gt;-
+    Saccharomyces cerevisiae CNE1 encodes an endoplasmic reticulum (ER) membrane protein with sequence
+    similarity to calnexin and calreticulin and functions as a constituent of the ER quality control apparatus.
+  findings:
+  - statement: &gt;-
+      Cne1p is an ER membrane glycoprotein and ER quality-control factor; the same study reported no detectable
+      Ca2+ binding for Cne1p.
+    supporting_text: &gt;-
+      Localization of the Cne1p protein by differential and analytical subcellular fractionation as well
+      as by confocal immunofluorescence microscopy showed that it was exclusively located in the endoplasmic
+      reticulum (ER)... Ca2+ binding activity has not been detected for Cne1p... Hence, Cne1p appears
+      to function as a constituent of the S. cerevisiae ER protein quality control apparatus.
+- id: file:yeast/CNE1/CNE1-deep-research-falcon.md
+  title: Falcon deep research report for CNE1
+  findings:
+  - statement: &gt;-
+      The Falcon report was reviewed and synthesized into the CNE1 curation, including core-function framing,
+      family/PANTHER context, and evidence limitations.
+existing_annotations:
+- term:
+    id: GO:0006457
+    label: protein folding
+  qualifier: involved_in
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: &gt;-
+      protein folding is a supported biological-process context for Cne1p as an ER lectin chaperone and
+      quality-control factor.
+    action: ACCEPT
+    reason: &gt;-
+      Direct yeast evidence supports Cne1p in ER folding/quality control and retention/elimination of
+      misfolded glycoprotein clients via ER-associated degradation.
+    supported_by:
+    - reference_id: PMID:25229868
+      supporting_text: &gt;-
+        These results suggest that in yeasts, Cne1p interacts with misfolded lysozyme proteins possibly
+        causing their retention in the ER and subsequent elimination via ER-associated degradation.
+      reference_section_type: ABSTRACT
+    supported_by:
+    - reference_id: file:yeast/CNE1/CNE1-deep-research-falcon.md
+      supporting_text: CNE1 (P27825) encodes Cne1p
+- term:
+    id: GO:0036503
+    label: ERAD pathway
+  qualifier: involved_in
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: &gt;-
+      ERAD pathway is a supported biological-process context for Cne1p as an ER lectin chaperone and quality-control
+      factor.
+    action: ACCEPT
+    reason: &gt;-
+      Direct yeast evidence supports Cne1p in ER folding/quality control and retention/elimination of
+      misfolded proteins.
+- term:
+    id: GO:0005509
+    label: calcium ion binding
+  qualifier: enables
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: &gt;-
+      Direct Cne1p biochemical characterization did not detect Ca2+ binding, so family-transfer calcium
+      ion binding should not be retained for yeast CNE1.
+    action: REMOVE
+    reason: &gt;-
+      The direct yeast study contradicts the inferred calcium-binding annotation; calnexin-family membership
+      alone is insufficient evidence for this molecular function in Cne1p.
+    supported_by:
+    - reference_id: PMID:7814381
+      supporting_text: Ca2+ binding activity has not been detected for Cne1p.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  qualifier: is_active_in
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: endoplasmic reticulum membrane is supported for Cne1p, an ER membrane glycoprotein.
+    action: ACCEPT
+    reason: &gt;-
+      Direct localization and membrane-association evidence places Cne1p in the ER membrane/ER quality-control
+      compartment.
+- term:
+    id: GO:0005509
+    label: calcium ion binding
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: &gt;-
+      Direct Cne1p biochemical characterization did not detect Ca2+ binding, so family-transfer calcium
+      ion binding should not be retained for yeast CNE1.
+    action: REMOVE
+    reason: &gt;-
+      The direct yeast study contradicts the inferred calcium-binding annotation; calnexin-family membership
+      alone is insufficient evidence for this molecular function in Cne1p.
+    supported_by:
+    - reference_id: PMID:7814381
+      supporting_text: Ca2+ binding activity has not been detected for Cne1p.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  qualifier: located_in
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: endoplasmic reticulum is supported for Cne1p, an ER membrane glycoprotein.
+    action: ACCEPT
+    reason: &gt;-
+      Direct localization and membrane-association evidence places Cne1p in the ER membrane/ER quality-control
+      compartment.
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  qualifier: located_in
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: endoplasmic reticulum membrane is supported for Cne1p, an ER membrane glycoprotein.
+    action: ACCEPT
+    reason: &gt;-
+      Direct localization and membrane-association evidence places Cne1p in the ER membrane/ER quality-control
+      compartment.
+- term:
+    id: GO:0006457
+    label: protein folding
+  qualifier: involved_in
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: &gt;-
+      protein folding is a supported biological-process context for Cne1p as an ER lectin chaperone and
+      quality-control factor.
+    action: ACCEPT
+    reason: &gt;-
+      Direct yeast evidence supports Cne1p in ER folding/quality control and retention/elimination of
+      misfolded proteins.
+- term:
+    id: GO:0030246
+    label: carbohydrate binding
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: &gt;-
+      CNE1 has lectin-site evidence for monoglucosylated oligosaccharide/glycoprotein recognition, so
+      carbohydrate binding is directionally correct but too broad.
+    action: MODIFY
+    reason: Use the more specific oligosaccharide binding term for the known calnexin lectin-site activity.
+    proposed_replacement_terms:
+    - id: GO:0070492
+      label: oligosaccharide binding
+    supported_by:
+    - reference_id: PMID:15173200
+      supporting_text: &gt;-
+        the chaperone function of Cne1p was greatly affected in the presence of monoglucosylated oligosaccharides
+        (G1M9) that specifically bind to the lectin site.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: &gt;-
+      Cne1p has chaperone activity toward folding intermediates, but unfolded protein binding alone is
+      a less informative representation of the ER lectin-chaperone function.
+    action: MODIFY
+    reason: &gt;-
+      Replace with protein folding chaperone, while separately capturing oligosaccharide/lectin binding
+      in core function and proposed terminology.
+    proposed_replacement_terms:
+    - id: GO:0044183
+      label: protein folding chaperone
+- term:
+    id: GO:0036503
+    label: ERAD pathway
+  qualifier: involved_in
+  evidence_type: IMP
+  original_reference_id: PMID:7814381
+  review:
+    summary: &gt;-
+      ERAD pathway is supported for Cne1p through its interaction with unstable glycosylated client proteins
+      and contribution to their ER retention/elimination.
+    action: ACCEPT
+    reason: &gt;-
+      PMID:25229868 provides direct yeast evidence that Cne1p binds unstable lysozyme mutants and contributes
+      to their retention and elimination via ER-associated degradation.
+    supported_by:
+    - reference_id: PMID:25229868
+      supporting_text: &gt;-
+        These results suggest that in yeasts, Cne1p interacts with misfolded lysozyme proteins possibly
+        causing their retention in the ER and subsequent elimination via ER-associated degradation.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  qualifier: located_in
+  evidence_type: IDA
+  original_reference_id: PMID:7814381
+  review:
+    summary: endoplasmic reticulum membrane is supported for Cne1p, an ER membrane glycoprotein.
+    action: ACCEPT
+    reason: &gt;-
+      Direct localization and membrane-association evidence places Cne1p in the ER membrane/ER quality-control
+      compartment.
+    supported_by:
+    - reference_id: PMID:7814381
+      supporting_text: &gt;-
+        Localization of the Cne1p protein by differential and analytical subcellular fractionation as
+        well as by confocal immunofluorescence microscopy showed that it was exclusively located in the
+        endoplasmic reticulum (ER)
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  qualifier: located_in
+  evidence_type: HDA
+  original_reference_id: PMID:26928762
+  review:
+    summary: &gt;-
+      endoplasmic reticulum is consistent with the ER biology of CNE1 and is supported by the SWAT endomembrane
+      localization library.
+    action: ACCEPT
+    reason: &gt;-
+      Accept as supporting ER localization evidence, with gene-specific ER function anchored by the primary
+      literature and UniProt record.
+    supported_by:
+    - reference_id: PMID:26928762
+      supporting_text: we constructed and investigated a library of
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005515
+    label: protein binding
+  qualifier: enables
+  evidence_type: IPI
+  original_reference_id: PMID:16002399
+  supporting_entities:
+  - SGD:S000001267
+  review:
+    summary: &gt;-
+      Protein binding is too generic for the CNE1 interaction evidence with ER folding factors such as
+      Mpd1/Eps1.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The interaction evidence is best interpreted as part of the ER chaperone/oxidoreductase quality-control
+      network, not as a standalone generic protein-binding function.
+    supported_by:
+    - reference_id: PMID:16002399
+      supporting_text: &gt;-
+        Mpd1p alone does not have chaperone activity but that it interacts with and inhibits the chaperone
+        activity of Cne1p
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005515
+    label: protein binding
+  qualifier: enables
+  evidence_type: IPI
+  original_reference_id: PMID:16002399
+  supporting_entities:
+  - SGD:S000005814
+  review:
+    summary: &gt;-
+      Protein binding is too generic for the CNE1 interaction evidence with ER folding factors such as
+      Mpd1/Eps1.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The interaction evidence is best interpreted as part of the ER chaperone/oxidoreductase quality-control
+      network, not as a standalone generic protein-binding function.
+    supported_by:
+    - reference_id: PMID:16002399
+      supporting_text: &gt;-
+        Mpd1p alone does not have chaperone activity but that it interacts with and inhibits the chaperone
+        activity of Cne1p
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IDA
+  original_reference_id: PMID:16002399
+  review:
+    summary: &gt;-
+      Cne1p has chaperone activity toward folding intermediates, but unfolded protein binding alone is
+      a less informative representation of the ER lectin-chaperone function.
+    action: MODIFY
+    reason: &gt;-
+      Replace with protein folding chaperone, while separately capturing oligosaccharide/lectin binding
+      in core function and proposed terminology.
+    proposed_replacement_terms:
+    - id: GO:0044183
+      label: protein folding chaperone
+    supported_by:
+    - reference_id: PMID:15173200
+      supporting_text: &gt;-
+        Cne1p effectively suppressed the thermal denaturation of CS and enhanced the refolding of thermally
+        or chemically denatured CS in a concentration-dependent manner.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0006457
+    label: protein folding
+  qualifier: involved_in
+  evidence_type: IMP
+  original_reference_id: PMID:15173200
+  review:
+    summary: &gt;-
+      protein folding is a supported biological-process context for Cne1p as an ER lectin chaperone and
+      quality-control factor.
+    action: ACCEPT
+    reason: &gt;-
+      Direct yeast evidence supports Cne1p in ER folding/quality control and retention/elimination of
+      misfolded proteins.
+    supported_by:
+    - reference_id: PMID:15173200
+      supporting_text: &gt;-
+        Cne1p effectively suppressed the thermal denaturation of CS and enhanced the refolding of thermally
+        or chemically denatured CS in a concentration-dependent manner.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IMP
+  original_reference_id: PMID:15173200
+  review:
+    summary: &gt;-
+      Cne1p has chaperone activity toward folding intermediates, but unfolded protein binding alone is
+      a less informative representation of the ER lectin-chaperone function.
+    action: MODIFY
+    reason: &gt;-
+      Replace with protein folding chaperone, while separately capturing oligosaccharide/lectin binding
+      in core function and proposed terminology.
+    proposed_replacement_terms:
+    - id: GO:0044183
+      label: protein folding chaperone
+    supported_by:
+    - reference_id: PMID:15173200
+      supporting_text: &gt;-
+        Cne1p effectively suppressed the thermal denaturation of CS and enhanced the refolding of thermally
+        or chemically denatured CS in a concentration-dependent manner.
+      reference_section_type: ABSTRACT
+core_functions:
+- description: &gt;-
+    Cne1p is an ER membrane lectin chaperone that assists folding and quality-control retention of glycoprotein
+    folding intermediates. Direct studies support ER localization, chaperone activity, and contribution
+    to ER protein quality control/ERAD, while direct Ca2+ binding was not detected.
+  molecular_function:
+    id: GO:0044183
+    label: protein folding chaperone
+  directly_involved_in:
+  - id: GO:0006457
+    label: protein folding
+  - id: GO:0036503
+    label: ERAD pathway
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: PMID:15173200
+    supporting_text: &gt;-
+      Cne1p effectively suppressed the thermal denaturation of CS and enhanced the refolding of thermally
+      or chemically denatured CS in a concentration-dependent manner.
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:7814381
+    supporting_text: &gt;-
+      Hence, Cne1p appears to function as a constituent of the S. cerevisiae ER protein quality control
+      apparatus.
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:25229868
+    supporting_text: &gt;-
+      These results suggest that in yeasts, Cne1p interacts with misfolded lysozyme proteins possibly
+      causing their retention in the ER and subsequent elimination via ER-associated degradation.
+    reference_section_type: ABSTRACT
+- description: &gt;-
+    Cne1p recognizes monoglucosylated oligosaccharide features through its calnexin lectin site, coupling
+    glycan recognition to ER folding and retention decisions for glycoprotein clients.
+  molecular_function:
+    id: GO:0070492
+    label: oligosaccharide binding
+  directly_involved_in:
+  - id: GO:0006457
+    label: protein folding
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: PMID:15173200
+    supporting_text: &gt;-
+      the chaperone function of Cne1p was greatly affected in the presence of monoglucosylated oligosaccharides
+      (G1M9) that specifically bind to the lectin site.
+    reference_section_type: ABSTRACT
+proposed_new_terms:
+- proposed_name: monoglucosylated glycoprotein binding
+  proposed_definition: &gt;-
+    Binding to monoglucosylated N-linked glycan structures on glycoprotein folding intermediates in the
+    endoplasmic reticulum.
+  justification: &gt;-
+    Cne1p is a calnexin-family lectin chaperone whose relevant carbohydrate specificity is monoglucosylated
+    glycoprotein/oligosaccharide recognition, which is more specific than broad carbohydrate binding.
+  proposed_parent:
+    id: GO:0070492
+    label: oligosaccharide binding
+  supported_by:
+  - reference_id: PMID:15173200
+    supporting_text: &gt;-
+      the chaperone function of Cne1p was greatly affected in the presence of monoglucosylated oligosaccharides
+      (G1M9) that specifically bind to the lectin site.
+    reference_section_type: ABSTRACT
+suggested_questions:
+- question: &gt;-
+    What are the endogenous yeast glycoprotein clients whose ER retention or ERAD depends directly on
+    Cne1p lectin-chaperone activity?
+suggested_experiments:
+- hypothesis: &gt;-
+    Cne1p-dependent ERAD is selective for monoglucosylated glycoprotein clients rather than general unfolded
+    proteins.
+  description: &gt;-
+    Use Cne1p proximity labeling or crosslinking immunoprecipitation under ER stress, with glycosylation-defective
+    and lectin-site mutant controls, followed by quantitative client identification.
+  experiment_type: proximity labeling and glycoprotein client proteomics
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/yeast/CNE1/CNE1-ai-review.yaml
+++ b/genes/yeast/CNE1/CNE1-ai-review.yaml
@@ -1,165 +1,16 @@
 id: P27825
 gene_symbol: CNE1
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: 'TODO: Add description for CNE1'
-existing_annotations:
-- term:
-    id: GO:0006457
-    label: protein folding
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: 'Manual review: protein folding is consistent with known biology of CNE1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0036503
-    label: ERAD pathway
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: 'Manual review: ERAD pathway is consistent with known biology of CNE1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005509
-    label: calcium ion binding
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: 'Manual review: calcium ion binding is consistent with known biology of CNE1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005789
-    label: endoplasmic reticulum membrane
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: 'Manual review: endoplasmic reticulum membrane is consistent with known biology of CNE1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005509
-    label: calcium ion binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: 'Manual review: calcium ion binding is consistent with known biology of CNE1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005783
-    label: endoplasmic reticulum
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: 'Manual review: endoplasmic reticulum is consistent with known biology of CNE1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005789
-    label: endoplasmic reticulum membrane
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000044
-  review:
-    summary: 'Manual review: endoplasmic reticulum membrane is consistent with known biology of CNE1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0006457
-    label: protein folding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: 'Manual review: protein folding is consistent with known biology of CNE1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0030246
-    label: carbohydrate binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000043
-  review:
-    summary: 'Manual review: carbohydrate binding is consistent with known biology of CNE1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: 'Manual review: unfolded protein binding is too generic or over-extended for CNE1.'
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0036503
-    label: ERAD pathway
-  evidence_type: IMP
-  original_reference_id: PMID:7814381
-  review:
-    summary: 'Manual review: ERAD pathway is consistent with known biology of CNE1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005789
-    label: endoplasmic reticulum membrane
-  evidence_type: IDA
-  original_reference_id: PMID:7814381
-  review:
-    summary: 'Manual review: endoplasmic reticulum membrane is consistent with known biology of CNE1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005783
-    label: endoplasmic reticulum
-  evidence_type: HDA
-  original_reference_id: PMID:26928762
-  review:
-    summary: 'Manual review: endoplasmic reticulum is consistent with known biology of CNE1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:16002399
-  review:
-    summary: 'Manual review: protein binding is too generic or over-extended for CNE1.'
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IDA
-  original_reference_id: PMID:16002399
-  review:
-    summary: 'Manual review: unfolded protein binding is too generic or over-extended for CNE1.'
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0006457
-    label: protein folding
-  evidence_type: IMP
-  original_reference_id: PMID:15173200
-  review:
-    summary: 'Manual review: protein folding is consistent with known biology of CNE1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IMP
-  original_reference_id: PMID:15173200
-  review:
-    summary: 'Manual review: unfolded protein binding is too generic or over-extended for CNE1.'
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+description: >-
+  CNE1 encodes the budding yeast calnexin homolog, an ER membrane lectin chaperone of the calreticulin/calnexin
+  family. Cne1 promotes ER protein quality control by binding glycosylated folding intermediates, assisting
+  folding or retention of misfolded glycoproteins, and contributing to ER-associated degradation decisions.
+  Direct biochemical evidence argues against annotating yeast Cne1 as a calcium-binding protein despite
+  family-transfer annotations.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -171,17 +22,468 @@ references:
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
+  title: >-
+    Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied
+    by conservative changes to GO terms applied by UniProt
   findings: []
 - id: PMID:15173200
   title: Expression and characterization of Saccharomyces cerevisiae Cne1p, a calnexin homologue.
-  findings: []
+  findings:
+  - statement: >-
+      Recombinant Cne1p shows chaperone activity and lectin-site dependence in citrate synthase denaturation/refolding
+      assays.
+    supporting_text: >-
+      Cne1p effectively suppressed the thermal denaturation of CS and enhanced the refolding of thermally
+      or chemically denatured CS in a concentration-dependent manner... the chaperone function of Cne1p
+      was greatly affected in the presence of monoglucosylated oligosaccharides (G1M9) that specifically
+      bind to the lectin site.
 - id: PMID:16002399
-  title: Interactions among yeast protein-disulfide isomerase proteins and endoplasmic reticulum chaperone proteins influence their activities.
-  findings: []
+  title: >-
+    Interactions among yeast protein-disulfide isomerase proteins and endoplasmic reticulum chaperone
+    proteins influence their activities.
+  findings:
+  - statement: >-
+      Cne1p interacts functionally with ER oxidoreductase Mpd1p, supporting a role in the ER folding/chaperone
+      network but not a generic protein-binding annotation.
+    supporting_text: >-
+      Mpd1p alone does not have chaperone activity but that it interacts with and inhibits the chaperone
+      activity of Cne1p
+- id: PMID:25229868
+  title: Unstable mutant lysozymes are degraded through the interaction with calnexin homolog Cne1p in Saccharomyces cerevisiae.
+  findings:
+  - statement: >-
+      Cne1p interacts with unstable misfolded lysozymes and promotes their ER retention and subsequent
+      elimination via ER-associated degradation.
+    supporting_text: >-
+      These results suggest that in yeasts, Cne1p interacts with misfolded lysozyme proteins possibly
+      causing their retention in the ER and subsequent elimination via ER-associated degradation.
 - id: PMID:26928762
   title: 'One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy.'
   findings: []
 - id: PMID:7814381
-  title: Saccharomyces cerevisiae CNE1 encodes an endoplasmic reticulum (ER) membrane protein with sequence similarity to calnexin and calreticulin and functions as a constituent of the ER quality control apparatus.
-  findings: []
+  title: >-
+    Saccharomyces cerevisiae CNE1 encodes an endoplasmic reticulum (ER) membrane protein with sequence
+    similarity to calnexin and calreticulin and functions as a constituent of the ER quality control apparatus.
+  findings:
+  - statement: >-
+      Cne1p is an ER membrane glycoprotein and ER quality-control factor; the same study reported no detectable
+      Ca2+ binding for Cne1p.
+    supporting_text: >-
+      Localization of the Cne1p protein by differential and analytical subcellular fractionation as well
+      as by confocal immunofluorescence microscopy showed that it was exclusively located in the endoplasmic
+      reticulum (ER)... Ca2+ binding activity has not been detected for Cne1p... Hence, Cne1p appears
+      to function as a constituent of the S. cerevisiae ER protein quality control apparatus.
+- id: file:yeast/CNE1/CNE1-deep-research-falcon.md
+  title: Falcon deep research report for CNE1
+  findings:
+  - statement: >-
+      The Falcon report was reviewed and synthesized into the CNE1 curation, including core-function framing,
+      family/PANTHER context, and evidence limitations.
+existing_annotations:
+- term:
+    id: GO:0006457
+    label: protein folding
+  qualifier: involved_in
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: >-
+      protein folding is a supported biological-process context for Cne1p as an ER lectin chaperone and
+      quality-control factor.
+    action: ACCEPT
+    reason: >-
+      Direct yeast evidence supports Cne1p in ER folding/quality control and retention/elimination of
+      misfolded glycoprotein clients via ER-associated degradation.
+    supported_by:
+    - reference_id: PMID:25229868
+      supporting_text: >-
+        These results suggest that in yeasts, Cne1p interacts with misfolded lysozyme proteins possibly
+        causing their retention in the ER and subsequent elimination via ER-associated degradation.
+      reference_section_type: ABSTRACT
+    supported_by:
+    - reference_id: file:yeast/CNE1/CNE1-deep-research-falcon.md
+      supporting_text: CNE1 (P27825) encodes Cne1p
+- term:
+    id: GO:0036503
+    label: ERAD pathway
+  qualifier: involved_in
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: >-
+      ERAD pathway is a supported biological-process context for Cne1p as an ER lectin chaperone and quality-control
+      factor.
+    action: ACCEPT
+    reason: >-
+      Direct yeast evidence supports Cne1p in ER folding/quality control and retention/elimination of
+      misfolded proteins.
+- term:
+    id: GO:0005509
+    label: calcium ion binding
+  qualifier: enables
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: >-
+      Direct Cne1p biochemical characterization did not detect Ca2+ binding, so family-transfer calcium
+      ion binding should not be retained for yeast CNE1.
+    action: REMOVE
+    reason: >-
+      The direct yeast study contradicts the inferred calcium-binding annotation; calnexin-family membership
+      alone is insufficient evidence for this molecular function in Cne1p.
+    supported_by:
+    - reference_id: PMID:7814381
+      supporting_text: Ca2+ binding activity has not been detected for Cne1p.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  qualifier: is_active_in
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: endoplasmic reticulum membrane is supported for Cne1p, an ER membrane glycoprotein.
+    action: ACCEPT
+    reason: >-
+      Direct localization and membrane-association evidence places Cne1p in the ER membrane/ER quality-control
+      compartment.
+- term:
+    id: GO:0005509
+    label: calcium ion binding
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: >-
+      Direct Cne1p biochemical characterization did not detect Ca2+ binding, so family-transfer calcium
+      ion binding should not be retained for yeast CNE1.
+    action: REMOVE
+    reason: >-
+      The direct yeast study contradicts the inferred calcium-binding annotation; calnexin-family membership
+      alone is insufficient evidence for this molecular function in Cne1p.
+    supported_by:
+    - reference_id: PMID:7814381
+      supporting_text: Ca2+ binding activity has not been detected for Cne1p.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  qualifier: located_in
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: endoplasmic reticulum is supported for Cne1p, an ER membrane glycoprotein.
+    action: ACCEPT
+    reason: >-
+      Direct localization and membrane-association evidence places Cne1p in the ER membrane/ER quality-control
+      compartment.
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  qualifier: located_in
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: endoplasmic reticulum membrane is supported for Cne1p, an ER membrane glycoprotein.
+    action: ACCEPT
+    reason: >-
+      Direct localization and membrane-association evidence places Cne1p in the ER membrane/ER quality-control
+      compartment.
+- term:
+    id: GO:0006457
+    label: protein folding
+  qualifier: involved_in
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: >-
+      protein folding is a supported biological-process context for Cne1p as an ER lectin chaperone and
+      quality-control factor.
+    action: ACCEPT
+    reason: >-
+      Direct yeast evidence supports Cne1p in ER folding/quality control and retention/elimination of
+      misfolded proteins.
+- term:
+    id: GO:0030246
+    label: carbohydrate binding
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: >-
+      CNE1 has lectin-site evidence for monoglucosylated oligosaccharide/glycoprotein recognition, so
+      carbohydrate binding is directionally correct but too broad.
+    action: MODIFY
+    reason: Use the more specific oligosaccharide binding term for the known calnexin lectin-site activity.
+    proposed_replacement_terms:
+    - id: GO:0070492
+      label: oligosaccharide binding
+    supported_by:
+    - reference_id: PMID:15173200
+      supporting_text: >-
+        the chaperone function of Cne1p was greatly affected in the presence of monoglucosylated oligosaccharides
+        (G1M9) that specifically bind to the lectin site.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: >-
+      Cne1p has chaperone activity toward folding intermediates, but unfolded protein binding alone is
+      a less informative representation of the ER lectin-chaperone function.
+    action: MODIFY
+    reason: >-
+      Replace with protein folding chaperone, while separately capturing oligosaccharide/lectin binding
+      in core function and proposed terminology.
+    proposed_replacement_terms:
+    - id: GO:0044183
+      label: protein folding chaperone
+- term:
+    id: GO:0036503
+    label: ERAD pathway
+  qualifier: involved_in
+  evidence_type: IMP
+  original_reference_id: PMID:7814381
+  review:
+    summary: >-
+      ERAD pathway is supported for Cne1p through its interaction with unstable glycosylated client proteins
+      and contribution to their ER retention/elimination.
+    action: ACCEPT
+    reason: >-
+      PMID:25229868 provides direct yeast evidence that Cne1p binds unstable lysozyme mutants and contributes
+      to their retention and elimination via ER-associated degradation.
+    supported_by:
+    - reference_id: PMID:25229868
+      supporting_text: >-
+        These results suggest that in yeasts, Cne1p interacts with misfolded lysozyme proteins possibly
+        causing their retention in the ER and subsequent elimination via ER-associated degradation.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  qualifier: located_in
+  evidence_type: IDA
+  original_reference_id: PMID:7814381
+  review:
+    summary: endoplasmic reticulum membrane is supported for Cne1p, an ER membrane glycoprotein.
+    action: ACCEPT
+    reason: >-
+      Direct localization and membrane-association evidence places Cne1p in the ER membrane/ER quality-control
+      compartment.
+    supported_by:
+    - reference_id: PMID:7814381
+      supporting_text: >-
+        Localization of the Cne1p protein by differential and analytical subcellular fractionation as
+        well as by confocal immunofluorescence microscopy showed that it was exclusively located in the
+        endoplasmic reticulum (ER)
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  qualifier: located_in
+  evidence_type: HDA
+  original_reference_id: PMID:26928762
+  review:
+    summary: >-
+      endoplasmic reticulum is consistent with the ER biology of CNE1 and is supported by the SWAT endomembrane
+      localization library.
+    action: ACCEPT
+    reason: >-
+      Accept as supporting ER localization evidence, with gene-specific ER function anchored by the primary
+      literature and UniProt record.
+    supported_by:
+    - reference_id: PMID:26928762
+      supporting_text: we constructed and investigated a library of
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005515
+    label: protein binding
+  qualifier: enables
+  evidence_type: IPI
+  original_reference_id: PMID:16002399
+  supporting_entities:
+  - SGD:S000001267
+  review:
+    summary: >-
+      Protein binding is too generic for the CNE1 interaction evidence with ER folding factors such as
+      Mpd1/Eps1.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      The interaction evidence is best interpreted as part of the ER chaperone/oxidoreductase quality-control
+      network, not as a standalone generic protein-binding function.
+    supported_by:
+    - reference_id: PMID:16002399
+      supporting_text: >-
+        Mpd1p alone does not have chaperone activity but that it interacts with and inhibits the chaperone
+        activity of Cne1p
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005515
+    label: protein binding
+  qualifier: enables
+  evidence_type: IPI
+  original_reference_id: PMID:16002399
+  supporting_entities:
+  - SGD:S000005814
+  review:
+    summary: >-
+      Protein binding is too generic for the CNE1 interaction evidence with ER folding factors such as
+      Mpd1/Eps1.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      The interaction evidence is best interpreted as part of the ER chaperone/oxidoreductase quality-control
+      network, not as a standalone generic protein-binding function.
+    supported_by:
+    - reference_id: PMID:16002399
+      supporting_text: >-
+        Mpd1p alone does not have chaperone activity but that it interacts with and inhibits the chaperone
+        activity of Cne1p
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IDA
+  original_reference_id: PMID:16002399
+  review:
+    summary: >-
+      Cne1p has chaperone activity toward folding intermediates, but unfolded protein binding alone is
+      a less informative representation of the ER lectin-chaperone function.
+    action: MODIFY
+    reason: >-
+      Replace with protein folding chaperone, while separately capturing oligosaccharide/lectin binding
+      in core function and proposed terminology.
+    proposed_replacement_terms:
+    - id: GO:0044183
+      label: protein folding chaperone
+    supported_by:
+    - reference_id: PMID:15173200
+      supporting_text: >-
+        Cne1p effectively suppressed the thermal denaturation of CS and enhanced the refolding of thermally
+        or chemically denatured CS in a concentration-dependent manner.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0006457
+    label: protein folding
+  qualifier: involved_in
+  evidence_type: IMP
+  original_reference_id: PMID:15173200
+  review:
+    summary: >-
+      protein folding is a supported biological-process context for Cne1p as an ER lectin chaperone and
+      quality-control factor.
+    action: ACCEPT
+    reason: >-
+      Direct yeast evidence supports Cne1p in ER folding/quality control and retention/elimination of
+      misfolded proteins.
+    supported_by:
+    - reference_id: PMID:15173200
+      supporting_text: >-
+        Cne1p effectively suppressed the thermal denaturation of CS and enhanced the refolding of thermally
+        or chemically denatured CS in a concentration-dependent manner.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IMP
+  original_reference_id: PMID:15173200
+  review:
+    summary: >-
+      Cne1p has chaperone activity toward folding intermediates, but unfolded protein binding alone is
+      a less informative representation of the ER lectin-chaperone function.
+    action: MODIFY
+    reason: >-
+      Replace with protein folding chaperone, while separately capturing oligosaccharide/lectin binding
+      in core function and proposed terminology.
+    proposed_replacement_terms:
+    - id: GO:0044183
+      label: protein folding chaperone
+    supported_by:
+    - reference_id: PMID:15173200
+      supporting_text: >-
+        Cne1p effectively suppressed the thermal denaturation of CS and enhanced the refolding of thermally
+        or chemically denatured CS in a concentration-dependent manner.
+      reference_section_type: ABSTRACT
+core_functions:
+- description: >-
+    Cne1p is an ER membrane lectin chaperone that assists folding and quality-control retention of glycoprotein
+    folding intermediates. Direct studies support ER localization, chaperone activity, and contribution
+    to ER protein quality control/ERAD, while direct Ca2+ binding was not detected.
+  molecular_function:
+    id: GO:0044183
+    label: protein folding chaperone
+  directly_involved_in:
+  - id: GO:0006457
+    label: protein folding
+  - id: GO:0036503
+    label: ERAD pathway
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: PMID:15173200
+    supporting_text: >-
+      Cne1p effectively suppressed the thermal denaturation of CS and enhanced the refolding of thermally
+      or chemically denatured CS in a concentration-dependent manner.
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:7814381
+    supporting_text: >-
+      Hence, Cne1p appears to function as a constituent of the S. cerevisiae ER protein quality control
+      apparatus.
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:25229868
+    supporting_text: >-
+      These results suggest that in yeasts, Cne1p interacts with misfolded lysozyme proteins possibly
+      causing their retention in the ER and subsequent elimination via ER-associated degradation.
+    reference_section_type: ABSTRACT
+- description: >-
+    Cne1p recognizes monoglucosylated oligosaccharide features through its calnexin lectin site, coupling
+    glycan recognition to ER folding and retention decisions for glycoprotein clients.
+  molecular_function:
+    id: GO:0070492
+    label: oligosaccharide binding
+  directly_involved_in:
+  - id: GO:0006457
+    label: protein folding
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: PMID:15173200
+    supporting_text: >-
+      the chaperone function of Cne1p was greatly affected in the presence of monoglucosylated oligosaccharides
+      (G1M9) that specifically bind to the lectin site.
+    reference_section_type: ABSTRACT
+proposed_new_terms:
+- proposed_name: monoglucosylated glycoprotein binding
+  proposed_definition: >-
+    Binding to monoglucosylated N-linked glycan structures on glycoprotein folding intermediates in the
+    endoplasmic reticulum.
+  justification: >-
+    Cne1p is a calnexin-family lectin chaperone whose relevant carbohydrate specificity is monoglucosylated
+    glycoprotein/oligosaccharide recognition, which is more specific than broad carbohydrate binding.
+  proposed_parent:
+    id: GO:0070492
+    label: oligosaccharide binding
+  supported_by:
+  - reference_id: PMID:15173200
+    supporting_text: >-
+      the chaperone function of Cne1p was greatly affected in the presence of monoglucosylated oligosaccharides
+      (G1M9) that specifically bind to the lectin site.
+    reference_section_type: ABSTRACT
+suggested_questions:
+- question: >-
+    What are the endogenous yeast glycoprotein clients whose ER retention or ERAD depends directly on
+    Cne1p lectin-chaperone activity?
+suggested_experiments:
+- hypothesis: >-
+    Cne1p-dependent ERAD is selective for monoglucosylated glycoprotein clients rather than general unfolded
+    proteins.
+  description: >-
+    Use Cne1p proximity labeling or crosslinking immunoprecipitation under ER stress, with glycosylation-defective
+    and lectin-site mutant controls, followed by quantitative client identification.
+  experiment_type: proximity labeling and glycoprotein client proteomics

--- a/genes/yeast/CNE1/CNE1-ai-review.yaml
+++ b/genes/yeast/CNE1/CNE1-ai-review.yaml
@@ -100,7 +100,6 @@ existing_annotations:
         These results suggest that in yeasts, Cne1p interacts with misfolded lysozyme proteins possibly
         causing their retention in the ER and subsequent elimination via ER-associated degradation.
       reference_section_type: ABSTRACT
-    supported_by:
     - reference_id: file:yeast/CNE1/CNE1-deep-research-falcon.md
       supporting_text: CNE1 (P27825) encodes Cne1p
 - term:

--- a/genes/yeast/CNE1/CNE1-ai-review.yaml
+++ b/genes/yeast/CNE1/CNE1-ai-review.yaml
@@ -117,6 +117,12 @@ existing_annotations:
     reason: >-
       Direct yeast evidence supports Cne1p in ER folding/quality control and retention/elimination of
       misfolded proteins.
+    supported_by:
+    - reference_id: PMID:25229868
+      supporting_text: >-
+        These results suggest that in yeasts, Cne1p interacts with misfolded lysozyme proteins possibly
+        causing their retention in the ER and subsequent elimination via ER-associated degradation.
+      reference_section_type: ABSTRACT
 - term:
     id: GO:0005509
     label: calcium ion binding

--- a/genes/yeast/CNE1/CNE1-deep-research-falcon.md
+++ b/genes/yeast/CNE1/CNE1-deep-research-falcon.md
@@ -1,0 +1,326 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-04T10:05:17.315911'
+end_time: '2026-05-04T10:11:59.894848'
+duration_seconds: 402.58
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: yeast
+  gene_id: CNE1
+  gene_symbol: CNE1
+  uniprot_accession: P27825
+  protein_description: 'RecName: Full=Calnexin homolog; Flags: Precursor;'
+  gene_info: Name=CNE1; OrderedLocusNames=YAL058W; ORFNames=FUN48;
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+  protein_family: Belongs to the calreticulin family. .
+  protein_domains: Calret/calnex. (IPR001580); Calret/calnex_CS. (IPR018124); Calreticulin/calnexin_P_dom_sf.
+    (IPR009033); ConA-like_dom_sf. (IPR013320); Calreticulin (PF00262)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 26
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P27825
+- **Protein Description:** RecName: Full=Calnexin homolog; Flags: Precursor;
+- **Gene Information:** Name=CNE1; OrderedLocusNames=YAL058W; ORFNames=FUN48;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the calreticulin family. .
+- **Key Domains:** Calret/calnex. (IPR001580); Calret/calnex_CS. (IPR018124); Calreticulin/calnexin_P_dom_sf. (IPR009033); ConA-like_dom_sf. (IPR013320); Calreticulin (PF00262)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "CNE1" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'CNE1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **CNE1** (gene ID: CNE1, UniProt: P27825) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P27825
+- **Protein Description:** RecName: Full=Calnexin homolog; Flags: Precursor;
+- **Gene Information:** Name=CNE1; OrderedLocusNames=YAL058W; ORFNames=FUN48;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the calreticulin family. .
+- **Key Domains:** Calret/calnex. (IPR001580); Calret/calnex_CS. (IPR018124); Calreticulin/calnexin_P_dom_sf. (IPR009033); ConA-like_dom_sf. (IPR013320); Calreticulin (PF00262)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "CNE1" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'CNE1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **CNE1** (gene ID: CNE1, UniProt: P27825) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+# Research Report: *Saccharomyces cerevisiae* **CNE1** (UniProt **P27825**) – Functional Annotation of the Yeast Calnexin Homolog
+
+## 0) Mandatory target verification (gene/protein identity)
+The UniProt accession **P27825** corresponds to *Saccharomyces cerevisiae* (S288c) **CNE1** (also **YAL058W**, ORF name **FUN48**) annotated as a **calnexin homolog** and member of the **calreticulin/calnexin family** (ER lectin chaperones). The experimental literature retrieved here consistently refers to yeast **Cne1p** as the *S. cerevisiae* calnexin homolog and ER membrane protein, matching the requested identity and organism. (parlati1996characterizationofcalnexin pages 50-54, xu2004expressionandcharacterization pages 1-2)
+
+## 1) Key concepts and definitions (current understanding)
+### 1.1 Calnexin-family lectin chaperones
+Calnexin (CNX) and calreticulin (CRT) are ER lectin chaperones that **selectively bind monoglucosylated N-glycans** on nascent glycoproteins to prevent aggregation and promote folding. CNX is typically membrane-tethered, whereas CRT is soluble. (suzuki2021foldingandquality pages 8-9)
+
+### 1.2 Yeast-specific features of the “calnexin cycle”
+A key conceptual difference between budding yeast and mammalian cells is **reglucosylation**. In organisms that encode UDP-glucose:glycoprotein glucosyltransferase (UGGT), UGGT can re-add glucose to promote repeated CNX/CRT binding; however, **the review evidence indicates *S. cerevisiae* lacks UGGT**, implying that calnexin binding may behave as a **more one-pass/irreversible step** in this species compared with canonical mammalian cycling. (piirainen2022theimpactof pages 2-3, parlati1996characterizationofcalnexin pages 155-157)
+
+### 1.3 ER quality control (ERQC) and ER-associated degradation (ERAD)
+ERQC encompasses mechanisms that retain folding intermediates, promote productive folding, and direct terminally misfolded proteins into ERAD. In budding yeast, ERQC/ERAD decisions integrate lectin-like surveillance with glycan processing and downstream degradation pathways. (piirainen2022theimpactof pages 6-7, piirainen2022theimpactof pages 2-3)
+
+## 2) CNE1 gene product: molecular function, binding specificity, localization, and pathway placement
+
+### 2.1 Subcellular localization and membrane association
+Early biochemical fractionation and microscopy established Cne1p as an **ER-localized integral membrane glycoprotein**.
+* Cne1p is **Endo H–sensitive**, consistent with ER-type N-glycosylation. (parlati1996characterizationofcalnexin pages 50-54)
+* Immunofluorescence/confocal microscopy shows Cne1p colocalizing with the ER lumenal marker **Kar2p/BiP**, with perinuclear and cortical ER patterns. (parlati1996characterizationofcalnexin pages 76-82)
+* It is strongly membrane-associated (not extractable by typical chaotropes/high salt/carbonate used to strip peripheral proteins). (parlati1996characterizationofcalnexin pages 50-54)
+
+### 2.2 Calcium binding: divergence from mammalian calnexin
+Unlike mammalian calnexin, yeast Cne1p was found to be **not a strong Ca2+-binding protein** in ^45Ca overlay assays, and the protein lacks the mammalian-like calcium-binding capacity emphasized in other systems. (parlati1996characterizationofcalnexin pages 150-152, parlati1996characterizationofcalnexin pages 76-82)
+
+### 2.3 Biochemical chaperone activity
+Recombinant Cne1p exhibits **molecular chaperone activity** in vitro:
+* A GST–Cne1p fusion protein **suppressed thermal denaturation** and enhanced **refolding of citrate synthase** in a concentration-dependent manner. (Xu et al., 2004; published May 2004; https://doi.org/10.1093/jb/mvh074) (xu2004expressionandcharacterization pages 1-2)
+
+### 2.4 Lectin specificity for monoglucosylated N-glycans
+Cne1p shows evidence of **lectin-like recognition of monoglucosylated N-glycans**, consistent with calnexin-family function:
+* Cne1p chaperone activity was strongly affected by a monoglucosylated oligosaccharide (reported as **G1M9**, consistent with **Glc1Man9GlcNAc2**), supporting a functional lectin site. (Xu et al., 2004; https://doi.org/10.1093/jb/mvh074) (xu2004expressionandcharacterization pages 1-2)
+* In a cellular context, binding of Cne1p to misfolded glycoprotein clients was **abolished by tunicamycin** (inhibits N-glycosylation), supporting **glycan-dependent recognition**. (Azakami et al., 2014; published Jul 2014; https://doi.org/10.1080/09168451.2014.918486) (azakami2014unstablemutantlysozymes pages 1-2)
+
+### 2.5 Experimentally supported client/substrate classes and outcomes (retention vs escape)
+Multiple experimental systems support Cne1p as an ERQC factor that **retains and promotes disposal of unstable glycoproteins**:
+* **Misfolded/unstable glycosylated lysozyme mutants**: Co-immunoprecipitation indicates Cne1p interacts with unstable glycosylated lysozyme mutants (e.g., G49N/D66H and others) and promotes their degradation/retention; **cne1Δ increases secretion** and alters intracellular localization of these unstable glycoproteins, consistent with loss of ER retention. (Azakami et al., 2014; https://doi.org/10.1080/09168451.2014.918486) (azakami2014unstablemutantlysozymes pages 1-2, azakami2014unstablemutantlysozymes pages 2-3)
+* **Trafficking QC reporters**: Deletion of CNE1 increased cell-surface expression of an ER-retained temperature-sensitive **Ste2 mutant (Ste2-3p)** and increased secretion of heterologous **α1-antitrypsin**, consistent with reduced ERQC retention. (parlati1996characterizationofcalnexin pages 50-54, parlati1996characterizationofcalnexin pages 150-152)
+
+### 2.6 Genetic/physiologic phenotypes and stress responses
+CNE1 is **nonessential** under standard growth conditions, and loss does not necessarily produce gross growth phenotypes, indicating functional buffering by other ER folding factors. (parlati1996characterizationofcalnexin pages 50-54, zhang2008theeffectof pages 1-4)
+
+However, deletion triggers compensatory changes consistent with ER stress buffering:
+* Under heat stress (37°C), a **cne1Δ** strain showed **increased PDI (protein disulfide isomerase) expression** at mRNA and protein levels relative to wild type, while growth remained similar; the authors interpret this as compensation for loss of calnexin function. (Zhang et al., 2008; published Jan 2008; https://doi.org/10.2478/s11658-007-0033-y) (zhang2008theeffectof pages 1-4)
+
+### 2.7 Interaction partners (what is supported vs not supported)
+Evidence in the retrieved set supports two interaction categories:
+1) **Client interactions**: direct binding to unstable glycosylated lysozyme mutants by co-IP (strong evidence). (azakami2014unstablemutantlysozymes pages 1-2)
+2) **Functional linkage to oxidoreductases**: evidence suggests interaction/function with PDI-family members (e.g., Mpd1p in vitro; and PDI induction in cne1Δ under heat stress), consistent with a cooperative ER folding network. (zhang2008theeffectof pages 1-4)
+
+In contrast, early broad immunoprecipitation efforts reported difficulty detecting transient association with endogenous proteins in yeast, consistent with **weak/transient** interactions typical of chaperones or limitations of the assay. (parlati1996characterizationofcalnexin pages 150-152)
+
+## 3) Recent developments and latest research (prioritizing 2023–2024)
+### 3.1 Availability of 2023–2024 CNE1-specific primary literature
+In the retrieved corpus, **direct 2023–2024 primary studies focused specifically on *S. cerevisiae* CNE1 were limited**. The strongest direct mechanistic evidence available in full text here comes from foundational primary studies (1996, 2004, 2008, 2014). (parlati1996characterizationofcalnexin pages 50-54, xu2004expressionandcharacterization pages 1-2, zhang2008theeffectof pages 1-4, azakami2014unstablemutantlysozymes pages 1-2)
+
+### 3.2 2022–2024 synthesis relevant to CNE1 function (glycoengineering/ERQC perspective)
+A 2022 review (Frontiers in Molecular Biosciences) provides a modern synthesis of how **glycoengineering can perturb ERQC**, including the calnexin pathway:
+* It reiterates that yeast calnexin (Cne1p) binds **Glc1Man9GlcNAc2**, and that glucosidase-mediated glucose trimming controls release from calnexin; it emphasizes that ***S. cerevisiae* lacks UGGT**, which changes the logic of repeated binding relative to mammalian systems. (Published Jun 2022; https://doi.org/10.3389/fmolb.2022.910709) (piirainen2022theimpactof pages 2-3)
+* It highlights an applied knowledge gap: many glycoengineered strains create ER N-glycans that may **bypass calnexin-dependent folding** or create glycans recognized by ERAD, yet the consequences for bioproduction proteins are not fully defined and may depend on the specific product. (piirainen2022theimpactof pages 5-6, piirainen2022theimpactof pages 4-5)
+
+Although not CNE1-centric, a 2024 yeast study on UPR induction by lipid imbalance underscores that UPR can be triggered independent of obvious proteostasis defects, reinforcing the broader context in which ERQC components like Cne1 operate (i.e., not all UPR phenotypes map cleanly to classical ERAD overload). (Published Sep 2024; https://doi.org/10.1091/mbc.e24-03-0121) (zhang2008theeffectof pages 1-4)
+
+## 4) Current applications and real-world implementations
+Direct industrial implementations generally do not target *S. cerevisiae* CNE1 alone, but CNE1 is part of the **engineering “toolbox”** for ER folding/secretory pathway tuning.
+
+### 4.1 Glycoengineering and secretory pathway optimization
+In glycoengineered yeasts intended for biopharmaceutical production, ER glycan structures can be altered in ways that may **reduce or eliminate canonical calnexin binding**; this is viewed as a design constraint/unknown that can influence folding efficiency, ERAD engagement, and overall yields. (piirainen2022theimpactof pages 5-6, piirainen2022theimpactof pages 2-3)
+
+### 4.2 Quality-control tuning for recombinant proteins (evidence-bearing examples)
+CNE1’s role in **retaining/degrading unstable glycoproteins** has been exploited experimentally using heterologous model proteins:
+* **Unstable glycosylated lysozyme mutants** are retained and degraded in a Cne1p-dependent manner; deletion increases secretion of unstable mutants, demonstrating a lever by which ERQC stringency can be altered. (Azakami et al., 2014; https://doi.org/10.1080/09168451.2014.918486) (azakami2014unstablemutantlysozymes pages 2-3, azakami2014unstablemutantlysozymes pages 1-2)
+* Increased secretion of heterologous **α1-antitrypsin** in a CNE1 deletion background supports the idea that manipulating CNE1 can shift the balance between retention/ERAD and export for certain recombinant proteins. (parlati1996characterizationofcalnexin pages 50-54)
+
+These studies represent concrete “real-world” implementations in research and bioprocess strain development: adjusting ERQC components such as CNE1 can change secretion of difficult-to-fold glycoproteins, but risks exporting misfolded products and/or increasing downstream quality burden. (parlati1996characterizationofcalnexin pages 50-54, azakami2014unstablemutantlysozymes pages 2-3)
+
+## 5) Expert opinions and analysis (authoritative synthesis)
+### 5.1 Expert synthesis: why CNE1 phenotypes are often subtle in budding yeast
+A recurring interpretation is that **cne1Δ phenotypes are modest** because *S. cerevisiae* can buffer ER folding defects through other chaperones/oxidoreductases and stress programs.
+* Heat stress experiments show induction of PDI upon CNE1 deletion, consistent with a compensatory ER folding network that can preserve growth. (zhang2008theeffectof pages 1-4)
+* Reviews argue that the absence of UGGT in *S. cerevisiae* changes the dependence on repeated calnexin binding, suggesting that calnexin’s role may be narrower or “one-pass” in budding yeast and/or more important for select substrates and stress conditions. (piirainen2022theimpactof pages 2-3, parlati1996characterizationofcalnexin pages 155-157)
+
+### 5.2 Expert synthesis: glycoengineering introduces new ERQC/ERAD unknowns
+The glycoengineering review emphasizes that most mechanistic ERQC evidence uses folding-deficient model substrates, and that **production-relevant proteins may behave differently**, sometimes not requiring glycans for folding. Nevertheless, altered ER glycans may change folding kinetics and ERAD engagement, making ERQC (including Cne1p) an important consideration in strain design. (piirainen2022theimpactof pages 5-6, piirainen2022theimpactof pages 4-5)
+
+## 6) Relevant statistics and quantitative data points from retrieved studies
+Because the retrieved set is dominated by mechanistic, substrate-focused studies, quantitative results are mostly presented as **effect directions** (e.g., increased secretion in deletion strains) rather than high-throughput statistics. Still, the following quantitative/structured points are supported:
+* Sequence similarity reported in early characterization: Cne1p is ~**24% identical** and **31% similar** to mammalian calnexin (useful for homology-based annotation but also highlights divergence). (parlati1996characterizationofcalnexin pages 50-54)
+* Cne1p glycosylation shift: apparent mass shift from ~**76 kDa to 60 kDa** upon Endo H treatment (supporting N-glycosylation and ER residence). (parlati1996characterizationofcalnexin pages 50-54)
+* ERAD-related kinetic note: degradation of unglycosylated pro–a-factor in microsomes described as cytosol- and ATP-dependent with a reported **~7.5 min half-life** (contextual evidence linking Cne1 to ERQC/ERAD handling of secretory substrates). (parlati1996characterizationofcalnexin pages 150-152)
+
+## 7) Consolidated evidence map (primary facts)
+The following table consolidates the strongest experimentally supported claims for functional annotation.
+
+| Aspect | Key findings | Evidence type/method | Primary source (first author year + DOI URL) | Citation ID |
+|---|---|---|---|---|
+| Identity/domains | CNE1 = YAL058W/FUN48; encodes the sole *S. cerevisiae* calnexin/calreticulin-family homolog; ~24% identity and ~31% similarity to mammalian calnexin | Gene cloning/sequence comparison; biochemical characterization | Parlati 1996; source text unavailable for DOI in retrieved context | (parlati1996characterizationofcalnexin pages 50-54) |
+| Localization/topology | ER-localized integral membrane glycoprotein; Endo H-sensitive N-glycosylation; colocalizes with Kar2/BiP; strong perinuclear and cortical ER pattern | Subcellular fractionation; carbonate/urea/high-salt extraction; Endo H shift; immunofluorescence/confocal microscopy | Parlati 1996; source text unavailable for DOI in retrieved context | (parlati1996characterizationofcalnexin pages 50-54, parlati1996characterizationofcalnexin pages 76-82) |
+| Localization/topology | Contains a transmembrane region but lacks a cytoplasmic tail; deletion of TM did not fully release protein from membranes, suggesting membrane retention via protein interactions | Domain analysis; membrane association assays of truncation mutants | Parlati 1996; source text unavailable for DOI in retrieved context | (parlati1996characterizationofcalnexin pages 150-152) |
+| Biochemical activity and binding specificity | Functions as a molecular chaperone; recombinant GST-Cne1p suppresses thermal aggregation and improves refolding of citrate synthase in a dose-dependent manner | In vitro thermal denaturation/refolding assay | Xu 2004; https://doi.org/10.1093/jb/mvh074 | (xu2004expressionandcharacterization pages 1-2) |
+| Biochemical activity and binding specificity | Lectin-like specificity for monoglucosylated N-glycan; chaperone activity strongly affected by G1M9 oligosaccharide (Glc1Man9GlcNAc2) | Recombinant protein assay with defined oligosaccharide competitor/modulator | Xu 2004; https://doi.org/10.1093/jb/mvh074 | (xu2004expressionandcharacterization pages 1-2) |
+| Biochemical activity and binding specificity | Not a strong Ca2+-binding protein; no detectable ^45Ca binding in overlay assays; unlike mammalian calnexin, lacks evident calcium-binding capacity | ^45Ca overlay; GST-fusion protein binding assay | Parlati 1996; source text unavailable for DOI in retrieved context | (parlati1996characterizationofcalnexin pages 150-152, parlati1996characterizationofcalnexin pages 76-82) |
+| Substrates/clients | Binds unstable glycosylated lysozyme mutants (e.g., G49N/D66H, G49N/C76A, K13D/G49N); interaction is glycan-dependent | Co-expression and co-immunoprecipitation | Azakami 2014; https://doi.org/10.1080/09168451.2014.918486 | (azakami2014unstablemutantlysozymes pages 1-2) |
+| Substrates/clients | Tunicamycin abolishes Cne1p interaction with mutant lysozymes, indicating dependence on N-linked glycosylation/lectin recognition | Tunicamycin perturbation of N-glycosylation; co-IP | Azakami 2014; https://doi.org/10.1080/09168451.2014.918486 | (azakami2014unstablemutantlysozymes pages 1-2) |
+| Substrates/clients | Influences intracellular retention of misfolded cargo such as temperature-sensitive Ste2-3p and unstable glycosylated lysozyme mutants; also affects secretion of heterologous α1-antitrypsin | Cell-surface expression assays; secretion assays; microscopy | Parlati 1996; source text unavailable for DOI in retrieved context; Azakami 2014; https://doi.org/10.1080/09168451.2014.918486 | (parlati1996characterizationofcalnexin pages 150-152, azakami2014unstablemutantlysozymes pages 2-3) |
+| Phenotypes of deletion | **cne1Δ** is viable and shows little or no gross defect in general growth or bulk secretion (acid phosphatase, a-factor) under standard conditions | Gene disruption; growth and secretion assays | Parlati 1996; source text unavailable for DOI in retrieved context; Zhang 2008; https://doi.org/10.2478/s11658-007-0033-y | (parlati1996characterizationofcalnexin pages 50-54, zhang2008theeffectof pages 1-4) |
+| Phenotypes of deletion | **cne1Δ** increases escape/secretion of unstable glycoproteins, consistent with loss of ER retention/quality control | Deletion strain comparison; secretion analysis | Xu 2004; https://doi.org/10.1093/jb/mvh074; Azakami 2014; https://doi.org/10.1080/09168451.2014.918486 | (xu2004expressionandcharacterization pages 1-2, azakami2014unstablemutantlysozymes pages 2-3) |
+| Phenotypes of deletion | **cne1Δ** elevates cell-surface expression of ER-retained mutant Ste2-3p and secretion of α1-antitrypsin, supporting a QC checkpoint role | Reporter trafficking assays; heterologous secretion assays | Parlati 1996; source text unavailable for DOI in retrieved context | (parlati1996characterizationofcalnexin pages 150-152, parlati1996characterizationofcalnexin pages 50-54) |
+| Phenotypes of deletion | Deletion induces compensatory ER stress responses, including increased PDI-family expression under heat stress; growth remains similar to WT at 37°C | mRNA/protein expression analysis; western blot; heat-stress growth assays | Zhang 2008; https://doi.org/10.2478/s11658-007-0033-y | (zhang2008theeffectof pages 1-4) |
+| Phenotypes of overexpression | Overexpression did not measurably alter general secretion of several standard reporters in early characterization studies | Overexpression strain analysis; secretion assays | Parlati 1996; source text unavailable for DOI in retrieved context | (parlati1996characterizationofcalnexin pages 150-152) |
+| Interaction partners | Functional linkage with PDI-family oxidoreductases; Mpd1p reported to interact with Cne1p in vitro; PDI upregulation may compensate for Cne1 loss during stress | In vitro interaction evidence; expression response analysis | Zhang 2008; https://doi.org/10.2478/s11658-007-0033-y | (zhang2008theeffectof pages 1-4) |
+| Interaction partners | Direct association demonstrated with unstable glycosylated lysozyme mutants; transient association with many endogenous cellular proteins was not detected in early studies | Co-IP for mutant clients; immunoprecipitation surveys | Azakami 2014; https://doi.org/10.1080/09168451.2014.918486; Parlati 1996; source text unavailable for DOI in retrieved context | (azakami2014unstablemutantlysozymes pages 1-2, parlati1996characterizationofcalnexin pages 150-152) |
+| Pathway/process | Constituent of ER protein quality control for nascent/misfolded glycoproteins; acts as ER lectin-chaperone with weaker/modified calnexin-cycle logic because *S. cerevisiae* lacks UGGT-mediated reglucosylation | Integration of genetic, biochemical, and client-retention evidence | Xu 2004; https://doi.org/10.1093/jb/mvh074; Zhang 2008; https://doi.org/10.2478/s11658-007-0033-y; Parlati 1996; source text unavailable for DOI in retrieved context | (xu2004expressionandcharacterization pages 1-2, zhang2008theeffectof pages 1-4, parlati1996characterizationofcalnexin pages 155-157) |
+| Pathway/process | Participates in ER retention and degradation of unstable glycoproteins, linking Cne1p to ER-associated degradation (ERAD)-related outcomes | Co-IP; glycosylation dependence; secretion/retention phenotypes in WT vs **cne1Δ** | Azakami 2014; https://doi.org/10.1080/09168451.2014.918486 | (azakami2014unstablemutantlysozymes pages 1-2, azakami2014unstablemutantlysozymes pages 2-3) |
+
+
+*Table: This table summarizes experimentally supported facts about the budding yeast calnexin homolog CNE1/P27825, emphasizing validated localization, biochemical activity, client specificity, phenotypes, and pathway placement. It is useful as a compact evidence map for functional annotation and for distinguishing strong experimental claims from broader inference.*
+
+## 8) Practical functional annotation summary (recommended wording)
+**CNE1 (P27825) encodes Cne1p, an ER-localized integral membrane lectin chaperone of the calnexin/calreticulin family that binds monoglucosylated N-glycans (Glc1Man9GlcNAc2) and participates in ER quality control by promoting folding and/or ER retention and ERAD targeting of unstable glycoproteins.** (xu2004expressionandcharacterization pages 1-2, azakami2014unstablemutantlysozymes pages 1-2, parlati1996characterizationofcalnexin pages 50-54, piirainen2022theimpactof pages 2-3)
+
+## 9) Evidence limitations and gaps
+* **2023–2024 CNE1-specific mechanistic primary literature** was not prominent in the retrieved full texts; therefore, the most precise statements here rely on foundational studies plus a 2022 authoritative synthesis. (xu2004expressionandcharacterization pages 1-2, azakami2014unstablemutantlysozymes pages 1-2, piirainen2022theimpactof pages 2-3)
+* The exact **endogenous client spectrum** of Cne1p in budding yeast remains incompletely resolved in this evidence set; strong client evidence is available for specific heterologous/mutant substrates (lysozyme mutants, Ste2-3p reporter, α1-antitrypsin). (azakami2014unstablemutantlysozymes pages 1-2, parlati1996characterizationofcalnexin pages 50-54)
+
+## 10) Key URLs (for user convenience)
+* Xu et al., 2004 (May 2004). “Expression and characterization of *S. cerevisiae* Cne1p, a calnexin homologue.” https://doi.org/10.1093/jb/mvh074 (xu2004expressionandcharacterization pages 1-2)
+* Zhang et al., 2008 (Jan 2008). “The effect of calnexin deletion on the expression level of PDI in *S. cerevisiae* under heat stress conditions.” https://doi.org/10.2478/s11658-007-0033-y (zhang2008theeffectof pages 1-4)
+* Azakami et al., 2014 (Jul 2014). “Unstable mutant lysozymes are degraded through the interaction with calnexin homolog Cne1p in *S. cerevisiae*.” https://doi.org/10.1080/09168451.2014.918486 (azakami2014unstablemutantlysozymes pages 1-2)
+* Piirainen & Frey, 2022 (Jun 2022). “The impact of glycoengineering on the ER quality control system in yeasts.” https://doi.org/10.3389/fmolb.2022.910709 (piirainen2022theimpactof pages 2-3)
+* Rajakumar et al., 2024 (Sep 2024). “Dysregulation of ceramide metabolism causes phytoceramide-dependent induction of the unfolded protein response.” https://doi.org/10.1091/mbc.e24-03-0121 (contextual UPR/ER homeostasis) (zhang2008theeffectof pages 1-4)
+
+
+References
+
+1. (parlati1996characterizationofcalnexin pages 50-54): F Parlati. Characterization of calnexin in saccharomyces cerevisiae and schizosaccharomyces pombe. Unknown journal, 1996.
+
+2. (xu2004expressionandcharacterization pages 1-2): Xiaohua Xu, Kunitoshi Kanbara, H. Azakami, and A. Kato. Expression and characterization of saccharomyces cerevisiae cne1p, a calnexin homologue. Journal of biochemistry, 135 5:615-8, May 2004. URL: https://doi.org/10.1093/jb/mvh074, doi:10.1093/jb/mvh074. This article has 49 citations and is from a peer-reviewed journal.
+
+3. (suzuki2021foldingandquality pages 8-9): Tadashi Suzuki and Haruhiko Fujihira. Folding and quality control of glycoproteins. Comprehensive Glycoscience, pages 1-28, Dec 2021. URL: https://doi.org/10.1016/b978-0-12-409547-2.14947-9, doi:10.1016/b978-0-12-409547-2.14947-9. This article has 12 citations.
+
+4. (piirainen2022theimpactof pages 2-3): Mari A. Piirainen and Alexander D. Frey. The impact of glycoengineering on the endoplasmic reticulum quality control system in yeasts. Frontiers in Molecular Biosciences, Jun 2022. URL: https://doi.org/10.3389/fmolb.2022.910709, doi:10.3389/fmolb.2022.910709. This article has 2 citations.
+
+5. (parlati1996characterizationofcalnexin pages 155-157): F Parlati. Characterization of calnexin in saccharomyces cerevisiae and schizosaccharomyces pombe. Unknown journal, 1996.
+
+6. (piirainen2022theimpactof pages 6-7): Mari A. Piirainen and Alexander D. Frey. The impact of glycoengineering on the endoplasmic reticulum quality control system in yeasts. Frontiers in Molecular Biosciences, Jun 2022. URL: https://doi.org/10.3389/fmolb.2022.910709, doi:10.3389/fmolb.2022.910709. This article has 2 citations.
+
+7. (parlati1996characterizationofcalnexin pages 76-82): F Parlati. Characterization of calnexin in saccharomyces cerevisiae and schizosaccharomyces pombe. Unknown journal, 1996.
+
+8. (parlati1996characterizationofcalnexin pages 150-152): F Parlati. Characterization of calnexin in saccharomyces cerevisiae and schizosaccharomyces pombe. Unknown journal, 1996.
+
+9. (azakami2014unstablemutantlysozymes pages 1-2): Hiroyuki Azakami, Masayoshi Uehara, Ryohei Matsuo, Yuta Tsurunaga, Yuichiro Yamashita, Masakatsu Usui, and Akio Kato. Unstable mutant lysozymes are degraded through the interaction with calnexin homolog cne1p in saccharomyces cerevisiae. Bioscience, Biotechnology, and Biochemistry, 78:1263-1269, Jul 2014. URL: https://doi.org/10.1080/09168451.2014.918486, doi:10.1080/09168451.2014.918486. This article has 2 citations.
+
+10. (azakami2014unstablemutantlysozymes pages 2-3): Hiroyuki Azakami, Masayoshi Uehara, Ryohei Matsuo, Yuta Tsurunaga, Yuichiro Yamashita, Masakatsu Usui, and Akio Kato. Unstable mutant lysozymes are degraded through the interaction with calnexin homolog cne1p in saccharomyces cerevisiae. Bioscience, Biotechnology, and Biochemistry, 78:1263-1269, Jul 2014. URL: https://doi.org/10.1080/09168451.2014.918486, doi:10.1080/09168451.2014.918486. This article has 2 citations.
+
+11. (zhang2008theeffectof pages 1-4): Huili Zhang, Jianwei He, Yanyan Ji, Akio Kato, and Youtao Song. The effect of calnexin deletion on the expression level of pdi in saccharomyces cerevisiae under heat stress conditions. Cellular and Molecular Biology Letters, Jan 2008. URL: https://doi.org/10.2478/s11658-007-0033-y, doi:10.2478/s11658-007-0033-y. This article has 16 citations and is from a peer-reviewed journal.
+
+12. (piirainen2022theimpactof pages 5-6): Mari A. Piirainen and Alexander D. Frey. The impact of glycoengineering on the endoplasmic reticulum quality control system in yeasts. Frontiers in Molecular Biosciences, Jun 2022. URL: https://doi.org/10.3389/fmolb.2022.910709, doi:10.3389/fmolb.2022.910709. This article has 2 citations.
+
+13. (piirainen2022theimpactof pages 4-5): Mari A. Piirainen and Alexander D. Frey. The impact of glycoengineering on the endoplasmic reticulum quality control system in yeasts. Frontiers in Molecular Biosciences, Jun 2022. URL: https://doi.org/10.3389/fmolb.2022.910709, doi:10.3389/fmolb.2022.910709. This article has 2 citations.
+
+## Citations
+
+1. suzuki2021foldingandquality pages 8-9
+2. parlati1996characterizationofcalnexin pages 50-54
+3. parlati1996characterizationofcalnexin pages 76-82
+4. xu2004expressionandcharacterization pages 1-2
+5. azakami2014unstablemutantlysozymes pages 1-2
+6. zhang2008theeffectof pages 1-4
+7. parlati1996characterizationofcalnexin pages 150-152
+8. piirainen2022theimpactof pages 2-3
+9. parlati1996characterizationofcalnexin pages 155-157
+10. piirainen2022theimpactof pages 6-7
+11. azakami2014unstablemutantlysozymes pages 2-3
+12. piirainen2022theimpactof pages 5-6
+13. piirainen2022theimpactof pages 4-5
+14. https://doi.org/10.1093/jb/mvh074
+15. https://doi.org/10.1080/09168451.2014.918486
+16. https://doi.org/10.2478/s11658-007-0033-y
+17. https://doi.org/10.3389/fmolb.2022.910709
+18. https://doi.org/10.1091/mbc.e24-03-0121
+19. https://doi.org/10.1093/jb/mvh074;
+20. https://doi.org/10.1080/09168451.2014.918486;
+21. https://doi.org/10.2478/s11658-007-0033-y;
+22. https://doi.org/10.1093/jb/mvh074,
+23. https://doi.org/10.1016/b978-0-12-409547-2.14947-9,
+24. https://doi.org/10.3389/fmolb.2022.910709,
+25. https://doi.org/10.1080/09168451.2014.918486,
+26. https://doi.org/10.2478/s11658-007-0033-y,

--- a/genes/yeast/NSG1/NSG1-ai-review.html
+++ b/genes/yeast/NSG1/NSG1-ai-review.html
@@ -1595,7 +1595,7 @@
 
                                 </span>
 
-                                <div class="support-text">Nsg1p functions naturally to limit degradation of Hmg2p when both proteins are at native levels</div>
+                                <div class="support-text">by directly interacting with the sterol-sensing domain (SSD)-containing transmembrane region</div>
 
                             </div>
 
@@ -2900,8 +2900,8 @@ existing_annotations:
       regulation occurs.
     supported_by:
     - reference_id: PMID:16270032
-      supporting_text: Nsg1p functions naturally to limit degradation of Hmg2p when both proteins are
-        at native levels
+      supporting_text: by directly interacting with the sterol-sensing domain (SSD)-containing
+        transmembrane region
       reference_section_type: ABSTRACT
 - term:
     id: GO:0016126

--- a/genes/yeast/NSG1/NSG1-ai-review.html
+++ b/genes/yeast/NSG1/NSG1-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>NSG1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P38837" target="_blank" class="term-link">
                         P38837
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Saccharomyces cerevisiae</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,24 +728,75 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="P38837" data-a="DESCRIPTION: TODO: Add description for NSG1..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="P38837" data-a="DESCRIPTION: NSG1 encodes an INSIG-family multi-pass endoplasmi..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TODO: Add description for NSG1</p>
+        <p>NSG1 encodes an INSIG-family multi-pass endoplasmic reticulum membrane protein that binds the sterol-sensing-domain-containing Hmg2 HMG-CoA reductase and stabilizes it against Hrd1-dependent ER-associated degradation. Its primary role is a selective transmembrane chaperone/regulator of Hmg2 stability in sterol pathway control; recent microscopy also supports condition-dependent residence at the nucleus-vacuole junction, but that localization is secondary to the Hmg2 quality-control function.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+    <div class="section">
+        <h2 class="section-title">Proposed New Ontology Terms</h2>
+
+        <div class="proposed-term">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>sterol-sensing domain protein chaperone activity</h3>
+                <span class="vote-buttons" data-g="P38837" data-a="sterol-sensing domain protein chaperone activity" data-r="" data-act="NEW">
+                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
+                </span>
+            </div>
+
+
+            <p><strong>Definition:</strong> Binding to and stabilizing the transmembrane sterol-sensing domain of a client protein to promote correct folding or prevent ER-associated degradation.</p>
+
+
+
+            <p><strong>Justification:</strong> NSG1/INSIG activity toward Hmg2 is more specific than generic unfolded protein binding or broad protein folding chaperone activity.</p>
+
+
+
+            <p><strong>Parent term:</strong>
+                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
+                    protein folding chaperone
+                </a>
+            </p>
+
+
+
+
+
+            <p><strong>Supporting Evidence:</strong></p>
+            <ul style="margin-left: 1rem;">
+
+                <li>
+
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/16270032" target="_blank" class="term-link">
+                        PMID:16270032
+                    </a>
+
+
+                    : We now show that the yeast INSIG homologs NSG1 and NSG2 function to control the stability of yeast Hmg2p, the HMGR isozyme that undergoes regulated ubiquitination. Yeast Nsgs inhibit degradation of Hmg2p in a highly specific manner, by directly interacting with the sterol-sensing domain (SSD)-containing transmembrane region.
+
+                </li>
+
+            </ul>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +809,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
                                     GO:0005783
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,46 +846,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: endoplasmic reticulum is consistent with known biology of NSG1.
+                            <strong>Summary:</strong> endoplasmic reticulum is consistent with NSG1 being a multi-pass ER membrane INSIG homolog.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Direct UniProt/literature evidence places NSG1 at the endoplasmic reticulum membrane, where Hmg2 regulation occurs.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016126" target="_blank" class="term-link">
                                     GO:0016126
                                 </a>
                             </span>
                             <span class="term-label">sterol biosynthetic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -846,46 +897,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: sterol biosynthetic process is consistent with known biology of NSG1.
+                            <strong>Summary:</strong> NSG1 supports sterol biosynthesis indirectly by stabilizing Hmg2, a sterol-pathway HMG-CoA reductase isozyme, rather than by catalyzing a sterol biosynthetic reaction.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Accept as a pathway participation annotation with the mechanism explicitly interpreted as Hmg2 stabilization/regulation; PANTHER family transfer is consistent with the direct yeast Hmg2 evidence.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16270032" target="_blank" class="term-link">
+                                        PMID:16270032
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We now show that the yeast INSIG homologs NSG1 and NSG2 function to control the stability of yeast Hmg2p, the HMGR isozyme that undergoes regulated ubiquitination. Yeast Nsgs inhibit degradation of Hmg2p in a highly specific manner, by directly interacting with the sterol-sensing domain (SSD)-containing transmembrane region.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/NSG1/NSG1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Primary function is **stabilization of the Hmg2 HMGR isozyme**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
                                     GO:0005789
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -897,57 +977,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: endoplasmic reticulum membrane is consistent with known biology of NSG1.
+                            <strong>Summary:</strong> endoplasmic reticulum membrane is consistent with NSG1 being a multi-pass ER membrane INSIG homolog.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Direct UniProt/literature evidence places NSG1 at the endoplasmic reticulum membrane, where Hmg2 regulation occurs.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18467557" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18467557
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An in vivo map of the yeast protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -959,57 +1039,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for NSG1.
+                            <strong>Summary:</strong> Generic protein binding annotations from interactome studies do not capture the specific NSG1/Hmg2 sterol-sensing-domain chaperone mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> The defensible NSG1 function is selective stabilization of SSD-containing Hmg2, not unspecific protein binding from high-throughput PPI evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27107014" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27107014
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An inter-species protein-protein interaction network across ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1021,57 +1101,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for NSG1.
+                            <strong>Summary:</strong> Generic protein binding annotations from interactome studies do not capture the specific NSG1/Hmg2 sterol-sensing-domain chaperone mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> The defensible NSG1 function is selective stabilization of SSD-containing Hmg2, not unspecific protein binding from high-throughput PPI evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/37968396" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:37968396
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The social and structural architecture of the yeast protein ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1083,57 +1163,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for NSG1.
+                            <strong>Summary:</strong> Generic protein binding annotations from interactome studies do not capture the specific NSG1/Hmg2 sterol-sensing-domain chaperone mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> The defensible NSG1 function is selective stabilization of SSD-containing Hmg2, not unspecific protein binding from high-throughput PPI evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071561" target="_blank" class="term-link">
                                     GO:0071561
                                 </a>
                             </span>
                             <span class="term-label">nucleus-vacuole junction</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/41132095" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:41132095
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Role of Pex31 in metabolic adaptation of the nucleus-vacuole...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1145,57 +1225,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: nucleus-vacuole junction may be context-dependent or peripheral for NSG1.
+                            <strong>Summary:</strong> NSG1 is detected at the nucleus-vacuole junction under glucose limitation, but this is a conditional localization rather than the primary mechanistic function.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Keep as a supported context-specific localization from the 2025 NVJ remodeling study, while not elevating it over the ER/Hmg2 core function.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/41132095" target="_blank" class="term-link">
+                                        PMID:41132095
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Here, we used systematic microscopy-based approaches to compare the NVJ at glucose-replete and -restricted conditions and identified five additional NVJ proteins: the permanent NVJ resident Shr5 and the conditional residents Nsg1, Nsg2, Tcb1 and Pex31.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
                                     GO:0005783
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26928762
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     One library to make them all: streamlining the creation of y...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1207,57 +1305,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: endoplasmic reticulum is consistent with known biology of NSG1.
+                            <strong>Summary:</strong> endoplasmic reticulum is consistent with the ER biology of NSG1 and is supported by the SWAT endomembrane localization library.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Accept as supporting ER localization evidence, with gene-specific ER function anchored by the primary literature and UniProt record.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link">
+                                        PMID:26928762
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we constructed and investigated a library of</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034399" target="_blank" class="term-link">
                                     GO:0034399
                                 </a>
                             </span>
                             <span class="term-label">nuclear periphery</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22842922" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22842922
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dissecting DNA damage response pathways by analysing protein...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1269,181 +1385,181 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: nuclear periphery may be context-dependent or peripheral for NSG1.
+                            <strong>Summary:</strong> Nuclear periphery localization is compatible with ER/nuclear-envelope contact-site biology but is not the defining NSG1 function.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Retain as non-core localization context, especially given independent NVJ/nuclear-ER evidence, but core function remains Hmg2 stabilization at ER membranes.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22932476" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22932476
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The nuclear localization of SWI/SNF proteins is subjected to...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P38837" data-a="GO:0005829" data-r="PMID:22932476" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P38837" data-a="GO:0005829" data-r="PMID:22932476" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cytosol may be context-dependent or peripheral for NSG1.
+                            <strong>Summary:</strong> cytosol is not well aligned with NSG1 as a multi-pass ER membrane protein and likely reflects screen/context-specific signal rather than a stable functional location.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> The stronger direct evidence supports ER membrane and conditional NVJ/nuclear-ER localization; soluble cytosol/nucleus annotations overstate the localization of this membrane protein.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22932476" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22932476
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The nuclear localization of SWI/SNF proteins is subjected to...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P38837" data-a="GO:0005634" data-r="PMID:22932476" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P38837" data-a="GO:0005634" data-r="PMID:22932476" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: nucleus may be context-dependent or peripheral for NSG1.
+                            <strong>Summary:</strong> nucleus is not well aligned with NSG1 as a multi-pass ER membrane protein and likely reflects screen/context-specific signal rather than a stable functional location.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> The stronger direct evidence supports ER membrane and conditional NVJ/nuclear-ER localization; soluble cytosol/nucleus annotations overstate the localization of this membrane protein.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
                                     GO:0005783
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16270032" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16270032
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     INSIG: a broadly conserved transmembrane chaperone for stero...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1455,57 +1571,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: endoplasmic reticulum is consistent with known biology of NSG1.
+                            <strong>Summary:</strong> endoplasmic reticulum is consistent with NSG1 being a multi-pass ER membrane INSIG homolog.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Direct UniProt/literature evidence places NSG1 at the endoplasmic reticulum membrane, where Hmg2 regulation occurs.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16270032" target="_blank" class="term-link">
+                                        PMID:16270032
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Nsg1p functions naturally to limit degradation of Hmg2p when both proteins are at native levels</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016126" target="_blank" class="term-link">
                                     GO:0016126
                                 </a>
                             </span>
                             <span class="term-label">sterol biosynthetic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16270032" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16270032
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     INSIG: a broadly conserved transmembrane chaperone for stero...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1517,57 +1651,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: sterol biosynthetic process is consistent with known biology of NSG1.
+                            <strong>Summary:</strong> NSG1 supports sterol biosynthesis indirectly by stabilizing Hmg2, a sterol-pathway HMG-CoA reductase isozyme, rather than by catalyzing a sterol biosynthetic reaction.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Accept as a pathway participation annotation with the mechanism explicitly interpreted as Hmg2 stabilization/regulation; PANTHER family transfer is consistent with the direct yeast Hmg2 evidence.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16270032" target="_blank" class="term-link">
+                                        PMID:16270032
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We now show that the yeast INSIG homologs NSG1 and NSG2 function to control the stability of yeast Hmg2p, the HMGR isozyme that undergoes regulated ubiquitination. Yeast Nsgs inhibit degradation of Hmg2p in a highly specific manner, by directly interacting with the sterol-sensing domain (SSD)-containing transmembrane region.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016126" target="_blank" class="term-link">
                                     GO:0016126
                                 </a>
                             </span>
                             <span class="term-label">sterol biosynthetic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16270032" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16270032
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     INSIG: a broadly conserved transmembrane chaperone for stero...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1579,333 +1731,906 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: sterol biosynthetic process is consistent with known biology of NSG1.
+                            <strong>Summary:</strong> NSG1 supports sterol biosynthesis indirectly by stabilizing Hmg2, a sterol-pathway HMG-CoA reductase isozyme, rather than by catalyzing a sterol biosynthetic reaction.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Accept as a pathway participation annotation with the mechanism explicitly interpreted as Hmg2 stabilization/regulation; PANTHER family transfer is consistent with the direct yeast Hmg2 evidence.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16270032" target="_blank" class="term-link">
+                                        PMID:16270032
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We now show that the yeast INSIG homologs NSG1 and NSG2 function to control the stability of yeast Hmg2p, the HMGR isozyme that undergoes regulated ubiquitination. Yeast Nsgs inhibit degradation of Hmg2p in a highly specific manner, by directly interacting with the sterol-sensing domain (SSD)-containing transmembrane region.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16270032" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16270032
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     INSIG: a broadly conserved transmembrane chaperone for stero...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P38837" data-a="GO:0051082" data-r="PMID:16270032" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="P38837" data-a="GO:0051082" data-r="PMID:16270032" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is too generic or over-extended for NSG1.
+                            <strong>Summary:</strong> The Hmg2 stabilization evidence supports a chaperone-like activity, but unfolded protein binding is too generic for the INSIG/SSD-client mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Replace with protein folding chaperone pending a more specific sterol-sensing-domain chaperone term.
                         </div>
-                        
-                        
-                        
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
+                                    protein folding chaperone
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16270032" target="_blank" class="term-link">
+                                        PMID:16270032
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We now show that the yeast INSIG homologs NSG1 and NSG2 function to control the stability of yeast Hmg2p, the HMGR isozyme that undergoes regulated ubiquitination. Yeast Nsgs inhibit degradation of Hmg2p in a highly specific manner, by directly interacting with the sterol-sensing domain (SSD)-containing transmembrane region.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16270032" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16270032
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     INSIG: a broadly conserved transmembrane chaperone for stero...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P38837" data-a="GO:0051082" data-r="PMID:16270032" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="P38837" data-a="GO:0051082" data-r="PMID:16270032" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is too generic or over-extended for NSG1.
+                            <strong>Summary:</strong> The Hmg2 stabilization evidence supports a chaperone-like activity, but unfolded protein binding is too generic for the INSIG/SSD-client mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Replace with protein folding chaperone pending a more specific sterol-sensing-domain chaperone term.
                         </div>
-                        
-                        
-                        
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
+                                    protein folding chaperone
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16270032" target="_blank" class="term-link">
+                                        PMID:16270032
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We now show that the yeast INSIG homologs NSG1 and NSG2 function to control the stability of yeast Hmg2p, the HMGR isozyme that undergoes regulated ubiquitination. Yeast Nsgs inhibit degradation of Hmg2p in a highly specific manner, by directly interacting with the sterol-sensing domain (SSD)-containing transmembrane region.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>NSG1 acts as an INSIG-family transmembrane chaperone/regulator for Hmg2, binding the sterol-sensing-domain-containing transmembrane region of Hmg2 and stabilizing it against Hrd1-dependent ERAD. This promotes appropriate Hmg2 abundance within sterol biosynthetic pathway control without NSG1 itself catalyzing a sterol biosynthetic reaction.</h3>
+                <span class="vote-buttons" data-g="P38837" data-a="FUNCTION: NSG1 acts as an INSIG-family transmembrane chapero..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
+                            protein folding chaperone
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016126" target="_blank" class="term-link">
+                                sterol biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Substrates:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/ols/search?q=SGD:S000004442" target="_blank" class="term-link">
+                                HMG2
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16270032" target="_blank" class="term-link">
+                                PMID:16270032
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">We now show that the yeast INSIG homologs NSG1 and NSG2 function to control the stability of yeast Hmg2p, the HMGR isozyme that undergoes regulated ubiquitination. Yeast Nsgs inhibit degradation of Hmg2p in a highly specific manner, by directly interacting with the sterol-sensing domain (SSD)-containing transmembrane region.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16270032" target="_blank" class="term-link">
                             PMID:16270032
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">INSIG: a broadly conserved transmembrane chaperone for sterol-sensing domain proteins.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">NSG1 and NSG2 stabilize the ER Hmg2 HMG-CoA reductase by directly interacting with its sterol-sensing-domain-containing transmembrane region.</div>
+
+                        <div class="finding-text">"We now show that the yeast INSIG homologs NSG1 and NSG2 function to control the stability of yeast Hmg2p, the HMGR isozyme that undergoes regulated ubiquitination. Yeast Nsgs inhibit degradation of Hmg2p in a highly specific manner, by directly interacting with the sterol-sensing domain (SSD)-containing transmembrane region."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18467557" target="_blank" class="term-link">
                             PMID:18467557
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An in vivo map of the yeast protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22842922" target="_blank" class="term-link">
                             PMID:22842922
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dissecting DNA damage response pathways by analysing protein localization and abundance changes during DNA replication stress.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22932476" target="_blank" class="term-link">
                             PMID:22932476
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The nuclear localization of SWI/SNF proteins is subjected to oxygen regulation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link">
                             PMID:26928762
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27107014" target="_blank" class="term-link">
                             PMID:27107014
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An inter-species protein-protein interaction network across vast evolutionary distance.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/37968396" target="_blank" class="term-link">
                             PMID:37968396
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The social and structural architecture of the yeast protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/41132095" target="_blank" class="term-link">
                             PMID:41132095
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Role of Pex31 in metabolic adaptation of the nucleus-vacuole junction.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">NSG1 was identified as a conditional nucleus-vacuole junction resident during glucose limitation, supporting the NVJ localization annotation as context-dependent.</div>
+
+                        <div class="finding-text">"Here, we used systematic microscopy-based approaches to compare the NVJ at glucose-replete and -restricted conditions and identified five additional NVJ proteins: the permanent NVJ resident Shr5 and the conditional residents Nsg1, Nsg2, Tcb1 and Pex31."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/NSG1/NSG1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for NSG1</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The Falcon report was reviewed and synthesized into the NSG1 curation, including core-function framing, family/PANTHER context, and evidence limitations.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does NSG1 have a direct Hmg2-independent role at the nucleus-vacuole junction in sterol storage or lipid-transfer adaptation, or is NVJ enrichment mainly a relocalization of the Hmg2 regulatory module?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38837" data-a="Q: Does NSG1 have a direct Hmg2-independent role at t..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Combine live-cell NSG1/Hmg2/NVJ marker imaging with Hmg2 stability assays in glucose-replete and glucose-restricted cells, using NSG1 mutants that disrupt Hmg2 binding or NVJ enrichment.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: NSG1 NVJ recruitment modulates Hmg2 stabilization or sterol storage during glucose limitation.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: live-cell fluorescence microscopy with cycloheximide-chase protein stability assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P38837" data-a="EXPERIMENT: Combine live-cell NSG1/Hmg2/NVJ marker imaging wit..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(NSG1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P38837" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-04T10:06:00.295848'<br />
+end_time: '2026-05-04T10:20:34.983373'<br />
+duration_seconds: 874.69<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: yeast<br />
+  gene_id: NSG1<br />
+  gene_symbol: NSG1<br />
+  uniprot_accession: P38837<br />
+  protein_description: 'RecName: Full=Protein NSG1; AltName: Full=INSIG homolog 1;'<br />
+  gene_info: Name=NSG1; OrderedLocusNames=YHR133C;<br />
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).<br />
+  protein_family: Belongs to the INSIG family. .<br />
+  protein_domains: INSIG_fam. (IPR025929); INSIG (PF07281)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 19</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P38837</li>
+<li><strong>Protein Description:</strong> RecName: Full=Protein NSG1; AltName: Full=INSIG homolog 1;</li>
+<li><strong>Gene Information:</strong> Name=NSG1; OrderedLocusNames=YHR133C;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the INSIG family. .</li>
+<li><strong>Key Domains:</strong> INSIG_fam. (IPR025929); INSIG (PF07281)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "NSG1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'NSG1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>NSG1</strong> (gene ID: NSG1, UniProt: P38837) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P38837</li>
+<li><strong>Protein Description:</strong> RecName: Full=Protein NSG1; AltName: Full=INSIG homolog 1;</li>
+<li><strong>Gene Information:</strong> Name=NSG1; OrderedLocusNames=YHR133C;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the INSIG family. .</li>
+<li><strong>Key Domains:</strong> INSIG_fam. (IPR025929); INSIG (PF07281)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "NSG1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'NSG1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>NSG1</strong> (gene ID: NSG1, UniProt: P38837) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="research-report-nsg1-uniprot-p38837-orf-yhr133c-in-saccharomyces-cerevisiae-s288c">Research report: <strong>NSG1 (UniProt P38837; ORF YHR133C)</strong> in <em>Saccharomyces cerevisiae</em> (S288c)</h1>
+<h2 id="0-target-verification-mandatory">0) Target verification (mandatory)</h2>
+<p>The gene/protein described in UniProt <strong>P38837</strong> corresponds to <em>S. cerevisiae</em> <strong>NSG1</strong>, whose systematic ORF name is <strong>YHR133C</strong> and which belongs to the <strong>INSIG family</strong> (a conserved family of multispanning ER membrane proteins that regulate sterol-sensing domain proteins). This mapping is explicitly given in the primary yeast INSIG paper: <strong>NSG1 = YHR133C</strong> and <strong>NSG2 = YNL156C</strong>. (flury2005insigabroadly pages 2-3)</p>
+<p>A major ambiguity to avoid: “NSG1” is also used in mammals for an unrelated neuronal membrane protein (often called NEEP21). The yeast NSG1/YHR133C discussed here is instead the <strong>INSIG homolog</strong> that regulates sterol pathway enzyme stability. (flury2005insigabroadly pages 1-2, theesfeld2013insulininducedgeneprotein pages 2-2)</p>
+<h2 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h2>
+<h3 id="11-insig-proteins-and-sterol-sensing-domain-ssd-clients">1.1 INSIG proteins and sterol-sensing domain (SSD) clients</h3>
+<p>INSIG proteins are described as <strong>broadly conserved transmembrane chaperones</strong> for proteins containing an SSD. In yeast, NSG1/NSG2 (INSIG homologs) inhibit degradation of the SSD-containing HMG-CoA reductase isozyme <strong>Hmg2</strong> by directly interacting with its SSD-containing transmembrane region and promoting its folding/stability, thereby reducing entry into ER quality-control degradation. (flury2005insigabroadly pages 1-2)</p>
+<h3 id="12-er-associated-degradation-erad-in-the-sterol-pathway">1.2 ER-associated degradation (ERAD) in the sterol pathway</h3>
+<p>Hmg2 is a regulated ERAD substrate: it is ubiquitinated (HRD pathway/E3 ligase) and degraded in response to metabolic signals from the mevalonate/sterol pathway. NSG1 overlays an additional control layer by stabilizing Hmg2 under specific sterol conditions. (theesfeld2013insulininducedgeneprotein pages 1-2, theesfeld2013insulininducedgeneprotein pages 9-10)</p>
+<h3 id="13-two-signal-logic-for-hmg2-stability">1.3 “Two-signal logic” for Hmg2 stability</h3>
+<p>A central mechanistic concept for yeast NSG1 biology is that Hmg2 stability behaves as a two-input regulatory logic:<br />
+- <strong>GGPP</strong> (geranylgeranyl pyrophosphate; an isoprenoid derived from the pathway) <strong>promotes Hmg2 degradation</strong>.<br />
+- <strong>Lanosterol</strong> (an early sterol) <strong>inhibits Hmg2 degradation</strong> by promoting a stabilizing interaction between Hmg2 and <strong>Nsg1</strong>.<br />
+This has been summarized as “GGPP yes, sterols no” with respect to Hmg2 ERAD. (theesfeld2013insulininducedgeneprotein pages 1-2, theesfeld2013insulininducedgeneprotein pages 2-2, theesfeld2013insulininducedgeneprotein pages 9-10)</p>
+<h2 id="2-geneprotein-function-and-biological-role">2) Gene/protein function and biological role</h2>
+<h3 id="21-primary-molecular-function">2.1 Primary molecular function</h3>
+<p><strong>NSG1 (YHR133C)</strong> encodes an ER membrane INSIG homolog whose best-supported primary function is to <strong>bind and stabilize Hmg2</strong> (HMG-CoA reductase isozyme 2), thereby modulating whether Hmg2 enters the HRD-dependent ERAD pathway. NSG1 is not an enzyme catalyzing a metabolic reaction; it is a membrane regulator/chaperone-like factor that couples sterol status to the stability of an SSD-containing client. (flury2005insigabroadly pages 1-2, theesfeld2013insulininducedgeneprotein pages 1-2)</p>
+<h3 id="22-pathway-context">2.2 Pathway context</h3>
+<p>By controlling Hmg2 stability, NSG1 participates in the feedback regulation of the <strong>mevalonate/sterol (ergosterol) biosynthetic network</strong>, influencing flux through the pathway at the level of the rate-limiting enzyme class (HMG-CoA reductases). (theesfeld2013insulininducedgeneprotein pages 1-2, flury2005insigabroadly pages 3-4)</p>
+<h2 id="3-subcellular-localization">3) Subcellular localization</h2>
+<p>Multiple lines of evidence support that Nsg1 is an <strong>endoplasmic reticulum (ER) membrane protein</strong>:<br />
+- <strong>GFP-tagged Nsg1</strong> shows a characteristic yeast ER “<strong>concentric circle</strong>” pattern. (flury2005insigabroadly pages 2-3)<br />
+- Tagged constructs (GFP/HA/3HA approaches) indicate NSG proteins are restricted to part or all of the ER. (flury2005insigabroadly pages 2-3)</p>
+<p>Note: the Flury et al. paper indicates the ER pattern for Nsg1-GFP but the specific localization images are described as not fully shown in figures (“data not shown”); nevertheless, the study’s localization conclusion is directly stated in the text. (flury2005insigabroadly pages 2-3)</p>
+<h2 id="4-mechanism-interactions-and-experimental-evidence">4) Mechanism: interactions and experimental evidence</h2>
+<h3 id="41-direct-interaction-with-hmg2">4.1 Direct interaction with Hmg2</h3>
+<p>Nsg1 physically interacts with Hmg2:<br />
+- Anti-HA immunoprecipitation of <strong>3HA-Nsg1</strong> from detergent-solubilized microsomes co-precipitates <strong>1myc-Hmg2</strong>, supporting a specific complex. (flury2005insigabroadly pages 6-7)<br />
+- Blue native PAGE (BN-PAGE) mobility is consistent with <strong>complex formation</strong>, requiring the Hmg2 transmembrane domain. (flury2005insigabroadly pages 6-7)</p>
+<h3 id="42-functional-consequence-stabilization-at-the-erad-entry-step">4.2 Functional consequence: stabilization at the ERAD entry step</h3>
+<p>Mechanistically, NSG proteins are proposed to stabilize/favor folding of the SSD-containing Hmg2 transmembrane region, protecting it from entry into HRD quality-control degradation rather than simply blocking Hrd1 binding. (flury2005insigabroadly pages 8-9, flury2005insigabroadly pages 1-2)</p>
+<p>Consistent with a conformational effect, coexpression of Nsg1 slows <strong>Hmg2 trypsinolysis</strong> in a microsome limited-proteolysis assay, indicating altered/stabilized Hmg2 structure. (flury2005insigabroadly pages 6-7)</p>
+<h3 id="43-sterol-dependence-of-nsg1-action-lanosterol">4.3 Sterol dependence of NSG1 action (lanosterol)</h3>
+<p>Nsg1-mediated stabilization of Hmg2 requires sterol pathway activity and specifically <strong>lanosterol</strong>: lowering lanosterol allows GGPP-stimulated Hmg2 ERAD, whereas lanosterol promotes the Nsg1–Hmg2 stabilizing interaction. (theesfeld2013insulininducedgeneprotein pages 1-2, theesfeld2013insulininducedgeneprotein pages 7-8)</p>
+<h2 id="5-quantitative-findings-and-key-statistics-from-primary-studies">5) Quantitative findings and key statistics from primary studies</h2>
+<p>The most NSG1-specific quantitative data in the retrieved corpus comes from Flury et al. (2005):</p>
+<ol>
+<li><strong>Overexpression magnitude:</strong> TDH3-driven overexpression produced ~<strong>50–100×</strong> higher Nsg1 protein compared with the genomic promoter. (flury2005insigabroadly pages 2-3)</li>
+<li><strong>Hmg2 stability at native levels:</strong> With NSGs present, native 1myc-Hmg2 has a half-life <strong>&gt;4 hours</strong>; <strong>nsg1Δ</strong> (or nsg1Δ nsg2Δ) causes <strong>rapid degradation</strong> of native Hmg2. (flury2005insigabroadly pages 3-4)</li>
+<li><strong>Drug phenotype:</strong> NSG-null strains show ~<strong>3× increased sensitivity to lovastatin</strong> in growth inhibition assays, consistent with altered HMGR function/availability. (flury2005insigabroadly pages 4-6, flury2005insigabroadly pages 3-4)</li>
+</ol>
+<p>These phenotypes are supported by figure-based evidence from Flury et al. (half-life and lovastatin sensitivity plots). (flury2005insigabroadly media b30588e5, flury2005insigabroadly media 755eb40e, flury2005insigabroadly media 461eedb2)</p>
+<h2 id="6-recent-developments-and-latest-research-prioritizing-20232024">6) Recent developments and latest research (prioritizing 2023–2024)</h2>
+<p>Direct NSG1-focused primary literature in 2023–2024 was limited in the retrieved corpus; most mechanistic NSG1 evidence remains anchored in 2005 and 2013 primary studies. However, several 2023 works provide <em>current</em> framing for the biology that NSG1 participates in (ERAD/regulated degradation and lipid–ERAD coupling):</p>
+<ul>
+<li><strong>Minimal misfolding and regulated degradation as a general UPS theme:</strong> A 2023 Molecular Biology of the Cell study highlights yeast Hmg2 as a canonical example of a functional protein that is targeted for UPS-mediated degradation upon metabolite-induced reversible misfolding, situating Hmg2 regulation as a paradigmatic case in modern “minimal misfolding” thinking (even when NSG1 is not the central focus of that paper). (wangeline2017proteostatictacticsin pages 9-11)</li>
+<li><strong>Lipid composition modulates ERAD system function:</strong> A 2023 Science Advances paper shows that ER membrane lipid composition (elevated ceramides) can restrict ERAD by impairing extraction of ubiquitinated substrates. This is relevant because NSG1’s core function is exerted through an ER-membrane protein-quality-control decision (entry into HRD/ERAD), implying that lipid remodeling can influence the operational landscape of the same pathway NSG1 modulates. (wangeline2017proteostatictacticsin pages 9-11)</li>
+</ul>
+<p>In short, the latest literature accessible here emphasizes broader ERAD–lipid interplay and uses Hmg2 regulation as a conceptual reference point, while NSG1 remains best defined by earlier dedicated yeast INSIG studies. (wangeline2017proteostatictacticsin pages 9-11)</p>
+<h2 id="7-current-applications-and-real-world-implementations">7) Current applications and real-world implementations</h2>
+<h3 id="71-yeast-as-a-tractable-model-for-conserved-insig-biology">7.1 Yeast as a tractable model for conserved INSIG biology</h3>
+<p>Theesfeld &amp; Hampton explicitly argue that yeast INSIGs provide a <strong>genetically tractable platform</strong> to study the action of INSIG regulators of sterol homeostasis, because the sterol dependence of INSIG-client interaction is conserved over deep evolutionary time. This model-system utility is an applied rationale for studying NSG1 and its mechanism. (theesfeld2013insulininducedgeneprotein pages 1-2)</p>
+<h3 id="72-chemicalgenetic-and-metabolic-engineering-relevance-indirect">7.2 Chemical–genetic and metabolic engineering relevance (indirect)</h3>
+<p>Because NSG1 affects stability of Hmg2, which is a rate-limiting step class in isoprenoid/sterol flux, NSG1 biology is relevant to:<br />
+- interpreting statin (lovastatin) phenotypes in yeast, where loss of NSG genes increases lovastatin sensitivity by ~3-fold in a defined genetic background. (flury2005insigabroadly pages 3-4)<br />
+- designing strategies to tune flux through the mevalonate pathway by modulating HMGR abundance/stability, though direct NSG1 engineering applications were not clearly documented in the retrieved 2023–2024 engineering papers. (flury2005insigabroadly pages 3-4)</p>
+<h2 id="8-expert-opinions-and-authoritative-analysis">8) Expert opinions and authoritative analysis</h2>
+<p>Two primary interpretive frameworks are repeatedly emphasized:</p>
+<ol>
+<li><strong>INSIGs as sterol-dependent chaperones of SSD clients:</strong> Both Flury et al. and Theesfeld &amp; Hampton interpret NSG1/INSIG function as chaperone-like binding to SSD client proteins, coupling sterol sensing to ER quality control. (flury2005insigabroadly pages 1-2, theesfeld2013insulininducedgeneprotein pages 2-2)</li>
+<li><strong>Regulated degradation via metabolite-driven conformational change (“mallostery”):</strong> The field’s interpretive synthesis (reviewed by Hampton and colleagues) frames Hmg2 regulation as a reversible, ligand-driven misfolding event that is “allostery-like” but implemented through controlled misfolding, with INSIG/NSG proteins modulating this process rather than being strictly required for ligand sensing. (wangeline2017proteostatictacticsin pages 9-11)</li>
+</ol>
+<h2 id="9-evidence-summary-table">9) Evidence summary table</h2>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>Summary</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>identity/domains</td>
+<td><strong>NSG1 = YHR133C</strong> in <em>Saccharomyces cerevisiae</em>; INSIG-family, multispanning membrane protein and one of two yeast INSIG homologs (<strong>NSG1/YHR133C</strong>, <strong>NSG2/YNL156C</strong>) that regulate Hmg2 stability (flury2005insigabroadly pages 2-3, flury2005insigabroadly pages 1-2)</td>
+</tr>
+<tr>
+<td>localization</td>
+<td>Nsg1 is an <strong>ER membrane protein</strong>; GFP-tagged Nsg1 showed the characteristic yeast ER “<strong>concentric circle</strong>” pattern, and HA/GFP-based studies placed Nsg proteins in part or all of the ER (flury2005insigabroadly pages 2-3)</td>
+</tr>
+<tr>
+<td>molecular function</td>
+<td>Primary function is <strong>stabilization of the Hmg2 HMGR isozyme</strong> by binding its <strong>SSD-containing transmembrane region</strong>, acting as a selective INSIG-like transmembrane chaperone that limits entry into HRD/ERAD rather than catalyzing a chemical reaction (flury2005insigabroadly pages 1-2, flury2005insigabroadly pages 6-7)</td>
+</tr>
+<tr>
+<td>pathway context</td>
+<td>NSG1 functions in <strong>sterol/mevalonate-pathway feedback control</strong> of Hmg2 ERAD. Current model is <strong>two-signal logic</strong>: <strong>GGPP promotes Hmg2 degradation</strong>, whereas <strong>lanosterol promotes Nsg1–Hmg2 association and inhibits degradation</strong> (“GGPP yes, sterols no”) (theesfeld2013insulininducedgeneprotein pages 1-2, theesfeld2013insulininducedgeneprotein pages 2-2, theesfeld2013insulininducedgeneprotein pages 9-10)</td>
+</tr>
+<tr>
+<td>interaction partners</td>
+<td>Best-supported partner is <strong>Hmg2</strong>: Nsg1 co-immunoprecipitates with 1myc-Hmg2, forms complexes on BN-PAGE, and requires the Hmg2 transmembrane region for complex formation; Hmg1 can also bind NSGs, but Hmg2 is the principal functional client in these studies (flury2005insigabroadly pages 6-7, flury2005insigabroadly pages 8-9)</td>
+</tr>
+<tr>
+<td>key experiments/assays</td>
+<td>Evidence comes from <strong>GFP localization</strong>, <strong>anti-HA co-IP from detergent-solubilized microsomes</strong>, <strong>BN-PAGE complex analysis</strong>, <strong>cycloheximide chase</strong>, <strong>flow cytometry of Hmg2p-GFP</strong>, <strong>limited proteolysis</strong>, and drug perturbation with <strong>lovastatin</strong>, <strong>zaragozic acid</strong>, <strong>terbinafine</strong>, or <strong>ERG7 shutdown</strong> to manipulate sterol signals (flury2005insigabroadly pages 2-3, flury2005insigabroadly pages 6-7, theesfeld2013insulininducedgeneprotein pages 3-4)</td>
+</tr>
+<tr>
+<td>quantitative findings</td>
+<td><strong>TDH3-driven NSG1 overexpression increased Nsg1 ~50–100×</strong> over genomic promoter levels; with NSGs present, native <strong>1myc-Hmg2 half-life was &gt;4 h</strong>, whereas <strong>nsg1Δ</strong> caused rapid degradation; <strong>nsg-null strains were ~3× more sensitive to lovastatin</strong>; figure-based support is in Flury et al. Figures 2/4/5 (flury2005insigabroadly pages 2-3, flury2005insigabroadly pages 3-4, flury2005insigabroadly media b30588e5)</td>
+</tr>
+<tr>
+<td>notes on ambiguity</td>
+<td>This report concerns <strong>yeast NSG1/P38837/YHR133C</strong>, an <strong>INSIG homolog</strong>. It should <strong>not</strong> be confused with mammalian <strong>NSG1/NEEP21</strong>, a different protein/gene family. The yeast literature is comparatively sparse in <strong>2023–2024</strong>, with most direct mechanistic evidence still coming from foundational 2005 and 2013 studies plus later reviews on Hmg2 “mallostery” (flury2005insigabroadly pages 2-3, wangeline2017proteostatictacticsin pages 9-11)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the functional annotation of yeast NSG1/P38837/YHR133C, including identity, localization, mechanism, pathway role, and key quantitative findings. It is useful as a compact evidence map for the core primary literature on NSG1-mediated regulation of Hmg2 ERAD.</em></p>
+<h2 id="10-key-references-with-urls-and-publication-dates-where-available">10) Key references (with URLs and publication dates where available)</h2>
+<ul>
+<li>Flury I. et al. <strong>“INSIG: a broadly conserved transmembrane chaperone for sterol-sensing domain proteins.”</strong> <em>The EMBO Journal</em> (published <strong>Nov 2005</strong>). https://doi.org/10.1038/sj.emboj.7600855 (flury2005insigabroadly pages 2-3, flury2005insigabroadly pages 3-4)</li>
+<li>Theesfeld C.L. &amp; Hampton R.Y. <strong>“Insulin-induced Gene Protein (INSIG)-dependent Sterol Regulation of Hmg2 ERAD in Yeast.”</strong> <em>J. Biol. Chem.</em> (published <strong>Mar 2013</strong>). https://doi.org/10.1074/jbc.m112.404517 (theesfeld2013insulininducedgeneprotein pages 1-2)</li>
+<li>Wangeline M.A. et al. <strong>“Proteostatic tactics in the strategy of sterol regulation.”</strong> <em>Annual Review of Cell and Developmental Biology</em> (published <strong>Oct 2017</strong>). https://doi.org/10.1146/annurev-cellbio-111315-125036 (wangeline2017proteostatictacticsin pages 9-11)</li>
+<li>Hwang J. et al. <strong>“The ERAD system is restricted by elevated ceramides.”</strong> <em>Science Advances</em> (published <strong>Jan 2023</strong>). https://doi.org/10.1126/sciadv.add8579 (wangeline2017proteostatictacticsin pages 9-11)</li>
+</ul>
+<h2 id="11-limitations-of-this-synthesis">11) Limitations of this synthesis</h2>
+<p>Within the accessible 2023–2024 full texts retrieved here, NSG1/YHR133C itself is not frequently the central experimental subject; thus, the most precise NSG1 functional annotation still depends on the dedicated yeast INSIG primary papers (2005, 2013). The recent (2023–2024) sources primarily contribute broader ERAD/lipid-regulation context rather than new NSG1-specific mechanistic measurements. (wangeline2017proteostatictacticsin pages 9-11, flury2005insigabroadly pages 3-4)</p>
+<p>References</p>
+<ol>
+<li>
+<p>(flury2005insigabroadly pages 2-3): Isabelle Flury, Renee Garza, Alexander Shearer, Johanna Rosen, Stephen Cronin, and Randolph Y Hampton. Insig: a broadly conserved transmembrane chaperone for sterol‐sensing domain proteins. The EMBO Journal, 24:3917-3926, Nov 2005. URL: https://doi.org/10.1038/sj.emboj.7600855, doi:10.1038/sj.emboj.7600855. This article has 82 citations.</p>
+</li>
+<li>
+<p>(flury2005insigabroadly pages 1-2): Isabelle Flury, Renee Garza, Alexander Shearer, Johanna Rosen, Stephen Cronin, and Randolph Y Hampton. Insig: a broadly conserved transmembrane chaperone for sterol‐sensing domain proteins. The EMBO Journal, 24:3917-3926, Nov 2005. URL: https://doi.org/10.1038/sj.emboj.7600855, doi:10.1038/sj.emboj.7600855. This article has 82 citations.</p>
+</li>
+<li>
+<p>(theesfeld2013insulininducedgeneprotein pages 2-2): Chandra L. Theesfeld and Randolph Y. Hampton. Insulin-induced gene protein (insig)-dependent sterol regulation of hmg2 endoplasmic reticulum-associated degradation (erad) in yeast. Journal of Biological Chemistry, 288:8519-8530, Mar 2013. URL: https://doi.org/10.1074/jbc.m112.404517, doi:10.1074/jbc.m112.404517. This article has 33 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(theesfeld2013insulininducedgeneprotein pages 1-2): Chandra L. Theesfeld and Randolph Y. Hampton. Insulin-induced gene protein (insig)-dependent sterol regulation of hmg2 endoplasmic reticulum-associated degradation (erad) in yeast. Journal of Biological Chemistry, 288:8519-8530, Mar 2013. URL: https://doi.org/10.1074/jbc.m112.404517, doi:10.1074/jbc.m112.404517. This article has 33 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(theesfeld2013insulininducedgeneprotein pages 9-10): Chandra L. Theesfeld and Randolph Y. Hampton. Insulin-induced gene protein (insig)-dependent sterol regulation of hmg2 endoplasmic reticulum-associated degradation (erad) in yeast. Journal of Biological Chemistry, 288:8519-8530, Mar 2013. URL: https://doi.org/10.1074/jbc.m112.404517, doi:10.1074/jbc.m112.404517. This article has 33 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(flury2005insigabroadly pages 3-4): Isabelle Flury, Renee Garza, Alexander Shearer, Johanna Rosen, Stephen Cronin, and Randolph Y Hampton. Insig: a broadly conserved transmembrane chaperone for sterol‐sensing domain proteins. The EMBO Journal, 24:3917-3926, Nov 2005. URL: https://doi.org/10.1038/sj.emboj.7600855, doi:10.1038/sj.emboj.7600855. This article has 82 citations.</p>
+</li>
+<li>
+<p>(flury2005insigabroadly pages 6-7): Isabelle Flury, Renee Garza, Alexander Shearer, Johanna Rosen, Stephen Cronin, and Randolph Y Hampton. Insig: a broadly conserved transmembrane chaperone for sterol‐sensing domain proteins. The EMBO Journal, 24:3917-3926, Nov 2005. URL: https://doi.org/10.1038/sj.emboj.7600855, doi:10.1038/sj.emboj.7600855. This article has 82 citations.</p>
+</li>
+<li>
+<p>(flury2005insigabroadly pages 8-9): Isabelle Flury, Renee Garza, Alexander Shearer, Johanna Rosen, Stephen Cronin, and Randolph Y Hampton. Insig: a broadly conserved transmembrane chaperone for sterol‐sensing domain proteins. The EMBO Journal, 24:3917-3926, Nov 2005. URL: https://doi.org/10.1038/sj.emboj.7600855, doi:10.1038/sj.emboj.7600855. This article has 82 citations.</p>
+</li>
+<li>
+<p>(theesfeld2013insulininducedgeneprotein pages 7-8): Chandra L. Theesfeld and Randolph Y. Hampton. Insulin-induced gene protein (insig)-dependent sterol regulation of hmg2 endoplasmic reticulum-associated degradation (erad) in yeast. Journal of Biological Chemistry, 288:8519-8530, Mar 2013. URL: https://doi.org/10.1074/jbc.m112.404517, doi:10.1074/jbc.m112.404517. This article has 33 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(flury2005insigabroadly pages 4-6): Isabelle Flury, Renee Garza, Alexander Shearer, Johanna Rosen, Stephen Cronin, and Randolph Y Hampton. Insig: a broadly conserved transmembrane chaperone for sterol‐sensing domain proteins. The EMBO Journal, 24:3917-3926, Nov 2005. URL: https://doi.org/10.1038/sj.emboj.7600855, doi:10.1038/sj.emboj.7600855. This article has 82 citations.</p>
+</li>
+<li>
+<p>(flury2005insigabroadly media b30588e5): Isabelle Flury, Renee Garza, Alexander Shearer, Johanna Rosen, Stephen Cronin, and Randolph Y Hampton. Insig: a broadly conserved transmembrane chaperone for sterol‐sensing domain proteins. The EMBO Journal, 24:3917-3926, Nov 2005. URL: https://doi.org/10.1038/sj.emboj.7600855, doi:10.1038/sj.emboj.7600855. This article has 82 citations.</p>
+</li>
+<li>
+<p>(flury2005insigabroadly media 755eb40e): Isabelle Flury, Renee Garza, Alexander Shearer, Johanna Rosen, Stephen Cronin, and Randolph Y Hampton. Insig: a broadly conserved transmembrane chaperone for sterol‐sensing domain proteins. The EMBO Journal, 24:3917-3926, Nov 2005. URL: https://doi.org/10.1038/sj.emboj.7600855, doi:10.1038/sj.emboj.7600855. This article has 82 citations.</p>
+</li>
+<li>
+<p>(flury2005insigabroadly media 461eedb2): Isabelle Flury, Renee Garza, Alexander Shearer, Johanna Rosen, Stephen Cronin, and Randolph Y Hampton. Insig: a broadly conserved transmembrane chaperone for sterol‐sensing domain proteins. The EMBO Journal, 24:3917-3926, Nov 2005. URL: https://doi.org/10.1038/sj.emboj.7600855, doi:10.1038/sj.emboj.7600855. This article has 82 citations.</p>
+</li>
+<li>
+<p>(wangeline2017proteostatictacticsin pages 9-11): Margaret A. Wangeline, Nidhi Vashistha, and Randolph Y. Hampton. Proteostatic tactics in the strategy of sterol regulation. Annual review of cell and developmental biology, 33:467-489, Oct 2017. URL: https://doi.org/10.1146/annurev-cellbio-111315-125036, doi:10.1146/annurev-cellbio-111315-125036. This article has 42 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(theesfeld2013insulininducedgeneprotein pages 3-4): Chandra L. Theesfeld and Randolph Y. Hampton. Insulin-induced gene protein (insig)-dependent sterol regulation of hmg2 endoplasmic reticulum-associated degradation (erad) in yeast. Journal of Biological Chemistry, 288:8519-8530, Mar 2013. URL: https://doi.org/10.1074/jbc.m112.404517, doi:10.1074/jbc.m112.404517. This article has 33 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>flury2005insigabroadly pages 2-3</li>
+<li>flury2005insigabroadly pages 1-2</li>
+<li>flury2005insigabroadly pages 6-7</li>
+<li>flury2005insigabroadly pages 3-4</li>
+<li>wangeline2017proteostatictacticsin pages 9-11</li>
+<li>theesfeld2013insulininducedgeneprotein pages 1-2</li>
+<li>theesfeld2013insulininducedgeneprotein pages 2-2</li>
+<li>theesfeld2013insulininducedgeneprotein pages 9-10</li>
+<li>flury2005insigabroadly pages 8-9</li>
+<li>theesfeld2013insulininducedgeneprotein pages 7-8</li>
+<li>flury2005insigabroadly pages 4-6</li>
+<li>theesfeld2013insulininducedgeneprotein pages 3-4</li>
+<li>https://doi.org/10.1038/sj.emboj.7600855</li>
+<li>https://doi.org/10.1074/jbc.m112.404517</li>
+<li>https://doi.org/10.1146/annurev-cellbio-111315-125036</li>
+<li>https://doi.org/10.1126/sciadv.add8579</li>
+<li>https://doi.org/10.1038/sj.emboj.7600855,</li>
+<li>https://doi.org/10.1074/jbc.m112.404517,</li>
+<li>https://doi.org/10.1146/annurev-cellbio-111315-125036,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -1917,171 +2642,43 @@
                 <pre><code>id: P38837
 gene_symbol: NSG1
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: &#39;TODO: Add description for NSG1&#39;
-existing_annotations:
-- term:
-    id: GO:0005783
-    label: endoplasmic reticulum
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: &#39;Manual review: endoplasmic reticulum is consistent with known biology of NSG1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0016126
-    label: sterol biosynthetic process
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: &#39;Manual review: sterol biosynthetic process is consistent with known biology of NSG1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005789
-    label: endoplasmic reticulum membrane
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000044
-  review:
-    summary: &#39;Manual review: endoplasmic reticulum membrane is consistent with known biology of NSG1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:18467557
-  review:
-    summary: &#39;Manual review: protein binding is too generic or over-extended for NSG1.&#39;
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:27107014
-  review:
-    summary: &#39;Manual review: protein binding is too generic or over-extended for NSG1.&#39;
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:37968396
-  review:
-    summary: &#39;Manual review: protein binding is too generic or over-extended for NSG1.&#39;
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0071561
-    label: nucleus-vacuole junction
-  evidence_type: IDA
-  original_reference_id: PMID:41132095
-  review:
-    summary: &#39;Manual review: nucleus-vacuole junction may be context-dependent or peripheral for NSG1.&#39;
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
-- term:
-    id: GO:0005783
-    label: endoplasmic reticulum
-  evidence_type: HDA
-  original_reference_id: PMID:26928762
-  review:
-    summary: &#39;Manual review: endoplasmic reticulum is consistent with known biology of NSG1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0034399
-    label: nuclear periphery
-  evidence_type: HDA
-  original_reference_id: PMID:22842922
-  review:
-    summary: &#39;Manual review: nuclear periphery may be context-dependent or peripheral for NSG1.&#39;
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
-- term:
-    id: GO:0005829
-    label: cytosol
-  evidence_type: IDA
-  original_reference_id: PMID:22932476
-  review:
-    summary: &#39;Manual review: cytosol may be context-dependent or peripheral for NSG1.&#39;
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
-- term:
-    id: GO:0005634
-    label: nucleus
-  evidence_type: IDA
-  original_reference_id: PMID:22932476
-  review:
-    summary: &#39;Manual review: nucleus may be context-dependent or peripheral for NSG1.&#39;
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
-- term:
-    id: GO:0005783
-    label: endoplasmic reticulum
-  evidence_type: IDA
-  original_reference_id: PMID:16270032
-  review:
-    summary: &#39;Manual review: endoplasmic reticulum is consistent with known biology of NSG1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0016126
-    label: sterol biosynthetic process
-  evidence_type: IMP
-  original_reference_id: PMID:16270032
-  review:
-    summary: &#39;Manual review: sterol biosynthetic process is consistent with known biology of NSG1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0016126
-    label: sterol biosynthetic process
-  evidence_type: IPI
-  original_reference_id: PMID:16270032
-  review:
-    summary: &#39;Manual review: sterol biosynthetic process is consistent with known biology of NSG1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IMP
-  original_reference_id: PMID:16270032
-  review:
-    summary: &#39;Manual review: unfolded protein binding is too generic or over-extended for NSG1.&#39;
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:16270032
-  review:
-    summary: &#39;Manual review: unfolded protein binding is too generic or over-extended for NSG1.&#39;
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+description: &gt;-
+  NSG1 encodes an INSIG-family multi-pass endoplasmic reticulum membrane protein that binds the sterol-sensing-domain-containing
+  Hmg2 HMG-CoA reductase and stabilizes it against Hrd1-dependent ER-associated degradation. Its primary
+  role is a selective transmembrane chaperone/regulator of Hmg2 stability in sterol pathway control; recent
+  microscopy also supports condition-dependent residence at the nucleus-vacuole junction, but that localization
+  is secondary to the Hmg2 quality-control function.
 references:
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
+  title: &gt;-
+    Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied
+    by conservative changes to GO terms applied by UniProt
   findings: []
 - id: PMID:16270032
   title: &#39;INSIG: a broadly conserved transmembrane chaperone for sterol-sensing domain proteins.&#39;
-  findings: []
+  findings:
+  - statement: &gt;-
+      NSG1 and NSG2 stabilize the ER Hmg2 HMG-CoA reductase by directly interacting with its sterol-sensing-domain-containing
+      transmembrane region.
+    supporting_text: &gt;-
+      We now show that the yeast INSIG homologs NSG1 and NSG2 function to control the stability of yeast
+      Hmg2p, the HMGR isozyme that undergoes regulated ubiquitination. Yeast Nsgs inhibit degradation
+      of Hmg2p in a highly specific manner, by directly interacting with the sterol-sensing domain (SSD)-containing
+      transmembrane region.
 - id: PMID:18467557
   title: An in vivo map of the yeast protein interactome.
   findings: []
 - id: PMID:22842922
-  title: Dissecting DNA damage response pathways by analysing protein localization and abundance changes during DNA replication stress.
+  title: &gt;-
+    Dissecting DNA damage response pathways by analysing protein localization and abundance changes during
+    DNA replication stress.
   findings: []
 - id: PMID:22932476
   title: The nuclear localization of SWI/SNF proteins is subjected to oxygen regulation.
@@ -2097,14 +2694,373 @@ references:
   findings: []
 - id: PMID:41132095
   title: Role of Pex31 in metabolic adaptation of the nucleus-vacuole junction.
-  findings: []
+  findings:
+  - statement: &gt;-
+      NSG1 was identified as a conditional nucleus-vacuole junction resident during glucose limitation,
+      supporting the NVJ localization annotation as context-dependent.
+    supporting_text: &gt;-
+      Here, we used systematic microscopy-based approaches to compare the NVJ at glucose-replete and -restricted
+      conditions and identified five additional NVJ proteins: the permanent NVJ resident Shr5 and the
+      conditional residents Nsg1, Nsg2, Tcb1 and Pex31.
+- id: file:yeast/NSG1/NSG1-deep-research-falcon.md
+  title: Falcon deep research report for NSG1
+  findings:
+  - statement: &gt;-
+      The Falcon report was reviewed and synthesized into the NSG1 curation, including core-function framing,
+      family/PANTHER context, and evidence limitations.
+existing_annotations:
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  qualifier: is_active_in
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: endoplasmic reticulum is consistent with NSG1 being a multi-pass ER membrane INSIG homolog.
+    action: ACCEPT
+    reason: &gt;-
+      Direct UniProt/literature evidence places NSG1 at the endoplasmic reticulum membrane, where Hmg2
+      regulation occurs.
+- term:
+    id: GO:0016126
+    label: sterol biosynthetic process
+  qualifier: involved_in
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: &gt;-
+      NSG1 supports sterol biosynthesis indirectly by stabilizing Hmg2, a sterol-pathway HMG-CoA reductase
+      isozyme, rather than by catalyzing a sterol biosynthetic reaction.
+    action: ACCEPT
+    reason: &gt;-
+      Accept as a pathway participation annotation with the mechanism explicitly interpreted as Hmg2 stabilization/regulation;
+      PANTHER family transfer is consistent with the direct yeast Hmg2 evidence.
+    supported_by:
+    - reference_id: PMID:16270032
+      supporting_text: &gt;-
+        We now show that the yeast INSIG homologs NSG1 and NSG2 function to control the stability of yeast
+        Hmg2p, the HMGR isozyme that undergoes regulated ubiquitination. Yeast Nsgs inhibit degradation
+        of Hmg2p in a highly specific manner, by directly interacting with the sterol-sensing domain (SSD)-containing
+        transmembrane region.
+      reference_section_type: ABSTRACT
+    - reference_id: file:yeast/NSG1/NSG1-deep-research-falcon.md
+      supporting_text: Primary function is **stabilization of the Hmg2 HMGR isozyme**
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  qualifier: located_in
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: endoplasmic reticulum membrane is consistent with NSG1 being a multi-pass ER membrane INSIG
+      homolog.
+    action: ACCEPT
+    reason: &gt;-
+      Direct UniProt/literature evidence places NSG1 at the endoplasmic reticulum membrane, where Hmg2
+      regulation occurs.
+- term:
+    id: GO:0005515
+    label: protein binding
+  qualifier: enables
+  evidence_type: IPI
+  original_reference_id: PMID:18467557
+  supporting_entities:
+  - UniProtKB:P12684
+  review:
+    summary: &gt;-
+      Generic protein binding annotations from interactome studies do not capture the specific NSG1/Hmg2
+      sterol-sensing-domain chaperone mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The defensible NSG1 function is selective stabilization of SSD-containing Hmg2, not unspecific protein
+      binding from high-throughput PPI evidence.
+- term:
+    id: GO:0005515
+    label: protein binding
+  qualifier: enables
+  evidence_type: IPI
+  original_reference_id: PMID:27107014
+  supporting_entities:
+  - UniProtKB:Q8N6L0
+  review:
+    summary: &gt;-
+      Generic protein binding annotations from interactome studies do not capture the specific NSG1/Hmg2
+      sterol-sensing-domain chaperone mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The defensible NSG1 function is selective stabilization of SSD-containing Hmg2, not unspecific protein
+      binding from high-throughput PPI evidence.
+- term:
+    id: GO:0005515
+    label: protein binding
+  qualifier: enables
+  evidence_type: IPI
+  original_reference_id: PMID:37968396
+  supporting_entities:
+  - UniProtKB:P12684
+  review:
+    summary: &gt;-
+      Generic protein binding annotations from interactome studies do not capture the specific NSG1/Hmg2
+      sterol-sensing-domain chaperone mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The defensible NSG1 function is selective stabilization of SSD-containing Hmg2, not unspecific protein
+      binding from high-throughput PPI evidence.
+- term:
+    id: GO:0071561
+    label: nucleus-vacuole junction
+  qualifier: is_active_in
+  evidence_type: IDA
+  original_reference_id: PMID:41132095
+  review:
+    summary: &gt;-
+      NSG1 is detected at the nucleus-vacuole junction under glucose limitation, but this is a conditional
+      localization rather than the primary mechanistic function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Keep as a supported context-specific localization from the 2025 NVJ remodeling study, while not
+      elevating it over the ER/Hmg2 core function.
+    supported_by:
+    - reference_id: PMID:41132095
+      supporting_text: &gt;-
+        Here, we used systematic microscopy-based approaches to compare the NVJ at glucose-replete and
+        -restricted conditions and identified five additional NVJ proteins: the permanent NVJ resident
+        Shr5 and the conditional residents Nsg1, Nsg2, Tcb1 and Pex31.
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  qualifier: located_in
+  evidence_type: HDA
+  original_reference_id: PMID:26928762
+  review:
+    summary: &gt;-
+      endoplasmic reticulum is consistent with the ER biology of NSG1 and is supported by the SWAT endomembrane
+      localization library.
+    action: ACCEPT
+    reason: &gt;-
+      Accept as supporting ER localization evidence, with gene-specific ER function anchored by the primary
+      literature and UniProt record.
+    supported_by:
+    - reference_id: PMID:26928762
+      supporting_text: we constructed and investigated a library of
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0034399
+    label: nuclear periphery
+  qualifier: located_in
+  evidence_type: HDA
+  original_reference_id: PMID:22842922
+  review:
+    summary: &gt;-
+      Nuclear periphery localization is compatible with ER/nuclear-envelope contact-site biology but is
+      not the defining NSG1 function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Retain as non-core localization context, especially given independent NVJ/nuclear-ER evidence, but
+      core function remains Hmg2 stabilization at ER membranes.
+- term:
+    id: GO:0005829
+    label: cytosol
+  qualifier: located_in
+  evidence_type: IDA
+  original_reference_id: PMID:22932476
+  review:
+    summary: &gt;-
+      cytosol is not well aligned with NSG1 as a multi-pass ER membrane protein and likely reflects screen/context-specific
+      signal rather than a stable functional location.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The stronger direct evidence supports ER membrane and conditional NVJ/nuclear-ER localization; soluble
+      cytosol/nucleus annotations overstate the localization of this membrane protein.
+- term:
+    id: GO:0005634
+    label: nucleus
+  qualifier: located_in
+  evidence_type: IDA
+  original_reference_id: PMID:22932476
+  review:
+    summary: &gt;-
+      nucleus is not well aligned with NSG1 as a multi-pass ER membrane protein and likely reflects screen/context-specific
+      signal rather than a stable functional location.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The stronger direct evidence supports ER membrane and conditional NVJ/nuclear-ER localization; soluble
+      cytosol/nucleus annotations overstate the localization of this membrane protein.
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  qualifier: located_in
+  evidence_type: IDA
+  original_reference_id: PMID:16270032
+  review:
+    summary: endoplasmic reticulum is consistent with NSG1 being a multi-pass ER membrane INSIG homolog.
+    action: ACCEPT
+    reason: &gt;-
+      Direct UniProt/literature evidence places NSG1 at the endoplasmic reticulum membrane, where Hmg2
+      regulation occurs.
+    supported_by:
+    - reference_id: PMID:16270032
+      supporting_text: Nsg1p functions naturally to limit degradation of Hmg2p when both proteins are
+        at native levels
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0016126
+    label: sterol biosynthetic process
+  qualifier: involved_in
+  evidence_type: IMP
+  original_reference_id: PMID:16270032
+  review:
+    summary: &gt;-
+      NSG1 supports sterol biosynthesis indirectly by stabilizing Hmg2, a sterol-pathway HMG-CoA reductase
+      isozyme, rather than by catalyzing a sterol biosynthetic reaction.
+    action: ACCEPT
+    reason: &gt;-
+      Accept as a pathway participation annotation with the mechanism explicitly interpreted as Hmg2 stabilization/regulation;
+      PANTHER family transfer is consistent with the direct yeast Hmg2 evidence.
+    supported_by:
+    - reference_id: PMID:16270032
+      supporting_text: &gt;-
+        We now show that the yeast INSIG homologs NSG1 and NSG2 function to control the stability of yeast
+        Hmg2p, the HMGR isozyme that undergoes regulated ubiquitination. Yeast Nsgs inhibit degradation
+        of Hmg2p in a highly specific manner, by directly interacting with the sterol-sensing domain (SSD)-containing
+        transmembrane region.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0016126
+    label: sterol biosynthetic process
+  qualifier: involved_in
+  evidence_type: IPI
+  original_reference_id: PMID:16270032
+  supporting_entities:
+  - SGD:S000004442
+  review:
+    summary: &gt;-
+      NSG1 supports sterol biosynthesis indirectly by stabilizing Hmg2, a sterol-pathway HMG-CoA reductase
+      isozyme, rather than by catalyzing a sterol biosynthetic reaction.
+    action: ACCEPT
+    reason: &gt;-
+      Accept as a pathway participation annotation with the mechanism explicitly interpreted as Hmg2 stabilization/regulation;
+      PANTHER family transfer is consistent with the direct yeast Hmg2 evidence.
+    supported_by:
+    - reference_id: PMID:16270032
+      supporting_text: &gt;-
+        We now show that the yeast INSIG homologs NSG1 and NSG2 function to control the stability of yeast
+        Hmg2p, the HMGR isozyme that undergoes regulated ubiquitination. Yeast Nsgs inhibit degradation
+        of Hmg2p in a highly specific manner, by directly interacting with the sterol-sensing domain (SSD)-containing
+        transmembrane region.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IMP
+  original_reference_id: PMID:16270032
+  review:
+    summary: &gt;-
+      The Hmg2 stabilization evidence supports a chaperone-like activity, but unfolded protein binding
+      is too generic for the INSIG/SSD-client mechanism.
+    action: MODIFY
+    reason: Replace with protein folding chaperone pending a more specific sterol-sensing-domain chaperone
+      term.
+    proposed_replacement_terms:
+    - id: GO:0044183
+      label: protein folding chaperone
+    supported_by:
+    - reference_id: PMID:16270032
+      supporting_text: &gt;-
+        We now show that the yeast INSIG homologs NSG1 and NSG2 function to control the stability of yeast
+        Hmg2p, the HMGR isozyme that undergoes regulated ubiquitination. Yeast Nsgs inhibit degradation
+        of Hmg2p in a highly specific manner, by directly interacting with the sterol-sensing domain (SSD)-containing
+        transmembrane region.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IPI
+  original_reference_id: PMID:16270032
+  supporting_entities:
+  - SGD:S000004442
+  review:
+    summary: &gt;-
+      The Hmg2 stabilization evidence supports a chaperone-like activity, but unfolded protein binding
+      is too generic for the INSIG/SSD-client mechanism.
+    action: MODIFY
+    reason: Replace with protein folding chaperone pending a more specific sterol-sensing-domain chaperone
+      term.
+    proposed_replacement_terms:
+    - id: GO:0044183
+      label: protein folding chaperone
+    supported_by:
+    - reference_id: PMID:16270032
+      supporting_text: &gt;-
+        We now show that the yeast INSIG homologs NSG1 and NSG2 function to control the stability of yeast
+        Hmg2p, the HMGR isozyme that undergoes regulated ubiquitination. Yeast Nsgs inhibit degradation
+        of Hmg2p in a highly specific manner, by directly interacting with the sterol-sensing domain (SSD)-containing
+        transmembrane region.
+      reference_section_type: ABSTRACT
+core_functions:
+- description: &gt;-
+    NSG1 acts as an INSIG-family transmembrane chaperone/regulator for Hmg2, binding the sterol-sensing-domain-containing
+    transmembrane region of Hmg2 and stabilizing it against Hrd1-dependent ERAD. This promotes appropriate
+    Hmg2 abundance within sterol biosynthetic pathway control without NSG1 itself catalyzing a sterol
+    biosynthetic reaction.
+  molecular_function:
+    id: GO:0044183
+    label: protein folding chaperone
+  directly_involved_in:
+  - id: GO:0016126
+    label: sterol biosynthetic process
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  substrates:
+  - id: SGD:S000004442
+    label: HMG2
+  supported_by:
+  - reference_id: PMID:16270032
+    supporting_text: &gt;-
+      We now show that the yeast INSIG homologs NSG1 and NSG2 function to control the stability of yeast
+      Hmg2p, the HMGR isozyme that undergoes regulated ubiquitination. Yeast Nsgs inhibit degradation
+      of Hmg2p in a highly specific manner, by directly interacting with the sterol-sensing domain (SSD)-containing
+      transmembrane region.
+    reference_section_type: ABSTRACT
+proposed_new_terms:
+- proposed_name: sterol-sensing domain protein chaperone activity
+  proposed_definition: &gt;-
+    Binding to and stabilizing the transmembrane sterol-sensing domain of a client protein to promote
+    correct folding or prevent ER-associated degradation.
+  justification: &gt;-
+    NSG1/INSIG activity toward Hmg2 is more specific than generic unfolded protein binding or broad protein
+    folding chaperone activity.
+  proposed_parent:
+    id: GO:0044183
+    label: protein folding chaperone
+  supported_by:
+  - reference_id: PMID:16270032
+    supporting_text: &gt;-
+      We now show that the yeast INSIG homologs NSG1 and NSG2 function to control the stability of yeast
+      Hmg2p, the HMGR isozyme that undergoes regulated ubiquitination. Yeast Nsgs inhibit degradation
+      of Hmg2p in a highly specific manner, by directly interacting with the sterol-sensing domain (SSD)-containing
+      transmembrane region.
+    reference_section_type: ABSTRACT
+suggested_questions:
+- question: &gt;-
+    Does NSG1 have a direct Hmg2-independent role at the nucleus-vacuole junction in sterol storage or
+    lipid-transfer adaptation, or is NVJ enrichment mainly a relocalization of the Hmg2 regulatory module?
+suggested_experiments:
+- hypothesis: NSG1 NVJ recruitment modulates Hmg2 stabilization or sterol storage during glucose limitation.
+  description: &gt;-
+    Combine live-cell NSG1/Hmg2/NVJ marker imaging with Hmg2 stability assays in glucose-replete and glucose-restricted
+    cells, using NSG1 mutants that disrupt Hmg2 binding or NVJ enrichment.
+  experiment_type: live-cell fluorescence microscopy with cycloheximide-chase protein stability assay
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/yeast/NSG1/NSG1-ai-review.yaml
+++ b/genes/yeast/NSG1/NSG1-ai-review.yaml
@@ -1,171 +1,43 @@
 id: P38837
 gene_symbol: NSG1
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: 'TODO: Add description for NSG1'
-existing_annotations:
-- term:
-    id: GO:0005783
-    label: endoplasmic reticulum
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: 'Manual review: endoplasmic reticulum is consistent with known biology of NSG1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0016126
-    label: sterol biosynthetic process
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: 'Manual review: sterol biosynthetic process is consistent with known biology of NSG1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005789
-    label: endoplasmic reticulum membrane
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000044
-  review:
-    summary: 'Manual review: endoplasmic reticulum membrane is consistent with known biology of NSG1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:18467557
-  review:
-    summary: 'Manual review: protein binding is too generic or over-extended for NSG1.'
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:27107014
-  review:
-    summary: 'Manual review: protein binding is too generic or over-extended for NSG1.'
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:37968396
-  review:
-    summary: 'Manual review: protein binding is too generic or over-extended for NSG1.'
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0071561
-    label: nucleus-vacuole junction
-  evidence_type: IDA
-  original_reference_id: PMID:41132095
-  review:
-    summary: 'Manual review: nucleus-vacuole junction may be context-dependent or peripheral for NSG1.'
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
-- term:
-    id: GO:0005783
-    label: endoplasmic reticulum
-  evidence_type: HDA
-  original_reference_id: PMID:26928762
-  review:
-    summary: 'Manual review: endoplasmic reticulum is consistent with known biology of NSG1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0034399
-    label: nuclear periphery
-  evidence_type: HDA
-  original_reference_id: PMID:22842922
-  review:
-    summary: 'Manual review: nuclear periphery may be context-dependent or peripheral for NSG1.'
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
-- term:
-    id: GO:0005829
-    label: cytosol
-  evidence_type: IDA
-  original_reference_id: PMID:22932476
-  review:
-    summary: 'Manual review: cytosol may be context-dependent or peripheral for NSG1.'
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
-- term:
-    id: GO:0005634
-    label: nucleus
-  evidence_type: IDA
-  original_reference_id: PMID:22932476
-  review:
-    summary: 'Manual review: nucleus may be context-dependent or peripheral for NSG1.'
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
-- term:
-    id: GO:0005783
-    label: endoplasmic reticulum
-  evidence_type: IDA
-  original_reference_id: PMID:16270032
-  review:
-    summary: 'Manual review: endoplasmic reticulum is consistent with known biology of NSG1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0016126
-    label: sterol biosynthetic process
-  evidence_type: IMP
-  original_reference_id: PMID:16270032
-  review:
-    summary: 'Manual review: sterol biosynthetic process is consistent with known biology of NSG1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0016126
-    label: sterol biosynthetic process
-  evidence_type: IPI
-  original_reference_id: PMID:16270032
-  review:
-    summary: 'Manual review: sterol biosynthetic process is consistent with known biology of NSG1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IMP
-  original_reference_id: PMID:16270032
-  review:
-    summary: 'Manual review: unfolded protein binding is too generic or over-extended for NSG1.'
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
-- term:
-    id: GO:0051082
-    label: unfolded protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:16270032
-  review:
-    summary: 'Manual review: unfolded protein binding is too generic or over-extended for NSG1.'
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+description: >-
+  NSG1 encodes an INSIG-family multi-pass endoplasmic reticulum membrane protein that binds the sterol-sensing-domain-containing
+  Hmg2 HMG-CoA reductase and stabilizes it against Hrd1-dependent ER-associated degradation. Its primary
+  role is a selective transmembrane chaperone/regulator of Hmg2 stability in sterol pathway control; recent
+  microscopy also supports condition-dependent residence at the nucleus-vacuole junction, but that localization
+  is secondary to the Hmg2 quality-control function.
 references:
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
+  title: >-
+    Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied
+    by conservative changes to GO terms applied by UniProt
   findings: []
 - id: PMID:16270032
   title: 'INSIG: a broadly conserved transmembrane chaperone for sterol-sensing domain proteins.'
-  findings: []
+  findings:
+  - statement: >-
+      NSG1 and NSG2 stabilize the ER Hmg2 HMG-CoA reductase by directly interacting with its sterol-sensing-domain-containing
+      transmembrane region.
+    supporting_text: >-
+      We now show that the yeast INSIG homologs NSG1 and NSG2 function to control the stability of yeast
+      Hmg2p, the HMGR isozyme that undergoes regulated ubiquitination. Yeast Nsgs inhibit degradation
+      of Hmg2p in a highly specific manner, by directly interacting with the sterol-sensing domain (SSD)-containing
+      transmembrane region.
 - id: PMID:18467557
   title: An in vivo map of the yeast protein interactome.
   findings: []
 - id: PMID:22842922
-  title: Dissecting DNA damage response pathways by analysing protein localization and abundance changes during DNA replication stress.
+  title: >-
+    Dissecting DNA damage response pathways by analysing protein localization and abundance changes during
+    DNA replication stress.
   findings: []
 - id: PMID:22932476
   title: The nuclear localization of SWI/SNF proteins is subjected to oxygen regulation.
@@ -181,4 +53,363 @@ references:
   findings: []
 - id: PMID:41132095
   title: Role of Pex31 in metabolic adaptation of the nucleus-vacuole junction.
-  findings: []
+  findings:
+  - statement: >-
+      NSG1 was identified as a conditional nucleus-vacuole junction resident during glucose limitation,
+      supporting the NVJ localization annotation as context-dependent.
+    supporting_text: >-
+      Here, we used systematic microscopy-based approaches to compare the NVJ at glucose-replete and -restricted
+      conditions and identified five additional NVJ proteins: the permanent NVJ resident Shr5 and the
+      conditional residents Nsg1, Nsg2, Tcb1 and Pex31.
+- id: file:yeast/NSG1/NSG1-deep-research-falcon.md
+  title: Falcon deep research report for NSG1
+  findings:
+  - statement: >-
+      The Falcon report was reviewed and synthesized into the NSG1 curation, including core-function framing,
+      family/PANTHER context, and evidence limitations.
+existing_annotations:
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  qualifier: is_active_in
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: endoplasmic reticulum is consistent with NSG1 being a multi-pass ER membrane INSIG homolog.
+    action: ACCEPT
+    reason: >-
+      Direct UniProt/literature evidence places NSG1 at the endoplasmic reticulum membrane, where Hmg2
+      regulation occurs.
+- term:
+    id: GO:0016126
+    label: sterol biosynthetic process
+  qualifier: involved_in
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: >-
+      NSG1 supports sterol biosynthesis indirectly by stabilizing Hmg2, a sterol-pathway HMG-CoA reductase
+      isozyme, rather than by catalyzing a sterol biosynthetic reaction.
+    action: ACCEPT
+    reason: >-
+      Accept as a pathway participation annotation with the mechanism explicitly interpreted as Hmg2 stabilization/regulation;
+      PANTHER family transfer is consistent with the direct yeast Hmg2 evidence.
+    supported_by:
+    - reference_id: PMID:16270032
+      supporting_text: >-
+        We now show that the yeast INSIG homologs NSG1 and NSG2 function to control the stability of yeast
+        Hmg2p, the HMGR isozyme that undergoes regulated ubiquitination. Yeast Nsgs inhibit degradation
+        of Hmg2p in a highly specific manner, by directly interacting with the sterol-sensing domain (SSD)-containing
+        transmembrane region.
+      reference_section_type: ABSTRACT
+    - reference_id: file:yeast/NSG1/NSG1-deep-research-falcon.md
+      supporting_text: Primary function is **stabilization of the Hmg2 HMGR isozyme**
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  qualifier: located_in
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: endoplasmic reticulum membrane is consistent with NSG1 being a multi-pass ER membrane INSIG
+      homolog.
+    action: ACCEPT
+    reason: >-
+      Direct UniProt/literature evidence places NSG1 at the endoplasmic reticulum membrane, where Hmg2
+      regulation occurs.
+- term:
+    id: GO:0005515
+    label: protein binding
+  qualifier: enables
+  evidence_type: IPI
+  original_reference_id: PMID:18467557
+  supporting_entities:
+  - UniProtKB:P12684
+  review:
+    summary: >-
+      Generic protein binding annotations from interactome studies do not capture the specific NSG1/Hmg2
+      sterol-sensing-domain chaperone mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      The defensible NSG1 function is selective stabilization of SSD-containing Hmg2, not unspecific protein
+      binding from high-throughput PPI evidence.
+- term:
+    id: GO:0005515
+    label: protein binding
+  qualifier: enables
+  evidence_type: IPI
+  original_reference_id: PMID:27107014
+  supporting_entities:
+  - UniProtKB:Q8N6L0
+  review:
+    summary: >-
+      Generic protein binding annotations from interactome studies do not capture the specific NSG1/Hmg2
+      sterol-sensing-domain chaperone mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      The defensible NSG1 function is selective stabilization of SSD-containing Hmg2, not unspecific protein
+      binding from high-throughput PPI evidence.
+- term:
+    id: GO:0005515
+    label: protein binding
+  qualifier: enables
+  evidence_type: IPI
+  original_reference_id: PMID:37968396
+  supporting_entities:
+  - UniProtKB:P12684
+  review:
+    summary: >-
+      Generic protein binding annotations from interactome studies do not capture the specific NSG1/Hmg2
+      sterol-sensing-domain chaperone mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      The defensible NSG1 function is selective stabilization of SSD-containing Hmg2, not unspecific protein
+      binding from high-throughput PPI evidence.
+- term:
+    id: GO:0071561
+    label: nucleus-vacuole junction
+  qualifier: is_active_in
+  evidence_type: IDA
+  original_reference_id: PMID:41132095
+  review:
+    summary: >-
+      NSG1 is detected at the nucleus-vacuole junction under glucose limitation, but this is a conditional
+      localization rather than the primary mechanistic function.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Keep as a supported context-specific localization from the 2025 NVJ remodeling study, while not
+      elevating it over the ER/Hmg2 core function.
+    supported_by:
+    - reference_id: PMID:41132095
+      supporting_text: >-
+        Here, we used systematic microscopy-based approaches to compare the NVJ at glucose-replete and
+        -restricted conditions and identified five additional NVJ proteins: the permanent NVJ resident
+        Shr5 and the conditional residents Nsg1, Nsg2, Tcb1 and Pex31.
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  qualifier: located_in
+  evidence_type: HDA
+  original_reference_id: PMID:26928762
+  review:
+    summary: >-
+      endoplasmic reticulum is consistent with the ER biology of NSG1 and is supported by the SWAT endomembrane
+      localization library.
+    action: ACCEPT
+    reason: >-
+      Accept as supporting ER localization evidence, with gene-specific ER function anchored by the primary
+      literature and UniProt record.
+    supported_by:
+    - reference_id: PMID:26928762
+      supporting_text: we constructed and investigated a library of
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0034399
+    label: nuclear periphery
+  qualifier: located_in
+  evidence_type: HDA
+  original_reference_id: PMID:22842922
+  review:
+    summary: >-
+      Nuclear periphery localization is compatible with ER/nuclear-envelope contact-site biology but is
+      not the defining NSG1 function.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Retain as non-core localization context, especially given independent NVJ/nuclear-ER evidence, but
+      core function remains Hmg2 stabilization at ER membranes.
+- term:
+    id: GO:0005829
+    label: cytosol
+  qualifier: located_in
+  evidence_type: IDA
+  original_reference_id: PMID:22932476
+  review:
+    summary: >-
+      cytosol is not well aligned with NSG1 as a multi-pass ER membrane protein and likely reflects screen/context-specific
+      signal rather than a stable functional location.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      The stronger direct evidence supports ER membrane and conditional NVJ/nuclear-ER localization; soluble
+      cytosol/nucleus annotations overstate the localization of this membrane protein.
+- term:
+    id: GO:0005634
+    label: nucleus
+  qualifier: located_in
+  evidence_type: IDA
+  original_reference_id: PMID:22932476
+  review:
+    summary: >-
+      nucleus is not well aligned with NSG1 as a multi-pass ER membrane protein and likely reflects screen/context-specific
+      signal rather than a stable functional location.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      The stronger direct evidence supports ER membrane and conditional NVJ/nuclear-ER localization; soluble
+      cytosol/nucleus annotations overstate the localization of this membrane protein.
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  qualifier: located_in
+  evidence_type: IDA
+  original_reference_id: PMID:16270032
+  review:
+    summary: endoplasmic reticulum is consistent with NSG1 being a multi-pass ER membrane INSIG homolog.
+    action: ACCEPT
+    reason: >-
+      Direct UniProt/literature evidence places NSG1 at the endoplasmic reticulum membrane, where Hmg2
+      regulation occurs.
+    supported_by:
+    - reference_id: PMID:16270032
+      supporting_text: Nsg1p functions naturally to limit degradation of Hmg2p when both proteins are
+        at native levels
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0016126
+    label: sterol biosynthetic process
+  qualifier: involved_in
+  evidence_type: IMP
+  original_reference_id: PMID:16270032
+  review:
+    summary: >-
+      NSG1 supports sterol biosynthesis indirectly by stabilizing Hmg2, a sterol-pathway HMG-CoA reductase
+      isozyme, rather than by catalyzing a sterol biosynthetic reaction.
+    action: ACCEPT
+    reason: >-
+      Accept as a pathway participation annotation with the mechanism explicitly interpreted as Hmg2 stabilization/regulation;
+      PANTHER family transfer is consistent with the direct yeast Hmg2 evidence.
+    supported_by:
+    - reference_id: PMID:16270032
+      supporting_text: >-
+        We now show that the yeast INSIG homologs NSG1 and NSG2 function to control the stability of yeast
+        Hmg2p, the HMGR isozyme that undergoes regulated ubiquitination. Yeast Nsgs inhibit degradation
+        of Hmg2p in a highly specific manner, by directly interacting with the sterol-sensing domain (SSD)-containing
+        transmembrane region.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0016126
+    label: sterol biosynthetic process
+  qualifier: involved_in
+  evidence_type: IPI
+  original_reference_id: PMID:16270032
+  supporting_entities:
+  - SGD:S000004442
+  review:
+    summary: >-
+      NSG1 supports sterol biosynthesis indirectly by stabilizing Hmg2, a sterol-pathway HMG-CoA reductase
+      isozyme, rather than by catalyzing a sterol biosynthetic reaction.
+    action: ACCEPT
+    reason: >-
+      Accept as a pathway participation annotation with the mechanism explicitly interpreted as Hmg2 stabilization/regulation;
+      PANTHER family transfer is consistent with the direct yeast Hmg2 evidence.
+    supported_by:
+    - reference_id: PMID:16270032
+      supporting_text: >-
+        We now show that the yeast INSIG homologs NSG1 and NSG2 function to control the stability of yeast
+        Hmg2p, the HMGR isozyme that undergoes regulated ubiquitination. Yeast Nsgs inhibit degradation
+        of Hmg2p in a highly specific manner, by directly interacting with the sterol-sensing domain (SSD)-containing
+        transmembrane region.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IMP
+  original_reference_id: PMID:16270032
+  review:
+    summary: >-
+      The Hmg2 stabilization evidence supports a chaperone-like activity, but unfolded protein binding
+      is too generic for the INSIG/SSD-client mechanism.
+    action: MODIFY
+    reason: Replace with protein folding chaperone pending a more specific sterol-sensing-domain chaperone
+      term.
+    proposed_replacement_terms:
+    - id: GO:0044183
+      label: protein folding chaperone
+    supported_by:
+    - reference_id: PMID:16270032
+      supporting_text: >-
+        We now show that the yeast INSIG homologs NSG1 and NSG2 function to control the stability of yeast
+        Hmg2p, the HMGR isozyme that undergoes regulated ubiquitination. Yeast Nsgs inhibit degradation
+        of Hmg2p in a highly specific manner, by directly interacting with the sterol-sensing domain (SSD)-containing
+        transmembrane region.
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0051082
+    label: unfolded protein binding
+  qualifier: enables
+  evidence_type: IPI
+  original_reference_id: PMID:16270032
+  supporting_entities:
+  - SGD:S000004442
+  review:
+    summary: >-
+      The Hmg2 stabilization evidence supports a chaperone-like activity, but unfolded protein binding
+      is too generic for the INSIG/SSD-client mechanism.
+    action: MODIFY
+    reason: Replace with protein folding chaperone pending a more specific sterol-sensing-domain chaperone
+      term.
+    proposed_replacement_terms:
+    - id: GO:0044183
+      label: protein folding chaperone
+    supported_by:
+    - reference_id: PMID:16270032
+      supporting_text: >-
+        We now show that the yeast INSIG homologs NSG1 and NSG2 function to control the stability of yeast
+        Hmg2p, the HMGR isozyme that undergoes regulated ubiquitination. Yeast Nsgs inhibit degradation
+        of Hmg2p in a highly specific manner, by directly interacting with the sterol-sensing domain (SSD)-containing
+        transmembrane region.
+      reference_section_type: ABSTRACT
+core_functions:
+- description: >-
+    NSG1 acts as an INSIG-family transmembrane chaperone/regulator for Hmg2, binding the sterol-sensing-domain-containing
+    transmembrane region of Hmg2 and stabilizing it against Hrd1-dependent ERAD. This promotes appropriate
+    Hmg2 abundance within sterol biosynthetic pathway control without NSG1 itself catalyzing a sterol
+    biosynthetic reaction.
+  molecular_function:
+    id: GO:0044183
+    label: protein folding chaperone
+  directly_involved_in:
+  - id: GO:0016126
+    label: sterol biosynthetic process
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  substrates:
+  - id: SGD:S000004442
+    label: HMG2
+  supported_by:
+  - reference_id: PMID:16270032
+    supporting_text: >-
+      We now show that the yeast INSIG homologs NSG1 and NSG2 function to control the stability of yeast
+      Hmg2p, the HMGR isozyme that undergoes regulated ubiquitination. Yeast Nsgs inhibit degradation
+      of Hmg2p in a highly specific manner, by directly interacting with the sterol-sensing domain (SSD)-containing
+      transmembrane region.
+    reference_section_type: ABSTRACT
+proposed_new_terms:
+- proposed_name: sterol-sensing domain protein chaperone activity
+  proposed_definition: >-
+    Binding to and stabilizing the transmembrane sterol-sensing domain of a client protein to promote
+    correct folding or prevent ER-associated degradation.
+  justification: >-
+    NSG1/INSIG activity toward Hmg2 is more specific than generic unfolded protein binding or broad protein
+    folding chaperone activity.
+  proposed_parent:
+    id: GO:0044183
+    label: protein folding chaperone
+  supported_by:
+  - reference_id: PMID:16270032
+    supporting_text: >-
+      We now show that the yeast INSIG homologs NSG1 and NSG2 function to control the stability of yeast
+      Hmg2p, the HMGR isozyme that undergoes regulated ubiquitination. Yeast Nsgs inhibit degradation
+      of Hmg2p in a highly specific manner, by directly interacting with the sterol-sensing domain (SSD)-containing
+      transmembrane region.
+    reference_section_type: ABSTRACT
+suggested_questions:
+- question: >-
+    Does NSG1 have a direct Hmg2-independent role at the nucleus-vacuole junction in sterol storage or
+    lipid-transfer adaptation, or is NVJ enrichment mainly a relocalization of the Hmg2 regulatory module?
+suggested_experiments:
+- hypothesis: NSG1 NVJ recruitment modulates Hmg2 stabilization or sterol storage during glucose limitation.
+  description: >-
+    Combine live-cell NSG1/Hmg2/NVJ marker imaging with Hmg2 stability assays in glucose-replete and glucose-restricted
+    cells, using NSG1 mutants that disrupt Hmg2 binding or NVJ enrichment.
+  experiment_type: live-cell fluorescence microscopy with cycloheximide-chase protein stability assay

--- a/genes/yeast/NSG1/NSG1-ai-review.yaml
+++ b/genes/yeast/NSG1/NSG1-ai-review.yaml
@@ -259,8 +259,8 @@ existing_annotations:
       regulation occurs.
     supported_by:
     - reference_id: PMID:16270032
-      supporting_text: Nsg1p functions naturally to limit degradation of Hmg2p when both proteins are
-        at native levels
+      supporting_text: by directly interacting with the sterol-sensing domain (SSD)-containing
+        transmembrane region
       reference_section_type: ABSTRACT
 - term:
     id: GO:0016126

--- a/genes/yeast/NSG1/NSG1-deep-research-falcon.md
+++ b/genes/yeast/NSG1/NSG1-deep-research-falcon.md
@@ -1,0 +1,296 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-04T10:06:00.295848'
+end_time: '2026-05-04T10:20:34.983373'
+duration_seconds: 874.69
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: yeast
+  gene_id: NSG1
+  gene_symbol: NSG1
+  uniprot_accession: P38837
+  protein_description: 'RecName: Full=Protein NSG1; AltName: Full=INSIG homolog 1;'
+  gene_info: Name=NSG1; OrderedLocusNames=YHR133C;
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+  protein_family: Belongs to the INSIG family. .
+  protein_domains: INSIG_fam. (IPR025929); INSIG (PF07281)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 19
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P38837
+- **Protein Description:** RecName: Full=Protein NSG1; AltName: Full=INSIG homolog 1;
+- **Gene Information:** Name=NSG1; OrderedLocusNames=YHR133C;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the INSIG family. .
+- **Key Domains:** INSIG_fam. (IPR025929); INSIG (PF07281)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "NSG1" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'NSG1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **NSG1** (gene ID: NSG1, UniProt: P38837) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P38837
+- **Protein Description:** RecName: Full=Protein NSG1; AltName: Full=INSIG homolog 1;
+- **Gene Information:** Name=NSG1; OrderedLocusNames=YHR133C;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the INSIG family. .
+- **Key Domains:** INSIG_fam. (IPR025929); INSIG (PF07281)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "NSG1" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'NSG1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **NSG1** (gene ID: NSG1, UniProt: P38837) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+# Research report: **NSG1 (UniProt P38837; ORF YHR133C)** in *Saccharomyces cerevisiae* (S288c)
+
+## 0) Target verification (mandatory)
+The gene/protein described in UniProt **P38837** corresponds to *S. cerevisiae* **NSG1**, whose systematic ORF name is **YHR133C** and which belongs to the **INSIG family** (a conserved family of multispanning ER membrane proteins that regulate sterol-sensing domain proteins). This mapping is explicitly given in the primary yeast INSIG paper: **NSG1 = YHR133C** and **NSG2 = YNL156C**. (flury2005insigabroadly pages 2-3)
+
+A major ambiguity to avoid: “NSG1” is also used in mammals for an unrelated neuronal membrane protein (often called NEEP21). The yeast NSG1/YHR133C discussed here is instead the **INSIG homolog** that regulates sterol pathway enzyme stability. (flury2005insigabroadly pages 1-2, theesfeld2013insulininducedgeneprotein pages 2-2)
+
+## 1) Key concepts and definitions (current understanding)
+
+### 1.1 INSIG proteins and sterol-sensing domain (SSD) clients
+INSIG proteins are described as **broadly conserved transmembrane chaperones** for proteins containing an SSD. In yeast, NSG1/NSG2 (INSIG homologs) inhibit degradation of the SSD-containing HMG-CoA reductase isozyme **Hmg2** by directly interacting with its SSD-containing transmembrane region and promoting its folding/stability, thereby reducing entry into ER quality-control degradation. (flury2005insigabroadly pages 1-2)
+
+### 1.2 ER-associated degradation (ERAD) in the sterol pathway
+Hmg2 is a regulated ERAD substrate: it is ubiquitinated (HRD pathway/E3 ligase) and degraded in response to metabolic signals from the mevalonate/sterol pathway. NSG1 overlays an additional control layer by stabilizing Hmg2 under specific sterol conditions. (theesfeld2013insulininducedgeneprotein pages 1-2, theesfeld2013insulininducedgeneprotein pages 9-10)
+
+### 1.3 “Two-signal logic” for Hmg2 stability
+A central mechanistic concept for yeast NSG1 biology is that Hmg2 stability behaves as a two-input regulatory logic:
+- **GGPP** (geranylgeranyl pyrophosphate; an isoprenoid derived from the pathway) **promotes Hmg2 degradation**.
+- **Lanosterol** (an early sterol) **inhibits Hmg2 degradation** by promoting a stabilizing interaction between Hmg2 and **Nsg1**.
+This has been summarized as “GGPP yes, sterols no” with respect to Hmg2 ERAD. (theesfeld2013insulininducedgeneprotein pages 1-2, theesfeld2013insulininducedgeneprotein pages 2-2, theesfeld2013insulininducedgeneprotein pages 9-10)
+
+## 2) Gene/protein function and biological role
+
+### 2.1 Primary molecular function
+**NSG1 (YHR133C)** encodes an ER membrane INSIG homolog whose best-supported primary function is to **bind and stabilize Hmg2** (HMG-CoA reductase isozyme 2), thereby modulating whether Hmg2 enters the HRD-dependent ERAD pathway. NSG1 is not an enzyme catalyzing a metabolic reaction; it is a membrane regulator/chaperone-like factor that couples sterol status to the stability of an SSD-containing client. (flury2005insigabroadly pages 1-2, theesfeld2013insulininducedgeneprotein pages 1-2)
+
+### 2.2 Pathway context
+By controlling Hmg2 stability, NSG1 participates in the feedback regulation of the **mevalonate/sterol (ergosterol) biosynthetic network**, influencing flux through the pathway at the level of the rate-limiting enzyme class (HMG-CoA reductases). (theesfeld2013insulininducedgeneprotein pages 1-2, flury2005insigabroadly pages 3-4)
+
+## 3) Subcellular localization
+Multiple lines of evidence support that Nsg1 is an **endoplasmic reticulum (ER) membrane protein**:
+- **GFP-tagged Nsg1** shows a characteristic yeast ER “**concentric circle**” pattern. (flury2005insigabroadly pages 2-3)
+- Tagged constructs (GFP/HA/3HA approaches) indicate NSG proteins are restricted to part or all of the ER. (flury2005insigabroadly pages 2-3)
+
+Note: the Flury et al. paper indicates the ER pattern for Nsg1-GFP but the specific localization images are described as not fully shown in figures (“data not shown”); nevertheless, the study’s localization conclusion is directly stated in the text. (flury2005insigabroadly pages 2-3)
+
+## 4) Mechanism: interactions and experimental evidence
+
+### 4.1 Direct interaction with Hmg2
+Nsg1 physically interacts with Hmg2:
+- Anti-HA immunoprecipitation of **3HA-Nsg1** from detergent-solubilized microsomes co-precipitates **1myc-Hmg2**, supporting a specific complex. (flury2005insigabroadly pages 6-7)
+- Blue native PAGE (BN-PAGE) mobility is consistent with **complex formation**, requiring the Hmg2 transmembrane domain. (flury2005insigabroadly pages 6-7)
+
+### 4.2 Functional consequence: stabilization at the ERAD entry step
+Mechanistically, NSG proteins are proposed to stabilize/favor folding of the SSD-containing Hmg2 transmembrane region, protecting it from entry into HRD quality-control degradation rather than simply blocking Hrd1 binding. (flury2005insigabroadly pages 8-9, flury2005insigabroadly pages 1-2)
+
+Consistent with a conformational effect, coexpression of Nsg1 slows **Hmg2 trypsinolysis** in a microsome limited-proteolysis assay, indicating altered/stabilized Hmg2 structure. (flury2005insigabroadly pages 6-7)
+
+### 4.3 Sterol dependence of NSG1 action (lanosterol)
+Nsg1-mediated stabilization of Hmg2 requires sterol pathway activity and specifically **lanosterol**: lowering lanosterol allows GGPP-stimulated Hmg2 ERAD, whereas lanosterol promotes the Nsg1–Hmg2 stabilizing interaction. (theesfeld2013insulininducedgeneprotein pages 1-2, theesfeld2013insulininducedgeneprotein pages 7-8)
+
+## 5) Quantitative findings and key statistics from primary studies
+The most NSG1-specific quantitative data in the retrieved corpus comes from Flury et al. (2005):
+
+1. **Overexpression magnitude:** TDH3-driven overexpression produced ~**50–100×** higher Nsg1 protein compared with the genomic promoter. (flury2005insigabroadly pages 2-3)
+2. **Hmg2 stability at native levels:** With NSGs present, native 1myc-Hmg2 has a half-life **>4 hours**; **nsg1Δ** (or nsg1Δ nsg2Δ) causes **rapid degradation** of native Hmg2. (flury2005insigabroadly pages 3-4)
+3. **Drug phenotype:** NSG-null strains show ~**3× increased sensitivity to lovastatin** in growth inhibition assays, consistent with altered HMGR function/availability. (flury2005insigabroadly pages 4-6, flury2005insigabroadly pages 3-4)
+
+These phenotypes are supported by figure-based evidence from Flury et al. (half-life and lovastatin sensitivity plots). (flury2005insigabroadly media b30588e5, flury2005insigabroadly media 755eb40e, flury2005insigabroadly media 461eedb2)
+
+## 6) Recent developments and latest research (prioritizing 2023–2024)
+Direct NSG1-focused primary literature in 2023–2024 was limited in the retrieved corpus; most mechanistic NSG1 evidence remains anchored in 2005 and 2013 primary studies. However, several 2023 works provide *current* framing for the biology that NSG1 participates in (ERAD/regulated degradation and lipid–ERAD coupling):
+
+- **Minimal misfolding and regulated degradation as a general UPS theme:** A 2023 Molecular Biology of the Cell study highlights yeast Hmg2 as a canonical example of a functional protein that is targeted for UPS-mediated degradation upon metabolite-induced reversible misfolding, situating Hmg2 regulation as a paradigmatic case in modern “minimal misfolding” thinking (even when NSG1 is not the central focus of that paper). (wangeline2017proteostatictacticsin pages 9-11)
+- **Lipid composition modulates ERAD system function:** A 2023 Science Advances paper shows that ER membrane lipid composition (elevated ceramides) can restrict ERAD by impairing extraction of ubiquitinated substrates. This is relevant because NSG1’s core function is exerted through an ER-membrane protein-quality-control decision (entry into HRD/ERAD), implying that lipid remodeling can influence the operational landscape of the same pathway NSG1 modulates. (wangeline2017proteostatictacticsin pages 9-11)
+
+In short, the latest literature accessible here emphasizes broader ERAD–lipid interplay and uses Hmg2 regulation as a conceptual reference point, while NSG1 remains best defined by earlier dedicated yeast INSIG studies. (wangeline2017proteostatictacticsin pages 9-11)
+
+## 7) Current applications and real-world implementations
+
+### 7.1 Yeast as a tractable model for conserved INSIG biology
+Theesfeld & Hampton explicitly argue that yeast INSIGs provide a **genetically tractable platform** to study the action of INSIG regulators of sterol homeostasis, because the sterol dependence of INSIG-client interaction is conserved over deep evolutionary time. This model-system utility is an applied rationale for studying NSG1 and its mechanism. (theesfeld2013insulininducedgeneprotein pages 1-2)
+
+### 7.2 Chemical–genetic and metabolic engineering relevance (indirect)
+Because NSG1 affects stability of Hmg2, which is a rate-limiting step class in isoprenoid/sterol flux, NSG1 biology is relevant to:
+- interpreting statin (lovastatin) phenotypes in yeast, where loss of NSG genes increases lovastatin sensitivity by ~3-fold in a defined genetic background. (flury2005insigabroadly pages 3-4)
+- designing strategies to tune flux through the mevalonate pathway by modulating HMGR abundance/stability, though direct NSG1 engineering applications were not clearly documented in the retrieved 2023–2024 engineering papers. (flury2005insigabroadly pages 3-4)
+
+## 8) Expert opinions and authoritative analysis
+Two primary interpretive frameworks are repeatedly emphasized:
+
+1. **INSIGs as sterol-dependent chaperones of SSD clients:** Both Flury et al. and Theesfeld & Hampton interpret NSG1/INSIG function as chaperone-like binding to SSD client proteins, coupling sterol sensing to ER quality control. (flury2005insigabroadly pages 1-2, theesfeld2013insulininducedgeneprotein pages 2-2)
+2. **Regulated degradation via metabolite-driven conformational change (“mallostery”):** The field’s interpretive synthesis (reviewed by Hampton and colleagues) frames Hmg2 regulation as a reversible, ligand-driven misfolding event that is “allostery-like” but implemented through controlled misfolding, with INSIG/NSG proteins modulating this process rather than being strictly required for ligand sensing. (wangeline2017proteostatictacticsin pages 9-11)
+
+## 9) Evidence summary table
+| Aspect | Summary |
+|---|---|
+| identity/domains | **NSG1 = YHR133C** in *Saccharomyces cerevisiae*; INSIG-family, multispanning membrane protein and one of two yeast INSIG homologs (**NSG1/YHR133C**, **NSG2/YNL156C**) that regulate Hmg2 stability (flury2005insigabroadly pages 2-3, flury2005insigabroadly pages 1-2) |
+| localization | Nsg1 is an **ER membrane protein**; GFP-tagged Nsg1 showed the characteristic yeast ER “**concentric circle**” pattern, and HA/GFP-based studies placed Nsg proteins in part or all of the ER (flury2005insigabroadly pages 2-3) |
+| molecular function | Primary function is **stabilization of the Hmg2 HMGR isozyme** by binding its **SSD-containing transmembrane region**, acting as a selective INSIG-like transmembrane chaperone that limits entry into HRD/ERAD rather than catalyzing a chemical reaction (flury2005insigabroadly pages 1-2, flury2005insigabroadly pages 6-7) |
+| pathway context | NSG1 functions in **sterol/mevalonate-pathway feedback control** of Hmg2 ERAD. Current model is **two-signal logic**: **GGPP promotes Hmg2 degradation**, whereas **lanosterol promotes Nsg1–Hmg2 association and inhibits degradation** (“GGPP yes, sterols no”) (theesfeld2013insulininducedgeneprotein pages 1-2, theesfeld2013insulininducedgeneprotein pages 2-2, theesfeld2013insulininducedgeneprotein pages 9-10) |
+| interaction partners | Best-supported partner is **Hmg2**: Nsg1 co-immunoprecipitates with 1myc-Hmg2, forms complexes on BN-PAGE, and requires the Hmg2 transmembrane region for complex formation; Hmg1 can also bind NSGs, but Hmg2 is the principal functional client in these studies (flury2005insigabroadly pages 6-7, flury2005insigabroadly pages 8-9) |
+| key experiments/assays | Evidence comes from **GFP localization**, **anti-HA co-IP from detergent-solubilized microsomes**, **BN-PAGE complex analysis**, **cycloheximide chase**, **flow cytometry of Hmg2p-GFP**, **limited proteolysis**, and drug perturbation with **lovastatin**, **zaragozic acid**, **terbinafine**, or **ERG7 shutdown** to manipulate sterol signals (flury2005insigabroadly pages 2-3, flury2005insigabroadly pages 6-7, theesfeld2013insulininducedgeneprotein pages 3-4) |
+| quantitative findings | **TDH3-driven NSG1 overexpression increased Nsg1 ~50–100×** over genomic promoter levels; with NSGs present, native **1myc-Hmg2 half-life was >4 h**, whereas **nsg1Δ** caused rapid degradation; **nsg-null strains were ~3× more sensitive to lovastatin**; figure-based support is in Flury et al. Figures 2/4/5 (flury2005insigabroadly pages 2-3, flury2005insigabroadly pages 3-4, flury2005insigabroadly media b30588e5) |
+| notes on ambiguity | This report concerns **yeast NSG1/P38837/YHR133C**, an **INSIG homolog**. It should **not** be confused with mammalian **NSG1/NEEP21**, a different protein/gene family. The yeast literature is comparatively sparse in **2023–2024**, with most direct mechanistic evidence still coming from foundational 2005 and 2013 studies plus later reviews on Hmg2 “mallostery” (flury2005insigabroadly pages 2-3, wangeline2017proteostatictacticsin pages 9-11) |
+
+
+*Table: This table summarizes the functional annotation of yeast NSG1/P38837/YHR133C, including identity, localization, mechanism, pathway role, and key quantitative findings. It is useful as a compact evidence map for the core primary literature on NSG1-mediated regulation of Hmg2 ERAD.*
+
+## 10) Key references (with URLs and publication dates where available)
+- Flury I. et al. **“INSIG: a broadly conserved transmembrane chaperone for sterol-sensing domain proteins.”** *The EMBO Journal* (published **Nov 2005**). https://doi.org/10.1038/sj.emboj.7600855 (flury2005insigabroadly pages 2-3, flury2005insigabroadly pages 3-4)
+- Theesfeld C.L. & Hampton R.Y. **“Insulin-induced Gene Protein (INSIG)-dependent Sterol Regulation of Hmg2 ERAD in Yeast.”** *J. Biol. Chem.* (published **Mar 2013**). https://doi.org/10.1074/jbc.m112.404517 (theesfeld2013insulininducedgeneprotein pages 1-2)
+- Wangeline M.A. et al. **“Proteostatic tactics in the strategy of sterol regulation.”** *Annual Review of Cell and Developmental Biology* (published **Oct 2017**). https://doi.org/10.1146/annurev-cellbio-111315-125036 (wangeline2017proteostatictacticsin pages 9-11)
+- Hwang J. et al. **“The ERAD system is restricted by elevated ceramides.”** *Science Advances* (published **Jan 2023**). https://doi.org/10.1126/sciadv.add8579 (wangeline2017proteostatictacticsin pages 9-11)
+
+## 11) Limitations of this synthesis
+Within the accessible 2023–2024 full texts retrieved here, NSG1/YHR133C itself is not frequently the central experimental subject; thus, the most precise NSG1 functional annotation still depends on the dedicated yeast INSIG primary papers (2005, 2013). The recent (2023–2024) sources primarily contribute broader ERAD/lipid-regulation context rather than new NSG1-specific mechanistic measurements. (wangeline2017proteostatictacticsin pages 9-11, flury2005insigabroadly pages 3-4)
+
+References
+
+1. (flury2005insigabroadly pages 2-3): Isabelle Flury, Renee Garza, Alexander Shearer, Johanna Rosen, Stephen Cronin, and Randolph Y Hampton. Insig: a broadly conserved transmembrane chaperone for sterol‐sensing domain proteins. The EMBO Journal, 24:3917-3926, Nov 2005. URL: https://doi.org/10.1038/sj.emboj.7600855, doi:10.1038/sj.emboj.7600855. This article has 82 citations.
+
+2. (flury2005insigabroadly pages 1-2): Isabelle Flury, Renee Garza, Alexander Shearer, Johanna Rosen, Stephen Cronin, and Randolph Y Hampton. Insig: a broadly conserved transmembrane chaperone for sterol‐sensing domain proteins. The EMBO Journal, 24:3917-3926, Nov 2005. URL: https://doi.org/10.1038/sj.emboj.7600855, doi:10.1038/sj.emboj.7600855. This article has 82 citations.
+
+3. (theesfeld2013insulininducedgeneprotein pages 2-2): Chandra L. Theesfeld and Randolph Y. Hampton. Insulin-induced gene protein (insig)-dependent sterol regulation of hmg2 endoplasmic reticulum-associated degradation (erad) in yeast. Journal of Biological Chemistry, 288:8519-8530, Mar 2013. URL: https://doi.org/10.1074/jbc.m112.404517, doi:10.1074/jbc.m112.404517. This article has 33 citations and is from a domain leading peer-reviewed journal.
+
+4. (theesfeld2013insulininducedgeneprotein pages 1-2): Chandra L. Theesfeld and Randolph Y. Hampton. Insulin-induced gene protein (insig)-dependent sterol regulation of hmg2 endoplasmic reticulum-associated degradation (erad) in yeast. Journal of Biological Chemistry, 288:8519-8530, Mar 2013. URL: https://doi.org/10.1074/jbc.m112.404517, doi:10.1074/jbc.m112.404517. This article has 33 citations and is from a domain leading peer-reviewed journal.
+
+5. (theesfeld2013insulininducedgeneprotein pages 9-10): Chandra L. Theesfeld and Randolph Y. Hampton. Insulin-induced gene protein (insig)-dependent sterol regulation of hmg2 endoplasmic reticulum-associated degradation (erad) in yeast. Journal of Biological Chemistry, 288:8519-8530, Mar 2013. URL: https://doi.org/10.1074/jbc.m112.404517, doi:10.1074/jbc.m112.404517. This article has 33 citations and is from a domain leading peer-reviewed journal.
+
+6. (flury2005insigabroadly pages 3-4): Isabelle Flury, Renee Garza, Alexander Shearer, Johanna Rosen, Stephen Cronin, and Randolph Y Hampton. Insig: a broadly conserved transmembrane chaperone for sterol‐sensing domain proteins. The EMBO Journal, 24:3917-3926, Nov 2005. URL: https://doi.org/10.1038/sj.emboj.7600855, doi:10.1038/sj.emboj.7600855. This article has 82 citations.
+
+7. (flury2005insigabroadly pages 6-7): Isabelle Flury, Renee Garza, Alexander Shearer, Johanna Rosen, Stephen Cronin, and Randolph Y Hampton. Insig: a broadly conserved transmembrane chaperone for sterol‐sensing domain proteins. The EMBO Journal, 24:3917-3926, Nov 2005. URL: https://doi.org/10.1038/sj.emboj.7600855, doi:10.1038/sj.emboj.7600855. This article has 82 citations.
+
+8. (flury2005insigabroadly pages 8-9): Isabelle Flury, Renee Garza, Alexander Shearer, Johanna Rosen, Stephen Cronin, and Randolph Y Hampton. Insig: a broadly conserved transmembrane chaperone for sterol‐sensing domain proteins. The EMBO Journal, 24:3917-3926, Nov 2005. URL: https://doi.org/10.1038/sj.emboj.7600855, doi:10.1038/sj.emboj.7600855. This article has 82 citations.
+
+9. (theesfeld2013insulininducedgeneprotein pages 7-8): Chandra L. Theesfeld and Randolph Y. Hampton. Insulin-induced gene protein (insig)-dependent sterol regulation of hmg2 endoplasmic reticulum-associated degradation (erad) in yeast. Journal of Biological Chemistry, 288:8519-8530, Mar 2013. URL: https://doi.org/10.1074/jbc.m112.404517, doi:10.1074/jbc.m112.404517. This article has 33 citations and is from a domain leading peer-reviewed journal.
+
+10. (flury2005insigabroadly pages 4-6): Isabelle Flury, Renee Garza, Alexander Shearer, Johanna Rosen, Stephen Cronin, and Randolph Y Hampton. Insig: a broadly conserved transmembrane chaperone for sterol‐sensing domain proteins. The EMBO Journal, 24:3917-3926, Nov 2005. URL: https://doi.org/10.1038/sj.emboj.7600855, doi:10.1038/sj.emboj.7600855. This article has 82 citations.
+
+11. (flury2005insigabroadly media b30588e5): Isabelle Flury, Renee Garza, Alexander Shearer, Johanna Rosen, Stephen Cronin, and Randolph Y Hampton. Insig: a broadly conserved transmembrane chaperone for sterol‐sensing domain proteins. The EMBO Journal, 24:3917-3926, Nov 2005. URL: https://doi.org/10.1038/sj.emboj.7600855, doi:10.1038/sj.emboj.7600855. This article has 82 citations.
+
+12. (flury2005insigabroadly media 755eb40e): Isabelle Flury, Renee Garza, Alexander Shearer, Johanna Rosen, Stephen Cronin, and Randolph Y Hampton. Insig: a broadly conserved transmembrane chaperone for sterol‐sensing domain proteins. The EMBO Journal, 24:3917-3926, Nov 2005. URL: https://doi.org/10.1038/sj.emboj.7600855, doi:10.1038/sj.emboj.7600855. This article has 82 citations.
+
+13. (flury2005insigabroadly media 461eedb2): Isabelle Flury, Renee Garza, Alexander Shearer, Johanna Rosen, Stephen Cronin, and Randolph Y Hampton. Insig: a broadly conserved transmembrane chaperone for sterol‐sensing domain proteins. The EMBO Journal, 24:3917-3926, Nov 2005. URL: https://doi.org/10.1038/sj.emboj.7600855, doi:10.1038/sj.emboj.7600855. This article has 82 citations.
+
+14. (wangeline2017proteostatictacticsin pages 9-11): Margaret A. Wangeline, Nidhi Vashistha, and Randolph Y. Hampton. Proteostatic tactics in the strategy of sterol regulation. Annual review of cell and developmental biology, 33:467-489, Oct 2017. URL: https://doi.org/10.1146/annurev-cellbio-111315-125036, doi:10.1146/annurev-cellbio-111315-125036. This article has 42 citations and is from a domain leading peer-reviewed journal.
+
+15. (theesfeld2013insulininducedgeneprotein pages 3-4): Chandra L. Theesfeld and Randolph Y. Hampton. Insulin-induced gene protein (insig)-dependent sterol regulation of hmg2 endoplasmic reticulum-associated degradation (erad) in yeast. Journal of Biological Chemistry, 288:8519-8530, Mar 2013. URL: https://doi.org/10.1074/jbc.m112.404517, doi:10.1074/jbc.m112.404517. This article has 33 citations and is from a domain leading peer-reviewed journal.
+
+## Citations
+
+1. flury2005insigabroadly pages 2-3
+2. flury2005insigabroadly pages 1-2
+3. flury2005insigabroadly pages 6-7
+4. flury2005insigabroadly pages 3-4
+5. wangeline2017proteostatictacticsin pages 9-11
+6. theesfeld2013insulininducedgeneprotein pages 1-2
+7. theesfeld2013insulininducedgeneprotein pages 2-2
+8. theesfeld2013insulininducedgeneprotein pages 9-10
+9. flury2005insigabroadly pages 8-9
+10. theesfeld2013insulininducedgeneprotein pages 7-8
+11. flury2005insigabroadly pages 4-6
+12. theesfeld2013insulininducedgeneprotein pages 3-4
+13. https://doi.org/10.1038/sj.emboj.7600855
+14. https://doi.org/10.1074/jbc.m112.404517
+15. https://doi.org/10.1146/annurev-cellbio-111315-125036
+16. https://doi.org/10.1126/sciadv.add8579
+17. https://doi.org/10.1038/sj.emboj.7600855,
+18. https://doi.org/10.1074/jbc.m112.404517,
+19. https://doi.org/10.1146/annurev-cellbio-111315-125036,

--- a/publications/PMID_25229868.md
+++ b/publications/PMID_25229868.md
@@ -1,0 +1,55 @@
+---
+pmid: '25229868'
+title: Unstable mutant lysozymes are degraded through the interaction with calnexin
+  homolog Cne1p in Saccharomyces cerevisiae.
+authors:
+- Azakami H
+- Uehara M
+- Matsuo R
+- Tsurunaga Y
+- Yamashita Y
+- Usui M
+- Kato A
+journal: Biosci Biotechnol Biochem
+year: '2014'
+full_text_available: false
+doi: 10.1080/09168451.2014.918486
+---
+
+# Unstable mutant lysozymes are degraded through the interaction with calnexin homolog Cne1p in Saccharomyces cerevisiae.
+**Authors:** Azakami H, Uehara M, Matsuo R, Tsurunaga Y, Yamashita Y, Usui M, Kato A
+**Journal:** Biosci Biotechnol Biochem (2014)
+**DOI:** [10.1080/09168451.2014.918486](https://doi.org/10.1080/09168451.2014.918486)
+
+## Abstract
+
+1. Biosci Biotechnol Biochem. 2014;78(7):1263-9. doi:
+10.1080/09168451.2014.918486.  Epub 2014 Jun 17.
+
+Unstable mutant lysozymes are degraded through the interaction with calnexin 
+homolog Cne1p in Saccharomyces cerevisiae.
+
+Azakami H(1), Uehara M, Matsuo R, Tsurunaga Y, Yamashita Y, Usui M, Kato A.
+
+Author information:
+(1)a Department of Biological Chemistry, Faculty of Agriculture , Yamaguchi 
+University , Yamaguchi , Japan.
+
+Cne1p is a yeast homolog of calnexin, which is a constituent of endoplasmic 
+reticulum (ER)-associated protein quality control system in mammals. Cne1p may 
+be involved in the degradation of misfolded lysozymes in Saccharomyces 
+cerevisiae. To test this, c-Myc-tagged lysozymes were expressed in 
+CNE1-deficient S. cerevisiae. The expression and secretion of an unstable 
+lysozyme mutant G49N/D66H were enhanced and its intracellular localization was 
+changed in the CNE1-deficient strain. Furthermore, when Cne1p was co-expressed 
+with unstable lysozyme mutants (G49N/D66H, G49N/C76A, and K13D/G49N), its 
+affinity to the misfolded mutant proteins was revealed by 
+co-immunoprecipitation. The interaction with Cne1p was abrogated by the addition 
+of tunicamycin, an inhibitor of N-glycosylation, indicating that N-linked 
+carbohydrates might be necessary for protein binding to Cne1p. These results 
+suggest that in yeasts, Cne1p interacts with misfolded lysozyme proteins 
+possibly causing their retention in the ER and subsequent elimination via 
+ER-associated degradation.
+
+DOI: 10.1080/09168451.2014.918486
+PMID: 25229868 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary

Adds completed yeast gene reviews for NSG1, CCT3, CCT5, CCT6, and CNE1.

This batch integrates Falcon deep research into each review and refreshes rendered HTML. Curator QA approved NSG1/CCT3/CCT5/CCT6 directly and flagged CNE1 ERAD support as needing stronger evidence; this PR adds the Azakami 2014 Cne1p/misfolded lysozyme PMID cache and uses it to support the CNE1 ERAD annotations/core function before revalidation.

## Validation

- `just validate yeast NSG1`
- `just validate yeast CCT3`
- `just validate yeast CCT5`
- `just validate yeast CCT6`
- `just validate yeast CNE1`
- `just render yeast NSG1`
- `just render yeast CCT3`
- `just render yeast CCT5`
- `just render yeast CCT6`
- `just render yeast CNE1`
- `git diff --check`