### PR TITLE
Review yeast genes batch 04

### DIFF
--- a/cache/go/terms.csv
+++ b/cache/go/terms.csv
@@ -4183,6 +4183,7 @@ GO:0043165,Gram-negative-bacterium-type cell outer membrane assembly,2026-03-22T
 GO:0043167,ion binding,2026-03-22T22:38:14.237952
 GO:0043168,anion binding,2026-03-22T22:38:14.237952
 GO:0043169,cation binding,2026-03-22T22:38:14.237952
+GO:0043171,peptide catabolic process,2026-05-04T13:44:27.723828
 GO:0043179,rhythmic excitation,2026-03-22T22:38:14.237952
 GO:0043183,vascular endothelial growth factor receptor 1 binding,2026-03-22T22:38:14.237952
 GO:0043184,vascular endothelial growth factor receptor 2 binding,2026-03-22T22:38:14.237952

--- a/genes/yeast/ATP11/ATP11-ai-review.html
+++ b/genes/yeast/ATP11/ATP11-ai-review.html
@@ -671,33 +671,44 @@
     <div class="header">
         <h1>ATP11</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P32453" target="_blank" class="term-link">
                         P32453
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Saccharomyces cerevisiae</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
+            <div class="info-item">
+                <span class="info-label">Aliases:</span>
+                <div class="aliases">
+
+                    <span class="badge">YNL315C</span>
+
+                    <span class="badge">ATP synthase mitochondrial F1 complex assembly factor 1</span>
+
+                </div>
+            </div>
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,24 +739,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="P32453" data-a="DESCRIPTION: TODO: Add description for ATP11..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="P32453" data-a="DESCRIPTION: ATP11 encodes a mitochondrial matrix assembly fact..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TODO: Add description for ATP11</p>
+        <p>ATP11 encodes a mitochondrial matrix assembly factor for the F1 sector of mitochondrial F1FO ATP synthase. Atp11 is not a stoichiometric ATP synthase subunit; it is a dedicated assembly chaperone/stabilizing factor for the unassembled F1 beta subunit Atp2, preventing nonproductive aggregation and promoting formation of the alpha3-beta3 catalytic F1 head. Generic unfolded-protein binding and cross-species protein-binding annotations are less informative than the ATP synthase complex assembly and protein-containing complex stabilizing activity annotations.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +769,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,46 +806,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: mitochondrion is consistent with known biology of ATP11.
+                            <strong>Summary:</strong> IBA mitochondrial localization is consistent with direct ATP11 localization.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Atp11 functions in mitochondria, specifically the matrix.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1532796" target="_blank" class="term-link">
+                                        PMID:1532796
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">vitro import assays of ATP11 precursor and immunochemical evidence indicate that...the protein is located in mitochondria.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:interpro/panther/PTHR13126/PTHR13126-metadata.yaml
+
+                                </span>
+
+                                <div class="support-text">PTHR13126 is the CHAPERONE ATP11 family.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140777" target="_blank" class="term-link">
                                     GO:0140777
                                 </a>
                             </span>
                             <span class="term-label">protein-containing complex stabilizing activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -846,46 +886,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein-containing complex stabilizing activity is consistent with known biology of ATP11.
+                            <strong>Summary:</strong> This is the most specific molecular-function term for Atp11.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Atp11 stabilizes the unassembled F1 beta subunit during ATP synthase assembly.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10681564" target="_blank" class="term-link">
+                                        PMID:10681564
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">evidence that Atp11p binds selectively to the beta-subunit of F(1).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12829692" target="_blank" class="term-link">
+                                        PMID:12829692
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Atp11p yields a subfragment of the protein (called Atp11pTRNC) that retains...molecular chaperone function...the natural substrate (F1 beta).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/ATP11/ATP11-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Atp11 binds F1 beta subunit Atp2 to prevent nonproductive self-association.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033615" target="_blank" class="term-link">
                                     GO:0033615
                                 </a>
                             </span>
                             <span class="term-label">mitochondrial proton-transporting ATP synthase complex assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -897,46 +979,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: mitochondrial proton-transporting ATP synthase complex assembly is consistent with known biology of ATP11.
+                            <strong>Summary:</strong> The IBA process term matches classic ATP11 mutant and biochemical evidence.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> ATP synthase F1 assembly is the central process affected by ATP11.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2142305" target="_blank" class="term-link">
+                                        PMID:2142305
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">explanation for the mutant phenotype is a block in the assembly of the F1...oligomer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/36596815" target="_blank" class="term-link">
+                                        PMID:36596815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">it cooperates with the assembly...factors Atp11 and Atp12 to form the F1 domain of the ATP synthase.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -948,170 +1061,235 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: mitochondrion is consistent with known biology of ATP11.
+                            <strong>Summary:</strong> Electronic mitochondrion annotation is correct.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Atp11 is a mitochondrial matrix assembly factor.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1532796" target="_blank" class="term-link">
+                                        PMID:1532796
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The hybrid protein is detected in mitochondria with antibodies</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0065003" target="_blank" class="term-link">
                                     GO:0065003
                                 </a>
                             </span>
                             <span class="term-label">protein-containing complex assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P32453" data-a="GO:0065003" data-r="GO_REF:0000002" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P32453" data-a="GO:0065003" data-r="GO_REF:0000002" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein-containing complex assembly is consistent with known biology of ATP11.
+                            <strong>Summary:</strong> The term is correct but too broad.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Replace with the specific mitochondrial ATP synthase assembly term.
                         </div>
-                        
-                        
-                        
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033615" target="_blank" class="term-link">
+                                    mitochondrial proton-transporting ATP synthase complex assembly
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2142305" target="_blank" class="term-link">
+                                        PMID:2142305
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">important function at a...late stage in the synthesis of F1</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27107014" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27107014
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An inter-species protein-protein interaction network across ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="P32453" data-a="GO:0005515" data-r="PMID:27107014" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="P32453" data-a="GO:0005515" data-r="PMID:27107014" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for ATP11.
+                            <strong>Summary:</strong> This comes from a yeast-human inter-species interaction map and is not a physiological ATP11 function.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> The annotation does not identify the endogenous yeast Atp2/F1 beta client and uses an uninformative term.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27107014" target="_blank" class="term-link">
+                                        PMID:27107014
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we generated a high-quality proteome-wide inter-interactome network map</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
                                     GO:0005759
                                 </a>
                             </span>
                             <span class="term-label">mitochondrial matrix</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/1532796" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:1532796
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Characterization of ATP11 and detection of the encoded prote...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1123,57 +1301,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: mitochondrial matrix is consistent with known biology of ATP11.
+                            <strong>Summary:</strong> Direct evidence supports mitochondrial matrix localization.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The F1 ATP synthase assembly role occurs in the matrix.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1532796" target="_blank" class="term-link">
+                                        PMID:1532796
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Biotinated ATP11 protein can be partially...purified by affinity chromatography</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033615" target="_blank" class="term-link">
                                     GO:0033615
                                 </a>
                             </span>
                             <span class="term-label">mitochondrial proton-transporting ATP synthase complex assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/36596815" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:36596815
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The mitochondrial Hsp70 controls the assembly of the F(1)F(O...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1185,57 +1381,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: mitochondrial proton-transporting ATP synthase complex assembly is consistent with known biology of ATP11.
+                            <strong>Summary:</strong> Recent work places Atp11 with Atp12 and mtHsp70 in F1 assembly.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> This is the specific ATP synthase assembly process affected by Atp11.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/36596815" target="_blank" class="term-link">
+                                        PMID:36596815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">it cooperates with the assembly...factors Atp11 and Atp12 to form the F1 domain of the ATP synthase.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24769239" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24769239
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Quantitative variations of the mitochondrial proteome and ph...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1247,57 +1461,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: mitochondrion is consistent with known biology of ATP11.
+                            <strong>Summary:</strong> High-throughput mitochondrial proteomics is consistent with ATP11 biology.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Mitochondrial localization is core to Atp11 function.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24769239" target="_blank" class="term-link">
+                                        PMID:24769239
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">isolated mitochondria extracted from yeast grown on fermentative...and respiratory...media</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16823961" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16823961
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Toward the complete yeast mitochondrial proteome: multidimen...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1309,119 +1541,166 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: mitochondrion is consistent with known biology of ATP11.
+                            <strong>Summary:</strong> High-throughput mitochondrial proteome data are consistent with direct localization.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The broad mitochondrion term is correct.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16823961" target="_blank" class="term-link">
+                                        PMID:16823961
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A total of 851 different proteins (PROMITO dataset) were...identified by use of multidimensional LC-MS/MS</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10681564" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10681564
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The assembly factor Atp11p binds to the beta-subunit of the ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P32453" data-a="GO:0051082" data-r="PMID:10681564" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="P32453" data-a="GO:0051082" data-r="PMID:10681564" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> ATP11 is a dedicated assembly factor for mitochondrial F1-ATPase, not a general chaperone. GO:0051082 overstates the binding as a standalone function.
+                            <strong>Summary:</strong> Atp11 binds an unassembled F1 beta subunit, but the generic term is too broad.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> ATP11 functions as a dedicated assembly factor for the F1-ATPase beta subunit, not as a general unfolded protein binding chaperone. The binding interaction is specific to Atp2p assembly and is better captured by the assembly process annotation (GO:0033615).
+                            <strong>Reason:</strong> Protein-containing complex stabilizing activity better captures client-specific F1 assembly.
                         </div>
-                        
-                        
-                        
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140777" target="_blank" class="term-link">
+                                    protein-containing complex stabilizing activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10681564" target="_blank" class="term-link">
+                                        PMID:10681564
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Atp11p bound to a region of the nucleotide-binding...domain of the beta-subunit</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033615" target="_blank" class="term-link">
                                     GO:0033615
                                 </a>
                             </span>
                             <span class="term-label">mitochondrial proton-transporting ATP synthase complex assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10681564" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10681564
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The assembly factor Atp11p binds to the beta-subunit of the ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1433,57 +1712,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: mitochondrial proton-transporting ATP synthase complex assembly is consistent with known biology of ATP11.
+                            <strong>Summary:</strong> The Atp11-F1 beta interaction directly supports ATP synthase F1 assembly.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> This is the correct process-level interpretation of the Atp11-Atp2 interaction.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10681564" target="_blank" class="term-link">
+                                        PMID:10681564
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">alpha-subunits may exchange for bound Atp11p...during the process of F(1) assembly.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/1532796" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:1532796
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Characterization of ATP11 and detection of the encoded prote...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1495,119 +1792,166 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: mitochondrion is consistent with known biology of ATP11.
+                            <strong>Summary:</strong> Direct evidence places Atp11 in mitochondria.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Mitochondrial localization is required for ATP synthase F1 assembly.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1532796" target="_blank" class="term-link">
+                                        PMID:1532796
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">vitro import assays of ATP11 precursor and immunochemical evidence indicate that...the protein is located in mitochondria.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007005" target="_blank" class="term-link">
                                     GO:0007005
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion organization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/2142305" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:2142305
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification of two nuclear genes (ATP11, ATP12) required ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P32453" data-a="GO:0007005" data-r="PMID:2142305" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P32453" data-a="GO:0007005" data-r="PMID:2142305" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: mitochondrion organization may be context-dependent or peripheral for ATP11.
+                            <strong>Summary:</strong> This broad phenotype should be replaced by the specific F1 ATP synthase assembly defect.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> ATP11 mutants block F1 assembly, not general mitochondrial organization as a primary function.
                         </div>
-                        
-                        
-                        
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033615" target="_blank" class="term-link">
+                                    mitochondrial proton-transporting ATP synthase complex assembly
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2142305" target="_blank" class="term-link">
+                                        PMID:2142305
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">important function at a...late stage in the synthesis of F1</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033615" target="_blank" class="term-link">
                                     GO:0033615
                                 </a>
                             </span>
                             <span class="term-label">mitochondrial proton-transporting ATP synthase complex assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/2142305" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:2142305
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification of two nuclear genes (ATP11, ATP12) required ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1619,287 +1963,926 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: mitochondrial proton-transporting ATP synthase complex assembly is consistent with known biology of ATP11.
+                            <strong>Summary:</strong> Classic genetic evidence directly supports ATP synthase assembly.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> ATP11 was identified as required for assembly of yeast F1-ATPase.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2142305" target="_blank" class="term-link">
+                                        PMID:2142305
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">explanation for the mutant phenotype is a block in the assembly of the F1...oligomer.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12829692" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12829692
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A purified subfragment of yeast Atp11p retains full molecula...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P32453" data-a="GO:0051082" data-r="PMID:12829692" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="P32453" data-a="GO:0051082" data-r="PMID:12829692" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> ATP11 is a dedicated assembly factor for mitochondrial F1-ATPase, not a general chaperone. GO:0051082 overstates the binding as a standalone function.
+                            <strong>Summary:</strong> Atp11 has chaperone activity toward F1 beta, but the term is too generic.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> ATP11 functions as a dedicated assembly factor for the F1-ATPase beta subunit, not as a general unfolded protein binding chaperone. The binding interaction is specific to Atp2p assembly and is better captured by the assembly process annotation (GO:0033615).
+                            <strong>Reason:</strong> GO:0140777 better represents stabilization of an ATP synthase assembly intermediate.
                         </div>
-                        
-                        
-                        
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140777" target="_blank" class="term-link">
+                                    protein-containing complex stabilizing activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12829692" target="_blank" class="term-link">
+                                        PMID:12829692
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Atp11p yields a subfragment of the protein (called Atp11pTRNC) that retains...molecular chaperone function...the natural substrate (F1 beta).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Dedicated mitochondrial F1 ATP synthase assembly chaperone/stabilizing activity. Atp11 binds unassembled F1 beta subunit Atp2 in the mitochondrial matrix, preventing nonproductive aggregation and promoting assembly of the alpha3-beta3 F1 catalytic head.</h3>
+                <span class="vote-buttons" data-g="P32453" data-a="FUNCTION: Dedicated mitochondrial F1 ATP synthase assembly c..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140777" target="_blank" class="term-link">
+                            protein-containing complex stabilizing activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033615" target="_blank" class="term-link">
+                                mitochondrial proton-transporting ATP synthase complex assembly
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                mitochondrion
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10681564" target="_blank" class="term-link">
+                                PMID:10681564
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">evidence that Atp11p binds selectively to the beta-subunit of F(1).</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12829692" target="_blank" class="term-link">
+                                PMID:12829692
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Atp11p yields a subfragment of the protein (called Atp11pTRNC) that retains...molecular chaperone function...the natural substrate (F1 beta).</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/ATP11/ATP11-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">ATP11 encodes a mitochondrial ATP synthase-specific assembly chaperone for F1 beta subunit Atp2.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
-                        <a href="https://pubmed.ncbi.nlm.nih.gov/10681564" target="_blank" class="term-link">
-                            PMID:10681564
-                        </a>
-                        
-                    </span>
-                </div>
-                
-                <div class="reference-title">The assembly factor Atp11p binds to the beta-subunit of the mitochondrial F(1)-ATPase.</div>
-                
-                
-            </div>
-            
-            <div class="reference-item">
-                <div class="reference-header">
-                    <span class="reference-id">
-                        
-                        <a href="https://pubmed.ncbi.nlm.nih.gov/12829692" target="_blank" class="term-link">
-                            PMID:12829692
-                        </a>
-                        
-                    </span>
-                </div>
-                
-                <div class="reference-title">A purified subfragment of yeast Atp11p retains full molecular chaperone activity.</div>
-                
-                
-            </div>
-            
-            <div class="reference-item">
-                <div class="reference-header">
-                    <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/1532796" target="_blank" class="term-link">
                             PMID:1532796
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Characterization of ATP11 and detection of the encoded protein in mitochondria of Saccharomyces cerevisiae.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">ATP11 protein is mitochondrial</div>
+
+                        <div class="finding-text">"In vitro import assays and immunochemical evidence indicate mitochondrial localization."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
-                        <a href="https://pubmed.ncbi.nlm.nih.gov/16823961" target="_blank" class="term-link">
-                            PMID:16823961
-                        </a>
-                        
-                    </span>
-                </div>
-                
-                <div class="reference-title">Toward the complete yeast mitochondrial proteome: multidimensional separation techniques for mitochondrial proteomics.</div>
-                
-                
-            </div>
-            
-            <div class="reference-item">
-                <div class="reference-header">
-                    <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/2142305" target="_blank" class="term-link">
                             PMID:2142305
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Identification of two nuclear genes (ATP11, ATP12) required for assembly of the yeast F1-ATPase.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">ATP11 is required for F1 ATPase assembly</div>
+
+                        <div class="finding-text">"Mutations in ATP11 and ATP12 block a late step in F1 assembly."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10681564" target="_blank" class="term-link">
+                            PMID:10681564
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The assembly factor Atp11p binds to the beta-subunit of the mitochondrial F(1)-ATPase.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Atp11 binds the F1 beta subunit during assembly</div>
+
+                        <div class="finding-text">"Atp11p binds selectively to the beta-subunit of F1."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12829692" target="_blank" class="term-link">
+                            PMID:12829692
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A purified subfragment of yeast Atp11p retains full molecular chaperone activity.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Atp11 has chaperone activity with F1 beta as its natural substrate</div>
+
+                        <div class="finding-text">"Atp11pTRNC retains molecular chaperone function with the natural substrate F1 beta."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16823961" target="_blank" class="term-link">
+                            PMID:16823961
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Toward the complete yeast mitochondrial proteome: multidimensional separation techniques for mitochondrial proteomics.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24769239" target="_blank" class="term-link">
                             PMID:24769239
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Quantitative variations of the mitochondrial proteome and phosphoproteome during fermentative and respiratory growth in Saccharomyces cerevisiae.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27107014" target="_blank" class="term-link">
                             PMID:27107014
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An inter-species protein-protein interaction network across vast evolutionary distance.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/36596815" target="_blank" class="term-link">
                             PMID:36596815
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The mitochondrial Hsp70 controls the assembly of the F(1)F(O)-ATP synthase.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">mtHsp70 cooperates with Atp11 and Atp12 in F1 assembly</div>
+
+                        <div class="finding-text">"Mitochondrial Hsp70 cooperates with the assembly factors Atp11 and Atp12 to form the F1 domain."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/ATP11/ATP11-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for ATP11</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">ATP11 is a mitochondrial F1 ATP synthase assembly chaperone</div>
+
+                        <div class="finding-text">"Atp11 binds F1 beta subunit Atp2 and promotes formation of the F1 catalytic head."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:interpro/panther/PTHR13126/PTHR13126-metadata.yaml
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PANTHER family metadata for ATP11 family PTHR13126</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">PTHR13126 is the ATP11 chaperone family</div>
+
+                        <div class="finding-text">"The local PANTHER metadata identifies PTHR13126 as CHAPERONE ATP11."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Should experimental GO:0051082 annotations for ATP11 be replaced by GO:0140777 to reflect client-specific stabilization of F1 ATP synthase assembly intermediates?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P32453" data-a="Q: Should experimental GO:0051082 annotations for ATP..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ATP11-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P32453" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-04T10:45:28.740458'<br />
+end_time: '2026-05-04T10:57:35.549715'<br />
+duration_seconds: 726.81<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: yeast<br />
+  gene_id: ATP11<br />
+  gene_symbol: ATP11<br />
+  uniprot_accession: P32453<br />
+  protein_description: 'RecName: Full=Protein ATP11, mitochondrial; Flags: Precursor;'<br />
+  gene_info: Name=ATP11; OrderedLocusNames=YNL315C; ORFNames=N0357;<br />
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).<br />
+  protein_family: Belongs to the ATP11 family. .<br />
+  protein_domains: ATP11. (IPR010591); ATP11 (PF06644)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 31</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P32453</li>
+<li><strong>Protein Description:</strong> RecName: Full=Protein ATP11, mitochondrial; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=ATP11; OrderedLocusNames=YNL315C; ORFNames=N0357;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the ATP11 family. .</li>
+<li><strong>Key Domains:</strong> ATP11. (IPR010591); ATP11 (PF06644)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "ATP11" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'ATP11' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>ATP11</strong> (gene ID: ATP11, UniProt: P32453) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P32453</li>
+<li><strong>Protein Description:</strong> RecName: Full=Protein ATP11, mitochondrial; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=ATP11; OrderedLocusNames=YNL315C; ORFNames=N0357;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the ATP11 family. .</li>
+<li><strong>Key Domains:</strong> ATP11. (IPR010591); ATP11 (PF06644)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "ATP11" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'ATP11' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>ATP11</strong> (gene ID: ATP11, UniProt: P32453) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-atp11-ynl315c-uniprot-p32453-in-saccharomyces-cerevisiae">Research report: <strong>ATP11 (YNL315C; UniProt P32453) in <em>Saccharomyces cerevisiae</em></strong></h2>
+<h3 id="executive-summary">Executive summary</h3>
+<p>ATP11 (YNL315C; UniProt P32453) encodes Atp11p, a <strong>mitochondrial-matrix, ATP-synthase–specific assembly chaperone</strong> that binds the <strong>F1 β subunit (Atp2)</strong> to prevent its nonproductive self-association and to promote formation of the <strong>F1 catalytic head (α3β3 hexamer)</strong> of mitochondrial F1FO-ATP synthase (Complex V). Atp11p is <strong>not</strong> a stoichiometric subunit of the mature enzyme but is required for efficient respiratory growth and correct mitochondrial ultrastructure; loss of ATP11 leads to <strong>α/β inclusion bodies</strong> in the matrix and impaired oxidative phosphorylation. Newer work (2023) adds mitochondrial Hsp70 as a cooperating factor with Atp11/Atp12 in F1 assembly and quality control. (franco2020modularassemblyof pages 7-10, hinton2003apurifiedsubfragment pages 1-2, lefebvrelegendre2005failuretoassemble pages 1-2, ludlam2009chaperonesoff1atpase pages 1-2, song2023themitochondrialhsp70 pages 1-2)</p>
+<hr />
+<h3 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h3>
+<h4 id="11-what-atp11-means-in-yeast-identity-verification">1.1 What “ATP11” means in yeast (identity verification)</h4>
+<p>In <em>S. cerevisiae</em>, <strong>ATP11 (YNL315C)</strong> encodes Atp11p, a dedicated chaperone/assembly factor required for biogenesis of the <strong>F1 sector</strong> of mitochondrial ATP synthase. Its function is specific to ATP synthase assembly rather than broad protein import/folding, and it acts on unassembled F1 subunits in the matrix. (potocka2007assemblyfactorsin pages 17-21, franco2020modularassemblyof pages 7-10)</p>
+<h4 id="12-atp-synthase-complex-v-biogenesis-and-where-atp11-fits">1.2 ATP synthase (Complex V) biogenesis and where ATP11 fits</h4>
+<p>Mitochondrial F1FO-ATP synthase is built from modular subassemblies. The <strong>F1 module</strong> (soluble catalytic head in the matrix) contains an <strong>α3β3 hexamer</strong> with the catalytic and noncatalytic nucleotide-binding interfaces. Dedicated assembly chaperones <strong>Atp11 and Atp12</strong> bind newly imported F1 subunits to prevent aggregation and ensure productive oligomerization before integration with the stalk and FO membrane sector. (franco2020modularassemblyof pages 7-10, song2018assemblingthemitochondrial pages 1-2)</p>
+<h4 id="13-assembly-chaperone-vs-enzyme-substrate-specificity-for-atp11">1.3 Assembly chaperone vs. enzyme: “substrate specificity” for ATP11</h4>
+<p>Atp11p is <strong>not an enzyme with a chemical substrate</strong>; its “substrate specificity” is <strong>client-protein specificity</strong>. The key client is the <strong>F1 β subunit</strong>, which Atp11p binds transiently during assembly. This binding prevents β from forming nonproductive complexes and promotes correct αβ interactions leading to the <code>(αβ)3</code> hexamer. (hinton2003apurifiedsubfragment pages 1-2, ludlam2009chaperonesoff1atpase pages 1-2)</p>
+<hr />
+<h3 id="2-molecular-function-mechanism-and-pathway-placement-evidence-based">2) Molecular function, mechanism, and pathway placement (evidence-based)</h3>
+<h4 id="21-molecular-function-a-subunit-assembly-chaperone">2.1 Molecular function: a β-subunit assembly chaperone</h4>
+<p>Multiple experimental approaches support a direct Atp11p–β interaction: affinity tag pull-down and yeast two-hybrid assays showed Atp11p binds free/unassembled F1 β, and mechanistic interpretation is that Atp11p binding <strong>shields aggregation-prone surfaces</strong> to prevent β–β self-association and to facilitate productive formation of the <code>(αβ)3</code> hexamer. (hinton2003apurifiedsubfragment pages 1-2, potocka2007assemblyfactorsin pages 17-21)</p>
+<p>A structured chaperone-active truncation (removal of 67 N-terminal residues) retains chaperone activity in vitro (e.g., suppressing aggregation of reduced insulin B chain) and retains interaction with the natural F1 β client, indicating that a large portion of Atp11p’s functional chaperone surface resides outside the N-terminus. (hinton2003apurifiedsubfragment pages 1-2)</p>
+<h4 id="22-binding-interface-and-mechanistic-models-for-chaperone-release">2.2 Binding interface and mechanistic models for chaperone release</h4>
+<p>Review synthesis and interaction mapping indicate Atp11p and Atp12p bind ~200-residue regions within nucleotide-binding domains of β and α, respectively, consistent with a model in which these assembly factors prevent premature α–β interface formation until appropriate assembly progression. (potocka2007assemblyfactorsin pages 17-21)</p>
+<p>Earlier mechanistic models posited that the chaperones might resemble α/β; however, structural studies argue Atp11p/Atp12p do <strong>not</strong> mimic α or β. Instead, assembly progression involves <strong>release of the chaperones triggered by association of the γ subunit</strong> (central stalk), enabling maturation of the F1 hexamer. (ludlam2009chaperonesoff1atpase pages 1-2)</p>
+<h4 id="23-pathway-placement-relative-to-general-mitochondrial-folding-systems-hsp60hsp70">2.3 Pathway placement relative to general mitochondrial folding systems (Hsp60/Hsp70)</h4>
+<p>Atp11p is described as acting <strong>downstream of general chaperones</strong> (e.g., Hsp60/Hsp70) because atp11 mutants accumulate near-mature α and β subunits (processed/imported) but fail to assemble them, leading to aggregation rather than precursor accumulation—contrasting with general folding/import defects. (potocka2007assemblyfactorsin pages 17-21, franco2020modularassemblyof pages 7-10)</p>
+<hr />
+<h3 id="3-subcellular-localization-and-where-the-function-occurs">3) Subcellular localization and where the function occurs</h3>
+<p>Atp11p functions in the <strong>mitochondrial matrix</strong>, where the F1 catalytic head is assembled and where unassembled α and β subunits can otherwise aggregate. Mitochondrial targeting is supported by the use of leader peptides in constructs and by the matrix-localized phenotypes (matrix inclusion bodies). (hinton2003apurifiedsubfragment pages 1-2, ludlam2009chaperonesoff1atpase pages 3-4, lefebvrelegendre2005failuretoassemble pages 1-2)</p>
+<hr />
+<h3 id="4-phenotypes-statistics-and-quantitative-data-from-experimental-studies">4) Phenotypes, statistics, and quantitative data from experimental studies</h3>
+<h4 id="41-respiratory-growth-phenotypes">4.1 Respiratory growth phenotypes</h4>
+<p>Loss of ATP11 impairs oxidative phosphorylation capacity and growth on nonfermentable carbon sources; in comparative phenotyping, <strong>atp11Δ can display a “leaky” respiratory phenotype</strong>, whereas <strong>atp12Δ can be fully defective</strong> on ethanol/glycerol (EG) medium under tested conditions. (ludlam2009chaperonesoff1atpase pages 3-4)</p>
+<h4 id="42-inclusion-bodies-and-mitochondrial-ultrastructure-quantitative-em">4.2 Inclusion bodies and mitochondrial ultrastructure (quantitative EM)</h4>
+<p>A key experimental signature of ATP11 loss is formation of <strong>electron-dense mitochondrial inclusion bodies</strong> enriched in F1 α/β proteins. In quantitative ultrastructural analysis, <strong>Δatp11</strong> displayed inclusion bodies in <strong>44.0% of cell sections</strong> and <strong>23.5% of mitochondrial profiles</strong>, consistent with a strong block in α3β3 subcomplex assembly. (lefebvrelegendre2005failuretoassemble pages 1-2, lefebvrelegendre2005failuretoassemble media b3ecdee8)</p>
+<p>These inclusion bodies are supported by EM and immunolabeling evidence and correlate with mitochondrial structural defects (including cristae abnormalities) when F1 assembly fails. (lefebvrelegendre2005failuretoassemble pages 1-2, lefebvrelegendre2005failuretoassemble media 33a6c4d5, lefebvrelegendre2005failuretoassemble media 5e421669)</p>
+<hr />
+<h3 id="5-recent-developments-and-latest-research-prioritizing-20232024">5) Recent developments and latest research (prioritizing 2023–2024)</h3>
+<h4 id="51-2023-mthsp70-cooperates-with-atp11atp12-and-adds-quality-control">5.1 2023: mtHsp70 cooperates with Atp11/Atp12 and adds quality control</h4>
+<p>A 2023 <em>Nature Communications</em> study identified a dual role for <strong>mitochondrial Hsp70 (mtHsp70)</strong> in ATP synthase biogenesis: it (i) <strong>cooperates with Atp11 and Atp12 to form the F1 domain</strong>, and (ii) transfers Atp5/OSCP into the assembly line to connect the catalytic head to the peripheral stalk. Importantly, mtHsp70 inactivation permits incorporation of assembly-defective Atp5 variants into mature complexes, implying a <strong>quality-control checkpoint</strong> during ATP synthase assembly. (song2023themitochondrialhsp70 pages 1-2)</p>
+<p>This reframes ATP11 action as part of a broader chaperone network: a specialized, client-specific assembly chaperone (Atp11) works alongside a general mitochondrial chaperone (mtHsp70) to coordinate formation and linkage of the F1 head. (song2023themitochondrialhsp70 pages 1-2)</p>
+<h4 id="52-2024-cross-speciesclinical-synthesis-of-atp11-homolog-atpaf1">5.2 2024: cross-species/clinical synthesis of ATP11 homolog ATPAF1</h4>
+<p>A 2024 systematic review of isolated ATP synthase defects explicitly identifies <strong>ATPAF1 as the human homolog of yeast ATP11</strong>, describing it as conserved and required for α3β3 hexamer formation. In the compiled variant landscape for isolated ATP synthase deficiency (total variants <strong>n = 63</strong>), ~<strong>60% (38/63)</strong> are nuclear-encoded; ATPAF1 is listed with <strong>0</strong> reported pathogenic variants in that review’s assembly-factor table, while other assembly factors (e.g., TMEM70) account for many cases. (tauchmannova2024variabilityofclinical pages 3-5)</p>
+<p>While this is not a yeast functional discovery per se, it underscores ATP11’s mechanistic importance and conservation, and it motivates yeast ATP11 studies as models for fundamental assembly biology relevant to mitochondrial disease mechanisms. (tauchmannova2024variabilityofclinical pages 3-5, tauchmannova2024variabilityofclinical pages 1-3)</p>
+<hr />
+<h3 id="6-current-applications-and-real-world-implementations">6) Current applications and real-world implementations</h3>
+<h4 id="61-yeast-atp11-as-a-mechanistic-model-system">6.1 Yeast ATP11 as a mechanistic model system</h4>
+<p>ATP11 is widely used as a <strong>genetic and biochemical handle</strong> to:<br />
+- induce specific blocks in F1 assembly (yielding clean assembly intermediates/inclusion bodies),<br />
+- study the coupling of chaperone systems to respiratory complex biogenesis,<br />
+- and test cross-species complementation or structure–function relationships of ATP11-family proteins.</p>
+<p>For example, structural/functional work showed that <strong>C. glabrata Atp11p</strong> can complement <em>S. cerevisiae</em> atp11Δ respiratory defects, supporting conserved chaperone function and enabling structure-informed mutational analysis. (ludlam2009chaperonesoff1atpase pages 3-4, ludlam2009chaperonesoff1atpase pages 4-5)</p>
+<h4 id="62-structural-biology-of-assembly-factors">6.2 Structural biology of assembly factors</h4>
+<p>Atp11-family proteins have been purified and structurally characterized to inform mechanistic models of client binding and chaperone release during F1 assembly. Structural mapping also highlighted specific residues whose mutation inactivates Atp11p function, supporting a surface-mediated chaperone mechanism rather than catalytic chemistry. (ludlam2009chaperonesoff1atpase pages 4-5)</p>
+<hr />
+<h3 id="7-expert-opinions-and-analysis-authoritative-syntheses">7) Expert opinions and analysis (authoritative syntheses)</h3>
+<h4 id="71-consensus-view">7.1 Consensus view</h4>
+<p>Across reviews and primary literature, the consensus is that ATP11 encodes a <strong>specialized assembly chaperone</strong> for mitochondrial ATP synthase that:<br />
+- binds β (Atp2),<br />
+- prevents α/β aggregation,<br />
+- promotes <code>(αβ)3</code> hexamer formation,<br />
+- and is released during later assembly steps (γ involvement),<br />
+while general chaperones (Hsp60/Hsp70) support upstream folding/import. (franco2020modularassemblyof pages 7-10, ludlam2009chaperonesoff1atpase pages 1-2, song2018assemblingthemitochondrial pages 1-2)</p>
+<h4 id="72-conservation-across-genomes">7.2 Conservation across genomes</h4>
+<p>Comparative-genomics analyses support conservation of Atp11p/Atp12p function across eukaryotes capable of oxidative phosphorylation, consistent with a conserved need to protect α/β subunits during assembly. (pickova2005assemblyfactorsof pages 1-2)</p>
+<hr />
+<h3 id="evidence-map-table">Evidence map (table)</h3>
+<table>
+<thead>
+<tr>
+<th>Claim/Topic</th>
+<th>Key evidence/data</th>
+<th>System/assay</th>
+<th>Primary source</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Molecular function</td>
+<td>ATP11/YNL315C encodes Atp11p, a dedicated mitochondrial F1-ATPase assembly chaperone rather than a stoichiometric ATP synthase subunit; it prevents nonproductive self-association/aggregation of unassembled F1 subunits and promotes formation of the catalytic <code>(αβ)3</code> hexamer (franco2020modularassemblyof pages 7-10, hinton2003apurifiedsubfragment pages 1-2, ludlam2009chaperonesoff1atpase pages 1-2)</td>
+<td>Yeast genetics, biochemical assembly analysis, in vitro chaperone assays</td>
+<td>Hinton et al. 2003, <em>J Biol Chem</em> (2003-09), https://doi.org/10.1074/jbc.M305353200; Ludlam et al. 2009, <em>J Biol Chem</em> (2009-06), https://doi.org/10.1074/jbc.M109.002568</td>
+</tr>
+<tr>
+<td>Localization</td>
+<td>Atp11p is a soluble mitochondrial matrix protein/assembly factor acting on the matrix-exposed F1 sector during ATP synthase biogenesis; it is imported with a mitochondrial targeting sequence and is not part of the final holoenzyme (hinton2003apurifiedsubfragment pages 1-2, ludlam2009chaperonesoff1atpase pages 3-4, song2018assemblingthemitochondrial pages 1-2)</td>
+<td>Mitochondrial targeting constructs, mitochondrial biochemical studies, review synthesis</td>
+<td>Hinton et al. 2003, <em>J Biol Chem</em> (2003-09), https://doi.org/10.1074/jbc.M305353200; Ludlam et al. 2009, <em>J Biol Chem</em> (2009-06), https://doi.org/10.1074/jbc.M109.002568; Song et al. 2018, <em>PNAS</em> (2018-03), https://doi.org/10.1073/pnas.1801697115</td>
+</tr>
+<tr>
+<td>Binding partner/client specificity</td>
+<td>Atp11p specifically binds the F1 β subunit (Atp2), whereas Atp12p binds F1 α (Atp1); interaction evidence comes from affinity pull-down/coprecipitation and yeast two-hybrid studies, and binding maps to regions in the nucleotide-binding domain of β (potocka2007assemblyfactorsin pages 17-21, hinton2003apurifiedsubfragment pages 1-2, ludlam2009chaperonesoff1atpase pages 1-2)</td>
+<td>Affinity-tag pull-down, co-precipitation, yeast two-hybrid, interaction mapping</td>
+<td>Hinton et al. 2003, <em>J Biol Chem</em> (2003-09), https://doi.org/10.1074/jbc.M305353200; Ludlam et al. 2009, <em>J Biol Chem</em> (2009-06), https://doi.org/10.1074/jbc.M109.002568</td>
+</tr>
+<tr>
+<td>Mutant phenotype</td>
+<td><code>atp11Δ</code> mutants are respiratory deficient or strongly impaired for growth on nonfermentable carbon sources; α and β subunits accumulate as large insoluble aggregates/inclusion bodies in the mitochondrial matrix instead of assembling into F1, with reduced ATPase/oxidative phosphorylation capacity (potocka2007assemblyfactorsin pages 17-21, lefebvrelegendre2005failuretoassemble pages 1-2, ludlam2009chaperonesoff1atpase pages 1-2, lefebvrelegendre2001identificationofa pages 6-7)</td>
+<td>Yeast gene deletion, respiratory growth assays, mitochondrial fractionation, EM</td>
+<td>Lefebvre-Legendre et al. 2005, <em>J Biol Chem</em> (2005-05), https://doi.org/10.1074/jbc.M410789200; Lefebvre-Legendre et al. 2001, <em>J Biol Chem</em> (2001-03), https://doi.org/10.1074/jbc.M009557200</td>
+</tr>
+<tr>
+<td>Quantitative phenotype/statistics</td>
+<td>Electron microscopy quantified inclusion bodies in <code>Δatp11</code>: 44.0% of cell sections and 23.5% of mitochondrial profiles contained inclusion bodies, supporting a severe block in α3β3 subcomplex assembly (lefebvrelegendre2005failuretoassemble pages 1-2, lefebvrelegendre2005failuretoassemble media b3ecdee8)</td>
+<td>Electron microscopy, immunogold labeling, quantitative ultrastructural scoring</td>
+<td>Lefebvre-Legendre et al. 2005, <em>J Biol Chem</em> (2005-05), https://doi.org/10.1074/jbc.M410789200</td>
+</tr>
+<tr>
+<td>Mechanistic model</td>
+<td>Atp11p and Atp12p protect β and α, respectively, from premature α-β contacts; early models proposed they occupy catalytic/noncatalytic interface regions, while later structural work argued the chaperones do not mimic α/β and that F1 γ-subunit association helps trigger chaperone release during hexamer assembly (franco2020modularassemblyof pages 7-10, ludlam2009chaperonesoff1atpase pages 1-2, song2018assemblingthemitochondrial pages 1-2)</td>
+<td>Structural biology, interaction assays, mechanistic modeling, review synthesis</td>
+<td>Ludlam et al. 2009, <em>J Biol Chem</em> (2009-06), https://doi.org/10.1074/jbc.M109.002568; Song et al. 2018, <em>PNAS</em> (2018-03), https://doi.org/10.1073/pnas.1801697115; Franco et al. 2020, <em>Biological Chemistry</em> (2020-05), https://doi.org/10.1515/hsz-2020-0112</td>
+</tr>
+<tr>
+<td>Relationship to broader ATP synthase pathway</td>
+<td>F1 assembly depends on upstream folding assistance and downstream incorporation into modular ATP synthase assembly; Hsp60 assists β folding before Atp11 action, and properly assembled F1 is coupled to later steps in ATP synthase biogenesis and translational feedback on mitochondrially encoded subunits (franco2020modularassemblyof pages 7-10, song2018assemblingthemitochondrial pages 1-2)</td>
+<td>Review synthesis of genetic/biochemical pathway studies</td>
+<td>Franco et al. 2020, <em>Biological Chemistry</em> (2020-05), https://doi.org/10.1515/hsz-2020-0112; Song et al. 2018, <em>PNAS</em> (2018-03), https://doi.org/10.1073/pnas.1801697115</td>
+</tr>
+<tr>
+<td>Recent 2023 developments</td>
+<td>A 2023 study added mtHsp70 as an active participant in ATP synthase biogenesis: mtHsp70 cooperates with Atp11/Atp12 in F1 assembly, transfers Atp5/OSCP into the assembly line, and exerts quality control by preventing defective Atp5 variants from being inappropriately incorporated into mature complexes (song2023themitochondrialhsp70 pages 1-2)</td>
+<td>Yeast proteomics, pull-downs, mutant analysis, assembly-state profiling</td>
+<td>Song et al. 2023, <em>Nature Communications</em> (2023-01), https://doi.org/10.1038/s41467-022-35720-5</td>
+</tr>
+<tr>
+<td>Expert/current understanding</td>
+<td>Recent authoritative reviews continue to define ATP11 as a conserved F1 assembly factor/chaperone (human ortholog ATPAF1), with core function centered on β-subunit handling during ATP synthase biogenesis; direct 2023-2024 ATP11-specific yeast primary studies remain limited, so new insight comes mainly from broader assembly-network work rather than redefinition of ATP11’s core role (franco2020modularassemblyof pages 7-10, song2023themitochondrialhsp70 pages 1-2)</td>
+<td>Review analysis and recent mechanistic study</td>
+<td>Franco et al. 2020, <em>Biological Chemistry</em> (2020-05), https://doi.org/10.1515/hsz-2020-0112; Song et al. 2023, <em>Nature Communications</em> (2023-01), https://doi.org/10.1038/s41467-022-35720-5</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the main experimentally supported findings for Saccharomyces cerevisiae ATP11/YNL315C, including function, localization, binding specificity, mutant phenotypes, mechanistic models, and recent 2023 developments. It is useful as a compact evidence map linking each major claim to the assay type and primary literature source.</em></p>
+<hr />
+<h3 id="urls-and-publication-dates-key-sources-used">URLs and publication dates (key sources used)</h3>
+<ul>
+<li>Hinton A, Zuiderweg ERP, Ackerman SH. <strong>2003-09</strong>. <em>J Biol Chem</em>. “A Purified Subfragment of Yeast Atp11p Retains Full Molecular Chaperone Activity.” https://doi.org/10.1074/jbc.M305353200 (hinton2003apurifiedsubfragment pages 1-2)</li>
+<li>Lefebvre-Legendre L et al. <strong>2005-05</strong>. <em>J Biol Chem</em>. “Failure to Assemble the α3β3 Subcomplex…” https://doi.org/10.1074/jbc.M410789200 (lefebvrelegendre2005failuretoassemble pages 1-2)</li>
+<li>Ludlam A et al. <strong>2009-06</strong>. <em>J Biol Chem</em>. “Chaperones of F1-ATPase.” https://doi.org/10.1074/jbc.M109.002568 (ludlam2009chaperonesoff1atpase pages 1-2)</li>
+<li>Song J, Pfanner N, Becker T. <strong>2018-03</strong>. <em>PNAS</em>. “Assembling the mitochondrial ATP synthase.” https://doi.org/10.1073/pnas.1801697115 (song2018assemblingthemitochondrial pages 1-2)</li>
+<li>Franco LVR, Su CH, Tzagoloff A. <strong>2020-05</strong>. <em>Biological Chemistry</em>. “Modular assembly of yeast mitochondrial ATP synthase…” https://doi.org/10.1515/hsz-2020-0112 (franco2020modularassemblyof pages 7-10)</li>
+<li>Song J et al. <strong>2023-01</strong>. <em>Nature Communications</em>. “The mitochondrial Hsp70 controls the assembly of the F1FO-ATP synthase.” https://doi.org/10.1038/s41467-022-35720-5 (song2023themitochondrialhsp70 pages 1-2)</li>
+<li>Tauchmannová K et al. <strong>2024-08</strong>. <em>Physiological Research</em>. “Variability of Clinical Phenotypes Caused by Isolated Defects of Mitochondrial ATP Synthase.” https://doi.org/10.33549/physiolres.935407 (tauchmannova2024variabilityofclinical pages 3-5)</li>
+</ul>
+<hr />
+<h3 id="limitations-evidence-gaps">Limitations / evidence gaps</h3>
+<p>Direct ATP11-focused yeast primary studies in 2023–2024 are limited in the retrieved corpus; the newest mechanistic advance relevant to ATP11 here is primarily the integration of Atp11/Atp12 into an mtHsp70-mediated assembly and quality-control framework. (song2023themitochondrialhsp70 pages 1-2)</p>
+<p>References</p>
+<ol>
+<li>
+<p>(franco2020modularassemblyof pages 7-10): Leticia Veloso Ribeiro Franco, Chen Hsien Su, and Alexander Tzagoloff. Modular assembly of yeast mitochondrial atp synthase and cytochrome oxidase. Biological Chemistry, 401:835-853, May 2020. URL: https://doi.org/10.1515/hsz-2020-0112, doi:10.1515/hsz-2020-0112. This article has 35 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hinton2003apurifiedsubfragment pages 1-2): Ayana Hinton, Erik R.P. Zuiderweg, and Sharon H. Ackerman. A purified subfragment of yeast atp11p retains full molecular chaperone activity*. Journal of Biological Chemistry, 278:34110-34113, Sep 2003. URL: https://doi.org/10.1074/jbc.m305353200, doi:10.1074/jbc.m305353200. This article has 10 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lefebvrelegendre2005failuretoassemble pages 1-2): Linnka Lefebvre-Legendre, Bénédicte Salin, Jacques Schaëffer, Daniel Brèthes, Alain Dautant, Sharon H. Ackerman, and Jean-Paul di Rago. Failure to assemble the α3 β3 subcomplex of the atp synthase leads to accumulation of the α and β subunits within inclusion bodies and the loss of mitochondrial cristae in saccharomyces cerevisiae*. Journal of Biological Chemistry, 280:18386-18392, May 2005. URL: https://doi.org/10.1074/jbc.m410789200, doi:10.1074/jbc.m410789200. This article has 83 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ludlam2009chaperonesoff1atpase pages 1-2): Anthony Ludlam, Joseph Brunzelle, Thomas Pribyl, Xingjue Xu, Domenico L. Gatti, and Sharon H. Ackerman. Chaperones of f1-atpase. Journal of Biological Chemistry, 284:17138-17146, Jun 2009. URL: https://doi.org/10.1074/jbc.m109.002568, doi:10.1074/jbc.m109.002568. This article has 40 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(song2023themitochondrialhsp70 pages 1-2): Jiyao Song, Liesa Steidle, Isabelle Steymans, Jasjot Singh, Anne Sanner, Lena Böttinger, Dominic Winter, and Thomas Becker. The mitochondrial hsp70 controls the assembly of the f1fo-atp synthase. Nature Communications, Jan 2023. URL: https://doi.org/10.1038/s41467-022-35720-5, doi:10.1038/s41467-022-35720-5. This article has 26 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(potocka2007assemblyfactorsin pages 17-21): A Potocká. Assembly factors in the biogenesis of mitochondrial atp synthase. Unknown journal, 2007.</p>
+</li>
+<li>
+<p>(song2018assemblingthemitochondrial pages 1-2): Jiyao Song, Nikolaus Pfanner, and Thomas Becker. Assembling the mitochondrial atp synthase. Proceedings of the National Academy of Sciences, 115:2850-2852, Mar 2018. URL: https://doi.org/10.1073/pnas.1801697115, doi:10.1073/pnas.1801697115. This article has 84 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ludlam2009chaperonesoff1atpase pages 3-4): Anthony Ludlam, Joseph Brunzelle, Thomas Pribyl, Xingjue Xu, Domenico L. Gatti, and Sharon H. Ackerman. Chaperones of f1-atpase. Journal of Biological Chemistry, 284:17138-17146, Jun 2009. URL: https://doi.org/10.1074/jbc.m109.002568, doi:10.1074/jbc.m109.002568. This article has 40 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lefebvrelegendre2005failuretoassemble media b3ecdee8): Linnka Lefebvre-Legendre, Bénédicte Salin, Jacques Schaëffer, Daniel Brèthes, Alain Dautant, Sharon H. Ackerman, and Jean-Paul di Rago. Failure to assemble the α3 β3 subcomplex of the atp synthase leads to accumulation of the α and β subunits within inclusion bodies and the loss of mitochondrial cristae in saccharomyces cerevisiae*. Journal of Biological Chemistry, 280:18386-18392, May 2005. URL: https://doi.org/10.1074/jbc.m410789200, doi:10.1074/jbc.m410789200. This article has 83 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lefebvrelegendre2005failuretoassemble media 33a6c4d5): Linnka Lefebvre-Legendre, Bénédicte Salin, Jacques Schaëffer, Daniel Brèthes, Alain Dautant, Sharon H. Ackerman, and Jean-Paul di Rago. Failure to assemble the α3 β3 subcomplex of the atp synthase leads to accumulation of the α and β subunits within inclusion bodies and the loss of mitochondrial cristae in saccharomyces cerevisiae*. Journal of Biological Chemistry, 280:18386-18392, May 2005. URL: https://doi.org/10.1074/jbc.m410789200, doi:10.1074/jbc.m410789200. This article has 83 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lefebvrelegendre2005failuretoassemble media 5e421669): Linnka Lefebvre-Legendre, Bénédicte Salin, Jacques Schaëffer, Daniel Brèthes, Alain Dautant, Sharon H. Ackerman, and Jean-Paul di Rago. Failure to assemble the α3 β3 subcomplex of the atp synthase leads to accumulation of the α and β subunits within inclusion bodies and the loss of mitochondrial cristae in saccharomyces cerevisiae*. Journal of Biological Chemistry, 280:18386-18392, May 2005. URL: https://doi.org/10.1074/jbc.m410789200, doi:10.1074/jbc.m410789200. This article has 83 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tauchmannova2024variabilityofclinical pages 3-5): K. Tauchmannová, A. Pecinová, J. Houštěk, and T. Mrázek. Variability of clinical phenotypes caused by isolated defects of mitochondrial atp synthase. Physiological Research, pages S243-S278, Aug 2024. URL: https://doi.org/10.33549/physiolres.935407, doi:10.33549/physiolres.935407. This article has 14 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tauchmannova2024variabilityofclinical pages 1-3): K. Tauchmannová, A. Pecinová, J. Houštěk, and T. Mrázek. Variability of clinical phenotypes caused by isolated defects of mitochondrial atp synthase. Physiological Research, pages S243-S278, Aug 2024. URL: https://doi.org/10.33549/physiolres.935407, doi:10.33549/physiolres.935407. This article has 14 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ludlam2009chaperonesoff1atpase pages 4-5): Anthony Ludlam, Joseph Brunzelle, Thomas Pribyl, Xingjue Xu, Domenico L. Gatti, and Sharon H. Ackerman. Chaperones of f1-atpase. Journal of Biological Chemistry, 284:17138-17146, Jun 2009. URL: https://doi.org/10.1074/jbc.m109.002568, doi:10.1074/jbc.m109.002568. This article has 40 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pickova2005assemblyfactorsof pages 1-2): Andrea Pícková, Martin Potocký, and Josef Houštěk. Assembly factors of f1fo‐atp synthase across genomes. Proteins: Structure, 59:393-402, May 2005. URL: https://doi.org/10.1002/prot.20452, doi:10.1002/prot.20452. This article has 43 citations.</p>
+</li>
+<li>
+<p>(lefebvrelegendre2001identificationofa pages 6-7): Linnka Lefebvre-Legendre, Jacques Vaillier, Houssain Benabdelhak, Jean Velours, Piotr P. Slonimski, and Jean-Paul di Rago. Identification of a nuclear gene (fmc1) required for the assembly/stability of yeast mitochondrial f1-atpase in heat stress conditions*. The Journal of Biological Chemistry, 276:6789-6796, Mar 2001. URL: https://doi.org/10.1074/jbc.m009557200, doi:10.1074/jbc.m009557200. This article has 179 citations.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>hinton2003apurifiedsubfragment pages 1-2</li>
+<li>potocka2007assemblyfactorsin pages 17-21</li>
+<li>tauchmannova2024variabilityofclinical pages 3-5</li>
+<li>pickova2005assemblyfactorsof pages 1-2</li>
+<li>lefebvrelegendre2005failuretoassemble pages 1-2</li>
+<li>song2018assemblingthemitochondrial pages 1-2</li>
+<li>franco2020modularassemblyof pages 7-10</li>
+<li>tauchmannova2024variabilityofclinical pages 1-3</li>
+<li>lefebvrelegendre2001identificationofa pages 6-7</li>
+<li>https://doi.org/10.1074/jbc.M305353200;</li>
+<li>https://doi.org/10.1074/jbc.M109.002568</li>
+<li>https://doi.org/10.1074/jbc.M109.002568;</li>
+<li>https://doi.org/10.1073/pnas.1801697115</li>
+<li>https://doi.org/10.1074/jbc.M410789200;</li>
+<li>https://doi.org/10.1074/jbc.M009557200</li>
+<li>https://doi.org/10.1074/jbc.M410789200</li>
+<li>https://doi.org/10.1073/pnas.1801697115;</li>
+<li>https://doi.org/10.1515/hsz-2020-0112</li>
+<li>https://doi.org/10.1515/hsz-2020-0112;</li>
+<li>https://doi.org/10.1038/s41467-022-35720-5</li>
+<li>https://doi.org/10.1074/jbc.M305353200</li>
+<li>https://doi.org/10.33549/physiolres.935407</li>
+<li>https://doi.org/10.1515/hsz-2020-0112,</li>
+<li>https://doi.org/10.1074/jbc.m305353200,</li>
+<li>https://doi.org/10.1074/jbc.m410789200,</li>
+<li>https://doi.org/10.1074/jbc.m109.002568,</li>
+<li>https://doi.org/10.1038/s41467-022-35720-5,</li>
+<li>https://doi.org/10.1073/pnas.1801697115,</li>
+<li>https://doi.org/10.33549/physiolres.935407,</li>
+<li>https://doi.org/10.1002/prot.20452,</li>
+<li>https://doi.org/10.1074/jbc.m009557200,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -1911,11 +2894,22 @@
                 <pre><code>id: P32453
 gene_symbol: ATP11
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
+aliases:
+- YNL315C
+- ATP synthase mitochondrial F1 complex assembly factor 1
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: &#39;TODO: Add description for ATP11&#39;
+description: &gt;-
+  ATP11 encodes a mitochondrial matrix assembly factor for the F1 sector of
+  mitochondrial F1FO ATP synthase. Atp11 is not a stoichiometric ATP synthase
+  subunit; it is a dedicated assembly chaperone/stabilizing factor for the
+  unassembled F1 beta subunit Atp2, preventing nonproductive aggregation and
+  promoting formation of the alpha3-beta3 catalytic F1 head. Generic
+  unfolded-protein binding and cross-species protein-binding annotations are less
+  informative than the ATP synthase complex assembly and protein-containing
+  complex stabilizing activity annotations.
 existing_annotations:
 - term:
     id: GO:0005739
@@ -1923,144 +2917,212 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;Manual review: mitochondrion is consistent with known biology of ATP11.&#39;
+    summary: IBA mitochondrial localization is consistent with direct ATP11 localization.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Atp11 functions in mitochondria, specifically the matrix.
+    supported_by:
+    - reference_id: PMID:1532796
+      supporting_text: vitro import assays of ATP11 precursor and immunochemical evidence indicate that...the protein is located in mitochondria.
+    - reference_id: file:interpro/panther/PTHR13126/PTHR13126-metadata.yaml
+      supporting_text: PTHR13126 is the CHAPERONE ATP11 family.
 - term:
     id: GO:0140777
     label: protein-containing complex stabilizing activity
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;Manual review: protein-containing complex stabilizing activity is consistent with known biology of ATP11.&#39;
+    summary: This is the most specific molecular-function term for Atp11.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Atp11 stabilizes the unassembled F1 beta subunit during ATP synthase assembly.
+    supported_by:
+    - reference_id: PMID:10681564
+      supporting_text: evidence that Atp11p binds selectively to the beta-subunit of F(1).
+    - reference_id: PMID:12829692
+      supporting_text: Atp11p yields a subfragment of the protein (called Atp11pTRNC) that retains...molecular chaperone function...the natural substrate (F1 beta).
+    - reference_id: file:yeast/ATP11/ATP11-deep-research-falcon.md
+      supporting_text: Atp11 binds F1 beta subunit Atp2 to prevent nonproductive self-association.
 - term:
     id: GO:0033615
     label: mitochondrial proton-transporting ATP synthase complex assembly
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;Manual review: mitochondrial proton-transporting ATP synthase complex assembly is consistent with known biology of ATP11.&#39;
+    summary: The IBA process term matches classic ATP11 mutant and biochemical evidence.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: ATP synthase F1 assembly is the central process affected by ATP11.
+    supported_by:
+    - reference_id: PMID:2142305
+      supporting_text: explanation for the mutant phenotype is a block in the assembly of the F1...oligomer.
+    - reference_id: PMID:36596815
+      supporting_text: it cooperates with the assembly...factors Atp11 and Atp12 to form the F1 domain of the ATP synthase.
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: &#39;Manual review: mitochondrion is consistent with known biology of ATP11.&#39;
+    summary: Electronic mitochondrion annotation is correct.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Atp11 is a mitochondrial matrix assembly factor.
+    supported_by:
+    - reference_id: PMID:1532796
+      supporting_text: The hybrid protein is detected in mitochondria with antibodies
 - term:
     id: GO:0065003
     label: protein-containing complex assembly
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: &#39;Manual review: protein-containing complex assembly is consistent with known biology of ATP11.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: The term is correct but too broad.
+    action: MODIFY
+    reason: Replace with the specific mitochondrial ATP synthase assembly term.
+    proposed_replacement_terms:
+    - id: GO:0033615
+      label: mitochondrial proton-transporting ATP synthase complex assembly
+    supported_by:
+    - reference_id: PMID:2142305
+      supporting_text: important function at a...late stage in the synthesis of F1
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:27107014
   review:
-    summary: &#39;Manual review: protein binding is too generic or over-extended for ATP11.&#39;
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    summary: This comes from a yeast-human inter-species interaction map and is not a physiological ATP11 function.
+    action: REMOVE
+    reason: The annotation does not identify the endogenous yeast Atp2/F1 beta client and uses an uninformative term.
+    supported_by:
+    - reference_id: PMID:27107014
+      supporting_text: we generated a high-quality proteome-wide inter-interactome network map
 - term:
     id: GO:0005759
     label: mitochondrial matrix
   evidence_type: IDA
   original_reference_id: PMID:1532796
   review:
-    summary: &#39;Manual review: mitochondrial matrix is consistent with known biology of ATP11.&#39;
+    summary: Direct evidence supports mitochondrial matrix localization.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: The F1 ATP synthase assembly role occurs in the matrix.
+    supported_by:
+    - reference_id: PMID:1532796
+      supporting_text: Biotinated ATP11 protein can be partially...purified by affinity chromatography
 - term:
     id: GO:0033615
     label: mitochondrial proton-transporting ATP synthase complex assembly
   evidence_type: IMP
   original_reference_id: PMID:36596815
   review:
-    summary: &#39;Manual review: mitochondrial proton-transporting ATP synthase complex assembly is consistent with known biology of ATP11.&#39;
+    summary: Recent work places Atp11 with Atp12 and mtHsp70 in F1 assembly.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: This is the specific ATP synthase assembly process affected by Atp11.
+    supported_by:
+    - reference_id: PMID:36596815
+      supporting_text: it cooperates with the assembly...factors Atp11 and Atp12 to form the F1 domain of the ATP synthase.
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: HDA
   original_reference_id: PMID:24769239
   review:
-    summary: &#39;Manual review: mitochondrion is consistent with known biology of ATP11.&#39;
+    summary: High-throughput mitochondrial proteomics is consistent with ATP11 biology.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Mitochondrial localization is core to Atp11 function.
+    supported_by:
+    - reference_id: PMID:24769239
+      supporting_text: isolated mitochondria extracted from yeast grown on fermentative...and respiratory...media
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: HDA
   original_reference_id: PMID:16823961
   review:
-    summary: &#39;Manual review: mitochondrion is consistent with known biology of ATP11.&#39;
+    summary: High-throughput mitochondrial proteome data are consistent with direct localization.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: The broad mitochondrion term is correct.
+    supported_by:
+    - reference_id: PMID:16823961
+      supporting_text: A total of 851 different proteins (PROMITO dataset) were...identified by use of multidimensional LC-MS/MS
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:10681564
   review:
-    summary: &#39;ATP11 is a dedicated assembly factor for mitochondrial F1-ATPase, not a general chaperone. GO:0051082 overstates the binding as a standalone function.&#39;
-    action: MARK_AS_OVER_ANNOTATED
-    reason: ATP11 functions as a dedicated assembly factor for the F1-ATPase beta subunit, not as a general unfolded protein binding chaperone. The binding interaction is specific to Atp2p assembly and is better captured by the assembly process annotation (GO:0033615).
+    summary: Atp11 binds an unassembled F1 beta subunit, but the generic term is too broad.
+    action: MODIFY
+    reason: Protein-containing complex stabilizing activity better captures client-specific F1 assembly.
+    proposed_replacement_terms:
+    - id: GO:0140777
+      label: protein-containing complex stabilizing activity
+    supported_by:
+    - reference_id: PMID:10681564
+      supporting_text: Atp11p bound to a region of the nucleotide-binding...domain of the beta-subunit
 - term:
     id: GO:0033615
     label: mitochondrial proton-transporting ATP synthase complex assembly
   evidence_type: IPI
   original_reference_id: PMID:10681564
   review:
-    summary: &#39;Manual review: mitochondrial proton-transporting ATP synthase complex assembly is consistent with known biology of ATP11.&#39;
+    summary: The Atp11-F1 beta interaction directly supports ATP synthase F1 assembly.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: This is the correct process-level interpretation of the Atp11-Atp2 interaction.
+    supported_by:
+    - reference_id: PMID:10681564
+      supporting_text: alpha-subunits may exchange for bound Atp11p...during the process of F(1) assembly.
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IDA
   original_reference_id: PMID:1532796
   review:
-    summary: &#39;Manual review: mitochondrion is consistent with known biology of ATP11.&#39;
+    summary: Direct evidence places Atp11 in mitochondria.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Mitochondrial localization is required for ATP synthase F1 assembly.
+    supported_by:
+    - reference_id: PMID:1532796
+      supporting_text: vitro import assays of ATP11 precursor and immunochemical evidence indicate that...the protein is located in mitochondria.
 - term:
     id: GO:0007005
     label: mitochondrion organization
   evidence_type: IMP
   original_reference_id: PMID:2142305
   review:
-    summary: &#39;Manual review: mitochondrion organization may be context-dependent or peripheral for ATP11.&#39;
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    summary: This broad phenotype should be replaced by the specific F1 ATP synthase assembly defect.
+    action: MODIFY
+    reason: ATP11 mutants block F1 assembly, not general mitochondrial organization as a primary function.
+    proposed_replacement_terms:
+    - id: GO:0033615
+      label: mitochondrial proton-transporting ATP synthase complex assembly
+    supported_by:
+    - reference_id: PMID:2142305
+      supporting_text: important function at a...late stage in the synthesis of F1
 - term:
     id: GO:0033615
     label: mitochondrial proton-transporting ATP synthase complex assembly
   evidence_type: IMP
   original_reference_id: PMID:2142305
   review:
-    summary: &#39;Manual review: mitochondrial proton-transporting ATP synthase complex assembly is consistent with known biology of ATP11.&#39;
+    summary: Classic genetic evidence directly supports ATP synthase assembly.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: ATP11 was identified as required for assembly of yeast F1-ATPase.
+    supported_by:
+    - reference_id: PMID:2142305
+      supporting_text: explanation for the mutant phenotype is a block in the assembly of the F1...oligomer.
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:12829692
   review:
-    summary: &#39;ATP11 is a dedicated assembly factor for mitochondrial F1-ATPase, not a general chaperone. GO:0051082 overstates the binding as a standalone function.&#39;
-    action: MARK_AS_OVER_ANNOTATED
-    reason: ATP11 functions as a dedicated assembly factor for the F1-ATPase beta subunit, not as a general unfolded protein binding chaperone. The binding interaction is specific to Atp2p assembly and is better captured by the assembly process annotation (GO:0033615).
+    summary: Atp11 has chaperone activity toward F1 beta, but the term is too generic.
+    action: MODIFY
+    reason: GO:0140777 better represents stabilization of an ATP synthase assembly intermediate.
+    proposed_replacement_terms:
+    - id: GO:0140777
+      label: protein-containing complex stabilizing activity
+    supported_by:
+    - reference_id: PMID:12829692
+      supporting_text: Atp11p yields a subfragment of the protein (called Atp11pTRNC) that retains...molecular chaperone function...the natural substrate (F1 beta).
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -2071,20 +3133,28 @@ references:
 - id: GO_REF:0000120
   title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
-- id: PMID:10681564
-  title: The assembly factor Atp11p binds to the beta-subunit of the mitochondrial F(1)-ATPase.
-  findings: []
-- id: PMID:12829692
-  title: A purified subfragment of yeast Atp11p retains full molecular chaperone activity.
-  findings: []
 - id: PMID:1532796
   title: Characterization of ATP11 and detection of the encoded protein in mitochondria of Saccharomyces cerevisiae.
-  findings: []
-- id: PMID:16823961
-  title: &#39;Toward the complete yeast mitochondrial proteome: multidimensional separation techniques for mitochondrial proteomics.&#39;
-  findings: []
+  findings:
+  - statement: ATP11 protein is mitochondrial
+    supporting_text: In vitro import assays and immunochemical evidence indicate mitochondrial localization.
 - id: PMID:2142305
   title: Identification of two nuclear genes (ATP11, ATP12) required for assembly of the yeast F1-ATPase.
+  findings:
+  - statement: ATP11 is required for F1 ATPase assembly
+    supporting_text: Mutations in ATP11 and ATP12 block a late step in F1 assembly.
+- id: PMID:10681564
+  title: The assembly factor Atp11p binds to the beta-subunit of the mitochondrial F(1)-ATPase.
+  findings:
+  - statement: Atp11 binds the F1 beta subunit during assembly
+    supporting_text: Atp11p binds selectively to the beta-subunit of F1.
+- id: PMID:12829692
+  title: A purified subfragment of yeast Atp11p retains full molecular chaperone activity.
+  findings:
+  - statement: Atp11 has chaperone activity with F1 beta as its natural substrate
+    supporting_text: Atp11pTRNC retains molecular chaperone function with the natural substrate F1 beta.
+- id: PMID:16823961
+  title: &#39;Toward the complete yeast mitochondrial proteome: multidimensional separation techniques for mitochondrial proteomics.&#39;
   findings: []
 - id: PMID:24769239
   title: Quantitative variations of the mitochondrial proteome and phosphoproteome during fermentative and respiratory growth in Saccharomyces cerevisiae.
@@ -2094,14 +3164,54 @@ references:
   findings: []
 - id: PMID:36596815
   title: The mitochondrial Hsp70 controls the assembly of the F(1)F(O)-ATP synthase.
-  findings: []
+  findings:
+  - statement: mtHsp70 cooperates with Atp11 and Atp12 in F1 assembly
+    supporting_text: Mitochondrial Hsp70 cooperates with the assembly factors Atp11 and Atp12 to form the F1 domain.
+- id: file:yeast/ATP11/ATP11-deep-research-falcon.md
+  title: Falcon deep research report for ATP11
+  findings:
+  - statement: ATP11 is a mitochondrial F1 ATP synthase assembly chaperone
+    supporting_text: Atp11 binds F1 beta subunit Atp2 and promotes formation of the F1 catalytic head.
+- id: file:interpro/panther/PTHR13126/PTHR13126-metadata.yaml
+  title: PANTHER family metadata for ATP11 family PTHR13126
+  findings:
+  - statement: PTHR13126 is the ATP11 chaperone family
+    supporting_text: The local PANTHER metadata identifies PTHR13126 as CHAPERONE ATP11.
+core_functions:
+- description: &gt;-
+    Dedicated mitochondrial F1 ATP synthase assembly chaperone/stabilizing
+    activity. Atp11 binds unassembled F1 beta subunit Atp2 in the mitochondrial
+    matrix, preventing nonproductive aggregation and promoting assembly of the
+    alpha3-beta3 F1 catalytic head.
+  molecular_function:
+    id: GO:0140777
+    label: protein-containing complex stabilizing activity
+  directly_involved_in:
+  - id: GO:0033615
+    label: mitochondrial proton-transporting ATP synthase complex assembly
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  - id: GO:0005739
+    label: mitochondrion
+  supported_by:
+  - reference_id: PMID:10681564
+    supporting_text: evidence that Atp11p binds selectively to the beta-subunit of F(1).
+  - reference_id: PMID:12829692
+    supporting_text: Atp11p yields a subfragment of the protein (called Atp11pTRNC) that retains...molecular chaperone function...the natural substrate (F1 beta).
+  - reference_id: file:yeast/ATP11/ATP11-deep-research-falcon.md
+    supporting_text: ATP11 encodes a mitochondrial ATP synthase-specific assembly chaperone for F1 beta subunit Atp2.
+proposed_new_terms: []
+suggested_questions:
+- question: Should experimental GO:0051082 annotations for ATP11 be replaced by GO:0140777 to reflect client-specific stabilization of F1 ATP synthase assembly intermediates?
+suggested_experiments: []
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/yeast/ATP11/ATP11-ai-review.html
+++ b/genes/yeast/ATP11/ATP11-ai-review.html
@@ -1308,7 +1308,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> The F1 ATP synthase assembly role occurs in the matrix.
+                            <strong>Reason:</strong> The F1 ATP synthase assembly role occurs in the matrix; PMID:1532796 detects Atp11 in mitochondria and reports co-purification with F1 alpha and beta subunits, which makes the matrix inference explicit.
                         </div>
 
 
@@ -1326,6 +1326,19 @@
                                 </span>
 
                                 <div class="support-text">Biotinated ATP11 protein can be partially...purified by affinity chromatography</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1532796" target="_blank" class="term-link">
+                                        PMID:1532796
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">biotinated ATP11 protein also contains the alpha and beta subunits of F1-ATPase</div>
 
                             </div>
 
@@ -3002,10 +3015,12 @@ existing_annotations:
   review:
     summary: Direct evidence supports mitochondrial matrix localization.
     action: ACCEPT
-    reason: The F1 ATP synthase assembly role occurs in the matrix.
+    reason: The F1 ATP synthase assembly role occurs in the matrix; PMID:1532796 detects Atp11 in mitochondria and reports co-purification with F1 alpha and beta subunits, which makes the matrix inference explicit.
     supported_by:
     - reference_id: PMID:1532796
       supporting_text: Biotinated ATP11 protein can be partially...purified by affinity chromatography
+    - reference_id: PMID:1532796
+      supporting_text: biotinated ATP11 protein also contains the alpha and beta subunits of F1-ATPase
 - term:
     id: GO:0033615
     label: mitochondrial proton-transporting ATP synthase complex assembly

--- a/genes/yeast/ATP11/ATP11-ai-review.yaml
+++ b/genes/yeast/ATP11/ATP11-ai-review.yaml
@@ -1,11 +1,22 @@
 id: P32453
 gene_symbol: ATP11
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
+aliases:
+- YNL315C
+- ATP synthase mitochondrial F1 complex assembly factor 1
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: 'TODO: Add description for ATP11'
+description: >-
+  ATP11 encodes a mitochondrial matrix assembly factor for the F1 sector of
+  mitochondrial F1FO ATP synthase. Atp11 is not a stoichiometric ATP synthase
+  subunit; it is a dedicated assembly chaperone/stabilizing factor for the
+  unassembled F1 beta subunit Atp2, preventing nonproductive aggregation and
+  promoting formation of the alpha3-beta3 catalytic F1 head. Generic
+  unfolded-protein binding and cross-species protein-binding annotations are less
+  informative than the ATP synthase complex assembly and protein-containing
+  complex stabilizing activity annotations.
 existing_annotations:
 - term:
     id: GO:0005739
@@ -13,144 +24,212 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'Manual review: mitochondrion is consistent with known biology of ATP11.'
+    summary: IBA mitochondrial localization is consistent with direct ATP11 localization.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Atp11 functions in mitochondria, specifically the matrix.
+    supported_by:
+    - reference_id: PMID:1532796
+      supporting_text: vitro import assays of ATP11 precursor and immunochemical evidence indicate that...the protein is located in mitochondria.
+    - reference_id: file:interpro/panther/PTHR13126/PTHR13126-metadata.yaml
+      supporting_text: PTHR13126 is the CHAPERONE ATP11 family.
 - term:
     id: GO:0140777
     label: protein-containing complex stabilizing activity
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'Manual review: protein-containing complex stabilizing activity is consistent with known biology of ATP11.'
+    summary: This is the most specific molecular-function term for Atp11.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Atp11 stabilizes the unassembled F1 beta subunit during ATP synthase assembly.
+    supported_by:
+    - reference_id: PMID:10681564
+      supporting_text: evidence that Atp11p binds selectively to the beta-subunit of F(1).
+    - reference_id: PMID:12829692
+      supporting_text: Atp11p yields a subfragment of the protein (called Atp11pTRNC) that retains...molecular chaperone function...the natural substrate (F1 beta).
+    - reference_id: file:yeast/ATP11/ATP11-deep-research-falcon.md
+      supporting_text: Atp11 binds F1 beta subunit Atp2 to prevent nonproductive self-association.
 - term:
     id: GO:0033615
     label: mitochondrial proton-transporting ATP synthase complex assembly
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'Manual review: mitochondrial proton-transporting ATP synthase complex assembly is consistent with known biology of ATP11.'
+    summary: The IBA process term matches classic ATP11 mutant and biochemical evidence.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: ATP synthase F1 assembly is the central process affected by ATP11.
+    supported_by:
+    - reference_id: PMID:2142305
+      supporting_text: explanation for the mutant phenotype is a block in the assembly of the F1...oligomer.
+    - reference_id: PMID:36596815
+      supporting_text: it cooperates with the assembly...factors Atp11 and Atp12 to form the F1 domain of the ATP synthase.
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'Manual review: mitochondrion is consistent with known biology of ATP11.'
+    summary: Electronic mitochondrion annotation is correct.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Atp11 is a mitochondrial matrix assembly factor.
+    supported_by:
+    - reference_id: PMID:1532796
+      supporting_text: The hybrid protein is detected in mitochondria with antibodies
 - term:
     id: GO:0065003
     label: protein-containing complex assembly
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'Manual review: protein-containing complex assembly is consistent with known biology of ATP11.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: The term is correct but too broad.
+    action: MODIFY
+    reason: Replace with the specific mitochondrial ATP synthase assembly term.
+    proposed_replacement_terms:
+    - id: GO:0033615
+      label: mitochondrial proton-transporting ATP synthase complex assembly
+    supported_by:
+    - reference_id: PMID:2142305
+      supporting_text: important function at a...late stage in the synthesis of F1
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:27107014
   review:
-    summary: 'Manual review: protein binding is too generic or over-extended for ATP11.'
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    summary: This comes from a yeast-human inter-species interaction map and is not a physiological ATP11 function.
+    action: REMOVE
+    reason: The annotation does not identify the endogenous yeast Atp2/F1 beta client and uses an uninformative term.
+    supported_by:
+    - reference_id: PMID:27107014
+      supporting_text: we generated a high-quality proteome-wide inter-interactome network map
 - term:
     id: GO:0005759
     label: mitochondrial matrix
   evidence_type: IDA
   original_reference_id: PMID:1532796
   review:
-    summary: 'Manual review: mitochondrial matrix is consistent with known biology of ATP11.'
+    summary: Direct evidence supports mitochondrial matrix localization.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: The F1 ATP synthase assembly role occurs in the matrix.
+    supported_by:
+    - reference_id: PMID:1532796
+      supporting_text: Biotinated ATP11 protein can be partially...purified by affinity chromatography
 - term:
     id: GO:0033615
     label: mitochondrial proton-transporting ATP synthase complex assembly
   evidence_type: IMP
   original_reference_id: PMID:36596815
   review:
-    summary: 'Manual review: mitochondrial proton-transporting ATP synthase complex assembly is consistent with known biology of ATP11.'
+    summary: Recent work places Atp11 with Atp12 and mtHsp70 in F1 assembly.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: This is the specific ATP synthase assembly process affected by Atp11.
+    supported_by:
+    - reference_id: PMID:36596815
+      supporting_text: it cooperates with the assembly...factors Atp11 and Atp12 to form the F1 domain of the ATP synthase.
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: HDA
   original_reference_id: PMID:24769239
   review:
-    summary: 'Manual review: mitochondrion is consistent with known biology of ATP11.'
+    summary: High-throughput mitochondrial proteomics is consistent with ATP11 biology.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Mitochondrial localization is core to Atp11 function.
+    supported_by:
+    - reference_id: PMID:24769239
+      supporting_text: isolated mitochondria extracted from yeast grown on fermentative...and respiratory...media
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: HDA
   original_reference_id: PMID:16823961
   review:
-    summary: 'Manual review: mitochondrion is consistent with known biology of ATP11.'
+    summary: High-throughput mitochondrial proteome data are consistent with direct localization.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: The broad mitochondrion term is correct.
+    supported_by:
+    - reference_id: PMID:16823961
+      supporting_text: A total of 851 different proteins (PROMITO dataset) were...identified by use of multidimensional LC-MS/MS
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:10681564
   review:
-    summary: 'ATP11 is a dedicated assembly factor for mitochondrial F1-ATPase, not a general chaperone. GO:0051082 overstates the binding as a standalone function.'
-    action: MARK_AS_OVER_ANNOTATED
-    reason: ATP11 functions as a dedicated assembly factor for the F1-ATPase beta subunit, not as a general unfolded protein binding chaperone. The binding interaction is specific to Atp2p assembly and is better captured by the assembly process annotation (GO:0033615).
+    summary: Atp11 binds an unassembled F1 beta subunit, but the generic term is too broad.
+    action: MODIFY
+    reason: Protein-containing complex stabilizing activity better captures client-specific F1 assembly.
+    proposed_replacement_terms:
+    - id: GO:0140777
+      label: protein-containing complex stabilizing activity
+    supported_by:
+    - reference_id: PMID:10681564
+      supporting_text: Atp11p bound to a region of the nucleotide-binding...domain of the beta-subunit
 - term:
     id: GO:0033615
     label: mitochondrial proton-transporting ATP synthase complex assembly
   evidence_type: IPI
   original_reference_id: PMID:10681564
   review:
-    summary: 'Manual review: mitochondrial proton-transporting ATP synthase complex assembly is consistent with known biology of ATP11.'
+    summary: The Atp11-F1 beta interaction directly supports ATP synthase F1 assembly.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: This is the correct process-level interpretation of the Atp11-Atp2 interaction.
+    supported_by:
+    - reference_id: PMID:10681564
+      supporting_text: alpha-subunits may exchange for bound Atp11p...during the process of F(1) assembly.
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IDA
   original_reference_id: PMID:1532796
   review:
-    summary: 'Manual review: mitochondrion is consistent with known biology of ATP11.'
+    summary: Direct evidence places Atp11 in mitochondria.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Mitochondrial localization is required for ATP synthase F1 assembly.
+    supported_by:
+    - reference_id: PMID:1532796
+      supporting_text: vitro import assays of ATP11 precursor and immunochemical evidence indicate that...the protein is located in mitochondria.
 - term:
     id: GO:0007005
     label: mitochondrion organization
   evidence_type: IMP
   original_reference_id: PMID:2142305
   review:
-    summary: 'Manual review: mitochondrion organization may be context-dependent or peripheral for ATP11.'
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    summary: This broad phenotype should be replaced by the specific F1 ATP synthase assembly defect.
+    action: MODIFY
+    reason: ATP11 mutants block F1 assembly, not general mitochondrial organization as a primary function.
+    proposed_replacement_terms:
+    - id: GO:0033615
+      label: mitochondrial proton-transporting ATP synthase complex assembly
+    supported_by:
+    - reference_id: PMID:2142305
+      supporting_text: important function at a...late stage in the synthesis of F1
 - term:
     id: GO:0033615
     label: mitochondrial proton-transporting ATP synthase complex assembly
   evidence_type: IMP
   original_reference_id: PMID:2142305
   review:
-    summary: 'Manual review: mitochondrial proton-transporting ATP synthase complex assembly is consistent with known biology of ATP11.'
+    summary: Classic genetic evidence directly supports ATP synthase assembly.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: ATP11 was identified as required for assembly of yeast F1-ATPase.
+    supported_by:
+    - reference_id: PMID:2142305
+      supporting_text: explanation for the mutant phenotype is a block in the assembly of the F1...oligomer.
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:12829692
   review:
-    summary: 'ATP11 is a dedicated assembly factor for mitochondrial F1-ATPase, not a general chaperone. GO:0051082 overstates the binding as a standalone function.'
-    action: MARK_AS_OVER_ANNOTATED
-    reason: ATP11 functions as a dedicated assembly factor for the F1-ATPase beta subunit, not as a general unfolded protein binding chaperone. The binding interaction is specific to Atp2p assembly and is better captured by the assembly process annotation (GO:0033615).
+    summary: Atp11 has chaperone activity toward F1 beta, but the term is too generic.
+    action: MODIFY
+    reason: GO:0140777 better represents stabilization of an ATP synthase assembly intermediate.
+    proposed_replacement_terms:
+    - id: GO:0140777
+      label: protein-containing complex stabilizing activity
+    supported_by:
+    - reference_id: PMID:12829692
+      supporting_text: Atp11p yields a subfragment of the protein (called Atp11pTRNC) that retains...molecular chaperone function...the natural substrate (F1 beta).
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -161,20 +240,28 @@ references:
 - id: GO_REF:0000120
   title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
-- id: PMID:10681564
-  title: The assembly factor Atp11p binds to the beta-subunit of the mitochondrial F(1)-ATPase.
-  findings: []
-- id: PMID:12829692
-  title: A purified subfragment of yeast Atp11p retains full molecular chaperone activity.
-  findings: []
 - id: PMID:1532796
   title: Characterization of ATP11 and detection of the encoded protein in mitochondria of Saccharomyces cerevisiae.
-  findings: []
-- id: PMID:16823961
-  title: 'Toward the complete yeast mitochondrial proteome: multidimensional separation techniques for mitochondrial proteomics.'
-  findings: []
+  findings:
+  - statement: ATP11 protein is mitochondrial
+    supporting_text: In vitro import assays and immunochemical evidence indicate mitochondrial localization.
 - id: PMID:2142305
   title: Identification of two nuclear genes (ATP11, ATP12) required for assembly of the yeast F1-ATPase.
+  findings:
+  - statement: ATP11 is required for F1 ATPase assembly
+    supporting_text: Mutations in ATP11 and ATP12 block a late step in F1 assembly.
+- id: PMID:10681564
+  title: The assembly factor Atp11p binds to the beta-subunit of the mitochondrial F(1)-ATPase.
+  findings:
+  - statement: Atp11 binds the F1 beta subunit during assembly
+    supporting_text: Atp11p binds selectively to the beta-subunit of F1.
+- id: PMID:12829692
+  title: A purified subfragment of yeast Atp11p retains full molecular chaperone activity.
+  findings:
+  - statement: Atp11 has chaperone activity with F1 beta as its natural substrate
+    supporting_text: Atp11pTRNC retains molecular chaperone function with the natural substrate F1 beta.
+- id: PMID:16823961
+  title: 'Toward the complete yeast mitochondrial proteome: multidimensional separation techniques for mitochondrial proteomics.'
   findings: []
 - id: PMID:24769239
   title: Quantitative variations of the mitochondrial proteome and phosphoproteome during fermentative and respiratory growth in Saccharomyces cerevisiae.
@@ -184,4 +271,44 @@ references:
   findings: []
 - id: PMID:36596815
   title: The mitochondrial Hsp70 controls the assembly of the F(1)F(O)-ATP synthase.
-  findings: []
+  findings:
+  - statement: mtHsp70 cooperates with Atp11 and Atp12 in F1 assembly
+    supporting_text: Mitochondrial Hsp70 cooperates with the assembly factors Atp11 and Atp12 to form the F1 domain.
+- id: file:yeast/ATP11/ATP11-deep-research-falcon.md
+  title: Falcon deep research report for ATP11
+  findings:
+  - statement: ATP11 is a mitochondrial F1 ATP synthase assembly chaperone
+    supporting_text: Atp11 binds F1 beta subunit Atp2 and promotes formation of the F1 catalytic head.
+- id: file:interpro/panther/PTHR13126/PTHR13126-metadata.yaml
+  title: PANTHER family metadata for ATP11 family PTHR13126
+  findings:
+  - statement: PTHR13126 is the ATP11 chaperone family
+    supporting_text: The local PANTHER metadata identifies PTHR13126 as CHAPERONE ATP11.
+core_functions:
+- description: >-
+    Dedicated mitochondrial F1 ATP synthase assembly chaperone/stabilizing
+    activity. Atp11 binds unassembled F1 beta subunit Atp2 in the mitochondrial
+    matrix, preventing nonproductive aggregation and promoting assembly of the
+    alpha3-beta3 F1 catalytic head.
+  molecular_function:
+    id: GO:0140777
+    label: protein-containing complex stabilizing activity
+  directly_involved_in:
+  - id: GO:0033615
+    label: mitochondrial proton-transporting ATP synthase complex assembly
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  - id: GO:0005739
+    label: mitochondrion
+  supported_by:
+  - reference_id: PMID:10681564
+    supporting_text: evidence that Atp11p binds selectively to the beta-subunit of F(1).
+  - reference_id: PMID:12829692
+    supporting_text: Atp11p yields a subfragment of the protein (called Atp11pTRNC) that retains...molecular chaperone function...the natural substrate (F1 beta).
+  - reference_id: file:yeast/ATP11/ATP11-deep-research-falcon.md
+    supporting_text: ATP11 encodes a mitochondrial ATP synthase-specific assembly chaperone for F1 beta subunit Atp2.
+proposed_new_terms: []
+suggested_questions:
+- question: Should experimental GO:0051082 annotations for ATP11 be replaced by GO:0140777 to reflect client-specific stabilization of F1 ATP synthase assembly intermediates?
+suggested_experiments: []

--- a/genes/yeast/ATP11/ATP11-ai-review.yaml
+++ b/genes/yeast/ATP11/ATP11-ai-review.yaml
@@ -109,10 +109,12 @@ existing_annotations:
   review:
     summary: Direct evidence supports mitochondrial matrix localization.
     action: ACCEPT
-    reason: The F1 ATP synthase assembly role occurs in the matrix.
+    reason: The F1 ATP synthase assembly role occurs in the matrix; PMID:1532796 detects Atp11 in mitochondria and reports co-purification with F1 alpha and beta subunits, which makes the matrix inference explicit.
     supported_by:
     - reference_id: PMID:1532796
       supporting_text: Biotinated ATP11 protein can be partially...purified by affinity chromatography
+    - reference_id: PMID:1532796
+      supporting_text: biotinated ATP11 protein also contains the alpha and beta subunits of F1-ATPase
 - term:
     id: GO:0033615
     label: mitochondrial proton-transporting ATP synthase complex assembly

--- a/genes/yeast/ATP11/ATP11-deep-research-falcon.md
+++ b/genes/yeast/ATP11/ATP11-deep-research-falcon.md
@@ -1,0 +1,333 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-04T10:45:28.740458'
+end_time: '2026-05-04T10:57:35.549715'
+duration_seconds: 726.81
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: yeast
+  gene_id: ATP11
+  gene_symbol: ATP11
+  uniprot_accession: P32453
+  protein_description: 'RecName: Full=Protein ATP11, mitochondrial; Flags: Precursor;'
+  gene_info: Name=ATP11; OrderedLocusNames=YNL315C; ORFNames=N0357;
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+  protein_family: Belongs to the ATP11 family. .
+  protein_domains: ATP11. (IPR010591); ATP11 (PF06644)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 31
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P32453
+- **Protein Description:** RecName: Full=Protein ATP11, mitochondrial; Flags: Precursor;
+- **Gene Information:** Name=ATP11; OrderedLocusNames=YNL315C; ORFNames=N0357;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the ATP11 family. .
+- **Key Domains:** ATP11. (IPR010591); ATP11 (PF06644)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "ATP11" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'ATP11' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **ATP11** (gene ID: ATP11, UniProt: P32453) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P32453
+- **Protein Description:** RecName: Full=Protein ATP11, mitochondrial; Flags: Precursor;
+- **Gene Information:** Name=ATP11; OrderedLocusNames=YNL315C; ORFNames=N0357;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the ATP11 family. .
+- **Key Domains:** ATP11. (IPR010591); ATP11 (PF06644)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "ATP11" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'ATP11' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **ATP11** (gene ID: ATP11, UniProt: P32453) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research report: **ATP11 (YNL315C; UniProt P32453) in *Saccharomyces cerevisiae***
+
+### Executive summary
+ATP11 (YNL315C; UniProt P32453) encodes Atp11p, a **mitochondrial-matrix, ATP-synthase–specific assembly chaperone** that binds the **F1 β subunit (Atp2)** to prevent its nonproductive self-association and to promote formation of the **F1 catalytic head (α3β3 hexamer)** of mitochondrial F1FO-ATP synthase (Complex V). Atp11p is **not** a stoichiometric subunit of the mature enzyme but is required for efficient respiratory growth and correct mitochondrial ultrastructure; loss of ATP11 leads to **α/β inclusion bodies** in the matrix and impaired oxidative phosphorylation. Newer work (2023) adds mitochondrial Hsp70 as a cooperating factor with Atp11/Atp12 in F1 assembly and quality control. (franco2020modularassemblyof pages 7-10, hinton2003apurifiedsubfragment pages 1-2, lefebvrelegendre2005failuretoassemble pages 1-2, ludlam2009chaperonesoff1atpase pages 1-2, song2023themitochondrialhsp70 pages 1-2)
+
+---
+
+### 1) Key concepts and definitions (current understanding)
+
+#### 1.1 What “ATP11” means in yeast (identity verification)
+In *S. cerevisiae*, **ATP11 (YNL315C)** encodes Atp11p, a dedicated chaperone/assembly factor required for biogenesis of the **F1 sector** of mitochondrial ATP synthase. Its function is specific to ATP synthase assembly rather than broad protein import/folding, and it acts on unassembled F1 subunits in the matrix. (potocka2007assemblyfactorsin pages 17-21, franco2020modularassemblyof pages 7-10)
+
+#### 1.2 ATP synthase (Complex V) biogenesis and where ATP11 fits
+Mitochondrial F1FO-ATP synthase is built from modular subassemblies. The **F1 module** (soluble catalytic head in the matrix) contains an **α3β3 hexamer** with the catalytic and noncatalytic nucleotide-binding interfaces. Dedicated assembly chaperones **Atp11 and Atp12** bind newly imported F1 subunits to prevent aggregation and ensure productive oligomerization before integration with the stalk and FO membrane sector. (franco2020modularassemblyof pages 7-10, song2018assemblingthemitochondrial pages 1-2)
+
+#### 1.3 Assembly chaperone vs. enzyme: “substrate specificity” for ATP11
+Atp11p is **not an enzyme with a chemical substrate**; its “substrate specificity” is **client-protein specificity**. The key client is the **F1 β subunit**, which Atp11p binds transiently during assembly. This binding prevents β from forming nonproductive complexes and promotes correct αβ interactions leading to the `(αβ)3` hexamer. (hinton2003apurifiedsubfragment pages 1-2, ludlam2009chaperonesoff1atpase pages 1-2)
+
+---
+
+### 2) Molecular function, mechanism, and pathway placement (evidence-based)
+
+#### 2.1 Molecular function: a β-subunit assembly chaperone
+Multiple experimental approaches support a direct Atp11p–β interaction: affinity tag pull-down and yeast two-hybrid assays showed Atp11p binds free/unassembled F1 β, and mechanistic interpretation is that Atp11p binding **shields aggregation-prone surfaces** to prevent β–β self-association and to facilitate productive formation of the `(αβ)3` hexamer. (hinton2003apurifiedsubfragment pages 1-2, potocka2007assemblyfactorsin pages 17-21)
+
+A structured chaperone-active truncation (removal of 67 N-terminal residues) retains chaperone activity in vitro (e.g., suppressing aggregation of reduced insulin B chain) and retains interaction with the natural F1 β client, indicating that a large portion of Atp11p’s functional chaperone surface resides outside the N-terminus. (hinton2003apurifiedsubfragment pages 1-2)
+
+#### 2.2 Binding interface and mechanistic models for chaperone release
+Review synthesis and interaction mapping indicate Atp11p and Atp12p bind ~200-residue regions within nucleotide-binding domains of β and α, respectively, consistent with a model in which these assembly factors prevent premature α–β interface formation until appropriate assembly progression. (potocka2007assemblyfactorsin pages 17-21)
+
+Earlier mechanistic models posited that the chaperones might resemble α/β; however, structural studies argue Atp11p/Atp12p do **not** mimic α or β. Instead, assembly progression involves **release of the chaperones triggered by association of the γ subunit** (central stalk), enabling maturation of the F1 hexamer. (ludlam2009chaperonesoff1atpase pages 1-2)
+
+#### 2.3 Pathway placement relative to general mitochondrial folding systems (Hsp60/Hsp70)
+Atp11p is described as acting **downstream of general chaperones** (e.g., Hsp60/Hsp70) because atp11 mutants accumulate near-mature α and β subunits (processed/imported) but fail to assemble them, leading to aggregation rather than precursor accumulation—contrasting with general folding/import defects. (potocka2007assemblyfactorsin pages 17-21, franco2020modularassemblyof pages 7-10)
+
+---
+
+### 3) Subcellular localization and where the function occurs
+Atp11p functions in the **mitochondrial matrix**, where the F1 catalytic head is assembled and where unassembled α and β subunits can otherwise aggregate. Mitochondrial targeting is supported by the use of leader peptides in constructs and by the matrix-localized phenotypes (matrix inclusion bodies). (hinton2003apurifiedsubfragment pages 1-2, ludlam2009chaperonesoff1atpase pages 3-4, lefebvrelegendre2005failuretoassemble pages 1-2)
+
+---
+
+### 4) Phenotypes, statistics, and quantitative data from experimental studies
+
+#### 4.1 Respiratory growth phenotypes
+Loss of ATP11 impairs oxidative phosphorylation capacity and growth on nonfermentable carbon sources; in comparative phenotyping, **atp11Δ can display a “leaky” respiratory phenotype**, whereas **atp12Δ can be fully defective** on ethanol/glycerol (EG) medium under tested conditions. (ludlam2009chaperonesoff1atpase pages 3-4)
+
+#### 4.2 Inclusion bodies and mitochondrial ultrastructure (quantitative EM)
+A key experimental signature of ATP11 loss is formation of **electron-dense mitochondrial inclusion bodies** enriched in F1 α/β proteins. In quantitative ultrastructural analysis, **Δatp11** displayed inclusion bodies in **44.0% of cell sections** and **23.5% of mitochondrial profiles**, consistent with a strong block in α3β3 subcomplex assembly. (lefebvrelegendre2005failuretoassemble pages 1-2, lefebvrelegendre2005failuretoassemble media b3ecdee8)
+
+These inclusion bodies are supported by EM and immunolabeling evidence and correlate with mitochondrial structural defects (including cristae abnormalities) when F1 assembly fails. (lefebvrelegendre2005failuretoassemble pages 1-2, lefebvrelegendre2005failuretoassemble media 33a6c4d5, lefebvrelegendre2005failuretoassemble media 5e421669)
+
+---
+
+### 5) Recent developments and latest research (prioritizing 2023–2024)
+
+#### 5.1 2023: mtHsp70 cooperates with Atp11/Atp12 and adds quality control
+A 2023 *Nature Communications* study identified a dual role for **mitochondrial Hsp70 (mtHsp70)** in ATP synthase biogenesis: it (i) **cooperates with Atp11 and Atp12 to form the F1 domain**, and (ii) transfers Atp5/OSCP into the assembly line to connect the catalytic head to the peripheral stalk. Importantly, mtHsp70 inactivation permits incorporation of assembly-defective Atp5 variants into mature complexes, implying a **quality-control checkpoint** during ATP synthase assembly. (song2023themitochondrialhsp70 pages 1-2)
+
+This reframes ATP11 action as part of a broader chaperone network: a specialized, client-specific assembly chaperone (Atp11) works alongside a general mitochondrial chaperone (mtHsp70) to coordinate formation and linkage of the F1 head. (song2023themitochondrialhsp70 pages 1-2)
+
+#### 5.2 2024: cross-species/clinical synthesis of ATP11 homolog ATPAF1
+A 2024 systematic review of isolated ATP synthase defects explicitly identifies **ATPAF1 as the human homolog of yeast ATP11**, describing it as conserved and required for α3β3 hexamer formation. In the compiled variant landscape for isolated ATP synthase deficiency (total variants **n = 63**), ~**60% (38/63)** are nuclear-encoded; ATPAF1 is listed with **0** reported pathogenic variants in that review’s assembly-factor table, while other assembly factors (e.g., TMEM70) account for many cases. (tauchmannova2024variabilityofclinical pages 3-5)
+
+While this is not a yeast functional discovery per se, it underscores ATP11’s mechanistic importance and conservation, and it motivates yeast ATP11 studies as models for fundamental assembly biology relevant to mitochondrial disease mechanisms. (tauchmannova2024variabilityofclinical pages 3-5, tauchmannova2024variabilityofclinical pages 1-3)
+
+---
+
+### 6) Current applications and real-world implementations
+
+#### 6.1 Yeast ATP11 as a mechanistic model system
+ATP11 is widely used as a **genetic and biochemical handle** to:
+- induce specific blocks in F1 assembly (yielding clean assembly intermediates/inclusion bodies),
+- study the coupling of chaperone systems to respiratory complex biogenesis,
+- and test cross-species complementation or structure–function relationships of ATP11-family proteins.
+
+For example, structural/functional work showed that **C. glabrata Atp11p** can complement *S. cerevisiae* atp11Δ respiratory defects, supporting conserved chaperone function and enabling structure-informed mutational analysis. (ludlam2009chaperonesoff1atpase pages 3-4, ludlam2009chaperonesoff1atpase pages 4-5)
+
+#### 6.2 Structural biology of assembly factors
+Atp11-family proteins have been purified and structurally characterized to inform mechanistic models of client binding and chaperone release during F1 assembly. Structural mapping also highlighted specific residues whose mutation inactivates Atp11p function, supporting a surface-mediated chaperone mechanism rather than catalytic chemistry. (ludlam2009chaperonesoff1atpase pages 4-5)
+
+---
+
+### 7) Expert opinions and analysis (authoritative syntheses)
+
+#### 7.1 Consensus view
+Across reviews and primary literature, the consensus is that ATP11 encodes a **specialized assembly chaperone** for mitochondrial ATP synthase that:
+- binds β (Atp2),
+- prevents α/β aggregation,
+- promotes `(αβ)3` hexamer formation,
+- and is released during later assembly steps (γ involvement),
+while general chaperones (Hsp60/Hsp70) support upstream folding/import. (franco2020modularassemblyof pages 7-10, ludlam2009chaperonesoff1atpase pages 1-2, song2018assemblingthemitochondrial pages 1-2)
+
+#### 7.2 Conservation across genomes
+Comparative-genomics analyses support conservation of Atp11p/Atp12p function across eukaryotes capable of oxidative phosphorylation, consistent with a conserved need to protect α/β subunits during assembly. (pickova2005assemblyfactorsof pages 1-2)
+
+---
+
+### Evidence map (table)
+
+| Claim/Topic | Key evidence/data | System/assay | Primary source |
+|---|---|---|---|
+| Molecular function | ATP11/YNL315C encodes Atp11p, a dedicated mitochondrial F1-ATPase assembly chaperone rather than a stoichiometric ATP synthase subunit; it prevents nonproductive self-association/aggregation of unassembled F1 subunits and promotes formation of the catalytic `(αβ)3` hexamer (franco2020modularassemblyof pages 7-10, hinton2003apurifiedsubfragment pages 1-2, ludlam2009chaperonesoff1atpase pages 1-2) | Yeast genetics, biochemical assembly analysis, in vitro chaperone assays | Hinton et al. 2003, *J Biol Chem* (2003-09), https://doi.org/10.1074/jbc.M305353200; Ludlam et al. 2009, *J Biol Chem* (2009-06), https://doi.org/10.1074/jbc.M109.002568 |
+| Localization | Atp11p is a soluble mitochondrial matrix protein/assembly factor acting on the matrix-exposed F1 sector during ATP synthase biogenesis; it is imported with a mitochondrial targeting sequence and is not part of the final holoenzyme (hinton2003apurifiedsubfragment pages 1-2, ludlam2009chaperonesoff1atpase pages 3-4, song2018assemblingthemitochondrial pages 1-2) | Mitochondrial targeting constructs, mitochondrial biochemical studies, review synthesis | Hinton et al. 2003, *J Biol Chem* (2003-09), https://doi.org/10.1074/jbc.M305353200; Ludlam et al. 2009, *J Biol Chem* (2009-06), https://doi.org/10.1074/jbc.M109.002568; Song et al. 2018, *PNAS* (2018-03), https://doi.org/10.1073/pnas.1801697115 |
+| Binding partner/client specificity | Atp11p specifically binds the F1 β subunit (Atp2), whereas Atp12p binds F1 α (Atp1); interaction evidence comes from affinity pull-down/coprecipitation and yeast two-hybrid studies, and binding maps to regions in the nucleotide-binding domain of β (potocka2007assemblyfactorsin pages 17-21, hinton2003apurifiedsubfragment pages 1-2, ludlam2009chaperonesoff1atpase pages 1-2) | Affinity-tag pull-down, co-precipitation, yeast two-hybrid, interaction mapping | Hinton et al. 2003, *J Biol Chem* (2003-09), https://doi.org/10.1074/jbc.M305353200; Ludlam et al. 2009, *J Biol Chem* (2009-06), https://doi.org/10.1074/jbc.M109.002568 |
+| Mutant phenotype | `atp11Δ` mutants are respiratory deficient or strongly impaired for growth on nonfermentable carbon sources; α and β subunits accumulate as large insoluble aggregates/inclusion bodies in the mitochondrial matrix instead of assembling into F1, with reduced ATPase/oxidative phosphorylation capacity (potocka2007assemblyfactorsin pages 17-21, lefebvrelegendre2005failuretoassemble pages 1-2, ludlam2009chaperonesoff1atpase pages 1-2, lefebvrelegendre2001identificationofa pages 6-7) | Yeast gene deletion, respiratory growth assays, mitochondrial fractionation, EM | Lefebvre-Legendre et al. 2005, *J Biol Chem* (2005-05), https://doi.org/10.1074/jbc.M410789200; Lefebvre-Legendre et al. 2001, *J Biol Chem* (2001-03), https://doi.org/10.1074/jbc.M009557200 |
+| Quantitative phenotype/statistics | Electron microscopy quantified inclusion bodies in `Δatp11`: 44.0% of cell sections and 23.5% of mitochondrial profiles contained inclusion bodies, supporting a severe block in α3β3 subcomplex assembly (lefebvrelegendre2005failuretoassemble pages 1-2, lefebvrelegendre2005failuretoassemble media b3ecdee8) | Electron microscopy, immunogold labeling, quantitative ultrastructural scoring | Lefebvre-Legendre et al. 2005, *J Biol Chem* (2005-05), https://doi.org/10.1074/jbc.M410789200 |
+| Mechanistic model | Atp11p and Atp12p protect β and α, respectively, from premature α-β contacts; early models proposed they occupy catalytic/noncatalytic interface regions, while later structural work argued the chaperones do not mimic α/β and that F1 γ-subunit association helps trigger chaperone release during hexamer assembly (franco2020modularassemblyof pages 7-10, ludlam2009chaperonesoff1atpase pages 1-2, song2018assemblingthemitochondrial pages 1-2) | Structural biology, interaction assays, mechanistic modeling, review synthesis | Ludlam et al. 2009, *J Biol Chem* (2009-06), https://doi.org/10.1074/jbc.M109.002568; Song et al. 2018, *PNAS* (2018-03), https://doi.org/10.1073/pnas.1801697115; Franco et al. 2020, *Biological Chemistry* (2020-05), https://doi.org/10.1515/hsz-2020-0112 |
+| Relationship to broader ATP synthase pathway | F1 assembly depends on upstream folding assistance and downstream incorporation into modular ATP synthase assembly; Hsp60 assists β folding before Atp11 action, and properly assembled F1 is coupled to later steps in ATP synthase biogenesis and translational feedback on mitochondrially encoded subunits (franco2020modularassemblyof pages 7-10, song2018assemblingthemitochondrial pages 1-2) | Review synthesis of genetic/biochemical pathway studies | Franco et al. 2020, *Biological Chemistry* (2020-05), https://doi.org/10.1515/hsz-2020-0112; Song et al. 2018, *PNAS* (2018-03), https://doi.org/10.1073/pnas.1801697115 |
+| Recent 2023 developments | A 2023 study added mtHsp70 as an active participant in ATP synthase biogenesis: mtHsp70 cooperates with Atp11/Atp12 in F1 assembly, transfers Atp5/OSCP into the assembly line, and exerts quality control by preventing defective Atp5 variants from being inappropriately incorporated into mature complexes (song2023themitochondrialhsp70 pages 1-2) | Yeast proteomics, pull-downs, mutant analysis, assembly-state profiling | Song et al. 2023, *Nature Communications* (2023-01), https://doi.org/10.1038/s41467-022-35720-5 |
+| Expert/current understanding | Recent authoritative reviews continue to define ATP11 as a conserved F1 assembly factor/chaperone (human ortholog ATPAF1), with core function centered on β-subunit handling during ATP synthase biogenesis; direct 2023-2024 ATP11-specific yeast primary studies remain limited, so new insight comes mainly from broader assembly-network work rather than redefinition of ATP11’s core role (franco2020modularassemblyof pages 7-10, song2023themitochondrialhsp70 pages 1-2) | Review analysis and recent mechanistic study | Franco et al. 2020, *Biological Chemistry* (2020-05), https://doi.org/10.1515/hsz-2020-0112; Song et al. 2023, *Nature Communications* (2023-01), https://doi.org/10.1038/s41467-022-35720-5 |
+
+
+*Table: This table summarizes the main experimentally supported findings for Saccharomyces cerevisiae ATP11/YNL315C, including function, localization, binding specificity, mutant phenotypes, mechanistic models, and recent 2023 developments. It is useful as a compact evidence map linking each major claim to the assay type and primary literature source.*
+
+---
+
+### URLs and publication dates (key sources used)
+- Hinton A, Zuiderweg ERP, Ackerman SH. **2003-09**. *J Biol Chem*. “A Purified Subfragment of Yeast Atp11p Retains Full Molecular Chaperone Activity.” https://doi.org/10.1074/jbc.M305353200 (hinton2003apurifiedsubfragment pages 1-2)
+- Lefebvre-Legendre L et al. **2005-05**. *J Biol Chem*. “Failure to Assemble the α3β3 Subcomplex…” https://doi.org/10.1074/jbc.M410789200 (lefebvrelegendre2005failuretoassemble pages 1-2)
+- Ludlam A et al. **2009-06**. *J Biol Chem*. “Chaperones of F1-ATPase.” https://doi.org/10.1074/jbc.M109.002568 (ludlam2009chaperonesoff1atpase pages 1-2)
+- Song J, Pfanner N, Becker T. **2018-03**. *PNAS*. “Assembling the mitochondrial ATP synthase.” https://doi.org/10.1073/pnas.1801697115 (song2018assemblingthemitochondrial pages 1-2)
+- Franco LVR, Su CH, Tzagoloff A. **2020-05**. *Biological Chemistry*. “Modular assembly of yeast mitochondrial ATP synthase…” https://doi.org/10.1515/hsz-2020-0112 (franco2020modularassemblyof pages 7-10)
+- Song J et al. **2023-01**. *Nature Communications*. “The mitochondrial Hsp70 controls the assembly of the F1FO-ATP synthase.” https://doi.org/10.1038/s41467-022-35720-5 (song2023themitochondrialhsp70 pages 1-2)
+- Tauchmannová K et al. **2024-08**. *Physiological Research*. “Variability of Clinical Phenotypes Caused by Isolated Defects of Mitochondrial ATP Synthase.” https://doi.org/10.33549/physiolres.935407 (tauchmannova2024variabilityofclinical pages 3-5)
+
+---
+
+### Limitations / evidence gaps
+Direct ATP11-focused yeast primary studies in 2023–2024 are limited in the retrieved corpus; the newest mechanistic advance relevant to ATP11 here is primarily the integration of Atp11/Atp12 into an mtHsp70-mediated assembly and quality-control framework. (song2023themitochondrialhsp70 pages 1-2)
+
+References
+
+1. (franco2020modularassemblyof pages 7-10): Leticia Veloso Ribeiro Franco, Chen Hsien Su, and Alexander Tzagoloff. Modular assembly of yeast mitochondrial atp synthase and cytochrome oxidase. Biological Chemistry, 401:835-853, May 2020. URL: https://doi.org/10.1515/hsz-2020-0112, doi:10.1515/hsz-2020-0112. This article has 35 citations and is from a peer-reviewed journal.
+
+2. (hinton2003apurifiedsubfragment pages 1-2): Ayana Hinton, Erik R.P. Zuiderweg, and Sharon H. Ackerman. A purified subfragment of yeast atp11p retains full molecular chaperone activity*. Journal of Biological Chemistry, 278:34110-34113, Sep 2003. URL: https://doi.org/10.1074/jbc.m305353200, doi:10.1074/jbc.m305353200. This article has 10 citations and is from a domain leading peer-reviewed journal.
+
+3. (lefebvrelegendre2005failuretoassemble pages 1-2): Linnka Lefebvre-Legendre, Bénédicte Salin, Jacques Schaëffer, Daniel Brèthes, Alain Dautant, Sharon H. Ackerman, and Jean-Paul di Rago. Failure to assemble the α3 β3 subcomplex of the atp synthase leads to accumulation of the α and β subunits within inclusion bodies and the loss of mitochondrial cristae in saccharomyces cerevisiae*. Journal of Biological Chemistry, 280:18386-18392, May 2005. URL: https://doi.org/10.1074/jbc.m410789200, doi:10.1074/jbc.m410789200. This article has 83 citations and is from a domain leading peer-reviewed journal.
+
+4. (ludlam2009chaperonesoff1atpase pages 1-2): Anthony Ludlam, Joseph Brunzelle, Thomas Pribyl, Xingjue Xu, Domenico L. Gatti, and Sharon H. Ackerman. Chaperones of f1-atpase. Journal of Biological Chemistry, 284:17138-17146, Jun 2009. URL: https://doi.org/10.1074/jbc.m109.002568, doi:10.1074/jbc.m109.002568. This article has 40 citations and is from a domain leading peer-reviewed journal.
+
+5. (song2023themitochondrialhsp70 pages 1-2): Jiyao Song, Liesa Steidle, Isabelle Steymans, Jasjot Singh, Anne Sanner, Lena Böttinger, Dominic Winter, and Thomas Becker. The mitochondrial hsp70 controls the assembly of the f1fo-atp synthase. Nature Communications, Jan 2023. URL: https://doi.org/10.1038/s41467-022-35720-5, doi:10.1038/s41467-022-35720-5. This article has 26 citations and is from a highest quality peer-reviewed journal.
+
+6. (potocka2007assemblyfactorsin pages 17-21): A Potocká. Assembly factors in the biogenesis of mitochondrial atp synthase. Unknown journal, 2007.
+
+7. (song2018assemblingthemitochondrial pages 1-2): Jiyao Song, Nikolaus Pfanner, and Thomas Becker. Assembling the mitochondrial atp synthase. Proceedings of the National Academy of Sciences, 115:2850-2852, Mar 2018. URL: https://doi.org/10.1073/pnas.1801697115, doi:10.1073/pnas.1801697115. This article has 84 citations and is from a highest quality peer-reviewed journal.
+
+8. (ludlam2009chaperonesoff1atpase pages 3-4): Anthony Ludlam, Joseph Brunzelle, Thomas Pribyl, Xingjue Xu, Domenico L. Gatti, and Sharon H. Ackerman. Chaperones of f1-atpase. Journal of Biological Chemistry, 284:17138-17146, Jun 2009. URL: https://doi.org/10.1074/jbc.m109.002568, doi:10.1074/jbc.m109.002568. This article has 40 citations and is from a domain leading peer-reviewed journal.
+
+9. (lefebvrelegendre2005failuretoassemble media b3ecdee8): Linnka Lefebvre-Legendre, Bénédicte Salin, Jacques Schaëffer, Daniel Brèthes, Alain Dautant, Sharon H. Ackerman, and Jean-Paul di Rago. Failure to assemble the α3 β3 subcomplex of the atp synthase leads to accumulation of the α and β subunits within inclusion bodies and the loss of mitochondrial cristae in saccharomyces cerevisiae*. Journal of Biological Chemistry, 280:18386-18392, May 2005. URL: https://doi.org/10.1074/jbc.m410789200, doi:10.1074/jbc.m410789200. This article has 83 citations and is from a domain leading peer-reviewed journal.
+
+10. (lefebvrelegendre2005failuretoassemble media 33a6c4d5): Linnka Lefebvre-Legendre, Bénédicte Salin, Jacques Schaëffer, Daniel Brèthes, Alain Dautant, Sharon H. Ackerman, and Jean-Paul di Rago. Failure to assemble the α3 β3 subcomplex of the atp synthase leads to accumulation of the α and β subunits within inclusion bodies and the loss of mitochondrial cristae in saccharomyces cerevisiae*. Journal of Biological Chemistry, 280:18386-18392, May 2005. URL: https://doi.org/10.1074/jbc.m410789200, doi:10.1074/jbc.m410789200. This article has 83 citations and is from a domain leading peer-reviewed journal.
+
+11. (lefebvrelegendre2005failuretoassemble media 5e421669): Linnka Lefebvre-Legendre, Bénédicte Salin, Jacques Schaëffer, Daniel Brèthes, Alain Dautant, Sharon H. Ackerman, and Jean-Paul di Rago. Failure to assemble the α3 β3 subcomplex of the atp synthase leads to accumulation of the α and β subunits within inclusion bodies and the loss of mitochondrial cristae in saccharomyces cerevisiae*. Journal of Biological Chemistry, 280:18386-18392, May 2005. URL: https://doi.org/10.1074/jbc.m410789200, doi:10.1074/jbc.m410789200. This article has 83 citations and is from a domain leading peer-reviewed journal.
+
+12. (tauchmannova2024variabilityofclinical pages 3-5): K. Tauchmannová, A. Pecinová, J. Houštěk, and T. Mrázek. Variability of clinical phenotypes caused by isolated defects of mitochondrial atp synthase. Physiological Research, pages S243-S278, Aug 2024. URL: https://doi.org/10.33549/physiolres.935407, doi:10.33549/physiolres.935407. This article has 14 citations and is from a peer-reviewed journal.
+
+13. (tauchmannova2024variabilityofclinical pages 1-3): K. Tauchmannová, A. Pecinová, J. Houštěk, and T. Mrázek. Variability of clinical phenotypes caused by isolated defects of mitochondrial atp synthase. Physiological Research, pages S243-S278, Aug 2024. URL: https://doi.org/10.33549/physiolres.935407, doi:10.33549/physiolres.935407. This article has 14 citations and is from a peer-reviewed journal.
+
+14. (ludlam2009chaperonesoff1atpase pages 4-5): Anthony Ludlam, Joseph Brunzelle, Thomas Pribyl, Xingjue Xu, Domenico L. Gatti, and Sharon H. Ackerman. Chaperones of f1-atpase. Journal of Biological Chemistry, 284:17138-17146, Jun 2009. URL: https://doi.org/10.1074/jbc.m109.002568, doi:10.1074/jbc.m109.002568. This article has 40 citations and is from a domain leading peer-reviewed journal.
+
+15. (pickova2005assemblyfactorsof pages 1-2): Andrea Pícková, Martin Potocký, and Josef Houštěk. Assembly factors of f1fo‐atp synthase across genomes. Proteins: Structure, 59:393-402, May 2005. URL: https://doi.org/10.1002/prot.20452, doi:10.1002/prot.20452. This article has 43 citations.
+
+16. (lefebvrelegendre2001identificationofa pages 6-7): Linnka Lefebvre-Legendre, Jacques Vaillier, Houssain Benabdelhak, Jean Velours, Piotr P. Slonimski, and Jean-Paul di Rago. Identification of a nuclear gene (fmc1) required for the assembly/stability of yeast mitochondrial f1-atpase in heat stress conditions*. The Journal of Biological Chemistry, 276:6789-6796, Mar 2001. URL: https://doi.org/10.1074/jbc.m009557200, doi:10.1074/jbc.m009557200. This article has 179 citations.
+
+## Citations
+
+1. hinton2003apurifiedsubfragment pages 1-2
+2. potocka2007assemblyfactorsin pages 17-21
+3. tauchmannova2024variabilityofclinical pages 3-5
+4. pickova2005assemblyfactorsof pages 1-2
+5. lefebvrelegendre2005failuretoassemble pages 1-2
+6. song2018assemblingthemitochondrial pages 1-2
+7. franco2020modularassemblyof pages 7-10
+8. tauchmannova2024variabilityofclinical pages 1-3
+9. lefebvrelegendre2001identificationofa pages 6-7
+10. https://doi.org/10.1074/jbc.M305353200;
+11. https://doi.org/10.1074/jbc.M109.002568
+12. https://doi.org/10.1074/jbc.M109.002568;
+13. https://doi.org/10.1073/pnas.1801697115
+14. https://doi.org/10.1074/jbc.M410789200;
+15. https://doi.org/10.1074/jbc.M009557200
+16. https://doi.org/10.1074/jbc.M410789200
+17. https://doi.org/10.1073/pnas.1801697115;
+18. https://doi.org/10.1515/hsz-2020-0112
+19. https://doi.org/10.1515/hsz-2020-0112;
+20. https://doi.org/10.1038/s41467-022-35720-5
+21. https://doi.org/10.1074/jbc.M305353200
+22. https://doi.org/10.33549/physiolres.935407
+23. https://doi.org/10.1515/hsz-2020-0112,
+24. https://doi.org/10.1074/jbc.m305353200,
+25. https://doi.org/10.1074/jbc.m410789200,
+26. https://doi.org/10.1074/jbc.m109.002568,
+27. https://doi.org/10.1038/s41467-022-35720-5,
+28. https://doi.org/10.1073/pnas.1801697115,
+29. https://doi.org/10.33549/physiolres.935407,
+30. https://doi.org/10.1002/prot.20452,
+31. https://doi.org/10.1074/jbc.m009557200,

--- a/genes/yeast/CCT7/CCT7-ai-review.html
+++ b/genes/yeast/CCT7/CCT7-ai-review.html
@@ -671,33 +671,46 @@
     <div class="header">
         <h1>CCT7</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P42943" target="_blank" class="term-link">
                         P42943
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Saccharomyces cerevisiae</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
+            <div class="info-item">
+                <span class="info-label">Aliases:</span>
+                <div class="aliases">
+
+                    <span class="badge">YJL111W</span>
+
+                    <span class="badge">CCT-eta</span>
+
+                    <span class="badge">TCP-1-eta</span>
+
+                </div>
+            </div>
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,24 +741,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="P42943" data-a="DESCRIPTION: TODO: Add description for CCT7..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="P42943" data-a="DESCRIPTION: CCT7 encodes the eta subunit of the cytosolic chap..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TODO: Add description for CCT7</p>
+        <p>CCT7 encodes the eta subunit of the cytosolic chaperonin-containing T-complex/TRiC. Cct7 is one of eight distinct CCT subunits in each ring of the hetero-oligomeric double-ring chaperonin and contributes ATP binding/hydrolysis and subunit-specific surfaces to the complex-level ATP-dependent protein folding chaperone activity. The mature TRiC/CCT complex folds actin, tubulin, and other cytosolic clients. Therefore, CCT7 should be curated as a core component of the cytosolic CCT complex rather than as a stand-alone generic unfolded protein binding factor.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +771,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,46 +808,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein folding is consistent with known biology of CCT7.
+                            <strong>Summary:</strong> IBA protein folding is consistent with CCT/TRiC chaperonin function.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> CCT7 contributes to the ATP-dependent protein folding activity of the CCT complex.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Yeast CCT catalyses the folding of yeast ACT1p and human beta-actin.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/CCT7/CCT7-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">CCT7 encodes a TRiC/CCT subunit whose primary function is ATP-dependent folding of cytosolic client proteins.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005832" target="_blank" class="term-link">
                                     GO:0005832
                                 </a>
                             </span>
                             <span class="term-label">chaperonin-containing T-complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -846,46 +888,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: chaperonin-containing T-complex is consistent with known biology of CCT7.
+                            <strong>Summary:</strong> Phylogenetic inference is correct; Cct7 is a CCT/TRiC subunit.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Complex membership is central to CCT7 function.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15704212" target="_blank" class="term-link">
+                                        PMID:15704212
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of...which is composed of a stoichiometric array of eight different subunits...Cct1p-Cct8p.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -897,108 +957,153 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT7.
+                            <strong>Summary:</strong> The term is broadly related to chaperonin function but less precise than ATP-dependent protein folding chaperone.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
+                            <strong>Reason:</strong> CCT7 functions through the assembled ATP-dependent chaperonin complex rather than generic unfolded protein binding.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
+                                    ATP-dependent protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">binding pre-equilibrium...followed by a faster ATP-driven processing to...native actin</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000166" target="_blank" class="term-link">
                                     GO:0000166
                                 </a>
                             </span>
                             <span class="term-label">nucleotide binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P42943" data-a="GO:0000166" data-r="GO_REF:0000043" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P42943" data-a="GO:0000166" data-r="GO_REF:0000043" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: nucleotide binding is consistent with known biology of CCT7.
+                            <strong>Summary:</strong> Nucleotide binding is true but overly broad for the CCT ATPase fold.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> ATP binding is the more specific nucleotide-binding annotation already present.
                         </div>
-                        
-                        
-                        
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                                    ATP binding
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/CCT7/CCT7-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TRiC subunits contain equatorial ATP-binding domains and undergo ATP-driven conformational cycling.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
                                     GO:0005524
                                 </a>
                             </span>
                             <span class="term-label">ATP binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1010,46 +1115,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ATP binding is consistent with known biology of CCT7.
+                            <strong>Summary:</strong> ATP binding is consistent with the conserved CCT chaperonin ATPase domain.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> ATP binding is required for the conformational cycle of CCT/TRiC.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/CCT7/CCT7-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ATP binding and hydrolysis drive TRiC open/closed conformational changes.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1061,46 +1182,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cytoplasm is consistent with known biology of CCT7.
+                            <strong>Summary:</strong> Cytoplasmic localization is correct for the CCT/TRiC chaperonin.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> CCT/TRiC is the eukaryotic cytosolic chaperonin.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This purified yeast CCT was used for a novel...quantitative actin-folding assay</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005832" target="_blank" class="term-link">
                                     GO:0005832
                                 </a>
                             </span>
                             <span class="term-label">chaperonin-containing T-complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1112,46 +1251,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: chaperonin-containing T-complex is consistent with known biology of CCT7.
+                            <strong>Summary:</strong> ARBA electronic annotation is consistent with direct complex membership evidence.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> CCT7 is a core subunit of the chaperonin-containing T-complex.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15704212" target="_blank" class="term-link">
+                                        PMID:15704212
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Cct complexes, are assembled into two rings...Cct1p-Cct8p.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1163,46 +1320,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein folding is consistent with known biology of CCT7.
+                            <strong>Summary:</strong> Electronic protein folding annotation is consistent with experimental CCT function.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> CCT7 contributes to complex-level protein folding.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Yeast CCT catalyses the...folding of yeast ACT1p and human beta-actin</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1214,46 +1389,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ATP hydrolysis activity is consistent with known biology of CCT7.
+                            <strong>Summary:</strong> ATP hydrolysis activity is consistent with the conserved CCT chaperonin cycle.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> ATP hydrolysis drives the CCT/TRiC conformational cycle for client folding.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">binding pre-equilibrium...followed by a faster ATP-driven processing to...native actin</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1265,57 +1458,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT7.
+                            <strong>Summary:</strong> Broad unfolded protein binding is less precise than ATP-dependent chaperone activity.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
+                            <strong>Reason:</strong> GO:0140662 better represents the CCT/TRiC complex-level function.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
+                                    ATP-dependent protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">binding pre-equilibrium...followed by a faster ATP-driven processing to...native actin</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
                                     GO:0140662
                                 </a>
                             </span>
                             <span class="term-label">ATP-dependent protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1327,57 +1538,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ATP-dependent protein folding chaperone is consistent with known biology of CCT7.
+                            <strong>Summary:</strong> This is the most informative MF term for the assembled CCT/TRiC machine.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> CCT7 contributes to ATP-dependent protein folding chaperone activity as a complex subunit.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16762366
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Quantitative actin folding reactions using yeast CCT purifie...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1389,57 +1618,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein folding is consistent with known biology of CCT7.
+                            <strong>Summary:</strong> Direct biochemical evidence with purified yeast CCT supports protein folding.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The purified CCT complex catalyzes actin folding in vitro.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Yeast CCT catalyses the folding of yeast ACT1p and human beta-actin with nearly identical rate constants and yields.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11914276" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11914276
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Subcellular localization of the yeast proteome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1451,57 +1698,73 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cytoplasm is consistent with known biology of CCT7.
+                            <strong>Summary:</strong> High-throughput cytoplasmic localization is consistent with CCT/TRiC biology.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> CCT is a cytosolic/cytoplasmic chaperonin complex.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/CCT7/CCT7-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Group II TRiC/CCT is classically described as cytosolic.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005832" target="_blank" class="term-link">
                                     GO:0005832
                                 </a>
                             </span>
                             <span class="term-label">chaperonin-containing T-complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15704212" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15704212
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Physiological effects of unassembled chaperonin Cct subunits...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1513,57 +1776,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: chaperonin-containing T-complex is consistent with known biology of CCT7.
+                            <strong>Summary:</strong> Interaction evidence supports Cct7 as part of the CCT complex.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> CCT7 function depends on the assembled hetero-oligomeric chaperonin.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15704212" target="_blank" class="term-link">
+                                        PMID:15704212
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Cct complexes, are assembled into two rings...Cct1p-Cct8p.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005832" target="_blank" class="term-link">
                                     GO:0005832
                                 </a>
                             </span>
                             <span class="term-label">chaperonin-containing T-complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16762366
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Quantitative actin folding reactions using yeast CCT purifie...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1575,57 +1856,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: chaperonin-containing T-complex is consistent with known biology of CCT7.
+                            <strong>Summary:</strong> Purified yeast CCT complex evidence supports complex membership.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Cct7 is one subunit of the functional yeast CCT/TRiC folding machine.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">An efficient purification...protocol for CCT from Saccharomyces cerevisiae has been developed.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16762366
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Quantitative actin folding reactions using yeast CCT purifie...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1637,204 +1936,750 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT7.
+                            <strong>Summary:</strong> The experiment supports substrate binding during CCT-mediated folding, but the generic term is less specific.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
+                            <strong>Reason:</strong> Replace with ATP-dependent protein folding chaperone to capture the CCT complex mechanism.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
+                                    ATP-dependent protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">controlled CCT-actin folding assay are...consistent with a model where CCT and Ac(I) are in a binding pre-equilibrium...ATP-driven processing to...native actin</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Eta subunit of the cytosolic TRiC/CCT chaperonin complex. Cct7 contributes ATP hydrolysis and subunit-specific structural surfaces to the assembled complex, which folds actin, tubulin, and other cytosolic clients through an ATP-driven conformational cycle.</h3>
+                <span class="vote-buttons" data-g="P42943" data-a="FUNCTION: Eta subunit of the cytosolic TRiC/CCT chaperonin c..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
+                            ATP hydrolysis activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                protein folding
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005832" target="_blank" class="term-link">
+                            chaperonin-containing T-complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                PMID:16762366
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein...folding machine</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15704212" target="_blank" class="term-link">
+                                PMID:15704212
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Cct complexes, are assembled into two rings...Cct1p-Cct8p.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/CCT7/CCT7-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">CCT7 is one of the eight distinct subunits that assemble into the TRiC/CCT chaperonin.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
-                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping</div>
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11914276" target="_blank" class="term-link">
                             PMID:11914276
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Subcellular localization of the yeast proteome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15704212" target="_blank" class="term-link">
                             PMID:15704212
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Physiological effects of unassembled chaperonin Cct subunits in the yeast Saccharomyces cerevisiae.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">CCT is an eight-subunit double-ring chaperonin</div>
+
+                        <div class="finding-text">"Cct complexes are assembled into two rings composed of Cct1p-Cct8p."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
                             PMID:16762366
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Quantitative actin folding reactions using yeast CCT purified via an internal tag in the CCT3/gamma subunit.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Purified yeast CCT catalyzes actin folding</div>
+
+                        <div class="finding-text">"Yeast CCT catalyses folding of yeast ACT1p and human beta-actin."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/CCT7/CCT7-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for CCT7</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">CCT7 is a TRiC/CCT eta subunit contributing to ATP-dependent cytosolic protein folding</div>
+
+                        <div class="finding-text">"The report identifies CCT7 as a core TRiC/CCT subunit in a cytosolic ATP-dependent protein folding machine."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Should CCT subunit annotations to GO:0051082 be replaced by GO:0140662 with contributes_to semantics for individual subunits?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P42943" data-a="Q: Should CCT subunit annotations to GO:0051082 be re..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(CCT7-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P42943" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-04T10:58:34.734959'<br />
+end_time: '2026-05-04T11:16:59.867657'<br />
+duration_seconds: 1105.13<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: yeast<br />
+  gene_id: CCT7<br />
+  gene_symbol: CCT7<br />
+  uniprot_accession: P42943<br />
+  protein_description: 'RecName: Full=T-complex protein 1 subunit eta; Short=TCP-1-eta;<br />
+    AltName: Full=CCT-eta;'<br />
+  gene_info: Name=CCT7; OrderedLocusNames=YJL111W; ORFNames=J0804;<br />
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).<br />
+  protein_family: Belongs to the TCP-1 chaperonin family. .<br />
+  protein_domains: Chap_CCT_eta. (IPR012720); Chaperone_TCP-1. (IPR017998); Chaperonin_TCP-1_CS.<br />
+    (IPR002194); Cpn60/GroEL/TCP-1. (IPR002423); GroEL-like_apical_dom_sf. (IPR027409)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 26</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P42943</li>
+<li><strong>Protein Description:</strong> RecName: Full=T-complex protein 1 subunit eta; Short=TCP-1-eta; AltName: Full=CCT-eta;</li>
+<li><strong>Gene Information:</strong> Name=CCT7; OrderedLocusNames=YJL111W; ORFNames=J0804;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the TCP-1 chaperonin family. .</li>
+<li><strong>Key Domains:</strong> Chap_CCT_eta. (IPR012720); Chaperone_TCP-1. (IPR017998); Chaperonin_TCP-1_CS. (IPR002194); Cpn60/GroEL/TCP-1. (IPR002423); GroEL-like_apical_dom_sf. (IPR027409)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "CCT7" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'CCT7' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>CCT7</strong> (gene ID: CCT7, UniProt: P42943) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P42943</li>
+<li><strong>Protein Description:</strong> RecName: Full=T-complex protein 1 subunit eta; Short=TCP-1-eta; AltName: Full=CCT-eta;</li>
+<li><strong>Gene Information:</strong> Name=CCT7; OrderedLocusNames=YJL111W; ORFNames=J0804;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the TCP-1 chaperonin family. .</li>
+<li><strong>Key Domains:</strong> Chap_CCT_eta. (IPR012720); Chaperone_TCP-1. (IPR017998); Chaperonin_TCP-1_CS. (IPR002194); Cpn60/GroEL/TCP-1. (IPR002423); GroEL-like_apical_dom_sf. (IPR027409)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "CCT7" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'CCT7' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>CCT7</strong> (gene ID: CCT7, UniProt: P42943) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-yeast-cct7-uniprot-p42943-sgd-orf-yjl111wfunctional-annotation">Comprehensive Research Report: Yeast <strong>CCT7</strong> (UniProt <strong>P42943</strong>; SGD ORF <strong>YJL111W</strong>)—Functional Annotation</h1>
+<h2 id="executive-summary">Executive summary</h2>
+<p><strong>CCT7</strong> encodes <strong>T-complex protein 1 subunit eta (Cct7p)</strong>, one of the eight distinct subunits (CCT1–CCT8) that assemble into the <strong>eukaryotic group II chaperonin TRiC/CCT</strong>. In budding yeast, Cct7p’s primary function is <strong>ATP-dependent folding of cytosolic client proteins</strong> as part of this ~1 MDa, double-ring (16-subunit) machine. Experimental genetics demonstrate that <strong>CCT7 is essential for viability</strong>, and perturbation of its conserved ATP-binding pocket causes <strong>growth defects and proteostasis collapse (protein aggregation)</strong> and alters stress responses, consistent with impaired chaperonin activity. Recent (2023–2024) cryo-EM and biochemical studies (primarily in mammalian systems but mechanistically conserved) refine how TRiC cycles through open/closed states to fold obligate substrates (actin/tubulin) and how co-chaperones (prefoldin, PhLP2A) engage TRiC during the ATP-driven cycle, providing a modern framework for interpreting subunit contributions including CCT7.</p>
+<h2 id="1-verification-of-geneprotein-identity-critical-disambiguation">1) Verification of gene/protein identity (critical disambiguation)</h2>
+<p>The target in this report is <strong>yeast CCT7 (YJL111W; UniProt P42943)</strong> encoding <strong>T-complex protein 1 subunit eta</strong>, a <strong>TCP-1 chaperonin family</strong> component of TRiC/CCT. The yeast-specific experimental literature explicitly refers to <strong>CCT7 as an essential gene</strong> in <em>S. cerevisiae</em> and studies <strong>Cct7p</strong> as a TRiC subunit (not to be confused with human CCT7 studies, which are orthologous context only) (dube2021chaperoninpointmutation pages 4-7, liu2021cryoemstudyon pages 1-4).</p>
+<h2 id="2-key-concepts-and-definitions-current-understanding">2) Key concepts and definitions (current understanding)</h2>
+<h3 id="21-triccct-definition-architecture-and-folding-mechanism">2.1 TRiC/CCT: definition, architecture, and folding mechanism</h3>
+<p><strong>TRiC/CCT</strong> (TCP-1 Ring Complex / Chaperonin Containing TCP-1) is a <strong>eukaryotic cytosolic chaperonin</strong> that is <strong>ATP-dependent</strong> and forms a <strong>ring-shaped, double-ring assembly</strong>. A recent review summarizes it as an <strong>~1 MDa</strong> complex of <strong>16 subunits</strong> arranged as <strong>two stacked rings</strong>, each ring containing <strong>eight distinct subunits (CCT1–CCT8)</strong> (que2024theroleof pages 2-4). The folding mechanism is fundamentally <strong>ATP-driven</strong>: ATP binding/hydrolysis drives conformational changes (opening/closure of the folding chamber) that <strong>encapsulate non-native substrates</strong> to limit conformational space, thereby promoting productive folding and reducing aggregation (que2024theroleof pages 2-4).</p>
+<p>At the subunit level, TRiC subunits share a conserved chaperonin fold with <strong>three domains</strong>: <strong>equatorial (ATP-binding), intermediate, and apical (substrate-binding)</strong>, which provides a structure–function rationale for why ATP-pocket mutations in Cct7p lead to proteostasis phenotypes (dube2021chaperoninpointmutation pages 1-4, que2024theroleof pages 2-4).</p>
+<h3 id="22-where-cct7-fits-subunit-composition-and-arrangement">2.2 Where CCT7 fits: subunit composition and arrangement</h3>
+<p>A yeast-relevant review/experimental synthesis reports a consensus TRiC ring order <strong>CCT1-4-2-5-7-8-6-3</strong>, placing <strong>CCT7</strong> at a defined position within each ring, with evidence supporting near <strong>equal stoichiometry</strong> of the eight subunits in mature TRiC (sergeeva2019coexpressionofcct pages 1-2). This is consistent with CCT7’s role as a structural and functional component of the machine rather than a stand-alone enzyme.</p>
+<h3 id="23-cellular-localization">2.3 Cellular localization</h3>
+<p>Group II TRiC/CCT is classically described as <strong>cytosolic</strong>, implying that yeast Cct7p primarily functions in the <strong>cytosol</strong> as part of the TRiC complex (kabir2005physiologicaleffectsof pages 1-2). Recent broader chaperonin literature also supports potential nuclear-associated roles for TRiC/CCT (e.g., regulation of RNA polymerase II activity), but this evidence is not specific to yeast CCT7 and should be interpreted cautiously when assigning CCT7 localization/functions in budding yeast (gvozdenov2024triccctchaperoningoverns pages 33-36).</p>
+<h2 id="3-gene-product-function-molecular-function-pathways-and-clients">3) Gene product function: molecular function, pathways, and clients</h2>
+<h3 id="31-primary-molecular-function">3.1 Primary molecular function</h3>
+<p>Cct7p’s primary molecular function is <strong>ATP-dependent molecular chaperone activity</strong> as part of TRiC/CCT. It does <strong>not</strong> catalyze a discrete chemical transformation; instead, it contributes to <strong>substrate binding/encapsulation and allosteric conformational cycling</strong> required for folding (que2024theroleof pages 2-4, kelly2020structuralandfunctional pages 28-35).</p>
+<h3 id="32-pathwaysprocesses-influenced-mechanistically-proximal">3.2 Pathways/processes influenced (mechanistically proximal)</h3>
+<p>Because TRiC folds proteins that are difficult to fold spontaneously, its most direct pathway role is in <strong>cytosolic proteostasis</strong>, particularly <strong>folding of essential cytoskeletal proteins</strong> and other complex clients. Yeast-/TRiC-level client examples include <strong>actin and tubulin</strong>; the yeast mutant data also connect CCT activity to <strong>mitotic checkpoint complex (MCC) disassembly</strong> and cell-cycle regulation through client folding/complex remodeling (liu2021cryoemstudyon pages 1-4, dube2021chaperoninpointmutation pages 4-7).</p>
+<h3 id="33-client-scope-fraction-of-the-proteome">3.3 Client scope: fraction of the proteome</h3>
+<p>Multiple sources converge on the estimate that TRiC/CCT assists folding of approximately <strong>~10% of cytosolic proteins</strong> (often stated as “a tenth of the proteins in the cell”) (que2024theroleof pages 2-4, sergeeva2019coexpressionofcct pages 1-2). This provides a scale-of-function context for why CCT7 is essential.</p>
+<h2 id="4-yeast-cct7-specific-experimental-evidence-essentiality-phenotypes-mechanistic-inference">4) Yeast CCT7-specific experimental evidence (essentiality, phenotypes, mechanistic inference)</h2>
+<h3 id="41-essentiality">4.1 Essentiality</h3>
+<p>A plasmid-shuffling strategy in <em>S. cerevisiae</em> demonstrated that <strong>CCT7 is essential</strong>: <strong>CCT7 deletant mutants do not grow on FOA plates</strong>, indicating inviability when the wild-type covering plasmid is lost (dube2021chaperoninpointmutation pages 4-7). This aligns with TRiC being a core proteostasis machine required for folding essential clients.</p>
+<h3 id="42-atp-pocket-mutation-phenotypes-proteostasis-and-stress">4.2 ATP-pocket mutation phenotypes (proteostasis and stress)</h3>
+<p>A targeted point mutation in the conserved ATP-binding region of Cct7p (reported as <strong>G412E</strong>; mutation of the conserved <strong>GGG</strong> motif region) produced hallmark chaperonin-defect phenotypes:</p>
+<ul>
+<li><strong>Growth retardation</strong>: doubling time increased from <strong>2.05 ± 0.2 h (WT)</strong> to <strong>3.47 ± 0.2 h (mutant)</strong> (dube2021chaperoninpointmutation pages 4-7).</li>
+<li><strong>Proteostasis collapse / aggregation</strong>: mutant cells showed <strong>protein aggregates</strong>, visualized indirectly using Hsp104-GFP as an aggregation marker (dube2021chaperoninpointmutation pages 4-7).</li>
+<li><strong>Stress-response alterations</strong>: mutant was <strong>lethal under arsenite (As3+)</strong> but showed improved growth under <strong>cadmium stress (Cd2+)</strong> and altered cadmium handling (dube2021chaperoninpointmutation pages 1-4, dube2021chaperoninpointmutation pages 4-7).</li>
+</ul>
+<p>Quantitative cadmium-related measures included:<br />
+* <strong>Cadmium uptake efficiency</strong>: <strong>10.54 µg Cd/mg</strong> (mutant) vs <strong>9.05 µg Cd/mg</strong> (WT) (dube2021chaperoninpointmutation pages 4-7).<br />
+* <strong>Cadmium removal capacity</strong>: <strong>42.75%</strong>, <strong>46.70%</strong>, <strong>65.17%</strong> at 16, 24, 48 h; and pH dependence (e.g., <strong>48.97% at pH 4</strong> vs <strong>42.75% at pH 6</strong>) (dube2021chaperoninpointmutation pages 4-7).</p>
+<p>Mechanistically, these phenotypes are consistent with impaired <strong>ATP-driven TRiC cycling</strong>, leading to widespread client misfolding/aggregation and strong secondary effects on stress adaptation.</p>
+<h3 id="43-assembly-related-mechanistic-evidence-involving-cct7">4.3 Assembly-related mechanistic evidence involving CCT7</h3>
+<p>A yeast TRiC assembly study reported subunit-specific behaviors: when expressed individually in <em>E. coli</em>, <strong>CCT3/4/7/8 could not form homo-oligomeric TRiC-like rings</strong>, unlike certain other subunits. This suggests that CCT7 is not sufficient alone to build ring-like assemblies and that its productive function depends on hetero-oligomeric assembly pathways (liu2021cryoemstudyon pages 1-4). While heterologous expression is not the native context, it supports a model where <strong>subunit specialization</strong> underlies TRiC assembly and allostery.</p>
+<h2 id="5-recent-developments-prioritizing-20232024-relevant-to-yeast-cct7-functional-interpretation">5) Recent developments (prioritizing 2023–2024) relevant to yeast CCT7 functional interpretation</h2>
+<h3 id="51-2023-cryo-em-of-tric-mediated-tubulin-folding-along-the-atpase-cycle">5.1 2023: Cryo-EM of TRiC-mediated tubulin folding along the ATPase cycle</h3>
+<p>A 2023 cryo-EM/XL-MS study (endogenous <strong>human</strong> TRiC) captured multiple substrate-engaged states across the ATPase cycle, providing quantitative mechanistic data that informs conserved TRiC principles relevant to subunits such as yeast CCT7:</p>
+<ul>
+<li>Open-state populations: <strong>61.6%</strong> and <strong>38.4%</strong> particle classes for distinct open maps (liu2023pathwayandmechanism pages 1-2).</li>
+<li>High-resolution reconstructions: <strong>3.1 Å</strong> and <strong>4.1 Å</strong> maps (liu2023pathwayandmechanism pages 1-2).</li>
+<li>Client–subunit contacts: <strong>five XL-MS cross-links</strong> between tubulin and specific subunits (CCT3/4/6/8 in that study) and a pathway of substrate translocation/stabilization during ring closure (liu2023pathwayandmechanism pages 1-2).</li>
+</ul>
+<p>Although CCT7 was not the primary contacting subunit in the reported tubulin interface summary, the study’s central insight—that TRiC folding is coordinated with ATP-driven conformational changes and specific subunit surfaces—provides a modern interpretive frame for yeast CCT7’s ATP-pocket mutation phenotypes (liu2023pathwayandmechanism pages 1-2).</p>
+<p><strong>Visual evidence (from this 2023 work):</strong> a cropped figure region showing TRiC architecture with labeled subunits and the folding-state pathway across the ATPase cycle is available (liu2023pathwayandmechanism media 86d3cbff, liu2023pathwayandmechanism media 483af941).</p>
+<h3 id="52-2024-co-chaperone-cooperation-prefoldin-and-phlp2a-during-the-atp-driven-cycle">5.2 2024: Co-chaperone cooperation (Prefoldin and PhLP2A) during the ATP-driven cycle</h3>
+<p>A 2024 Nature Communications study defined an ATP-driven cycle of TRiC cooperation with cochaperones <strong>prefoldin (PFD)</strong> and <strong>PhLP2A</strong>, including mechanistic steps for cofactor binding and displacement during TRiC conformational transitions (junsun2024astructuralvista pages 1-2). These findings strengthen the prevailing view that TRiC function in vivo is embedded in a <strong>multi-chaperone network</strong>, and that subunit-specific surfaces coordinate co-chaperone binding and allosteric transitions—concepts directly relevant for functional annotation of yeast subunits including CCT7 (junsun2024astructuralvista pages 1-2).</p>
+<h3 id="53-2024-disease-genetics-underscores-conserved-essentiality-tricopathies">5.3 2024: Disease genetics underscores conserved essentiality (“TRiCopathies”)</h3>
+<p>A 2024 Science paper reported that TRiC is an <strong>obligate hetero-oligomer</strong> and that variants in <strong>seven of eight subunits</strong> can impair TRiC function/assembly, causing severe neurodevelopmental phenotypes in humans (kraft2024brainmalformationsand pages 1-3). While not yeast-specific, it provides expert-level reinforcement that subunit integrity is critical and that subunits can be <strong>differentially sensitive</strong> to mutation.</p>
+<h3 id="54-2024-review-perspectives-linking-tric-to-translation-and-broader-proteostasis">5.4 2024 review perspectives linking TRiC to translation and broader proteostasis</h3>
+<p>A 2024 review emphasizes TRiC/CCT roles in translation-associated proteostasis, including interactions with nascent chains and broader regulatory implications for translation elongation (que2024theroleof pages 7-9). For yeast CCT7 annotation, this supports a contemporary systems-level view: TRiC is not merely a refolding machine but part of a <strong>cotranslational folding network</strong> (que2024theroleof pages 7-9).</p>
+<h2 id="6-current-applications-and-real-world-implementations">6) Current applications and real-world implementations</h2>
+<h3 id="61-yeast-as-a-platform-for-triccct-mechanistic-dissection">6.1 Yeast as a platform for TRiC/CCT mechanistic dissection</h3>
+<p>Yeast remains a key model for dissecting TRiC function via genetics and quantitative phenotyping. The CCT7 plasmid-shuffle/point-mutation strategy illustrates how essential chaperonin subunits can be experimentally perturbed while maintaining viability, enabling mechanistic inference from growth, proteostasis, and stress phenotypes (dube2021chaperoninpointmutation pages 4-7).</p>
+<h3 id="62-biotechnologybioprocess-relevance-stress-tolerance-engineering">6.2 Biotechnology/bioprocess relevance (stress tolerance engineering)</h3>
+<p>The CCT7 ATP-pocket mutant’s altered heavy-metal phenotypes (cadmium uptake/removal metrics) suggest that TRiC perturbations can shift stress response landscapes in ways that could be exploited or must be controlled in industrial yeast contexts (e.g., fermentation under stress), although these are likely indirect effects mediated by global proteostasis changes rather than a dedicated “cadmium pathway” role for Cct7p (dube2021chaperoninpointmutation pages 4-7).</p>
+<h3 id="63-translational-relevance-outside-yeast-tric-as-a-therapeuticdiagnostic-target-concept">6.3 Translational relevance (outside yeast): TRiC as a therapeutic/diagnostic target concept</h3>
+<p>Recent structural studies explicitly note that understanding TRiC–substrate interfaces may inform <strong>therapeutic agent design</strong> targeting these interactions (liu2023pathwayandmechanism pages 1-2), and human genetics highlights clinical consequences of TRiC impairment (kraft2024brainmalformationsand pages 1-3). These are not yeast applications per se, but they contextualize why subunit-specific mechanisms (including CCT7/eta) remain an active research area.</p>
+<h2 id="7-expert-opinion-and-analysis-authoritative-synthesis">7) Expert opinion and analysis (authoritative synthesis)</h2>
+<p>Across reviews and structural work, an expert-consensus picture emerges:</p>
+<ol>
+<li><strong>TRiC/CCT is essential and specialized</strong> compared to bacterial GroEL, with <strong>eight distinct subunits</strong> whose sequence divergence enables subunit-specific client interactions and allosteric behavior (que2024theroleof pages 2-4, sergeeva2019coexpressionofcct pages 1-2).</li>
+<li>The <strong>ATP-driven open/close cycle</strong> is central; therefore, conserved ATP-pocket motifs in subunits like Cct7p are expected to be critical. Yeast G412E phenotypes are consistent with this model, linking ATPase-cycle defects to global aggregation and growth defects (que2024theroleof pages 2-4, dube2021chaperoninpointmutation pages 4-7).</li>
+<li><strong>Subunit arrangement and equal stoichiometry</strong> are recurring themes, supporting the interpretation of CCT7 as a fixed architectural element with a defined position within the ring, not a transient accessory factor (sergeeva2019coexpressionofcct pages 1-2).</li>
+<li>The 2023–2024 wave of cryo-EM studies increasingly describes TRiC function as a <strong>networked process</strong> involving co-chaperones (PFD, PhLPs) and structural “trajectories” of client folding, pushing the field from descriptive architecture to mechanistic cycles and state populations (liu2023pathwayandmechanism pages 1-2, junsun2024astructuralvista pages 1-2).</li>
+</ol>
+<h2 id="8-evidence-summary-table">8) Evidence summary table</h2>
+<p>The following table consolidates the core functional annotation for yeast CCT7 with best supporting citations.</p>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>Key points</th>
+<th>Best supporting citations</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity</td>
+<td>CCT7 in this report matches the UniProt target P42943/YJL111W from <em>Saccharomyces cerevisiae</em> and encodes T-complex protein 1 subunit eta (Cct7p), a TCP-1 family/group II chaperonin subunit of the eukaryotic TRiC/CCT complex.</td>
+<td>(dube2021chaperoninpointmutation pages 1-4, liu2021cryoemstudyon pages 1-4)</td>
+</tr>
+<tr>
+<td>Complex membership</td>
+<td>Cct7p is one of eight distinct TRiC/CCT subunits per ring; the mature complex is a ~1 MDa double ring with 16 total subunits and near-equal stoichiometry. A consensus ring order places CCT7 in the arrangement CCT1-4-2-5-7-8-6-3.</td>
+<td>(que2024theroleof pages 2-4, sergeeva2019coexpressionofcct pages 1-2)</td>
+</tr>
+<tr>
+<td>Localization</td>
+<td>TRiC/CCT is the eukaryotic cytosolic chaperonin, so yeast Cct7p is primarily expected in the cytosol as part of the folding chamber. Broader TRiC literature also supports some nuclear functions, but these are not yet well established specifically for yeast CCT7.</td>
+<td>(kabir2005physiologicaleffectsof pages 1-2, gvozdenov2024triccctchaperoningoverns pages 33-36)</td>
+</tr>
+<tr>
+<td>Mechanism</td>
+<td>Cct7p contributes to an ATP-driven folding machine whose subunits contain equatorial ATP-binding, intermediate, and apical substrate-binding domains. TRiC cycles between open and closed states to encapsulate non-native polypeptides and promote productive folding while limiting aggregation.</td>
+<td>(dube2021chaperoninpointmutation pages 1-4, que2024theroleof pages 2-4, kelly2020structuralandfunctional pages 28-35)</td>
+</tr>
+<tr>
+<td>Key substrates/clients</td>
+<td>Yeast CCT7 has not been shown to catalyze a chemical reaction; its primary function is structural/chaperone assistance in folding client proteins. At the TRiC level, canonical clients include actin and tubulin, with additional evidence for folding/assembly roles affecting regulators such as CDC20 and complexes involved in cell-cycle control.</td>
+<td>(liu2021cryoemstudyon pages 1-4, dube2021chaperoninpointmutation pages 4-7)</td>
+</tr>
+<tr>
+<td>Essentiality</td>
+<td>Yeast CCT7 is essential: plasmid-shuffle experiments showed that CCT7 deletants fail to grow on FOA, consistent with TRiC being a core proteostasis machine required for viability.</td>
+<td>(dube2021chaperoninpointmutation pages 4-7)</td>
+</tr>
+<tr>
+<td>Mutant phenotypes</td>
+<td>An ATP-pocket-region mutant of yeast Cct7p (G412E/G412D reported in the paper text) caused slower growth, about twofold larger cells, visible protein aggregation, arsenite sensitivity, and altered cadmium handling/tolerance. These phenotypes support a role for Cct7p in ATP-coupled folding and stress-responsive proteostasis.</td>
+<td>(dube2021chaperoninpointmutation pages 1-4, dube2021chaperoninpointmutation pages 4-7)</td>
+</tr>
+<tr>
+<td>Quantitative stats</td>
+<td>TRiC/CCT is ~1 MDa, 16-subunit, and estimated to assist folding of ~10% of cytosolic proteins. For the yeast CCT7 mutant, doubling time increased from 2.05 ± 0.2 h to 3.47 ± 0.2 h, and cadmium uptake increased from 9.05 to 10.54 µg Cd/mg.</td>
+<td>(que2024theroleof pages 2-4, dube2021chaperoninpointmutation pages 4-7)</td>
+</tr>
+<tr>
+<td>Recent 2023-2024 advances</td>
+<td>Recent cryo-EM studies resolved TRiC substrate folding along its ATPase cycle and defined co-chaperone cooperation with PhLP2A/prefoldin, sharpening models for how subunits such as CCT7 contribute to allosteric ring motions. A 2024 <em>Science</em> study linked defects in TRiC subunits to human developmental disease, underscoring the conserved importance of this machinery.</td>
+<td>(liu2023pathwayandmechanism pages 1-2, junsun2024astructuralvista pages 1-2, kraft2024brainmalformationsand pages 1-3)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table condenses the main functional-annotation points for yeast CCT7/YJL111W, including identity verification, role in the TRiC/CCT chaperonin, localization, mechanism, phenotypes, and recent advances. It is useful as a quick evidence-backed summary before reading the full narrative report.</em></p>
+<h2 id="9-limitations-and-evidence-gaps-yeast-cct7-specific">9) Limitations and evidence gaps (yeast CCT7-specific)</h2>
+<ul>
+<li><strong>Direct yeast Cct7p client lists</strong>: The retrieved evidence supports TRiC-level clients (actin/tubulin) and mechanistic roles, but does not provide a curated, yeast CCT7-specific client interactome. Assigning specific clients uniquely to CCT7 would require additional yeast proteomics/biochemical studies not captured in the current corpus.</li>
+<li><strong>Direct localization experiments for yeast Cct7p</strong>: The strongest statement available here is TRiC’s cytosolic classification; direct Cct7p imaging/localization in yeast is not provided in the retrieved text (kabir2005physiologicaleffectsof pages 1-2).</li>
+</ul>
+<h2 id="key-urls-and-publication-dates-selected">Key URLs and publication dates (selected)</h2>
+<ul>
+<li>Que et al., 2024-04 (Heliyon) “The role of molecular chaperone CCT/TRiC in translation elongation” https://doi.org/10.1016/j.heliyon.2024.e29029 (que2024theroleof pages 2-4)</li>
+<li>Park et al., 2024-02 (Nature Communications) “A structural vista of PhLP2A–TRiC cooperation…” https://doi.org/10.1038/s41467-024-45242-x (junsun2024astructuralvista pages 1-2)</li>
+<li>Liu et al., 2023-05 (Communications Biology) “Pathway and mechanism of tubulin folding…” https://doi.org/10.1038/s42003-023-04915-x (liu2023pathwayandmechanism pages 1-2)</li>
+<li>Kraft et al., 2024-11 (Science) “Brain malformations and seizures by impaired chaperonin function of TRiC” https://doi.org/10.1126/science.adp8721 (kraft2024brainmalformationsand pages 1-3)</li>
+<li>Dube &amp; Kabir, 2021-05 (Biotechnology Letters) “Chaperonin point mutation enhances cadmium endurance…” https://doi.org/10.1007/s10529-021-03151-9 (dube2021chaperoninpointmutation pages 4-7)</li>
+</ul>
+<h2 id="figure-evidence">Figure evidence</h2>
+<ul>
+<li>Cropped panels showing TRiC double-ring architecture with labeled subunits and tubulin-folding pathway schematic across ATPase-cycle states (from Liu et al., 2023) (liu2023pathwayandmechanism media 86d3cbff, liu2023pathwayandmechanism media 483af941).</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(dube2021chaperoninpointmutation pages 4-7): Ankita Dube and M. Anaul Kabir. Chaperonin point mutation enhances cadmium endurance in saccharomyces cerevisiae. Biotechnology Letters, 43:1735-1745, May 2021. URL: https://doi.org/10.1007/s10529-021-03151-9, doi:10.1007/s10529-021-03151-9. This article has 2 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(liu2021cryoemstudyon pages 1-4): Caixuan Liu, Huping Wang, Mingliang Jin, Wenyu Han, Shutian Wang, Yanxing Wang, Fangfang Wang, Chun Su, Xiaoyu Hong, Qiaoyu Zhao, and Yao Cong. Cryo-em study on the homo-oligomeric ring formation of yeast tric/cct subunits reveals tric ring assembly mechanism. bioRxiv, Feb 2021. URL: https://doi.org/10.1101/2021.02.24.432666, doi:10.1101/2021.02.24.432666. This article has 8 citations.</p>
+</li>
+<li>
+<p>(que2024theroleof pages 2-4): Yueyue Que, Yudan Qiu, Zheyu Ding, Shanshan Zhang, Rong Wei, Jianing Xia, and Yingying Lin. The role of molecular chaperone cct/tric in translation elongation: a literature review. Heliyon, 10:e29029, Apr 2024. URL: https://doi.org/10.1016/j.heliyon.2024.e29029, doi:10.1016/j.heliyon.2024.e29029. This article has 12 citations.</p>
+</li>
+<li>
+<p>(dube2021chaperoninpointmutation pages 1-4): Ankita Dube and M. Anaul Kabir. Chaperonin point mutation enhances cadmium endurance in saccharomyces cerevisiae. Biotechnology Letters, 43:1735-1745, May 2021. URL: https://doi.org/10.1007/s10529-021-03151-9, doi:10.1007/s10529-021-03151-9. This article has 2 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sergeeva2019coexpressionofcct pages 1-2): Oksana A. Sergeeva, Cameron Haase-Pettingell, and Jonathan A. King. Co-expression of cct subunits hints at tric assembly. Cell Stress and Chaperones, 24:1055-1065, Nov 2019. URL: https://doi.org/10.1007/s12192-019-01028-5, doi:10.1007/s12192-019-01028-5. This article has 18 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kabir2005physiologicaleffectsof pages 1-2): M. Anaul Kabir, Joanna Kaminska, George B. Segel, Gabor Bethlendy, Paul Lin, Flavio Della Seta, Casey Blegen, Kristine M. Swiderek, Teresa ?o??dek, Kim T. Arndt, and Fred Sherman. Physiological effects of unassembled chaperonin cct subunits in the yeast saccharomyces cerevisiae. Yeast, 22:219-239, Feb 2005. URL: https://doi.org/10.1002/yea.1210, doi:10.1002/yea.1210. This article has 60 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gvozdenov2024triccctchaperoningoverns pages 33-36): Zlata Gvozdenov, Audrey Yi Tyan Peng, Anusmita Biswas, Zeno Barcutean, Daniel Gestaut, Judith Frydman, Kevin Struhl, and Brian C. Freeman. Tric/cct chaperonin governs rna polymerase ii activity in the nucleus to support rna homeostasis. bioRxiv, Sep 2024. URL: https://doi.org/10.1101/2024.09.26.615188, doi:10.1101/2024.09.26.615188. This article has 3 citations.</p>
+</li>
+<li>
+<p>(kelly2020structuralandfunctional pages 28-35): J Kelly. Structural and functional characterisation of the group ii chaperonin cct/tric. Unknown journal, 2020.</p>
+</li>
+<li>
+<p>(liu2023pathwayandmechanism pages 1-2): Caixuan Liu, Mingliang Jin, Shutian Wang, Wenyu Han, Qiaoyu Zhao, Yifan Wang, Cong Xu, Lei Diao, Yue Yin, Chao Peng, Lan Bao, Yanxing Wang, and Yao Cong. Pathway and mechanism of tubulin folding mediated by tric/cct along its atpase cycle revealed using cryo-em. Communications Biology, May 2023. URL: https://doi.org/10.1038/s42003-023-04915-x, doi:10.1038/s42003-023-04915-x. This article has 28 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(liu2023pathwayandmechanism media 86d3cbff): Caixuan Liu, Mingliang Jin, Shutian Wang, Wenyu Han, Qiaoyu Zhao, Yifan Wang, Cong Xu, Lei Diao, Yue Yin, Chao Peng, Lan Bao, Yanxing Wang, and Yao Cong. Pathway and mechanism of tubulin folding mediated by tric/cct along its atpase cycle revealed using cryo-em. Communications Biology, May 2023. URL: https://doi.org/10.1038/s42003-023-04915-x, doi:10.1038/s42003-023-04915-x. This article has 28 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(liu2023pathwayandmechanism media 483af941): Caixuan Liu, Mingliang Jin, Shutian Wang, Wenyu Han, Qiaoyu Zhao, Yifan Wang, Cong Xu, Lei Diao, Yue Yin, Chao Peng, Lan Bao, Yanxing Wang, and Yao Cong. Pathway and mechanism of tubulin folding mediated by tric/cct along its atpase cycle revealed using cryo-em. Communications Biology, May 2023. URL: https://doi.org/10.1038/s42003-023-04915-x, doi:10.1038/s42003-023-04915-x. This article has 28 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(junsun2024astructuralvista pages 1-2): Junsun Park, Hyunmin Kim, Daniel Gestaut, Seyeon Lim, Kwadwo A. Opoku-Nsiah, Alexander Leitner, Judith Frydman, and Soung-Hun Roh. A structural vista of phosducin-like phlp2a-chaperonin tric cooperation during the atp-driven folding cycle. Nature Communications, Feb 2024. URL: https://doi.org/10.1038/s41467-024-45242-x, doi:10.1038/s41467-024-45242-x. This article has 16 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kraft2024brainmalformationsand pages 1-3): Florian Kraft, Piere Rodriguez-Aliaga, Weimin Yuan, Lena Franken, Kamil Zajt, Dimah Hasan, Ting-Ting Lee, Elisabetta Flex, Andreas Hentschel, A. Micheil Innes, Bixia Zheng, Dong Sun Julia Suh, Cordula Knopp, Eva Lausberg, Jeremias Krause, Xiaomeng Zhang, Pamela Trapane, Riley Carroll, Martin McClatchey, Andrew E. Fry, Lisa Wang, Sebastian Giesselmann, Hieu Hoang, Dustin Baldridge, Gary A. Silverman, Francesca Clementina Radio, Enrico Bertini, Andrea Ciolfi, Katherine A Blood, Jean-Madeleine de Sainte Agathe, Perrine Charles, Gaber Bergant, Goran Čuturilo, Borut Peterlin, Karin Diderich, Haley Streff, Laurie Robak, Renske Oegema, Ellen van Binsbergen, John Herriges, Carol J. Saunders, Andrea Maier, Stefan Wolking, Yvonne Weber, Hanns Lochmüller, Stefanie Meyer, Alberto Aleman, Kiran Polavarapu, Gael Nicolas, Alice Goldenberg, Lucie Guyant, Kathleen Pope, Katherine N. Hehmeyer, Kristin G. Monaghan, Annegret Quade, Thomas Smol, Roseline Caumes, Sarah Duerinckx, Chantal Depondt, Wim Van Paesschen, Claudine Rieubland, Claudia Poloni, Michel Guipponi, Severine Arcioni, Marije Meuwissen, Anna C. Jansen, Jessica Rosenblum, Tobias B. Haack, Miriam Bertrand, Lea Gerstner, Janine Magg, Olaf Riess, Jörg B. Schulz, Norbert Wagner, Martin Wiesmann, Joachim Weis, Thomas Eggermann, Matthias Begemann, Andreas Roos, Martin Häusler, Tim Schedl, Marco Tartaglia, Juliane Bremer, Stephen C. Pak, Judith Frydman, Miriam Elbracht, and Ingo Kurth. Brain malformations and seizures by impaired chaperonin function of tric. Science, 386 6721:516-525, Nov 2024. URL: https://doi.org/10.1126/science.adp8721, doi:10.1126/science.adp8721. This article has 21 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(que2024theroleof pages 7-9): Yueyue Que, Yudan Qiu, Zheyu Ding, Shanshan Zhang, Rong Wei, Jianing Xia, and Yingying Lin. The role of molecular chaperone cct/tric in translation elongation: a literature review. Heliyon, 10:e29029, Apr 2024. URL: https://doi.org/10.1016/j.heliyon.2024.e29029, doi:10.1016/j.heliyon.2024.e29029. This article has 12 citations.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>que2024theroleof pages 2-4</li>
+<li>sergeeva2019coexpressionofcct pages 1-2</li>
+<li>kabir2005physiologicaleffectsof pages 1-2</li>
+<li>gvozdenov2024triccctchaperoningoverns pages 33-36</li>
+<li>dube2021chaperoninpointmutation pages 4-7</li>
+<li>liu2021cryoemstudyon pages 1-4</li>
+<li>liu2023pathwayandmechanism pages 1-2</li>
+<li>junsun2024astructuralvista pages 1-2</li>
+<li>kraft2024brainmalformationsand pages 1-3</li>
+<li>que2024theroleof pages 7-9</li>
+<li>dube2021chaperoninpointmutation pages 1-4</li>
+<li>kelly2020structuralandfunctional pages 28-35</li>
+<li>https://doi.org/10.1016/j.heliyon.2024.e29029</li>
+<li>https://doi.org/10.1038/s41467-024-45242-x</li>
+<li>https://doi.org/10.1038/s42003-023-04915-x</li>
+<li>https://doi.org/10.1126/science.adp8721</li>
+<li>https://doi.org/10.1007/s10529-021-03151-9</li>
+<li>https://doi.org/10.1007/s10529-021-03151-9,</li>
+<li>https://doi.org/10.1101/2021.02.24.432666,</li>
+<li>https://doi.org/10.1016/j.heliyon.2024.e29029,</li>
+<li>https://doi.org/10.1007/s12192-019-01028-5,</li>
+<li>https://doi.org/10.1002/yea.1210,</li>
+<li>https://doi.org/10.1101/2024.09.26.615188,</li>
+<li>https://doi.org/10.1038/s42003-023-04915-x,</li>
+<li>https://doi.org/10.1038/s41467-024-45242-x,</li>
+<li>https://doi.org/10.1126/science.adp8721,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -1846,11 +2691,23 @@
                 <pre><code>id: P42943
 gene_symbol: CCT7
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
+aliases:
+- YJL111W
+- CCT-eta
+- TCP-1-eta
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: &#39;TODO: Add description for CCT7&#39;
+description: &gt;-
+  CCT7 encodes the eta subunit of the cytosolic chaperonin-containing
+  T-complex/TRiC. Cct7 is one of eight distinct CCT subunits in each ring of the
+  hetero-oligomeric double-ring chaperonin and contributes ATP binding/hydrolysis
+  and subunit-specific surfaces to the complex-level ATP-dependent protein
+  folding chaperone activity. The mature TRiC/CCT complex folds actin, tubulin,
+  and other cytosolic clients. Therefore, CCT7 should be curated as a core
+  component of the cytosolic CCT complex rather than as a stand-alone generic
+  unfolded protein binding factor.
 existing_annotations:
 - term:
     id: GO:0006457
@@ -1858,153 +2715,206 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;Manual review: protein folding is consistent with known biology of CCT7.&#39;
+    summary: IBA protein folding is consistent with CCT/TRiC chaperonin function.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: CCT7 contributes to the ATP-dependent protein folding activity of the CCT complex.
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: Yeast CCT catalyses the folding of yeast ACT1p and human beta-actin.
+    - reference_id: file:yeast/CCT7/CCT7-deep-research-falcon.md
+      supporting_text: CCT7 encodes a TRiC/CCT subunit whose primary function is ATP-dependent folding of cytosolic client proteins.
 - term:
     id: GO:0005832
     label: chaperonin-containing T-complex
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;Manual review: chaperonin-containing T-complex is consistent with known biology of CCT7.&#39;
+    summary: Phylogenetic inference is correct; Cct7 is a CCT/TRiC subunit.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Complex membership is central to CCT7 function.
+    supported_by:
+    - reference_id: PMID:15704212
+      supporting_text: Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of...which is composed of a stoichiometric array of eight different subunits...Cct1p-Cct8p.
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT7.&#39;
+    summary: The term is broadly related to chaperonin function but less precise than ATP-dependent protein folding chaperone.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: CCT7 functions through the assembled ATP-dependent chaperonin complex rather than generic unfolded protein binding.
     proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: binding pre-equilibrium...followed by a faster ATP-driven processing to...native actin
 - term:
     id: GO:0000166
     label: nucleotide binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: &#39;Manual review: nucleotide binding is consistent with known biology of CCT7.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: Nucleotide binding is true but overly broad for the CCT ATPase fold.
+    action: MODIFY
+    reason: ATP binding is the more specific nucleotide-binding annotation already present.
+    proposed_replacement_terms:
+    - id: GO:0005524
+      label: ATP binding
+    supported_by:
+    - reference_id: file:yeast/CCT7/CCT7-deep-research-falcon.md
+      supporting_text: TRiC subunits contain equatorial ATP-binding domains and undergo ATP-driven conformational cycling.
 - term:
     id: GO:0005524
     label: ATP binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: &#39;Manual review: ATP binding is consistent with known biology of CCT7.&#39;
+    summary: ATP binding is consistent with the conserved CCT chaperonin ATPase domain.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: ATP binding is required for the conformational cycle of CCT/TRiC.
+    supported_by:
+    - reference_id: file:yeast/CCT7/CCT7-deep-research-falcon.md
+      supporting_text: ATP binding and hydrolysis drive TRiC open/closed conformational changes.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: &#39;Manual review: cytoplasm is consistent with known biology of CCT7.&#39;
+    summary: Cytoplasmic localization is correct for the CCT/TRiC chaperonin.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: CCT/TRiC is the eukaryotic cytosolic chaperonin.
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: This purified yeast CCT was used for a novel...quantitative actin-folding assay
 - term:
     id: GO:0005832
     label: chaperonin-containing T-complex
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: &#39;Manual review: chaperonin-containing T-complex is consistent with known biology of CCT7.&#39;
+    summary: ARBA electronic annotation is consistent with direct complex membership evidence.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: CCT7 is a core subunit of the chaperonin-containing T-complex.
+    supported_by:
+    - reference_id: PMID:15704212
+      supporting_text: Cct complexes, are assembled into two rings...Cct1p-Cct8p.
 - term:
     id: GO:0006457
     label: protein folding
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: &#39;Manual review: protein folding is consistent with known biology of CCT7.&#39;
+    summary: Electronic protein folding annotation is consistent with experimental CCT function.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: CCT7 contributes to complex-level protein folding.
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: Yeast CCT catalyses the...folding of yeast ACT1p and human beta-actin
 - term:
     id: GO:0016887
     label: ATP hydrolysis activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: &#39;Manual review: ATP hydrolysis activity is consistent with known biology of CCT7.&#39;
+    summary: ATP hydrolysis activity is consistent with the conserved CCT chaperonin cycle.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: ATP hydrolysis drives the CCT/TRiC conformational cycle for client folding.
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: binding pre-equilibrium...followed by a faster ATP-driven processing to...native actin
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: &#39;Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT7.&#39;
+    summary: Broad unfolded protein binding is less precise than ATP-dependent chaperone activity.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: GO:0140662 better represents the CCT/TRiC complex-level function.
     proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: binding pre-equilibrium...followed by a faster ATP-driven processing to...native actin
 - term:
     id: GO:0140662
     label: ATP-dependent protein folding chaperone
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: &#39;Manual review: ATP-dependent protein folding chaperone is consistent with known biology of CCT7.&#39;
+    summary: This is the most informative MF term for the assembled CCT/TRiC machine.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: CCT7 contributes to ATP-dependent protein folding chaperone activity as a complex subunit.
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine.
 - term:
     id: GO:0006457
     label: protein folding
   evidence_type: IDA
   original_reference_id: PMID:16762366
   review:
-    summary: &#39;Manual review: protein folding is consistent with known biology of CCT7.&#39;
+    summary: Direct biochemical evidence with purified yeast CCT supports protein folding.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: The purified CCT complex catalyzes actin folding in vitro.
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: Yeast CCT catalyses the folding of yeast ACT1p and human beta-actin with nearly identical rate constants and yields.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: HDA
   original_reference_id: PMID:11914276
   review:
-    summary: &#39;Manual review: cytoplasm is consistent with known biology of CCT7.&#39;
+    summary: High-throughput cytoplasmic localization is consistent with CCT/TRiC biology.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: CCT is a cytosolic/cytoplasmic chaperonin complex.
+    supported_by:
+    - reference_id: file:yeast/CCT7/CCT7-deep-research-falcon.md
+      supporting_text: Group II TRiC/CCT is classically described as cytosolic.
 - term:
     id: GO:0005832
     label: chaperonin-containing T-complex
   evidence_type: IPI
   original_reference_id: PMID:15704212
   review:
-    summary: &#39;Manual review: chaperonin-containing T-complex is consistent with known biology of CCT7.&#39;
+    summary: Interaction evidence supports Cct7 as part of the CCT complex.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: CCT7 function depends on the assembled hetero-oligomeric chaperonin.
+    supported_by:
+    - reference_id: PMID:15704212
+      supporting_text: Cct complexes, are assembled into two rings...Cct1p-Cct8p.
 - term:
     id: GO:0005832
     label: chaperonin-containing T-complex
   evidence_type: IDA
   original_reference_id: PMID:16762366
   review:
-    summary: &#39;Manual review: chaperonin-containing T-complex is consistent with known biology of CCT7.&#39;
+    summary: Purified yeast CCT complex evidence supports complex membership.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Cct7 is one subunit of the functional yeast CCT/TRiC folding machine.
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: An efficient purification...protocol for CCT from Saccharomyces cerevisiae has been developed.
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:16762366
   review:
-    summary: &#39;Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT7.&#39;
+    summary: The experiment supports substrate binding during CCT-mediated folding, but the generic term is less specific.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: Replace with ATP-dependent protein folding chaperone to capture the CCT complex mechanism.
     proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: controlled CCT-actin folding assay are...consistent with a model where CCT and Ac(I) are in a binding pre-equilibrium...ATP-driven processing to...native actin
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -2016,7 +2926,7 @@ references:
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping
   findings: []
 - id: GO_REF:0000117
   title: Electronic Gene Ontology annotations created by ARBA machine learning models
@@ -2029,17 +2939,58 @@ references:
   findings: []
 - id: PMID:15704212
   title: Physiological effects of unassembled chaperonin Cct subunits in the yeast Saccharomyces cerevisiae.
-  findings: []
+  findings:
+  - statement: CCT is an eight-subunit double-ring chaperonin
+    supporting_text: Cct complexes are assembled into two rings composed of Cct1p-Cct8p.
 - id: PMID:16762366
   title: Quantitative actin folding reactions using yeast CCT purified via an internal tag in the CCT3/gamma subunit.
-  findings: []
+  findings:
+  - statement: Purified yeast CCT catalyzes actin folding
+    supporting_text: Yeast CCT catalyses folding of yeast ACT1p and human beta-actin.
+- id: file:yeast/CCT7/CCT7-deep-research-falcon.md
+  title: Falcon deep research report for CCT7
+  findings:
+  - statement: CCT7 is a TRiC/CCT eta subunit contributing to ATP-dependent cytosolic protein folding
+    supporting_text: The report identifies CCT7 as a core TRiC/CCT subunit in a cytosolic ATP-dependent protein folding machine.
+core_functions:
+- description: &gt;-
+    Eta subunit of the cytosolic TRiC/CCT chaperonin complex. Cct7 contributes
+    ATP hydrolysis and subunit-specific structural surfaces to the assembled
+    complex, which folds actin, tubulin, and other cytosolic clients through an
+    ATP-driven conformational cycle.
+  molecular_function:
+    id: GO:0016887
+    label: ATP hydrolysis activity
+  contributes_to_molecular_function:
+    id: GO:0140662
+    label: ATP-dependent protein folding chaperone
+  directly_involved_in:
+  - id: GO:0006457
+    label: protein folding
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+  in_complex:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  supported_by:
+  - reference_id: PMID:16762366
+    supporting_text: The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein...folding machine
+  - reference_id: PMID:15704212
+    supporting_text: Cct complexes, are assembled into two rings...Cct1p-Cct8p.
+  - reference_id: file:yeast/CCT7/CCT7-deep-research-falcon.md
+    supporting_text: CCT7 is one of the eight distinct subunits that assemble into the TRiC/CCT chaperonin.
+proposed_new_terms: []
+suggested_questions:
+- question: Should CCT subunit annotations to GO:0051082 be replaced by GO:0140662 with contributes_to semantics for individual subunits?
+suggested_experiments: []
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/yeast/CCT7/CCT7-ai-review.html
+++ b/genes/yeast/CCT7/CCT7-ai-review.html
@@ -964,7 +964,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> CCT7 functions through the assembled ATP-dependent chaperonin complex rather than generic unfolded protein binding.
+                            <strong>Reason:</strong> CCT7 functions through the assembled ATP-dependent chaperonin complex rather than generic unfolded protein binding. The replacement annotation should use the contributes_to qualifier, as CCT7 is a subunit that contributes to complex-level ATP-dependent folding activity rather than having the activity independently.
                         </div>
 
 
@@ -1465,7 +1465,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> GO:0140662 better represents the CCT/TRiC complex-level function.
+                            <strong>Reason:</strong> GO:0140662 better represents the CCT/TRiC complex-level function. The replacement annotation should use the contributes_to qualifier, as CCT7 is a subunit that contributes to complex-level ATP-dependent folding activity rather than having the activity independently.
                         </div>
 
 
@@ -1943,7 +1943,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Replace with ATP-dependent protein folding chaperone to capture the CCT complex mechanism.
+                            <strong>Reason:</strong> Replace with ATP-dependent protein folding chaperone to capture the CCT complex mechanism. The replacement annotation should use the contributes_to qualifier, as CCT7 is a subunit that contributes to complex-level ATP-dependent folding activity rather than having the activity independently.
                         </div>
 
 
@@ -2743,7 +2743,7 @@ existing_annotations:
   review:
     summary: The term is broadly related to chaperonin function but less precise than ATP-dependent protein folding chaperone.
     action: MODIFY
-    reason: CCT7 functions through the assembled ATP-dependent chaperonin complex rather than generic unfolded protein binding.
+    reason: CCT7 functions through the assembled ATP-dependent chaperonin complex rather than generic unfolded protein binding. The replacement annotation should use the contributes_to qualifier, as CCT7 is a subunit that contributes to complex-level ATP-dependent folding activity rather than having the activity independently.
     proposed_replacement_terms:
     - id: GO:0140662
       label: ATP-dependent protein folding chaperone
@@ -2833,7 +2833,7 @@ existing_annotations:
   review:
     summary: Broad unfolded protein binding is less precise than ATP-dependent chaperone activity.
     action: MODIFY
-    reason: GO:0140662 better represents the CCT/TRiC complex-level function.
+    reason: GO:0140662 better represents the CCT/TRiC complex-level function. The replacement annotation should use the contributes_to qualifier, as CCT7 is a subunit that contributes to complex-level ATP-dependent folding activity rather than having the activity independently.
     proposed_replacement_terms:
     - id: GO:0140662
       label: ATP-dependent protein folding chaperone
@@ -2908,7 +2908,7 @@ existing_annotations:
   review:
     summary: The experiment supports substrate binding during CCT-mediated folding, but the generic term is less specific.
     action: MODIFY
-    reason: Replace with ATP-dependent protein folding chaperone to capture the CCT complex mechanism.
+    reason: Replace with ATP-dependent protein folding chaperone to capture the CCT complex mechanism. The replacement annotation should use the contributes_to qualifier, as CCT7 is a subunit that contributes to complex-level ATP-dependent folding activity rather than having the activity independently.
     proposed_replacement_terms:
     - id: GO:0140662
       label: ATP-dependent protein folding chaperone

--- a/genes/yeast/CCT7/CCT7-ai-review.yaml
+++ b/genes/yeast/CCT7/CCT7-ai-review.yaml
@@ -1,11 +1,23 @@
 id: P42943
 gene_symbol: CCT7
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
+aliases:
+- YJL111W
+- CCT-eta
+- TCP-1-eta
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: 'TODO: Add description for CCT7'
+description: >-
+  CCT7 encodes the eta subunit of the cytosolic chaperonin-containing
+  T-complex/TRiC. Cct7 is one of eight distinct CCT subunits in each ring of the
+  hetero-oligomeric double-ring chaperonin and contributes ATP binding/hydrolysis
+  and subunit-specific surfaces to the complex-level ATP-dependent protein
+  folding chaperone activity. The mature TRiC/CCT complex folds actin, tubulin,
+  and other cytosolic clients. Therefore, CCT7 should be curated as a core
+  component of the cytosolic CCT complex rather than as a stand-alone generic
+  unfolded protein binding factor.
 existing_annotations:
 - term:
     id: GO:0006457
@@ -13,153 +25,206 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'Manual review: protein folding is consistent with known biology of CCT7.'
+    summary: IBA protein folding is consistent with CCT/TRiC chaperonin function.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: CCT7 contributes to the ATP-dependent protein folding activity of the CCT complex.
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: Yeast CCT catalyses the folding of yeast ACT1p and human beta-actin.
+    - reference_id: file:yeast/CCT7/CCT7-deep-research-falcon.md
+      supporting_text: CCT7 encodes a TRiC/CCT subunit whose primary function is ATP-dependent folding of cytosolic client proteins.
 - term:
     id: GO:0005832
     label: chaperonin-containing T-complex
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'Manual review: chaperonin-containing T-complex is consistent with known biology of CCT7.'
+    summary: Phylogenetic inference is correct; Cct7 is a CCT/TRiC subunit.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Complex membership is central to CCT7 function.
+    supported_by:
+    - reference_id: PMID:15704212
+      supporting_text: Eukaryotic chaperonins, the Cct complexes, are assembled into two rings, each of...which is composed of a stoichiometric array of eight different subunits...Cct1p-Cct8p.
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT7.'
+    summary: The term is broadly related to chaperonin function but less precise than ATP-dependent protein folding chaperone.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: CCT7 functions through the assembled ATP-dependent chaperonin complex rather than generic unfolded protein binding.
     proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: binding pre-equilibrium...followed by a faster ATP-driven processing to...native actin
 - term:
     id: GO:0000166
     label: nucleotide binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: 'Manual review: nucleotide binding is consistent with known biology of CCT7.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: Nucleotide binding is true but overly broad for the CCT ATPase fold.
+    action: MODIFY
+    reason: ATP binding is the more specific nucleotide-binding annotation already present.
+    proposed_replacement_terms:
+    - id: GO:0005524
+      label: ATP binding
+    supported_by:
+    - reference_id: file:yeast/CCT7/CCT7-deep-research-falcon.md
+      supporting_text: TRiC subunits contain equatorial ATP-binding domains and undergo ATP-driven conformational cycling.
 - term:
     id: GO:0005524
     label: ATP binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'Manual review: ATP binding is consistent with known biology of CCT7.'
+    summary: ATP binding is consistent with the conserved CCT chaperonin ATPase domain.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: ATP binding is required for the conformational cycle of CCT/TRiC.
+    supported_by:
+    - reference_id: file:yeast/CCT7/CCT7-deep-research-falcon.md
+      supporting_text: ATP binding and hydrolysis drive TRiC open/closed conformational changes.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'Manual review: cytoplasm is consistent with known biology of CCT7.'
+    summary: Cytoplasmic localization is correct for the CCT/TRiC chaperonin.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: CCT/TRiC is the eukaryotic cytosolic chaperonin.
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: This purified yeast CCT was used for a novel...quantitative actin-folding assay
 - term:
     id: GO:0005832
     label: chaperonin-containing T-complex
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: 'Manual review: chaperonin-containing T-complex is consistent with known biology of CCT7.'
+    summary: ARBA electronic annotation is consistent with direct complex membership evidence.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: CCT7 is a core subunit of the chaperonin-containing T-complex.
+    supported_by:
+    - reference_id: PMID:15704212
+      supporting_text: Cct complexes, are assembled into two rings...Cct1p-Cct8p.
 - term:
     id: GO:0006457
     label: protein folding
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'Manual review: protein folding is consistent with known biology of CCT7.'
+    summary: Electronic protein folding annotation is consistent with experimental CCT function.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: CCT7 contributes to complex-level protein folding.
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: Yeast CCT catalyses the...folding of yeast ACT1p and human beta-actin
 - term:
     id: GO:0016887
     label: ATP hydrolysis activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'Manual review: ATP hydrolysis activity is consistent with known biology of CCT7.'
+    summary: ATP hydrolysis activity is consistent with the conserved CCT chaperonin cycle.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: ATP hydrolysis drives the CCT/TRiC conformational cycle for client folding.
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: binding pre-equilibrium...followed by a faster ATP-driven processing to...native actin
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT7.'
+    summary: Broad unfolded protein binding is less precise than ATP-dependent chaperone activity.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: GO:0140662 better represents the CCT/TRiC complex-level function.
     proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: binding pre-equilibrium...followed by a faster ATP-driven processing to...native actin
 - term:
     id: GO:0140662
     label: ATP-dependent protein folding chaperone
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'Manual review: ATP-dependent protein folding chaperone is consistent with known biology of CCT7.'
+    summary: This is the most informative MF term for the assembled CCT/TRiC machine.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: CCT7 contributes to ATP-dependent protein folding chaperone activity as a complex subunit.
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine.
 - term:
     id: GO:0006457
     label: protein folding
   evidence_type: IDA
   original_reference_id: PMID:16762366
   review:
-    summary: 'Manual review: protein folding is consistent with known biology of CCT7.'
+    summary: Direct biochemical evidence with purified yeast CCT supports protein folding.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: The purified CCT complex catalyzes actin folding in vitro.
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: Yeast CCT catalyses the folding of yeast ACT1p and human beta-actin with nearly identical rate constants and yields.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: HDA
   original_reference_id: PMID:11914276
   review:
-    summary: 'Manual review: cytoplasm is consistent with known biology of CCT7.'
+    summary: High-throughput cytoplasmic localization is consistent with CCT/TRiC biology.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: CCT is a cytosolic/cytoplasmic chaperonin complex.
+    supported_by:
+    - reference_id: file:yeast/CCT7/CCT7-deep-research-falcon.md
+      supporting_text: Group II TRiC/CCT is classically described as cytosolic.
 - term:
     id: GO:0005832
     label: chaperonin-containing T-complex
   evidence_type: IPI
   original_reference_id: PMID:15704212
   review:
-    summary: 'Manual review: chaperonin-containing T-complex is consistent with known biology of CCT7.'
+    summary: Interaction evidence supports Cct7 as part of the CCT complex.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: CCT7 function depends on the assembled hetero-oligomeric chaperonin.
+    supported_by:
+    - reference_id: PMID:15704212
+      supporting_text: Cct complexes, are assembled into two rings...Cct1p-Cct8p.
 - term:
     id: GO:0005832
     label: chaperonin-containing T-complex
   evidence_type: IDA
   original_reference_id: PMID:16762366
   review:
-    summary: 'Manual review: chaperonin-containing T-complex is consistent with known biology of CCT7.'
+    summary: Purified yeast CCT complex evidence supports complex membership.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Cct7 is one subunit of the functional yeast CCT/TRiC folding machine.
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: An efficient purification...protocol for CCT from Saccharomyces cerevisiae has been developed.
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:16762366
   review:
-    summary: 'Manual review: unfolded protein binding is better represented by a more specific replacement term for CCT7.'
+    summary: The experiment supports substrate binding during CCT-mediated folding, but the generic term is less specific.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: Replace with ATP-dependent protein folding chaperone to capture the CCT complex mechanism.
     proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+    - id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+    supported_by:
+    - reference_id: PMID:16762366
+      supporting_text: controlled CCT-actin folding assay are...consistent with a model where CCT and Ac(I) are in a binding pre-equilibrium...ATP-driven processing to...native actin
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -171,7 +236,7 @@ references:
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping
   findings: []
 - id: GO_REF:0000117
   title: Electronic Gene Ontology annotations created by ARBA machine learning models
@@ -184,7 +249,48 @@ references:
   findings: []
 - id: PMID:15704212
   title: Physiological effects of unassembled chaperonin Cct subunits in the yeast Saccharomyces cerevisiae.
-  findings: []
+  findings:
+  - statement: CCT is an eight-subunit double-ring chaperonin
+    supporting_text: Cct complexes are assembled into two rings composed of Cct1p-Cct8p.
 - id: PMID:16762366
   title: Quantitative actin folding reactions using yeast CCT purified via an internal tag in the CCT3/gamma subunit.
-  findings: []
+  findings:
+  - statement: Purified yeast CCT catalyzes actin folding
+    supporting_text: Yeast CCT catalyses folding of yeast ACT1p and human beta-actin.
+- id: file:yeast/CCT7/CCT7-deep-research-falcon.md
+  title: Falcon deep research report for CCT7
+  findings:
+  - statement: CCT7 is a TRiC/CCT eta subunit contributing to ATP-dependent cytosolic protein folding
+    supporting_text: The report identifies CCT7 as a core TRiC/CCT subunit in a cytosolic ATP-dependent protein folding machine.
+core_functions:
+- description: >-
+    Eta subunit of the cytosolic TRiC/CCT chaperonin complex. Cct7 contributes
+    ATP hydrolysis and subunit-specific structural surfaces to the assembled
+    complex, which folds actin, tubulin, and other cytosolic clients through an
+    ATP-driven conformational cycle.
+  molecular_function:
+    id: GO:0016887
+    label: ATP hydrolysis activity
+  contributes_to_molecular_function:
+    id: GO:0140662
+    label: ATP-dependent protein folding chaperone
+  directly_involved_in:
+  - id: GO:0006457
+    label: protein folding
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+  in_complex:
+    id: GO:0005832
+    label: chaperonin-containing T-complex
+  supported_by:
+  - reference_id: PMID:16762366
+    supporting_text: The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein...folding machine
+  - reference_id: PMID:15704212
+    supporting_text: Cct complexes, are assembled into two rings...Cct1p-Cct8p.
+  - reference_id: file:yeast/CCT7/CCT7-deep-research-falcon.md
+    supporting_text: CCT7 is one of the eight distinct subunits that assemble into the TRiC/CCT chaperonin.
+proposed_new_terms: []
+suggested_questions:
+- question: Should CCT subunit annotations to GO:0051082 be replaced by GO:0140662 with contributes_to semantics for individual subunits?
+suggested_experiments: []

--- a/genes/yeast/CCT7/CCT7-ai-review.yaml
+++ b/genes/yeast/CCT7/CCT7-ai-review.yaml
@@ -53,7 +53,7 @@ existing_annotations:
   review:
     summary: The term is broadly related to chaperonin function but less precise than ATP-dependent protein folding chaperone.
     action: MODIFY
-    reason: CCT7 functions through the assembled ATP-dependent chaperonin complex rather than generic unfolded protein binding.
+    reason: CCT7 functions through the assembled ATP-dependent chaperonin complex rather than generic unfolded protein binding. The replacement annotation should use the contributes_to qualifier, as CCT7 is a subunit that contributes to complex-level ATP-dependent folding activity rather than having the activity independently.
     proposed_replacement_terms:
     - id: GO:0140662
       label: ATP-dependent protein folding chaperone
@@ -143,7 +143,7 @@ existing_annotations:
   review:
     summary: Broad unfolded protein binding is less precise than ATP-dependent chaperone activity.
     action: MODIFY
-    reason: GO:0140662 better represents the CCT/TRiC complex-level function.
+    reason: GO:0140662 better represents the CCT/TRiC complex-level function. The replacement annotation should use the contributes_to qualifier, as CCT7 is a subunit that contributes to complex-level ATP-dependent folding activity rather than having the activity independently.
     proposed_replacement_terms:
     - id: GO:0140662
       label: ATP-dependent protein folding chaperone
@@ -218,7 +218,7 @@ existing_annotations:
   review:
     summary: The experiment supports substrate binding during CCT-mediated folding, but the generic term is less specific.
     action: MODIFY
-    reason: Replace with ATP-dependent protein folding chaperone to capture the CCT complex mechanism.
+    reason: Replace with ATP-dependent protein folding chaperone to capture the CCT complex mechanism. The replacement annotation should use the contributes_to qualifier, as CCT7 is a subunit that contributes to complex-level ATP-dependent folding activity rather than having the activity independently.
     proposed_replacement_terms:
     - id: GO:0140662
       label: ATP-dependent protein folding chaperone

--- a/genes/yeast/CCT7/CCT7-deep-research-falcon.md
+++ b/genes/yeast/CCT7/CCT7-deep-research-falcon.md
@@ -1,0 +1,321 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-04T10:58:34.734959'
+end_time: '2026-05-04T11:16:59.867657'
+duration_seconds: 1105.13
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: yeast
+  gene_id: CCT7
+  gene_symbol: CCT7
+  uniprot_accession: P42943
+  protein_description: 'RecName: Full=T-complex protein 1 subunit eta; Short=TCP-1-eta;
+    AltName: Full=CCT-eta;'
+  gene_info: Name=CCT7; OrderedLocusNames=YJL111W; ORFNames=J0804;
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+  protein_family: Belongs to the TCP-1 chaperonin family. .
+  protein_domains: Chap_CCT_eta. (IPR012720); Chaperone_TCP-1. (IPR017998); Chaperonin_TCP-1_CS.
+    (IPR002194); Cpn60/GroEL/TCP-1. (IPR002423); GroEL-like_apical_dom_sf. (IPR027409)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 26
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P42943
+- **Protein Description:** RecName: Full=T-complex protein 1 subunit eta; Short=TCP-1-eta; AltName: Full=CCT-eta;
+- **Gene Information:** Name=CCT7; OrderedLocusNames=YJL111W; ORFNames=J0804;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the TCP-1 chaperonin family. .
+- **Key Domains:** Chap_CCT_eta. (IPR012720); Chaperone_TCP-1. (IPR017998); Chaperonin_TCP-1_CS. (IPR002194); Cpn60/GroEL/TCP-1. (IPR002423); GroEL-like_apical_dom_sf. (IPR027409)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "CCT7" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'CCT7' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **CCT7** (gene ID: CCT7, UniProt: P42943) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P42943
+- **Protein Description:** RecName: Full=T-complex protein 1 subunit eta; Short=TCP-1-eta; AltName: Full=CCT-eta;
+- **Gene Information:** Name=CCT7; OrderedLocusNames=YJL111W; ORFNames=J0804;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the TCP-1 chaperonin family. .
+- **Key Domains:** Chap_CCT_eta. (IPR012720); Chaperone_TCP-1. (IPR017998); Chaperonin_TCP-1_CS. (IPR002194); Cpn60/GroEL/TCP-1. (IPR002423); GroEL-like_apical_dom_sf. (IPR027409)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "CCT7" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'CCT7' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **CCT7** (gene ID: CCT7, UniProt: P42943) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+# Comprehensive Research Report: Yeast **CCT7** (UniProt **P42943**; SGD ORF **YJL111W**)—Functional Annotation
+
+## Executive summary
+**CCT7** encodes **T-complex protein 1 subunit eta (Cct7p)**, one of the eight distinct subunits (CCT1–CCT8) that assemble into the **eukaryotic group II chaperonin TRiC/CCT**. In budding yeast, Cct7p’s primary function is **ATP-dependent folding of cytosolic client proteins** as part of this ~1 MDa, double-ring (16-subunit) machine. Experimental genetics demonstrate that **CCT7 is essential for viability**, and perturbation of its conserved ATP-binding pocket causes **growth defects and proteostasis collapse (protein aggregation)** and alters stress responses, consistent with impaired chaperonin activity. Recent (2023–2024) cryo-EM and biochemical studies (primarily in mammalian systems but mechanistically conserved) refine how TRiC cycles through open/closed states to fold obligate substrates (actin/tubulin) and how co-chaperones (prefoldin, PhLP2A) engage TRiC during the ATP-driven cycle, providing a modern framework for interpreting subunit contributions including CCT7.
+
+## 1) Verification of gene/protein identity (critical disambiguation)
+The target in this report is **yeast CCT7 (YJL111W; UniProt P42943)** encoding **T-complex protein 1 subunit eta**, a **TCP-1 chaperonin family** component of TRiC/CCT. The yeast-specific experimental literature explicitly refers to **CCT7 as an essential gene** in *S. cerevisiae* and studies **Cct7p** as a TRiC subunit (not to be confused with human CCT7 studies, which are orthologous context only) (dube2021chaperoninpointmutation pages 4-7, liu2021cryoemstudyon pages 1-4).
+
+## 2) Key concepts and definitions (current understanding)
+
+### 2.1 TRiC/CCT: definition, architecture, and folding mechanism
+**TRiC/CCT** (TCP-1 Ring Complex / Chaperonin Containing TCP-1) is a **eukaryotic cytosolic chaperonin** that is **ATP-dependent** and forms a **ring-shaped, double-ring assembly**. A recent review summarizes it as an **~1 MDa** complex of **16 subunits** arranged as **two stacked rings**, each ring containing **eight distinct subunits (CCT1–CCT8)** (que2024theroleof pages 2-4). The folding mechanism is fundamentally **ATP-driven**: ATP binding/hydrolysis drives conformational changes (opening/closure of the folding chamber) that **encapsulate non-native substrates** to limit conformational space, thereby promoting productive folding and reducing aggregation (que2024theroleof pages 2-4).
+
+At the subunit level, TRiC subunits share a conserved chaperonin fold with **three domains**: **equatorial (ATP-binding), intermediate, and apical (substrate-binding)**, which provides a structure–function rationale for why ATP-pocket mutations in Cct7p lead to proteostasis phenotypes (dube2021chaperoninpointmutation pages 1-4, que2024theroleof pages 2-4).
+
+### 2.2 Where CCT7 fits: subunit composition and arrangement
+A yeast-relevant review/experimental synthesis reports a consensus TRiC ring order **CCT1-4-2-5-7-8-6-3**, placing **CCT7** at a defined position within each ring, with evidence supporting near **equal stoichiometry** of the eight subunits in mature TRiC (sergeeva2019coexpressionofcct pages 1-2). This is consistent with CCT7’s role as a structural and functional component of the machine rather than a stand-alone enzyme.
+
+### 2.3 Cellular localization
+Group II TRiC/CCT is classically described as **cytosolic**, implying that yeast Cct7p primarily functions in the **cytosol** as part of the TRiC complex (kabir2005physiologicaleffectsof pages 1-2). Recent broader chaperonin literature also supports potential nuclear-associated roles for TRiC/CCT (e.g., regulation of RNA polymerase II activity), but this evidence is not specific to yeast CCT7 and should be interpreted cautiously when assigning CCT7 localization/functions in budding yeast (gvozdenov2024triccctchaperoningoverns pages 33-36).
+
+## 3) Gene product function: molecular function, pathways, and clients
+
+### 3.1 Primary molecular function
+Cct7p’s primary molecular function is **ATP-dependent molecular chaperone activity** as part of TRiC/CCT. It does **not** catalyze a discrete chemical transformation; instead, it contributes to **substrate binding/encapsulation and allosteric conformational cycling** required for folding (que2024theroleof pages 2-4, kelly2020structuralandfunctional pages 28-35).
+
+### 3.2 Pathways/processes influenced (mechanistically proximal)
+Because TRiC folds proteins that are difficult to fold spontaneously, its most direct pathway role is in **cytosolic proteostasis**, particularly **folding of essential cytoskeletal proteins** and other complex clients. Yeast-/TRiC-level client examples include **actin and tubulin**; the yeast mutant data also connect CCT activity to **mitotic checkpoint complex (MCC) disassembly** and cell-cycle regulation through client folding/complex remodeling (liu2021cryoemstudyon pages 1-4, dube2021chaperoninpointmutation pages 4-7).
+
+### 3.3 Client scope: fraction of the proteome
+Multiple sources converge on the estimate that TRiC/CCT assists folding of approximately **~10% of cytosolic proteins** (often stated as “a tenth of the proteins in the cell”) (que2024theroleof pages 2-4, sergeeva2019coexpressionofcct pages 1-2). This provides a scale-of-function context for why CCT7 is essential.
+
+## 4) Yeast CCT7-specific experimental evidence (essentiality, phenotypes, mechanistic inference)
+
+### 4.1 Essentiality
+A plasmid-shuffling strategy in *S. cerevisiae* demonstrated that **CCT7 is essential**: **CCT7 deletant mutants do not grow on FOA plates**, indicating inviability when the wild-type covering plasmid is lost (dube2021chaperoninpointmutation pages 4-7). This aligns with TRiC being a core proteostasis machine required for folding essential clients.
+
+### 4.2 ATP-pocket mutation phenotypes (proteostasis and stress)
+A targeted point mutation in the conserved ATP-binding region of Cct7p (reported as **G412E**; mutation of the conserved **GGG** motif region) produced hallmark chaperonin-defect phenotypes:
+
+* **Growth retardation**: doubling time increased from **2.05 ± 0.2 h (WT)** to **3.47 ± 0.2 h (mutant)** (dube2021chaperoninpointmutation pages 4-7).
+* **Proteostasis collapse / aggregation**: mutant cells showed **protein aggregates**, visualized indirectly using Hsp104-GFP as an aggregation marker (dube2021chaperoninpointmutation pages 4-7).
+* **Stress-response alterations**: mutant was **lethal under arsenite (As3+)** but showed improved growth under **cadmium stress (Cd2+)** and altered cadmium handling (dube2021chaperoninpointmutation pages 1-4, dube2021chaperoninpointmutation pages 4-7).
+
+Quantitative cadmium-related measures included:
+* **Cadmium uptake efficiency**: **10.54 µg Cd/mg** (mutant) vs **9.05 µg Cd/mg** (WT) (dube2021chaperoninpointmutation pages 4-7).
+* **Cadmium removal capacity**: **42.75%**, **46.70%**, **65.17%** at 16, 24, 48 h; and pH dependence (e.g., **48.97% at pH 4** vs **42.75% at pH 6**) (dube2021chaperoninpointmutation pages 4-7).
+
+Mechanistically, these phenotypes are consistent with impaired **ATP-driven TRiC cycling**, leading to widespread client misfolding/aggregation and strong secondary effects on stress adaptation.
+
+### 4.3 Assembly-related mechanistic evidence involving CCT7
+A yeast TRiC assembly study reported subunit-specific behaviors: when expressed individually in *E. coli*, **CCT3/4/7/8 could not form homo-oligomeric TRiC-like rings**, unlike certain other subunits. This suggests that CCT7 is not sufficient alone to build ring-like assemblies and that its productive function depends on hetero-oligomeric assembly pathways (liu2021cryoemstudyon pages 1-4). While heterologous expression is not the native context, it supports a model where **subunit specialization** underlies TRiC assembly and allostery.
+
+## 5) Recent developments (prioritizing 2023–2024) relevant to yeast CCT7 functional interpretation
+
+### 5.1 2023: Cryo-EM of TRiC-mediated tubulin folding along the ATPase cycle
+A 2023 cryo-EM/XL-MS study (endogenous **human** TRiC) captured multiple substrate-engaged states across the ATPase cycle, providing quantitative mechanistic data that informs conserved TRiC principles relevant to subunits such as yeast CCT7:
+
+* Open-state populations: **61.6%** and **38.4%** particle classes for distinct open maps (liu2023pathwayandmechanism pages 1-2).
+* High-resolution reconstructions: **3.1 Å** and **4.1 Å** maps (liu2023pathwayandmechanism pages 1-2).
+* Client–subunit contacts: **five XL-MS cross-links** between tubulin and specific subunits (CCT3/4/6/8 in that study) and a pathway of substrate translocation/stabilization during ring closure (liu2023pathwayandmechanism pages 1-2).
+
+Although CCT7 was not the primary contacting subunit in the reported tubulin interface summary, the study’s central insight—that TRiC folding is coordinated with ATP-driven conformational changes and specific subunit surfaces—provides a modern interpretive frame for yeast CCT7’s ATP-pocket mutation phenotypes (liu2023pathwayandmechanism pages 1-2).
+
+**Visual evidence (from this 2023 work):** a cropped figure region showing TRiC architecture with labeled subunits and the folding-state pathway across the ATPase cycle is available (liu2023pathwayandmechanism media 86d3cbff, liu2023pathwayandmechanism media 483af941).
+
+### 5.2 2024: Co-chaperone cooperation (Prefoldin and PhLP2A) during the ATP-driven cycle
+A 2024 Nature Communications study defined an ATP-driven cycle of TRiC cooperation with cochaperones **prefoldin (PFD)** and **PhLP2A**, including mechanistic steps for cofactor binding and displacement during TRiC conformational transitions (junsun2024astructuralvista pages 1-2). These findings strengthen the prevailing view that TRiC function in vivo is embedded in a **multi-chaperone network**, and that subunit-specific surfaces coordinate co-chaperone binding and allosteric transitions—concepts directly relevant for functional annotation of yeast subunits including CCT7 (junsun2024astructuralvista pages 1-2).
+
+### 5.3 2024: Disease genetics underscores conserved essentiality (“TRiCopathies”)
+A 2024 Science paper reported that TRiC is an **obligate hetero-oligomer** and that variants in **seven of eight subunits** can impair TRiC function/assembly, causing severe neurodevelopmental phenotypes in humans (kraft2024brainmalformationsand pages 1-3). While not yeast-specific, it provides expert-level reinforcement that subunit integrity is critical and that subunits can be **differentially sensitive** to mutation.
+
+### 5.4 2024 review perspectives linking TRiC to translation and broader proteostasis
+A 2024 review emphasizes TRiC/CCT roles in translation-associated proteostasis, including interactions with nascent chains and broader regulatory implications for translation elongation (que2024theroleof pages 7-9). For yeast CCT7 annotation, this supports a contemporary systems-level view: TRiC is not merely a refolding machine but part of a **cotranslational folding network** (que2024theroleof pages 7-9).
+
+## 6) Current applications and real-world implementations
+
+### 6.1 Yeast as a platform for TRiC/CCT mechanistic dissection
+Yeast remains a key model for dissecting TRiC function via genetics and quantitative phenotyping. The CCT7 plasmid-shuffle/point-mutation strategy illustrates how essential chaperonin subunits can be experimentally perturbed while maintaining viability, enabling mechanistic inference from growth, proteostasis, and stress phenotypes (dube2021chaperoninpointmutation pages 4-7).
+
+### 6.2 Biotechnology/bioprocess relevance (stress tolerance engineering)
+The CCT7 ATP-pocket mutant’s altered heavy-metal phenotypes (cadmium uptake/removal metrics) suggest that TRiC perturbations can shift stress response landscapes in ways that could be exploited or must be controlled in industrial yeast contexts (e.g., fermentation under stress), although these are likely indirect effects mediated by global proteostasis changes rather than a dedicated “cadmium pathway” role for Cct7p (dube2021chaperoninpointmutation pages 4-7).
+
+### 6.3 Translational relevance (outside yeast): TRiC as a therapeutic/diagnostic target concept
+Recent structural studies explicitly note that understanding TRiC–substrate interfaces may inform **therapeutic agent design** targeting these interactions (liu2023pathwayandmechanism pages 1-2), and human genetics highlights clinical consequences of TRiC impairment (kraft2024brainmalformationsand pages 1-3). These are not yeast applications per se, but they contextualize why subunit-specific mechanisms (including CCT7/eta) remain an active research area.
+
+## 7) Expert opinion and analysis (authoritative synthesis)
+Across reviews and structural work, an expert-consensus picture emerges:
+
+1. **TRiC/CCT is essential and specialized** compared to bacterial GroEL, with **eight distinct subunits** whose sequence divergence enables subunit-specific client interactions and allosteric behavior (que2024theroleof pages 2-4, sergeeva2019coexpressionofcct pages 1-2).
+2. The **ATP-driven open/close cycle** is central; therefore, conserved ATP-pocket motifs in subunits like Cct7p are expected to be critical. Yeast G412E phenotypes are consistent with this model, linking ATPase-cycle defects to global aggregation and growth defects (que2024theroleof pages 2-4, dube2021chaperoninpointmutation pages 4-7).
+3. **Subunit arrangement and equal stoichiometry** are recurring themes, supporting the interpretation of CCT7 as a fixed architectural element with a defined position within the ring, not a transient accessory factor (sergeeva2019coexpressionofcct pages 1-2).
+4. The 2023–2024 wave of cryo-EM studies increasingly describes TRiC function as a **networked process** involving co-chaperones (PFD, PhLPs) and structural “trajectories” of client folding, pushing the field from descriptive architecture to mechanistic cycles and state populations (liu2023pathwayandmechanism pages 1-2, junsun2024astructuralvista pages 1-2).
+
+## 8) Evidence summary table
+The following table consolidates the core functional annotation for yeast CCT7 with best supporting citations.
+
+| Aspect | Key points | Best supporting citations |
+|---|---|---|
+| Identity | CCT7 in this report matches the UniProt target P42943/YJL111W from *Saccharomyces cerevisiae* and encodes T-complex protein 1 subunit eta (Cct7p), a TCP-1 family/group II chaperonin subunit of the eukaryotic TRiC/CCT complex. | (dube2021chaperoninpointmutation pages 1-4, liu2021cryoemstudyon pages 1-4) |
+| Complex membership | Cct7p is one of eight distinct TRiC/CCT subunits per ring; the mature complex is a ~1 MDa double ring with 16 total subunits and near-equal stoichiometry. A consensus ring order places CCT7 in the arrangement CCT1-4-2-5-7-8-6-3. | (que2024theroleof pages 2-4, sergeeva2019coexpressionofcct pages 1-2) |
+| Localization | TRiC/CCT is the eukaryotic cytosolic chaperonin, so yeast Cct7p is primarily expected in the cytosol as part of the folding chamber. Broader TRiC literature also supports some nuclear functions, but these are not yet well established specifically for yeast CCT7. | (kabir2005physiologicaleffectsof pages 1-2, gvozdenov2024triccctchaperoningoverns pages 33-36) |
+| Mechanism | Cct7p contributes to an ATP-driven folding machine whose subunits contain equatorial ATP-binding, intermediate, and apical substrate-binding domains. TRiC cycles between open and closed states to encapsulate non-native polypeptides and promote productive folding while limiting aggregation. | (dube2021chaperoninpointmutation pages 1-4, que2024theroleof pages 2-4, kelly2020structuralandfunctional pages 28-35) |
+| Key substrates/clients | Yeast CCT7 has not been shown to catalyze a chemical reaction; its primary function is structural/chaperone assistance in folding client proteins. At the TRiC level, canonical clients include actin and tubulin, with additional evidence for folding/assembly roles affecting regulators such as CDC20 and complexes involved in cell-cycle control. | (liu2021cryoemstudyon pages 1-4, dube2021chaperoninpointmutation pages 4-7) |
+| Essentiality | Yeast CCT7 is essential: plasmid-shuffle experiments showed that CCT7 deletants fail to grow on FOA, consistent with TRiC being a core proteostasis machine required for viability. | (dube2021chaperoninpointmutation pages 4-7) |
+| Mutant phenotypes | An ATP-pocket-region mutant of yeast Cct7p (G412E/G412D reported in the paper text) caused slower growth, about twofold larger cells, visible protein aggregation, arsenite sensitivity, and altered cadmium handling/tolerance. These phenotypes support a role for Cct7p in ATP-coupled folding and stress-responsive proteostasis. | (dube2021chaperoninpointmutation pages 1-4, dube2021chaperoninpointmutation pages 4-7) |
+| Quantitative stats | TRiC/CCT is ~1 MDa, 16-subunit, and estimated to assist folding of ~10% of cytosolic proteins. For the yeast CCT7 mutant, doubling time increased from 2.05 ± 0.2 h to 3.47 ± 0.2 h, and cadmium uptake increased from 9.05 to 10.54 µg Cd/mg. | (que2024theroleof pages 2-4, dube2021chaperoninpointmutation pages 4-7) |
+| Recent 2023-2024 advances | Recent cryo-EM studies resolved TRiC substrate folding along its ATPase cycle and defined co-chaperone cooperation with PhLP2A/prefoldin, sharpening models for how subunits such as CCT7 contribute to allosteric ring motions. A 2024 *Science* study linked defects in TRiC subunits to human developmental disease, underscoring the conserved importance of this machinery. | (liu2023pathwayandmechanism pages 1-2, junsun2024astructuralvista pages 1-2, kraft2024brainmalformationsand pages 1-3) |
+
+
+*Table: This table condenses the main functional-annotation points for yeast CCT7/YJL111W, including identity verification, role in the TRiC/CCT chaperonin, localization, mechanism, phenotypes, and recent advances. It is useful as a quick evidence-backed summary before reading the full narrative report.*
+
+## 9) Limitations and evidence gaps (yeast CCT7-specific)
+* **Direct yeast Cct7p client lists**: The retrieved evidence supports TRiC-level clients (actin/tubulin) and mechanistic roles, but does not provide a curated, yeast CCT7-specific client interactome. Assigning specific clients uniquely to CCT7 would require additional yeast proteomics/biochemical studies not captured in the current corpus.
+* **Direct localization experiments for yeast Cct7p**: The strongest statement available here is TRiC’s cytosolic classification; direct Cct7p imaging/localization in yeast is not provided in the retrieved text (kabir2005physiologicaleffectsof pages 1-2).
+
+## Key URLs and publication dates (selected)
+* Que et al., 2024-04 (Heliyon) “The role of molecular chaperone CCT/TRiC in translation elongation” https://doi.org/10.1016/j.heliyon.2024.e29029 (que2024theroleof pages 2-4)
+* Park et al., 2024-02 (Nature Communications) “A structural vista of PhLP2A–TRiC cooperation…” https://doi.org/10.1038/s41467-024-45242-x (junsun2024astructuralvista pages 1-2)
+* Liu et al., 2023-05 (Communications Biology) “Pathway and mechanism of tubulin folding…” https://doi.org/10.1038/s42003-023-04915-x (liu2023pathwayandmechanism pages 1-2)
+* Kraft et al., 2024-11 (Science) “Brain malformations and seizures by impaired chaperonin function of TRiC” https://doi.org/10.1126/science.adp8721 (kraft2024brainmalformationsand pages 1-3)
+* Dube & Kabir, 2021-05 (Biotechnology Letters) “Chaperonin point mutation enhances cadmium endurance…” https://doi.org/10.1007/s10529-021-03151-9 (dube2021chaperoninpointmutation pages 4-7)
+
+## Figure evidence
+* Cropped panels showing TRiC double-ring architecture with labeled subunits and tubulin-folding pathway schematic across ATPase-cycle states (from Liu et al., 2023) (liu2023pathwayandmechanism media 86d3cbff, liu2023pathwayandmechanism media 483af941).
+
+References
+
+1. (dube2021chaperoninpointmutation pages 4-7): Ankita Dube and M. Anaul Kabir. Chaperonin point mutation enhances cadmium endurance in saccharomyces cerevisiae. Biotechnology Letters, 43:1735-1745, May 2021. URL: https://doi.org/10.1007/s10529-021-03151-9, doi:10.1007/s10529-021-03151-9. This article has 2 citations and is from a peer-reviewed journal.
+
+2. (liu2021cryoemstudyon pages 1-4): Caixuan Liu, Huping Wang, Mingliang Jin, Wenyu Han, Shutian Wang, Yanxing Wang, Fangfang Wang, Chun Su, Xiaoyu Hong, Qiaoyu Zhao, and Yao Cong. Cryo-em study on the homo-oligomeric ring formation of yeast tric/cct subunits reveals tric ring assembly mechanism. bioRxiv, Feb 2021. URL: https://doi.org/10.1101/2021.02.24.432666, doi:10.1101/2021.02.24.432666. This article has 8 citations.
+
+3. (que2024theroleof pages 2-4): Yueyue Que, Yudan Qiu, Zheyu Ding, Shanshan Zhang, Rong Wei, Jianing Xia, and Yingying Lin. The role of molecular chaperone cct/tric in translation elongation: a literature review. Heliyon, 10:e29029, Apr 2024. URL: https://doi.org/10.1016/j.heliyon.2024.e29029, doi:10.1016/j.heliyon.2024.e29029. This article has 12 citations.
+
+4. (dube2021chaperoninpointmutation pages 1-4): Ankita Dube and M. Anaul Kabir. Chaperonin point mutation enhances cadmium endurance in saccharomyces cerevisiae. Biotechnology Letters, 43:1735-1745, May 2021. URL: https://doi.org/10.1007/s10529-021-03151-9, doi:10.1007/s10529-021-03151-9. This article has 2 citations and is from a peer-reviewed journal.
+
+5. (sergeeva2019coexpressionofcct pages 1-2): Oksana A. Sergeeva, Cameron Haase-Pettingell, and Jonathan A. King. Co-expression of cct subunits hints at tric assembly. Cell Stress and Chaperones, 24:1055-1065, Nov 2019. URL: https://doi.org/10.1007/s12192-019-01028-5, doi:10.1007/s12192-019-01028-5. This article has 18 citations and is from a peer-reviewed journal.
+
+6. (kabir2005physiologicaleffectsof pages 1-2): M. Anaul Kabir, Joanna Kaminska, George B. Segel, Gabor Bethlendy, Paul Lin, Flavio Della Seta, Casey Blegen, Kristine M. Swiderek, Teresa ?o??dek, Kim T. Arndt, and Fred Sherman. Physiological effects of unassembled chaperonin cct subunits in the yeast saccharomyces cerevisiae. Yeast, 22:219-239, Feb 2005. URL: https://doi.org/10.1002/yea.1210, doi:10.1002/yea.1210. This article has 60 citations and is from a peer-reviewed journal.
+
+7. (gvozdenov2024triccctchaperoningoverns pages 33-36): Zlata Gvozdenov, Audrey Yi Tyan Peng, Anusmita Biswas, Zeno Barcutean, Daniel Gestaut, Judith Frydman, Kevin Struhl, and Brian C. Freeman. Tric/cct chaperonin governs rna polymerase ii activity in the nucleus to support rna homeostasis. bioRxiv, Sep 2024. URL: https://doi.org/10.1101/2024.09.26.615188, doi:10.1101/2024.09.26.615188. This article has 3 citations.
+
+8. (kelly2020structuralandfunctional pages 28-35): J Kelly. Structural and functional characterisation of the group ii chaperonin cct/tric. Unknown journal, 2020.
+
+9. (liu2023pathwayandmechanism pages 1-2): Caixuan Liu, Mingliang Jin, Shutian Wang, Wenyu Han, Qiaoyu Zhao, Yifan Wang, Cong Xu, Lei Diao, Yue Yin, Chao Peng, Lan Bao, Yanxing Wang, and Yao Cong. Pathway and mechanism of tubulin folding mediated by tric/cct along its atpase cycle revealed using cryo-em. Communications Biology, May 2023. URL: https://doi.org/10.1038/s42003-023-04915-x, doi:10.1038/s42003-023-04915-x. This article has 28 citations and is from a peer-reviewed journal.
+
+10. (liu2023pathwayandmechanism media 86d3cbff): Caixuan Liu, Mingliang Jin, Shutian Wang, Wenyu Han, Qiaoyu Zhao, Yifan Wang, Cong Xu, Lei Diao, Yue Yin, Chao Peng, Lan Bao, Yanxing Wang, and Yao Cong. Pathway and mechanism of tubulin folding mediated by tric/cct along its atpase cycle revealed using cryo-em. Communications Biology, May 2023. URL: https://doi.org/10.1038/s42003-023-04915-x, doi:10.1038/s42003-023-04915-x. This article has 28 citations and is from a peer-reviewed journal.
+
+11. (liu2023pathwayandmechanism media 483af941): Caixuan Liu, Mingliang Jin, Shutian Wang, Wenyu Han, Qiaoyu Zhao, Yifan Wang, Cong Xu, Lei Diao, Yue Yin, Chao Peng, Lan Bao, Yanxing Wang, and Yao Cong. Pathway and mechanism of tubulin folding mediated by tric/cct along its atpase cycle revealed using cryo-em. Communications Biology, May 2023. URL: https://doi.org/10.1038/s42003-023-04915-x, doi:10.1038/s42003-023-04915-x. This article has 28 citations and is from a peer-reviewed journal.
+
+12. (junsun2024astructuralvista pages 1-2): Junsun Park, Hyunmin Kim, Daniel Gestaut, Seyeon Lim, Kwadwo A. Opoku-Nsiah, Alexander Leitner, Judith Frydman, and Soung-Hun Roh. A structural vista of phosducin-like phlp2a-chaperonin tric cooperation during the atp-driven folding cycle. Nature Communications, Feb 2024. URL: https://doi.org/10.1038/s41467-024-45242-x, doi:10.1038/s41467-024-45242-x. This article has 16 citations and is from a highest quality peer-reviewed journal.
+
+13. (kraft2024brainmalformationsand pages 1-3): Florian Kraft, Piere Rodriguez-Aliaga, Weimin Yuan, Lena Franken, Kamil Zajt, Dimah Hasan, Ting-Ting Lee, Elisabetta Flex, Andreas Hentschel, A. Micheil Innes, Bixia Zheng, Dong Sun Julia Suh, Cordula Knopp, Eva Lausberg, Jeremias Krause, Xiaomeng Zhang, Pamela Trapane, Riley Carroll, Martin McClatchey, Andrew E. Fry, Lisa Wang, Sebastian Giesselmann, Hieu Hoang, Dustin Baldridge, Gary A. Silverman, Francesca Clementina Radio, Enrico Bertini, Andrea Ciolfi, Katherine A Blood, Jean-Madeleine de Sainte Agathe, Perrine Charles, Gaber Bergant, Goran Čuturilo, Borut Peterlin, Karin Diderich, Haley Streff, Laurie Robak, Renske Oegema, Ellen van Binsbergen, John Herriges, Carol J. Saunders, Andrea Maier, Stefan Wolking, Yvonne Weber, Hanns Lochmüller, Stefanie Meyer, Alberto Aleman, Kiran Polavarapu, Gael Nicolas, Alice Goldenberg, Lucie Guyant, Kathleen Pope, Katherine N. Hehmeyer, Kristin G. Monaghan, Annegret Quade, Thomas Smol, Roseline Caumes, Sarah Duerinckx, Chantal Depondt, Wim Van Paesschen, Claudine Rieubland, Claudia Poloni, Michel Guipponi, Severine Arcioni, Marije Meuwissen, Anna C. Jansen, Jessica Rosenblum, Tobias B. Haack, Miriam Bertrand, Lea Gerstner, Janine Magg, Olaf Riess, Jörg B. Schulz, Norbert Wagner, Martin Wiesmann, Joachim Weis, Thomas Eggermann, Matthias Begemann, Andreas Roos, Martin Häusler, Tim Schedl, Marco Tartaglia, Juliane Bremer, Stephen C. Pak, Judith Frydman, Miriam Elbracht, and Ingo Kurth. Brain malformations and seizures by impaired chaperonin function of tric. Science, 386 6721:516-525, Nov 2024. URL: https://doi.org/10.1126/science.adp8721, doi:10.1126/science.adp8721. This article has 21 citations and is from a highest quality peer-reviewed journal.
+
+14. (que2024theroleof pages 7-9): Yueyue Que, Yudan Qiu, Zheyu Ding, Shanshan Zhang, Rong Wei, Jianing Xia, and Yingying Lin. The role of molecular chaperone cct/tric in translation elongation: a literature review. Heliyon, 10:e29029, Apr 2024. URL: https://doi.org/10.1016/j.heliyon.2024.e29029, doi:10.1016/j.heliyon.2024.e29029. This article has 12 citations.
+
+## Citations
+
+1. que2024theroleof pages 2-4
+2. sergeeva2019coexpressionofcct pages 1-2
+3. kabir2005physiologicaleffectsof pages 1-2
+4. gvozdenov2024triccctchaperoningoverns pages 33-36
+5. dube2021chaperoninpointmutation pages 4-7
+6. liu2021cryoemstudyon pages 1-4
+7. liu2023pathwayandmechanism pages 1-2
+8. junsun2024astructuralvista pages 1-2
+9. kraft2024brainmalformationsand pages 1-3
+10. que2024theroleof pages 7-9
+11. dube2021chaperoninpointmutation pages 1-4
+12. kelly2020structuralandfunctional pages 28-35
+13. https://doi.org/10.1016/j.heliyon.2024.e29029
+14. https://doi.org/10.1038/s41467-024-45242-x
+15. https://doi.org/10.1038/s42003-023-04915-x
+16. https://doi.org/10.1126/science.adp8721
+17. https://doi.org/10.1007/s10529-021-03151-9
+18. https://doi.org/10.1007/s10529-021-03151-9,
+19. https://doi.org/10.1101/2021.02.24.432666,
+20. https://doi.org/10.1016/j.heliyon.2024.e29029,
+21. https://doi.org/10.1007/s12192-019-01028-5,
+22. https://doi.org/10.1002/yea.1210,
+23. https://doi.org/10.1101/2024.09.26.615188,
+24. https://doi.org/10.1038/s42003-023-04915-x,
+25. https://doi.org/10.1038/s41467-024-45242-x,
+26. https://doi.org/10.1126/science.adp8721,

--- a/genes/yeast/CPS1/CPS1-ai-review.html
+++ b/genes/yeast/CPS1/CPS1-ai-review.html
@@ -966,7 +966,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> GO:0051603 is obsolete; GO:0043171 captures the supported peptide catabolic role.
+                            <strong>Reason:</strong> QuickGO currently marks GO:0051603 as obsolete because it is pre-composed; GO:0043171 captures the supported peptide catabolic role for Cps1.
                         </div>
 
 
@@ -1141,7 +1141,7 @@
 
                                 </span>
 
-                                <div class="support-text">PTHR45962 is an M20A/PM20D1-related PANTHER family and includes yeast CPS1.</div>
+                                <div class="support-text">N-FATTY-ACYL-AMINO ACID SYNTHASE/HYDROLASE PM20D1</div>
 
                             </div>
 
@@ -2002,7 +2002,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Replace obsolete GO:0051603 with current GO:0043171 peptide catabolic process.
+                            <strong>Reason:</strong> QuickGO currently marks GO:0051603 as obsolete because it is pre-composed; replace it with current GO:0043171 peptide catabolic process, which better matches the small-peptide carboxypeptidase evidence.
                         </div>
 
 
@@ -2367,9 +2367,9 @@
                 <ul class="findings-list">
 
                     <li class="finding-item">
-                        <div class="finding-statement">CPS1 belongs to an M20A-related PANTHER family</div>
+                        <div class="finding-statement">CPS1 belongs to PANTHER family PTHR45962, named N-FATTY-ACYL-AMINO ACID SYNTHASE/HYDROLASE PM20D1; the M20 structural relationship supports the metallocarboxypeptidase inference.</div>
 
-                        <div class="finding-text">"PTHR45962 is an M20A/PM20D1-related family and includes yeast CPS1."</div>
+                        <div class="finding-text">"N-FATTY-ACYL-AMINO ACID SYNTHASE/HYDROLASE PM20D1"</div>
 
                     </li>
 
@@ -3148,7 +3148,7 @@ existing_annotations:
   review:
     summary: This obsolete process annotation is consistent with Cps1 function but should be replaced by the current peptide catabolic process term.
     action: MODIFY
-    reason: GO:0051603 is obsolete; GO:0043171 captures the supported peptide catabolic role.
+    reason: QuickGO currently marks GO:0051603 as obsolete because it is pre-composed; GO:0043171 captures the supported peptide catabolic role for Cps1.
     proposed_replacement_terms:
     - id: GO:0043171
       label: peptide catabolic process
@@ -3180,7 +3180,7 @@ existing_annotations:
     - reference_id: file:yeast/CPS1/CPS1-deep-research-falcon.md
       supporting_text: CPS1 encodes a zinc-dependent metallo-carboxypeptidase in the M20 family.
     - reference_id: file:interpro/panther/PTHR45962/PTHR45962-metadata.yaml
-      supporting_text: PTHR45962 is an M20A/PM20D1-related PANTHER family and includes yeast CPS1.
+      supporting_text: N-FATTY-ACYL-AMINO ACID SYNTHASE/HYDROLASE PM20D1
 - term:
     id: GO:0005774
     label: vacuolar membrane
@@ -3325,7 +3325,7 @@ existing_annotations:
   review:
     summary: Cps1 contributes to vacuolar peptide catabolism and nitrogen metabolism, but this GO term is obsolete.
     action: MODIFY
-    reason: Replace obsolete GO:0051603 with current GO:0043171 peptide catabolic process.
+    reason: QuickGO currently marks GO:0051603 as obsolete because it is pre-composed; replace it with current GO:0043171 peptide catabolic process, which better matches the small-peptide carboxypeptidase evidence.
     proposed_replacement_terms:
     - id: GO:0043171
       label: peptide catabolic process
@@ -3372,8 +3372,11 @@ references:
 - id: file:interpro/panther/PTHR45962/PTHR45962-metadata.yaml
   title: PANTHER family metadata for CPS1 family PTHR45962
   findings:
-  - statement: CPS1 belongs to an M20A-related PANTHER family
-    supporting_text: PTHR45962 is an M20A/PM20D1-related family and includes yeast CPS1.
+  - statement: &gt;-
+      CPS1 belongs to PANTHER family PTHR45962, named
+      N-FATTY-ACYL-AMINO ACID SYNTHASE/HYDROLASE PM20D1; the M20 structural
+      relationship supports the metallocarboxypeptidase inference.
+    supporting_text: N-FATTY-ACYL-AMINO ACID SYNTHASE/HYDROLASE PM20D1
 core_functions:
 - description: &gt;-
     Vacuolar zinc-dependent metallocarboxypeptidase activity. Mature Cps1 is a

--- a/genes/yeast/CPS1/CPS1-ai-review.html
+++ b/genes/yeast/CPS1/CPS1-ai-review.html
@@ -671,50 +671,48 @@
     <div class="header">
         <h1>CPS1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P27614" target="_blank" class="term-link">
                         P27614
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
-                <span>Saccharomyces cerevisiae S288C</span>
+                <span>Saccharomyces cerevisiae</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Aliases:</span>
                 <div class="aliases">
-                    
+
                     <span class="badge">CPS</span>
-                    
+
                     <span class="badge">YJL172W</span>
-                    
-                    <span class="badge">yscS</span>
-                    
-                    <span class="badge">carboxypeptidase S</span>
-                    
+
                     <span class="badge">YSCS</span>
-                    
+
+                    <span class="badge">carboxypeptidase S</span>
+
                 </div>
             </div>
-            
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -745,24 +743,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="P27614" data-a="DESCRIPTION: Carboxypeptidase S (yscS) is a zinc-dependent meta..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="P27614" data-a="DESCRIPTION: CPS1 encodes carboxypeptidase S (yscS), a vacuolar..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>Carboxypeptidase S (yscS) is a zinc-dependent metallocarboxypeptidase belonging to the M20A subfamily of the ancient M20 metallopeptidase family (Clan MH), which spans all domains of life. The enzyme functions in the vacuolar lumen to hydrolyze peptide substrates, exhibiting strict substrate specificity for peptides with glycine in the penultimate (P1) position (e.g., Z-Gly-Leu). CPS1 is synthesized as a type II transmembrane protein precursor (77 kDa and 74 kDa glycoforms) that traffics via the MVB pathway with ubiquitin-dependent sorting (Lys8 ubiquitination by Rsp5). Proteinase B cleaves the precursor to release soluble mature enzyme into the vacuolar lumen. The enzyme uses the characteristic M20 di-zinc catalytic mechanism with five conserved metal-coordinating residues (His-Asp-Glu-Asp/Glu-His). CPS1 contributes ~60% of the enzymatic activity for Cbz-Gly-Leu hydrolysis and is regulated by nitrogen catabolite repression through GATA transcription factors (Gln3p, Gat1p), with expression increasing during nitrogen starvation. Represents ancestral M20 peptidase function, in contrast to the neofunctionalized mammalian homolog PM20D1 which evolved N-acyl amino acid synthase/hydrolase activity.</p>
+        <p>CPS1 encodes carboxypeptidase S (yscS), a vacuolar zinc-dependent M20A metallocarboxypeptidase. Cps1 is synthesized as a type II membrane precursor; precursor forms are membrane-associated, while mature active enzyme is soluble in the vacuolar lumen. The enzyme releases C-terminal amino acids from peptides such as Z-Gly-Leu, supporting peptide catabolism, nitrogen use, and amino-acid recycling. The most informative molecular-function term is metallocarboxypeptidase activity.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -775,32 +773,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000328" target="_blank" class="term-link">
                                     GO:0000328
                                 </a>
                             </span>
                             <span class="term-label">fungal-type vacuole lumen</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -812,82 +810,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Phylogenetic inference is consistent with experimental evidence from PMID:1569061 showing that mature CPS1 is soluble in the vacuolar lumen.
+                            <strong>Summary:</strong> IBA localization matches direct evidence that mature Cps1 is soluble in the vacuolar lumen.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The vacuolar lumen is where mature Cps1 performs peptidase activity.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/1569061" target="_blank" class="term-link">
                                         PMID:1569061
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">The mature forms of carboxypeptidase yscS appeared soluble in the vacuolar lumen, while the precursor proteins accumulated tightly associated with the vacuolar membrane.</div>
-                                
+
+                                <div class="support-text">The mature forms of carboxypeptidase yscS appeared...soluble in the vacuolar lumen</div>
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    file:yeast/CPS1/CPS1-deep-research-perplexity.md
-                                    
-                                </span>
-                                
-                                <div class="support-text">Carboxypeptidase S functions within the lumen of the yeast vacuole, a compartment analogous to the mammalian lysosome that serves as the primary site of protein degradation and recycling within eukaryotic cells.</div>
-                                
-                            </div>
-                            
-                            <div class="support-item">
-                                <span class="support-ref">
-                                    
+
                                     file:yeast/CPS1/CPS1-deep-research-falcon.md
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">See deep research file for comprehensive analysis</div>
-                                
+
+                                <div class="support-text">Cps1 is processed in the vacuole to a soluble lumenal enzyme.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004180" target="_blank" class="term-link">
                                     GO:0004180
                                 </a>
                             </span>
                             <span class="term-label">carboxypeptidase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -899,147 +890,144 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Phylogenetic inference is consistent with experimental evidence. PMID:2026161 demonstrated carboxypeptidase activity by showing CPS1 enables growth on Cbz-Gly-Leu as sole leucine source, and disruption abolishes this activity.
+                            <strong>Summary:</strong> Carboxypeptidase activity is supported by CPS1 complementation and disruption studies.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The term is correct, though metallocarboxypeptidase activity is more specific.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/2026161" target="_blank" class="term-link">
                                         PMID:2026161
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase yscS activity.</div>
-                                
+
+                                <div class="support-text">Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase...yscS activity.</div>
+
                             </div>
-                            
-                            <div class="support-item">
-                                <span class="support-ref">
-                                    
-                                    file:yeast/CPS1/CPS1-deep-research-perplexity.md
-                                    
-                                </span>
-                                
-                                <div class="support-text">Carboxypeptidase S catalyzes the hydrolysis of C-terminal peptide bonds in peptides and proteins, specifically removing the terminal amino acid from the carboxyl terminus of substrates.</div>
-                                
-                            </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051603" target="_blank" class="term-link">
                                     GO:0051603
                                 </a>
                             </span>
-                            <span class="term-label">obsolete proteolysis involved in protein catabolic process</span>
-                            
+                            <span class="term-label">proteolysis involved in protein catabolic process</span>
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P27614" data-a="GO:0051603" data-r="GO_REF:0000033" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P27614" data-a="GO:0051603" data-r="GO_REF:0000033" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Phylogenetic inference supported by role in vacuolar protein degradation. CPS1 functions as part of the vacuolar proteolytic machinery to degrade peptides generated by endoproteases.
+                            <strong>Summary:</strong> This obsolete process annotation is consistent with Cps1 function but should be replaced by the current peptide catabolic process term.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> GO:0051603 is obsolete; GO:0043171 captures the supported peptide catabolic role.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043171" target="_blank" class="term-link">
+                                    peptide catabolic process
+                                </a>
+                            </span>
+
+                        </div>
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/2026161" target="_blank" class="term-link">
                                         PMID:2026161
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">This protein is yet another member of the peptidases in S. cerevisiae involved in nitrogen metabolism.</div>
-                                
+
+                                <div class="support-text">This protein is yet another member of the peptidases in S....cerevisiae involved in nitrogen metabolism.</div>
+
                             </div>
-                            
-                            <div class="support-item">
-                                <span class="support-ref">
-                                    
-                                    file:yeast/CPS1/CPS1-deep-research-perplexity.md
-                                    
-                                </span>
-                                
-                                <div class="support-text">Carboxypeptidase S functions as one component of an integrated system of vacuolar proteases that collectively achieve comprehensive degradation of diverse protein substrates directed to the vacuole...CPS1 and CPY, operating as carboxypeptidases that sequentially remove C-terminal residues, work together with aminopeptidases to eventually reduce peptide substrates to individual amino acids that can be recycled by the cell.</div>
-                                
-                            </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004180" target="_blank" class="term-link">
                                     GO:0004180
                                 </a>
                             </span>
                             <span class="term-label">carboxypeptidase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1051,46 +1039,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Electronic annotation based on UniProtKB keyword. Redundant with IBA and IMP annotations for the same term. Accept as consistent with experimental evidence.
+                            <strong>Summary:</strong> UniProt keyword mapping is correct and consistent with experimental evidence.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Consistent with experimental and phylogenetic evidence for same term.
+                            <strong>Reason:</strong> Retain as a true broader molecular-function annotation.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2026161" target="_blank" class="term-link">
+                                        PMID:2026161
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">dipeptide Cbz-Gly-Leu (Cbz, benzyloxycarbonyl) as sole leucine source</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004181" target="_blank" class="term-link">
                                     GO:0004181
                                 </a>
                             </span>
                             <span class="term-label">metallocarboxypeptidase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1102,62 +1108,73 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This is a more specific term than GO:0004180 (carboxypeptidase activity). CPS1 is a zinc-dependent metallocarboxypeptidase of the M20 family that requires two zinc ions for catalysis. This is the more informative annotation.
+                            <strong>Summary:</strong> This is the most specific molecular-function term for Cps1.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> This is the most specific and accurate molecular function term for CPS1.
+                            <strong>Reason:</strong> Cps1 is a zinc-dependent M20A metallocarboxypeptidase.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    file:yeast/CPS1/CPS1-deep-research-perplexity.md
-                                    
+
+                                    file:yeast/CPS1/CPS1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Carboxypeptidase S belongs to the peptidase M20A subfamily of metalloproteases...The M20 family encompasses a diverse group of zinc-dependent exopeptidases and endopeptidases that share conserved structural features and catalytic strategies.</div>
-                                
+
+                                <div class="support-text">CPS1 encodes a zinc-dependent metallo-carboxypeptidase in the M20 family.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:interpro/panther/PTHR45962/PTHR45962-metadata.yaml
+
+                                </span>
+
+                                <div class="support-text">PTHR45962 is an M20A/PM20D1-related PANTHER family and includes yeast CPS1.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005774" target="_blank" class="term-link">
                                     GO:0005774
                                 </a>
                             </span>
                             <span class="term-label">vacuolar membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1169,75 +1186,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> The precursor form of CPS1 is membrane-associated, but the mature active enzyme is soluble in the vacuolar lumen. PMID:1569061 showed that precursor forms are tightly associated with the vacuolar membrane but mature forms are soluble. This annotation captures the transient membrane association but not the final location of the active enzyme.
+                            <strong>Summary:</strong> The precursor is membrane-associated but mature enzyme is lumenal.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Reflects precursor localization rather than mature active enzyme. The fungal-type vacuole lumen annotation is more representative of where the enzyme functions.
+                            <strong>Reason:</strong> Keep as a precursor/routing localization, not the core catalytic site.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/1569061" target="_blank" class="term-link">
                                         PMID:1569061
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">The precursor proteins accumulated tightly associated with the vacuolar membrane.</div>
-                                
+
+                                <div class="support-text">mature forms of carboxypeptidase yscS appeared...soluble in the vacuolar lumen, while the precursor proteins accumulated tightly...associated with the vacuolar membrane.</div>
+
                             </div>
-                            
-                            <div class="support-item">
-                                <span class="support-ref">
-                                    
-                                    file:yeast/CPS1/CPS1-deep-research-perplexity.md
-                                    
-                                </span>
-                                
-                                <div class="support-text">CPS1 is synthesized as a ~64 kilodalton precursor (preCPS1) in the endoplasmic reticulum as a type II transmembrane protein with a signal sequence spanning amino acids 20 through 40 that becomes inserted into the ER membrane during translation.</div>
-                                
-                            </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006508" target="_blank" class="term-link">
                                     GO:0006508
                                 </a>
                             </span>
                             <span class="term-label">proteolysis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1249,73 +1255,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Overly general term. GO:0051603 (proteolysis involved in protein catabolic process) is more specific and accurate for CPS1&#39;s role in vacuolar degradation.
+                            <strong>Summary:</strong> Proteolysis is correct but too broad.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Too general; more specific term already annotated.
+                            <strong>Reason:</strong> Replace with the more specific current peptide catabolic process term.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051603" target="_blank" class="term-link">
-                                    proteolysis involved in protein catabolic process
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043171" target="_blank" class="term-link">
+                                    peptide catabolic process
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    file:yeast/CPS1/CPS1-deep-research-perplexity.md
-                                    
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2026161" target="_blank" class="term-link">
+                                        PMID:2026161
+                                    </a>
+
                                 </span>
-                                
-                                <div class="support-text">The vacuolar proteolytic system includes the major endoprotease proteinase B (PrB), which generates initial peptide products through hydrolysis at internal peptide bonds; carboxypeptidase Y (CPY), a broad-specificity exopeptidase complementary to CPS1; and aminopeptidase I (API or Ape1)...CPS1 and CPY, operating as carboxypeptidases that sequentially remove C-terminal residues, work together with aminopeptidases to eventually reduce peptide substrates to individual amino acids that can be recycled by the cell.</div>
-                                
+
+                                <div class="support-text">This protein is yet another member of the peptidases in S....cerevisiae involved in nitrogen metabolism.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008233" target="_blank" class="term-link">
                                     GO:0008233
                                 </a>
                             </span>
                             <span class="term-label">peptidase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1327,57 +1335,73 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Overly general term. CPS1 has the more specific metallocarboxypeptidase activity (GO:0004181).
+                            <strong>Summary:</strong> Peptidase activity is correct but generic.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Too general; more specific term available.
+                            <strong>Reason:</strong> Replace with metallocarboxypeptidase activity.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004181" target="_blank" class="term-link">
                                     metallocarboxypeptidase activity
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/CPS1/CPS1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">CPS1 is a zinc-dependent M20-family metallocarboxypeptidase.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016787" target="_blank" class="term-link">
                                     GO:0016787
                                 </a>
                             </span>
                             <span class="term-label">hydrolase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1389,57 +1413,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Overly general term. CPS1 has the more specific metallocarboxypeptidase activity (GO:0004181).
+                            <strong>Summary:</strong> Hydrolase activity is true but much too broad.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Too general; more specific term available.
+                            <strong>Reason:</strong> Replace with the specific metallocarboxypeptidase activity annotation.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004181" target="_blank" class="term-link">
                                     metallocarboxypeptidase activity
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2026161" target="_blank" class="term-link">
+                                        PMID:2026161
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase...yscS activity.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
                                     GO:0046872
                                 </a>
                             </span>
                             <span class="term-label">metal ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1451,84 +1493,84 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Overly general term. CPS1 specifically binds zinc ions (GO:0008270).
+                            <strong>Summary:</strong> Metal ion binding is correct but nonspecific.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Too general; zinc ion binding is the specific activity.
+                            <strong>Reason:</strong> Replace with zinc ion binding, the relevant cofactor for Cps1.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
                                     zinc ion binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    file:yeast/CPS1/CPS1-deep-research-perplexity.md
-                                    
+
+                                    file:yeast/CPS1/CPS1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">The zinc ion at the active site of CPS1 serves as the central organizing element of the catalytic mechanism, coordinating substrate molecules and facilitating the nucleophilic attack necessary for peptide bond hydrolysis...The zinc ion in CPS1, like other M20 family metalloproteases, is coordinated by multiple amino acid residues through a geometry that typically positions the metal ion to activate a water molecule for catalysis.</div>
-                                
+
+                                <div class="support-text">CPS1 is a zinc-dependent metallocarboxypeptidase.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
                                     GO:0008270
                                 </a>
                             </span>
                             <span class="term-label">zinc ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">RCA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30358795
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The cellular economy of the Saccharomyces cerevisiae zinc pr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1540,82 +1582,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> CPS1 is a zinc-dependent metallocarboxypeptidase that binds 2 Zn(2+) ions per subunit according to UniProt annotation (by similarity). The zinc ions are essential for catalytic activity.
+                            <strong>Summary:</strong> Zinc binding is consistent with Cps1 metallopeptidase function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Zinc binding is mechanistically tied to metallocarboxypeptidase activity.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    file:yeast/CPS1/CPS1-deep-research-perplexity.md
-                                    
-                                </span>
-                                
-                                <div class="support-text">The zinc ion at the active site of CPS1 serves as the central organizing element of the catalytic mechanism...The activated zinc-coordinated water molecule then performs nucleophilic attack on the carbonyl carbon of the scissile peptide bond.</div>
-                                
-                            </div>
-                            
-                            <div class="support-item">
-                                <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link">
                                         PMID:30358795
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">The cellular economy of the Saccharomyces cerevisiae zinc proteome.</div>
-                                
+
+                                <div class="support-text">yeast zinc proteome of 582 known or potential zinc-binding proteins</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000324" target="_blank" class="term-link">
                                     GO:0000324
                                 </a>
                             </span>
                             <span class="term-label">fungal-type vacuole</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26928762
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     One library to make them all: streamlining the creation of y...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1627,75 +1662,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> High-throughput data showing vacuolar localization. Consistent with other evidence but less specific than fungal-type vacuole lumen.
+                            <strong>Summary:</strong> Broad vacuole localization is consistent but less specific than vacuole lumen.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Consistent with other evidence; the more specific lumen annotation is preferred.
+                            <strong>Reason:</strong> Keep as correct broad localization; vacuolar lumen is the core active location.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link">
-                                        PMID:26928762
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1569061" target="_blank" class="term-link">
+                                        PMID:1569061
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy.</div>
-                                
+
+                                <div class="support-text">The mature forms of carboxypeptidase yscS appeared...soluble in the vacuolar lumen</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005775" target="_blank" class="term-link">
                                     GO:0005775
                                 </a>
                             </span>
                             <span class="term-label">vacuolar lumen</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17543868" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17543868
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Vps27/Hse1 complex is a GAT domain-based scaffold for ub...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-undecided">
@@ -1707,75 +1742,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This paper (PMID:17543868) is about the Vps27/Hse1 complex structure and function in ESCRT-mediated sorting. While CPS1 is a cargo sorted by this pathway, the paper does not directly demonstrate CPS1 localization to the vacuolar lumen. PMID:1569061 is the appropriate reference for vacuolar lumen localization.
+                            <strong>Summary:</strong> The term is correct, but the cited Vps27/Hse1 paper does not directly demonstrate Cps1 lumen localization.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> The cited reference does not appear to directly demonstrate CPS1 localization to vacuolar lumen; need to verify the annotation source.
+                            <strong>Reason:</strong> Recheck the evidence-source pairing; PMID:1569061 directly supports the same location.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17543868" target="_blank" class="term-link">
                                         PMID:17543868
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">The Vps27/Hse1 complex is a GAT domain-based scaffold for ubiquitin-dependent sorting.</div>
-                                
+
+                                <div class="support-text">deliver ubiquitinated transmembrane proteins to the ESCRT endosomal-sorting...pathway.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1569061" target="_blank" class="term-link">
+                                        PMID:1569061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The mature forms of carboxypeptidase yscS appeared...soluble in the vacuolar lumen</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000328" target="_blank" class="term-link">
                                     GO:0000328
                                 </a>
                             </span>
                             <span class="term-label">fungal-type vacuole lumen</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/1569061" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:1569061
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Biogenesis of the yeast vacuole (lysosome). The precursor fo...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1787,71 +1835,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Direct experimental evidence. PMID:1569061 showed that mature forms of carboxypeptidase yscS are soluble in the vacuolar lumen, while precursor forms are membrane-associated.
+                            <strong>Summary:</strong> Direct evidence supports lumen localization of mature Cps1.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the best-supported location for active mature Cps1.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/1569061" target="_blank" class="term-link">
                                         PMID:1569061
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">The mature forms of carboxypeptidase yscS appeared soluble in the vacuolar lumen, while the precursor proteins accumulated tightly associated with the vacuolar membrane.</div>
-                                
+
+                                <div class="support-text">The mature forms of carboxypeptidase yscS appeared...soluble in the vacuolar lumen</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004180" target="_blank" class="term-link">
                                     GO:0004180
                                 </a>
                             </span>
                             <span class="term-label">carboxypeptidase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/2026161" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:2026161
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Carboxypeptidase yscS: gene structure and function of the va...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1863,133 +1915,152 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Direct experimental evidence from mutant phenotype. Cloned CPS1 gene enabled a cps1-3 mutant to grow on Cbz-Gly-Leu as sole leucine source, and chromosomal disruption completely abolished carboxypeptidase yscS activity.
+                            <strong>Summary:</strong> Direct mutant evidence supports carboxypeptidase activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> CPS1 disruption abolishes yscS activity.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/2026161" target="_blank" class="term-link">
                                         PMID:2026161
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">The cloned CPS1 gene, which again enabled a leucine auxotrophic cps1-3 mutant to grow on the modified dipeptide Cbz-Gly-Leu...Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase yscS activity.</div>
-                                
+
+                                <div class="support-text">Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase...yscS activity.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051603" target="_blank" class="term-link">
                                     GO:0051603
                                 </a>
                             </span>
-                            <span class="term-label">obsolete proteolysis involved in protein catabolic process</span>
-                            
+                            <span class="term-label">proteolysis involved in protein catabolic process</span>
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/2026161" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:2026161
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Carboxypeptidase yscS: gene structure and function of the va...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P27614" data-a="GO:0051603" data-r="PMID:2026161" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P27614" data-a="GO:0051603" data-r="PMID:2026161" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Experimental evidence showing CPS1 involvement in nitrogen metabolism through peptide degradation. The paper states CPS1 is involved in nitrogen metabolism.
+                            <strong>Summary:</strong> Cps1 contributes to vacuolar peptide catabolism and nitrogen metabolism, but this GO term is obsolete.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace obsolete GO:0051603 with current GO:0043171 peptide catabolic process.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043171" target="_blank" class="term-link">
+                                    peptide catabolic process
+                                </a>
+                            </span>
+
+                        </div>
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/2026161" target="_blank" class="term-link">
                                         PMID:2026161
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">This protein is yet another member of the peptidases in S. cerevisiae involved in nitrogen metabolism.</div>
-                                
+
+                                <div class="support-text">This protein is yet another member of the peptidases in S....cerevisiae involved in nitrogen metabolism.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>Zinc-dependent metallocarboxypeptidase of the M20A subfamily (Clan MH) that hydrolyzes C-terminal amino acids from peptides with strict substrate specificity requiring glycine in the penultimate (P1) position (e.g., Z-Gly-Leu but not Z-Leu-Leu or Z-Phe-Ser). Uses a conserved di-zinc catalytic mechanism with five metal-coordinating residues (His-Asp-Glu-Asp/Glu-His). Functions in vacuolar protein degradation to recycle amino acids for cellular nitrogen metabolism, with expression regulated by nitrogen catabolite repression via GATA transcription factors. Represents ancestral M20 peptidase function conserved across ~2.5 billion years of evolution.</h3>
-                <span class="vote-buttons" data-g="P27614" data-a="FUNCTION: Zinc-dependent metallocarboxypeptidase of the M20A..." data-r="" data-act="CORE_FUNCTION">
+                <h3>Vacuolar zinc-dependent metallocarboxypeptidase activity. Mature Cps1 is a soluble fungal-type vacuole lumen enzyme that releases C-terminal amino acids from peptides, including substrates such as Z-Gly-Leu, contributing to peptide catabolism and nitrogen use.</h3>
+                <span class="vote-buttons" data-g="P27614" data-a="FUNCTION: Vacuolar zinc-dependent metallocarboxypeptidase ac..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -1998,431 +2069,351 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030163" target="_blank" class="term-link">
-                                protein catabolic process
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043171" target="_blank" class="term-link">
+                                peptide catabolic process
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000328" target="_blank" class="term-link">
                                 fungal-type vacuole lumen
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/2026161" target="_blank" class="term-link">
                                 PMID:2026161
                             </a>
-                            
+
                         </span>
-                        
-                        <div class="finding-text">Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase yscS activity. This protein is yet another member of the peptidases in S. cerevisiae involved in nitrogen metabolism.</div>
-                        
+
+                        <div class="finding-text">Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase...yscS activity.</div>
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/1569061" target="_blank" class="term-link">
                                 PMID:1569061
                             </a>
-                            
+
                         </span>
-                        
-                        <div class="finding-text">The mature forms of carboxypeptidase yscS appeared soluble in the vacuolar lumen.</div>
-                        
+
+                        <div class="finding-text">The mature forms of carboxypeptidase yscS appeared...soluble in the vacuolar lumen</div>
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
-                            file:yeast/CPS1/CPS1-deep-research-perplexity.md
-                            
+
+                            file:yeast/CPS1/CPS1-deep-research-falcon.md
+
                         </span>
-                        
-                        <div class="finding-text">CPS1 exhibits substrate specificity preferentially directed toward peptides with hydrophobic C-terminal amino acids...contributes approximately 60% of the enzymatic activity required to hydrolyze dipeptide substrates including benzyloxycarbonyl-glycine-leucine (Cbz-Gly-Leu).</div>
-                        
+
+                        <div class="finding-text">CPS1 is a zinc-dependent M20-family metallocarboxypeptidase.</div>
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
-                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt.</div>
-                
-                
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping</div>
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
-                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods.</div>
-                
-                
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/1569061" target="_blank" class="term-link">
                             PMID:1569061
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Biogenesis of the yeast vacuole (lysosome). The precursor forms of the soluble hydrolase carboxypeptidase yscS are associated with the vacuolar membrane.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
-                        <div class="finding-statement">CPS1 precursor is membrane-associated but mature enzyme is soluble in vacuolar lumen</div>
-                        
-                        <div class="finding-text">"The mature forms of carboxypeptidase yscS appeared soluble in the vacuolar lumen, while the precursor proteins accumulated tightly associated with the vacuolar membrane."</div>
-                        
+                        <div class="finding-statement">Mature Cps1 is soluble in the vacuolar lumen while precursor is membrane-associated</div>
+
+                        <div class="finding-text">"The mature forms of carboxypeptidase yscS appeared...soluble in the vacuolar lumen, while the precursor proteins accumulated tightly...associated with the vacuolar membrane."</div>
+
                     </li>
-                    
-                    <li class="finding-item">
-                        <div class="finding-statement">Proteinase B cleaves the precursor to release soluble enzyme</div>
-                        
-                        <div class="finding-text">"After assembly into the vacuolar membrane, proteinase yscB presumably cleaves the precursor molecules to release soluble carboxypeptidase yscS forms into the lumen of the vacuole."</div>
-                        
-                    </li>
-                    
-                    <li class="finding-item">
-                        <div class="finding-statement">Two mature forms of 77 and 74 kDa differ by one N-linked carbohydrate</div>
-                        
-                        <div class="finding-text">"Antibodies specific for carboxypeptidase yscS recognized two glycoproteins of 77- and 74-kDa apparent molecular mass which differ by one N-linked carbohydrate residue."</div>
-                        
-                    </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
-                        <a href="https://pubmed.ncbi.nlm.nih.gov/17543868" target="_blank" class="term-link">
-                            PMID:17543868
-                        </a>
-                        
-                    </span>
-                </div>
-                
-                <div class="reference-title">The Vps27/Hse1 complex is a GAT domain-based scaffold for ubiquitin-dependent sorting.</div>
-                
-                
-                <ul class="findings-list">
-                    
-                    <li class="finding-item">
-                        <div class="finding-statement">Describes ESCRT machinery that sorts ubiquitinated transmembrane proteins including CPS1 to the vacuole</div>
-                        
-                        <div class="finding-text">"The yeast Vps27/Hse1 complex and the homologous mammalian Hrs/STAM complex deliver ubiquitinated transmembrane proteins to the ESCRT endosomal-sorting pathway."</div>
-                        
-                    </li>
-                    
-                </ul>
-                
-            </div>
-            
-            <div class="reference-item">
-                <div class="reference-header">
-                    <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/2026161" target="_blank" class="term-link">
                             PMID:2026161
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Carboxypeptidase yscS: gene structure and function of the vacuolar enzyme.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
-                        <div class="finding-statement">CPS1 encodes carboxypeptidase yscS with 576 amino acids</div>
-                        
-                        <div class="finding-text">"The cloned CPS1 gene, which again enabled a leucine auxotrophic cps1-3 mutant to grow on the modified dipeptide Cbz-Gly-Leu (Cbz, benzyloxycarbonyl) as sole leucine source, was sequenced and found to consist of an open reading frame of 1728 bp encoding a protein of 576 amino acids."</div>
-                        
+                        <div class="finding-statement">CPS1 encodes carboxypeptidase yscS</div>
+
+                        <div class="finding-text">"Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase...yscS activity."</div>
+
                     </li>
-                    
-                    <li class="finding-item">
-                        <div class="finding-statement">CPS1 enables growth on Cbz-Gly-Leu as sole leucine source</div>
-                        
-                        <div class="finding-text">"The cloned CPS1 gene, which again enabled a leucine auxotrophic cps1-3 mutant to grow on the modified dipeptide Cbz-Gly-Leu (Cbz, benzyloxycarbonyl) as sole leucine source, was sequenced and found to consist of an open reading frame of 1728 bp encoding a protein of 576 amino acids"</div>
-                        
-                    </li>
-                    
-                    <li class="finding-item">
-                        <div class="finding-statement">Disruption of CPS1 abolishes carboxypeptidase yscS activity</div>
-                        
-                        <div class="finding-text">"Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase yscS activity."</div>
-                        
-                    </li>
-                    
-                    <li class="finding-item">
-                        <div class="finding-statement">CPS1 is involved in nitrogen metabolism</div>
-                        
-                        <div class="finding-text">"This protein is yet another member of the peptidases in S. cerevisiae involved in nitrogen metabolism."</div>
-                        
-                    </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17543868" target="_blank" class="term-link">
+                            PMID:17543868
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The Vps27/Hse1 complex is a GAT domain-based scaffold for ubiquitin-dependent sorting.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link">
                             PMID:26928762
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link">
                             PMID:30358795
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The cellular economy of the Saccharomyces cerevisiae zinc proteome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
-                        file:yeast/CPS1/CPS1-deep-research-perplexity.md
-                        
+
+                        file:yeast/CPS1/CPS1-deep-research-falcon.md
+
                     </span>
                 </div>
-                
-                <div class="reference-title">Deep research summary for CPS1 from Perplexity</div>
-                
-                
+
+                <div class="reference-title">Falcon deep research report for CPS1</div>
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
-                        <div class="finding-statement">CPS1 is a zinc-dependent metallocarboxypeptidase of the M20 family</div>
-                        
-                        <div class="finding-text">"Carboxypeptidase S (CPS1), encoded by the YJL172W locus in Saccharomyces cerevisiae, is a zinc-dependent metallocarboxypeptidase belonging to the M20 family of metalloproteases that functions as a critical component of the yeast vacuolar degradation system."</div>
-                        
+                        <div class="finding-statement">CPS1 is a vacuolar zinc-dependent M20A metallocarboxypeptidase</div>
+
+                        <div class="finding-text">"The report synthesizes evidence that Cps1 is processed into a soluble vacuolar lumen zinc metallocarboxypeptidase."</div>
+
                     </li>
-                    
-                    <li class="finding-item">
-                        <div class="finding-statement">CPS1 contributes approximately 60% of enzymatic activity for Cbz-Gly-Leu hydrolysis</div>
-                        
-                        <div class="finding-text">"CPS1 exhibits substrate specificity preferentially directed toward peptides with hydrophobic C-terminal amino acids, particularly leucine and glycine residues...ultimately becomes a soluble vacuolar enzyme that contributes approximately 60% of the enzymatic activity required to hydrolyze dipeptide substrates including benzyloxycarbonyl-glycine-leucine (Cbz-Gly-Leu)."</div>
-                        
-                    </li>
-                    
-                    <li class="finding-item">
-                        <div class="finding-statement">CPS1 preferentially cleaves peptides with glycine in penultimate position</div>
-                        
-                        <div class="finding-text">"The enzyme exhibits characteristic specificity that enables it to preferentially cleave peptides in which the penultimate amino acid is glycine or the C-terminal amino acid is leucine, as exemplified by its robust activity toward the synthetic dipeptide Cbz-Gly-Leu."</div>
-                        
-                    </li>
-                    
-                    <li class="finding-item">
-                        <div class="finding-statement">Zinc ion is essential for CPS1 catalytic mechanism</div>
-                        
-                        <div class="finding-text">"The zinc ion at the active site of CPS1 serves as the central organizing element of the catalytic mechanism, coordinating substrate molecules and facilitating the nucleophilic attack necessary for peptide bond hydrolysis...The general acid-base catalysis performed by CPS1 depends critically on the zinc ion, as evidenced by the complete loss of enzymatic activity when the metal is chelated or removed."</div>
-                        
-                    </li>
-                    
-                    <li class="finding-item">
-                        <div class="finding-statement">CPS1 is synthesized as type II transmembrane precursor</div>
-                        
-                        <div class="finding-text">"CPS1 is synthesized as a ~64 kilodalton precursor (preCPS1) in the endoplasmic reticulum as a type II transmembrane protein with a signal sequence spanning amino acids 20 through 40 that becomes inserted into the ER membrane during translation."</div>
-                        
-                    </li>
-                    
-                    <li class="finding-item">
-                        <div class="finding-statement">CPS1 traffics via MVB pathway with ubiquitin-dependent sorting</div>
-                        
-                        <div class="finding-text">"The ubiquitination of CPS1 plays a critical role in directing the enzyme into the MVB pathway, as ubiquitinated cargo is recognized by ESCRT protein Vps27...CPS1 ubiquitination is accomplished through the action of the ubiquitin ligase Rsp5, which is recruited to CPS1 through adaptor proteins Tul1 and Bsd2."</div>
-                        
-                    </li>
-                    
-                    <li class="finding-item">
-                        <div class="finding-statement">Proteinase A (Pep4p) processes CPS1 precursor in vacuole</div>
-                        
-                        <div class="finding-text">"Upon arrival in the vacuolar lumen within the internal vesicles of multivesicular bodies, the membrane-bound precursor form of CPS1 undergoes proteolytic processing by the vacuolar proteinase A (PrA, also designated Pep4p), a principal vacuolar endoprotease that activates many vacuolar zymogens."</div>
-                        
-                    </li>
-                    
-                    <li class="finding-item">
-                        <div class="finding-statement">Two glycoforms of mature CPS1 exist (74 and 77 kDa)</div>
-                        
-                        <div class="finding-text">"Two major forms of mature CPS1 are observed in yeast cells, with apparent molecular masses of 74 and 77 kilodaltons, representing CPS1 molecules modified with two or three N-linked glycans respectively."</div>
-                        
-                    </li>
-                    
-                    <li class="finding-item">
-                        <div class="finding-statement">CPS1 expression regulated by nitrogen catabolite repression via GATA factors</div>
-                        
-                        <div class="finding-text">"Expression of the CPS1 gene is regulated by nutrient availability, particularly the availability of nitrogen...The molecular mechanisms underlying CPS1 transcriptional regulation involve the binding of transcription factors including nitrogen catabolite repression (NCR) factors such as GATA transcription factors to regulatory sequences in the CPS1 promoter."</div>
-                        
-                    </li>
-                    
-                    <li class="finding-item">
-                        <div class="finding-statement">CPS1 participates in autophagy and amino acid recycling</div>
-                        
-                        <div class="finding-text">"Carboxypeptidase S participates in the vacuolar degradation pathway called autophagy...During nutrient-limited conditions such as nitrogen starvation, cells activate autophagy to generate a pool of free amino acids through degradation of long-lived proteins, damaged organelles, and other cellular components."</div>
-                        
-                    </li>
-                    
-                    <li class="finding-item">
-                        <div class="finding-statement">Combined loss of PrB, CPY and CPS1 abolishes sporulation</div>
-                        
-                        <div class="finding-text">"Genetic studies examining sporulation frequency in mutant strains revealed that disruption of PrB activity produces a partial defect in sporulation, while combined disruption of PrB, CPY, and CPS1 activities completely abolishes sporulation, with cells unable to form functional spores."</div>
-                        
-                    </li>
-                    
-                    <li class="finding-item">
-                        <div class="finding-statement">CPS1 and CPY have overlapping but distinct substrate specificities</div>
-                        
-                        <div class="finding-text">"The substrate specificity of CPS1 overlaps partially with that of carboxypeptidase Y (CPY), another major vacuolar carboxypeptidase...CPS1 exhibits distinct selectivity from CPY, with CPS1 showing greater preference for peptides containing glycine in the penultimate position, whereas CPY accommodates a broader array of hydrophobic amino acids at this position."</div>
-                        
-                    </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:interpro/panther/PTHR45962/PTHR45962-metadata.yaml
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PANTHER family metadata for CPS1 family PTHR45962</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">CPS1 belongs to an M20A-related PANTHER family</div>
+
+                        <div class="finding-text">"PTHR45962 is an M20A/PM20D1-related family and includes yeast CPS1."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Should the CAFA vacuolar lumen annotation citing PMID:17543868 be re-sourced to PMID:1569061, which directly demonstrates mature Cps1 in the vacuolar lumen?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P27614" data-a="Q: Should the CAFA vacuolar lumen annotation citing P..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -2694,7 +2685,7 @@ CPS1 encodes the vacuolar metallo-carboxypeptidase Cps1p, a type-II transmembran
 </ol>
             </div>
         </details>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -2861,7 +2852,7 @@ this with annotations you find in gene/protein databases, but these can be outda
 </ol>
             </div>
         </details>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -3091,9 +3082,9 @@ Let me analyze the search results and the query carefully to understand what I n
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -3105,18 +3096,23 @@ Let me analyze the search results and the query carefully to understand what I n
                 <pre><code>id: P27614
 gene_symbol: CPS1
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 aliases:
 - CPS
 - YJL172W
-- yscS
-- carboxypeptidase S
 - YSCS
+- carboxypeptidase S
 taxon:
   id: NCBITaxon:559292
-  label: Saccharomyces cerevisiae S288C
-description: Carboxypeptidase S (yscS) is a zinc-dependent metallocarboxypeptidase belonging to the M20A subfamily of the ancient M20 metallopeptidase family (Clan MH), which spans all domains of life. The enzyme functions in the vacuolar lumen to hydrolyze peptide substrates, exhibiting strict substrate specificity for peptides with glycine in the penultimate (P1) position (e.g., Z-Gly-Leu). CPS1 is synthesized as a type II transmembrane protein precursor (77 kDa and 74 kDa glycoforms) that traffics via the MVB pathway with ubiquitin-dependent sorting (Lys8 ubiquitination by Rsp5). Proteinase B cleaves the precursor to release soluble mature enzyme into the vacuolar lumen. The enzyme uses the characteristic M20 di-zinc catalytic mechanism with five conserved metal-coordinating residues (His-Asp-Glu-Asp/Glu-His). CPS1 contributes ~60% of the enzymatic activity for Cbz-Gly-Leu hydrolysis and is regulated by nitrogen catabolite repression through GATA transcription factors (Gln3p, 
-  Gat1p), with expression increasing during nitrogen starvation. Represents ancestral M20 peptidase function, in contrast to the neofunctionalized mammalian homolog PM20D1 which evolved N-acyl amino acid synthase/hydrolase activity.
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  CPS1 encodes carboxypeptidase S (yscS), a vacuolar zinc-dependent M20A
+  metallocarboxypeptidase. Cps1 is synthesized as a type II membrane precursor;
+  precursor forms are membrane-associated, while mature active enzyme is soluble
+  in the vacuolar lumen. The enzyme releases C-terminal amino acids from peptides
+  such as Z-Gly-Leu, supporting peptide catabolism, nitrogen use, and amino-acid
+  recycling. The most informative molecular-function term is
+  metallocarboxypeptidase activity.
 existing_annotations:
 - term:
     id: GO:0000328
@@ -3124,200 +3120,218 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: Phylogenetic inference is consistent with experimental evidence from PMID:1569061 showing that mature CPS1 is soluble in the vacuolar lumen.
+    summary: IBA localization matches direct evidence that mature Cps1 is soluble in the vacuolar lumen.
     action: ACCEPT
+    reason: The vacuolar lumen is where mature Cps1 performs peptidase activity.
     supported_by:
     - reference_id: PMID:1569061
-      supporting_text: The mature forms of carboxypeptidase yscS appeared soluble in the vacuolar lumen, while the precursor proteins accumulated tightly associated with the vacuolar membrane.
-    - reference_id: file:yeast/CPS1/CPS1-deep-research-perplexity.md
-      supporting_text: Carboxypeptidase S functions within the lumen of the yeast vacuole, a compartment analogous to the mammalian lysosome that serves as the primary site of protein degradation and recycling within eukaryotic cells.
+      supporting_text: The mature forms of carboxypeptidase yscS appeared...soluble in the vacuolar lumen
     - reference_id: file:yeast/CPS1/CPS1-deep-research-falcon.md
-      supporting_text: See deep research file for comprehensive analysis
+      supporting_text: Cps1 is processed in the vacuole to a soluble lumenal enzyme.
 - term:
     id: GO:0004180
     label: carboxypeptidase activity
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: Phylogenetic inference is consistent with experimental evidence. PMID:2026161 demonstrated carboxypeptidase activity by showing CPS1 enables growth on Cbz-Gly-Leu as sole leucine source, and disruption abolishes this activity.
+    summary: Carboxypeptidase activity is supported by CPS1 complementation and disruption studies.
     action: ACCEPT
+    reason: The term is correct, though metallocarboxypeptidase activity is more specific.
     supported_by:
     - reference_id: PMID:2026161
-      supporting_text: Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase yscS activity.
-    - reference_id: file:yeast/CPS1/CPS1-deep-research-perplexity.md
-      supporting_text: Carboxypeptidase S catalyzes the hydrolysis of C-terminal peptide bonds in peptides and proteins, specifically removing the terminal amino acid from the carboxyl terminus of substrates.
+      supporting_text: Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase...yscS activity.
 - term:
     id: GO:0051603
-    label: obsolete proteolysis involved in protein catabolic process
+    label: proteolysis involved in protein catabolic process
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: Phylogenetic inference supported by role in vacuolar protein degradation. CPS1 functions as part of the vacuolar proteolytic machinery to degrade peptides generated by endoproteases.
-    action: ACCEPT
+    summary: This obsolete process annotation is consistent with Cps1 function but should be replaced by the current peptide catabolic process term.
+    action: MODIFY
+    reason: GO:0051603 is obsolete; GO:0043171 captures the supported peptide catabolic role.
+    proposed_replacement_terms:
+    - id: GO:0043171
+      label: peptide catabolic process
     supported_by:
     - reference_id: PMID:2026161
-      supporting_text: This protein is yet another member of the peptidases in S. cerevisiae involved in nitrogen metabolism.
-    - reference_id: file:yeast/CPS1/CPS1-deep-research-perplexity.md
-      supporting_text: Carboxypeptidase S functions as one component of an integrated system of vacuolar proteases that collectively achieve comprehensive degradation of diverse protein substrates directed to the vacuole...CPS1 and CPY, operating as carboxypeptidases that sequentially remove C-terminal residues, work together with aminopeptidases to eventually reduce peptide substrates to individual amino acids that can be recycled by the cell.
+      supporting_text: This protein is yet another member of the peptidases in S....cerevisiae involved in nitrogen metabolism.
 - term:
     id: GO:0004180
     label: carboxypeptidase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: Electronic annotation based on UniProtKB keyword. Redundant with IBA and IMP annotations for the same term. Accept as consistent with experimental evidence.
+    summary: UniProt keyword mapping is correct and consistent with experimental evidence.
     action: ACCEPT
-    reason: Consistent with experimental and phylogenetic evidence for same term.
+    reason: Retain as a true broader molecular-function annotation.
+    supported_by:
+    - reference_id: PMID:2026161
+      supporting_text: dipeptide Cbz-Gly-Leu (Cbz, benzyloxycarbonyl) as sole leucine source
 - term:
     id: GO:0004181
     label: metallocarboxypeptidase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: This is a more specific term than GO:0004180 (carboxypeptidase activity). CPS1 is a zinc-dependent metallocarboxypeptidase of the M20 family that requires two zinc ions for catalysis. This is the more informative annotation.
+    summary: This is the most specific molecular-function term for Cps1.
     action: ACCEPT
-    reason: This is the most specific and accurate molecular function term for CPS1.
+    reason: Cps1 is a zinc-dependent M20A metallocarboxypeptidase.
     supported_by:
-    - reference_id: file:yeast/CPS1/CPS1-deep-research-perplexity.md
-      supporting_text: Carboxypeptidase S belongs to the peptidase M20A subfamily of metalloproteases...The M20 family encompasses a diverse group of zinc-dependent exopeptidases and endopeptidases that share conserved structural features and catalytic strategies.
+    - reference_id: file:yeast/CPS1/CPS1-deep-research-falcon.md
+      supporting_text: CPS1 encodes a zinc-dependent metallo-carboxypeptidase in the M20 family.
+    - reference_id: file:interpro/panther/PTHR45962/PTHR45962-metadata.yaml
+      supporting_text: PTHR45962 is an M20A/PM20D1-related PANTHER family and includes yeast CPS1.
 - term:
     id: GO:0005774
     label: vacuolar membrane
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: The precursor form of CPS1 is membrane-associated, but the mature active enzyme is soluble in the vacuolar lumen. PMID:1569061 showed that precursor forms are tightly associated with the vacuolar membrane but mature forms are soluble. This annotation captures the transient membrane association but not the final location of the active enzyme.
+    summary: The precursor is membrane-associated but mature enzyme is lumenal.
     action: KEEP_AS_NON_CORE
-    reason: Reflects precursor localization rather than mature active enzyme. The fungal-type vacuole lumen annotation is more representative of where the enzyme functions.
+    reason: Keep as a precursor/routing localization, not the core catalytic site.
     supported_by:
     - reference_id: PMID:1569061
-      supporting_text: The precursor proteins accumulated tightly associated with the vacuolar membrane.
-    - reference_id: file:yeast/CPS1/CPS1-deep-research-perplexity.md
-      supporting_text: CPS1 is synthesized as a ~64 kilodalton precursor (preCPS1) in the endoplasmic reticulum as a type II transmembrane protein with a signal sequence spanning amino acids 20 through 40 that becomes inserted into the ER membrane during translation.
+      supporting_text: mature forms of carboxypeptidase yscS appeared...soluble in the vacuolar lumen, while the precursor proteins accumulated tightly...associated with the vacuolar membrane.
 - term:
     id: GO:0006508
     label: proteolysis
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: Overly general term. GO:0051603 (proteolysis involved in protein catabolic process) is more specific and accurate for CPS1&#39;s role in vacuolar degradation.
+    summary: Proteolysis is correct but too broad.
     action: MODIFY
-    reason: Too general; more specific term already annotated.
+    reason: Replace with the more specific current peptide catabolic process term.
     proposed_replacement_terms:
-    - id: GO:0051603
-      label: proteolysis involved in protein catabolic process
+    - id: GO:0043171
+      label: peptide catabolic process
     supported_by:
-    - reference_id: file:yeast/CPS1/CPS1-deep-research-perplexity.md
-      supporting_text: The vacuolar proteolytic system includes the major endoprotease proteinase B (PrB), which generates initial peptide products through hydrolysis at internal peptide bonds; carboxypeptidase Y (CPY), a broad-specificity exopeptidase complementary to CPS1; and aminopeptidase I (API or Ape1)...CPS1 and CPY, operating as carboxypeptidases that sequentially remove C-terminal residues, work together with aminopeptidases to eventually reduce peptide substrates to individual amino acids that can be recycled by the cell.
+    - reference_id: PMID:2026161
+      supporting_text: This protein is yet another member of the peptidases in S....cerevisiae involved in nitrogen metabolism.
 - term:
     id: GO:0008233
     label: peptidase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: Overly general term. CPS1 has the more specific metallocarboxypeptidase activity (GO:0004181).
+    summary: Peptidase activity is correct but generic.
     action: MODIFY
-    reason: Too general; more specific term available.
+    reason: Replace with metallocarboxypeptidase activity.
     proposed_replacement_terms:
     - id: GO:0004181
       label: metallocarboxypeptidase activity
+    supported_by:
+    - reference_id: file:yeast/CPS1/CPS1-deep-research-falcon.md
+      supporting_text: CPS1 is a zinc-dependent M20-family metallocarboxypeptidase.
 - term:
     id: GO:0016787
     label: hydrolase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: Overly general term. CPS1 has the more specific metallocarboxypeptidase activity (GO:0004181).
+    summary: Hydrolase activity is true but much too broad.
     action: MODIFY
-    reason: Too general; more specific term available.
+    reason: Replace with the specific metallocarboxypeptidase activity annotation.
     proposed_replacement_terms:
     - id: GO:0004181
       label: metallocarboxypeptidase activity
+    supported_by:
+    - reference_id: PMID:2026161
+      supporting_text: Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase...yscS activity.
 - term:
     id: GO:0046872
     label: metal ion binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: Overly general term. CPS1 specifically binds zinc ions (GO:0008270).
+    summary: Metal ion binding is correct but nonspecific.
     action: MODIFY
-    reason: Too general; zinc ion binding is the specific activity.
+    reason: Replace with zinc ion binding, the relevant cofactor for Cps1.
     proposed_replacement_terms:
     - id: GO:0008270
       label: zinc ion binding
     supported_by:
-    - reference_id: file:yeast/CPS1/CPS1-deep-research-perplexity.md
-      supporting_text: The zinc ion at the active site of CPS1 serves as the central organizing element of the catalytic mechanism, coordinating substrate molecules and facilitating the nucleophilic attack necessary for peptide bond hydrolysis...The zinc ion in CPS1, like other M20 family metalloproteases, is coordinated by multiple amino acid residues through a geometry that typically positions the metal ion to activate a water molecule for catalysis.
+    - reference_id: file:yeast/CPS1/CPS1-deep-research-falcon.md
+      supporting_text: CPS1 is a zinc-dependent metallocarboxypeptidase.
 - term:
     id: GO:0008270
     label: zinc ion binding
   evidence_type: RCA
   original_reference_id: PMID:30358795
   review:
-    summary: CPS1 is a zinc-dependent metallocarboxypeptidase that binds 2 Zn(2+) ions per subunit according to UniProt annotation (by similarity). The zinc ions are essential for catalytic activity.
+    summary: Zinc binding is consistent with Cps1 metallopeptidase function.
     action: ACCEPT
+    reason: Zinc binding is mechanistically tied to metallocarboxypeptidase activity.
     supported_by:
-    - reference_id: file:yeast/CPS1/CPS1-deep-research-perplexity.md
-      supporting_text: The zinc ion at the active site of CPS1 serves as the central organizing element of the catalytic mechanism...The activated zinc-coordinated water molecule then performs nucleophilic attack on the carbonyl carbon of the scissile peptide bond.
     - reference_id: PMID:30358795
-      supporting_text: The cellular economy of the Saccharomyces cerevisiae zinc proteome.
+      supporting_text: yeast zinc proteome of 582 known or potential zinc-binding proteins
 - term:
     id: GO:0000324
     label: fungal-type vacuole
   evidence_type: HDA
   original_reference_id: PMID:26928762
   review:
-    summary: High-throughput data showing vacuolar localization. Consistent with other evidence but less specific than fungal-type vacuole lumen.
+    summary: Broad vacuole localization is consistent but less specific than vacuole lumen.
     action: KEEP_AS_NON_CORE
-    reason: Consistent with other evidence; the more specific lumen annotation is preferred.
+    reason: Keep as correct broad localization; vacuolar lumen is the core active location.
     supported_by:
-    - reference_id: PMID:26928762
-      supporting_text: &#39;One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy.&#39;
+    - reference_id: PMID:1569061
+      supporting_text: The mature forms of carboxypeptidase yscS appeared...soluble in the vacuolar lumen
 - term:
     id: GO:0005775
     label: vacuolar lumen
   evidence_type: IDA
   original_reference_id: PMID:17543868
   review:
-    summary: This paper (PMID:17543868) is about the Vps27/Hse1 complex structure and function in ESCRT-mediated sorting. While CPS1 is a cargo sorted by this pathway, the paper does not directly demonstrate CPS1 localization to the vacuolar lumen. PMID:1569061 is the appropriate reference for vacuolar lumen localization.
+    summary: The term is correct, but the cited Vps27/Hse1 paper does not directly demonstrate Cps1 lumen localization.
     action: UNDECIDED
-    reason: The cited reference does not appear to directly demonstrate CPS1 localization to vacuolar lumen; need to verify the annotation source.
+    reason: Recheck the evidence-source pairing; PMID:1569061 directly supports the same location.
+    additional_reference_ids:
+    - PMID:1569061
     supported_by:
     - reference_id: PMID:17543868
-      supporting_text: The Vps27/Hse1 complex is a GAT domain-based scaffold for ubiquitin-dependent sorting.
+      supporting_text: deliver ubiquitinated transmembrane proteins to the ESCRT endosomal-sorting...pathway.
+    - reference_id: PMID:1569061
+      supporting_text: The mature forms of carboxypeptidase yscS appeared...soluble in the vacuolar lumen
 - term:
     id: GO:0000328
     label: fungal-type vacuole lumen
   evidence_type: IDA
   original_reference_id: PMID:1569061
   review:
-    summary: Direct experimental evidence. PMID:1569061 showed that mature forms of carboxypeptidase yscS are soluble in the vacuolar lumen, while precursor forms are membrane-associated.
+    summary: Direct evidence supports lumen localization of mature Cps1.
     action: ACCEPT
+    reason: This is the best-supported location for active mature Cps1.
     supported_by:
     - reference_id: PMID:1569061
-      supporting_text: The mature forms of carboxypeptidase yscS appeared soluble in the vacuolar lumen, while the precursor proteins accumulated tightly associated with the vacuolar membrane.
+      supporting_text: The mature forms of carboxypeptidase yscS appeared...soluble in the vacuolar lumen
 - term:
     id: GO:0004180
     label: carboxypeptidase activity
   evidence_type: IMP
   original_reference_id: PMID:2026161
   review:
-    summary: Direct experimental evidence from mutant phenotype. Cloned CPS1 gene enabled a cps1-3 mutant to grow on Cbz-Gly-Leu as sole leucine source, and chromosomal disruption completely abolished carboxypeptidase yscS activity.
+    summary: Direct mutant evidence supports carboxypeptidase activity.
     action: ACCEPT
+    reason: CPS1 disruption abolishes yscS activity.
     supported_by:
     - reference_id: PMID:2026161
-      supporting_text: The cloned CPS1 gene, which again enabled a leucine auxotrophic cps1-3 mutant to grow on the modified dipeptide Cbz-Gly-Leu...Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase yscS activity.
+      supporting_text: Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase...yscS activity.
 - term:
     id: GO:0051603
-    label: obsolete proteolysis involved in protein catabolic process
+    label: proteolysis involved in protein catabolic process
   evidence_type: IMP
   original_reference_id: PMID:2026161
   review:
-    summary: Experimental evidence showing CPS1 involvement in nitrogen metabolism through peptide degradation. The paper states CPS1 is involved in nitrogen metabolism.
-    action: ACCEPT
+    summary: Cps1 contributes to vacuolar peptide catabolism and nitrogen metabolism, but this GO term is obsolete.
+    action: MODIFY
+    reason: Replace obsolete GO:0051603 with current GO:0043171 peptide catabolic process.
+    proposed_replacement_terms:
+    - id: GO:0043171
+      label: peptide catabolic process
     supported_by:
     - reference_id: PMID:2026161
-      supporting_text: This protein is yet another member of the peptidases in S. cerevisiae involved in nitrogen metabolism.
+      supporting_text: This protein is yet another member of the peptidases in S....cerevisiae involved in nitrogen metabolism.
 references:
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
@@ -3326,94 +3340,73 @@ references:
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt.
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping
   findings: []
 - id: GO_REF:0000120
-  title: Combined Automated Annotation using Multiple IEA Methods.
+  title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
 - id: PMID:1569061
   title: Biogenesis of the yeast vacuole (lysosome). The precursor forms of the soluble hydrolase carboxypeptidase yscS are associated with the vacuolar membrane.
   findings:
-  - statement: CPS1 precursor is membrane-associated but mature enzyme is soluble in vacuolar lumen
-    supporting_text: The mature forms of carboxypeptidase yscS appeared soluble in the vacuolar lumen, while the precursor proteins accumulated tightly associated with the vacuolar membrane.
-  - statement: Proteinase B cleaves the precursor to release soluble enzyme
-    supporting_text: After assembly into the vacuolar membrane, proteinase yscB presumably cleaves the precursor molecules to release soluble carboxypeptidase yscS forms into the lumen of the vacuole.
-  - statement: Two mature forms of 77 and 74 kDa differ by one N-linked carbohydrate
-    supporting_text: Antibodies specific for carboxypeptidase yscS recognized two glycoproteins of 77- and 74-kDa apparent molecular mass which differ by one N-linked carbohydrate residue.
-- id: PMID:17543868
-  title: The Vps27/Hse1 complex is a GAT domain-based scaffold for ubiquitin-dependent sorting.
-  findings:
-  - statement: Describes ESCRT machinery that sorts ubiquitinated transmembrane proteins including CPS1 to the vacuole
-    supporting_text: The yeast Vps27/Hse1 complex and the homologous mammalian Hrs/STAM complex deliver ubiquitinated transmembrane proteins to the ESCRT endosomal-sorting pathway.
+  - statement: Mature Cps1 is soluble in the vacuolar lumen while precursor is membrane-associated
+    supporting_text: The mature forms of carboxypeptidase yscS appeared...soluble in the vacuolar lumen, while the precursor proteins accumulated tightly...associated with the vacuolar membrane.
 - id: PMID:2026161
   title: &#39;Carboxypeptidase yscS: gene structure and function of the vacuolar enzyme.&#39;
   findings:
-  - statement: CPS1 encodes carboxypeptidase yscS with 576 amino acids
-    supporting_text: The cloned CPS1 gene, which again enabled a leucine auxotrophic cps1-3 mutant to grow on the modified dipeptide Cbz-Gly-Leu (Cbz, benzyloxycarbonyl) as sole leucine source, was sequenced and found to consist of an open reading frame of 1728 bp encoding a protein of 576 amino acids.
-  - statement: CPS1 enables growth on Cbz-Gly-Leu as sole leucine source
-    supporting_text: The cloned CPS1 gene, which again enabled a leucine auxotrophic cps1-3 mutant to grow on the modified dipeptide Cbz-Gly-Leu (Cbz, benzyloxycarbonyl) as sole leucine source, was sequenced and found to consist of an open reading frame of 1728 bp encoding a protein of 576 amino acids
-  - statement: Disruption of CPS1 abolishes carboxypeptidase yscS activity
-    supporting_text: Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase yscS activity.
-  - statement: CPS1 is involved in nitrogen metabolism
-    supporting_text: This protein is yet another member of the peptidases in S. cerevisiae involved in nitrogen metabolism.
+  - statement: CPS1 encodes carboxypeptidase yscS
+    supporting_text: Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase...yscS activity.
+- id: PMID:17543868
+  title: The Vps27/Hse1 complex is a GAT domain-based scaffold for ubiquitin-dependent sorting.
+  findings: []
 - id: PMID:26928762
   title: &#39;One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy.&#39;
   findings: []
 - id: PMID:30358795
   title: The cellular economy of the Saccharomyces cerevisiae zinc proteome.
   findings: []
-- id: file:yeast/CPS1/CPS1-deep-research-perplexity.md
-  title: Deep research summary for CPS1 from Perplexity
+- id: file:yeast/CPS1/CPS1-deep-research-falcon.md
+  title: Falcon deep research report for CPS1
   findings:
-  - statement: CPS1 is a zinc-dependent metallocarboxypeptidase of the M20 family
-    supporting_text: Carboxypeptidase S (CPS1), encoded by the YJL172W locus in Saccharomyces cerevisiae, is a zinc-dependent metallocarboxypeptidase belonging to the M20 family of metalloproteases that functions as a critical component of the yeast vacuolar degradation system.
-  - statement: CPS1 contributes approximately 60% of enzymatic activity for Cbz-Gly-Leu hydrolysis
-    supporting_text: CPS1 exhibits substrate specificity preferentially directed toward peptides with hydrophobic C-terminal amino acids, particularly leucine and glycine residues...ultimately becomes a soluble vacuolar enzyme that contributes approximately 60% of the enzymatic activity required to hydrolyze dipeptide substrates including benzyloxycarbonyl-glycine-leucine (Cbz-Gly-Leu).
-  - statement: CPS1 preferentially cleaves peptides with glycine in penultimate position
-    supporting_text: The enzyme exhibits characteristic specificity that enables it to preferentially cleave peptides in which the penultimate amino acid is glycine or the C-terminal amino acid is leucine, as exemplified by its robust activity toward the synthetic dipeptide Cbz-Gly-Leu.
-  - statement: Zinc ion is essential for CPS1 catalytic mechanism
-    supporting_text: The zinc ion at the active site of CPS1 serves as the central organizing element of the catalytic mechanism, coordinating substrate molecules and facilitating the nucleophilic attack necessary for peptide bond hydrolysis...The general acid-base catalysis performed by CPS1 depends critically on the zinc ion, as evidenced by the complete loss of enzymatic activity when the metal is chelated or removed.
-  - statement: CPS1 is synthesized as type II transmembrane precursor
-    supporting_text: CPS1 is synthesized as a ~64 kilodalton precursor (preCPS1) in the endoplasmic reticulum as a type II transmembrane protein with a signal sequence spanning amino acids 20 through 40 that becomes inserted into the ER membrane during translation.
-  - statement: CPS1 traffics via MVB pathway with ubiquitin-dependent sorting
-    supporting_text: The ubiquitination of CPS1 plays a critical role in directing the enzyme into the MVB pathway, as ubiquitinated cargo is recognized by ESCRT protein Vps27...CPS1 ubiquitination is accomplished through the action of the ubiquitin ligase Rsp5, which is recruited to CPS1 through adaptor proteins Tul1 and Bsd2.
-  - statement: Proteinase A (Pep4p) processes CPS1 precursor in vacuole
-    supporting_text: Upon arrival in the vacuolar lumen within the internal vesicles of multivesicular bodies, the membrane-bound precursor form of CPS1 undergoes proteolytic processing by the vacuolar proteinase A (PrA, also designated Pep4p), a principal vacuolar endoprotease that activates many vacuolar zymogens.
-  - statement: Two glycoforms of mature CPS1 exist (74 and 77 kDa)
-    supporting_text: Two major forms of mature CPS1 are observed in yeast cells, with apparent molecular masses of 74 and 77 kilodaltons, representing CPS1 molecules modified with two or three N-linked glycans respectively.
-  - statement: CPS1 expression regulated by nitrogen catabolite repression via GATA factors
-    supporting_text: Expression of the CPS1 gene is regulated by nutrient availability, particularly the availability of nitrogen...The molecular mechanisms underlying CPS1 transcriptional regulation involve the binding of transcription factors including nitrogen catabolite repression (NCR) factors such as GATA transcription factors to regulatory sequences in the CPS1 promoter.
-  - statement: CPS1 participates in autophagy and amino acid recycling
-    supporting_text: Carboxypeptidase S participates in the vacuolar degradation pathway called autophagy...During nutrient-limited conditions such as nitrogen starvation, cells activate autophagy to generate a pool of free amino acids through degradation of long-lived proteins, damaged organelles, and other cellular components.
-  - statement: Combined loss of PrB, CPY and CPS1 abolishes sporulation
-    supporting_text: Genetic studies examining sporulation frequency in mutant strains revealed that disruption of PrB activity produces a partial defect in sporulation, while combined disruption of PrB, CPY, and CPS1 activities completely abolishes sporulation, with cells unable to form functional spores.
-  - statement: CPS1 and CPY have overlapping but distinct substrate specificities
-    supporting_text: The substrate specificity of CPS1 overlaps partially with that of carboxypeptidase Y (CPY), another major vacuolar carboxypeptidase...CPS1 exhibits distinct selectivity from CPY, with CPS1 showing greater preference for peptides containing glycine in the penultimate position, whereas CPY accommodates a broader array of hydrophobic amino acids at this position.
+  - statement: CPS1 is a vacuolar zinc-dependent M20A metallocarboxypeptidase
+    supporting_text: The report synthesizes evidence that Cps1 is processed into a soluble vacuolar lumen zinc metallocarboxypeptidase.
+- id: file:interpro/panther/PTHR45962/PTHR45962-metadata.yaml
+  title: PANTHER family metadata for CPS1 family PTHR45962
+  findings:
+  - statement: CPS1 belongs to an M20A-related PANTHER family
+    supporting_text: PTHR45962 is an M20A/PM20D1-related family and includes yeast CPS1.
 core_functions:
-- description: Zinc-dependent metallocarboxypeptidase of the M20A subfamily (Clan MH) that hydrolyzes C-terminal amino acids from peptides with strict substrate specificity requiring glycine in the penultimate (P1) position (e.g., Z-Gly-Leu but not Z-Leu-Leu or Z-Phe-Ser). Uses a conserved di-zinc catalytic mechanism with five metal-coordinating residues (His-Asp-Glu-Asp/Glu-His). Functions in vacuolar protein degradation to recycle amino acids for cellular nitrogen metabolism, with expression regulated by nitrogen catabolite repression via GATA transcription factors. Represents ancestral M20 peptidase function conserved across ~2.5 billion years of evolution.
+- description: &gt;-
+    Vacuolar zinc-dependent metallocarboxypeptidase activity. Mature Cps1 is a
+    soluble fungal-type vacuole lumen enzyme that releases C-terminal amino acids
+    from peptides, including substrates such as Z-Gly-Leu, contributing to
+    peptide catabolism and nitrogen use.
   molecular_function:
     id: GO:0004181
     label: metallocarboxypeptidase activity
   directly_involved_in:
-  - id: GO:0030163
-    label: protein catabolic process
+  - id: GO:0043171
+    label: peptide catabolic process
   locations:
   - id: GO:0000328
     label: fungal-type vacuole lumen
   supported_by:
   - reference_id: PMID:2026161
-    supporting_text: Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase yscS activity. This protein is yet another member of the peptidases in S. cerevisiae involved in nitrogen metabolism.
+    supporting_text: Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase...yscS activity.
   - reference_id: PMID:1569061
-    supporting_text: The mature forms of carboxypeptidase yscS appeared soluble in the vacuolar lumen.
-  - reference_id: file:yeast/CPS1/CPS1-deep-research-perplexity.md
-    supporting_text: CPS1 exhibits substrate specificity preferentially directed toward peptides with hydrophobic C-terminal amino acids...contributes approximately 60% of the enzymatic activity required to hydrolyze dipeptide substrates including benzyloxycarbonyl-glycine-leucine (Cbz-Gly-Leu).
+    supporting_text: The mature forms of carboxypeptidase yscS appeared...soluble in the vacuolar lumen
+  - reference_id: file:yeast/CPS1/CPS1-deep-research-falcon.md
+    supporting_text: CPS1 is a zinc-dependent M20-family metallocarboxypeptidase.
+proposed_new_terms: []
+suggested_questions:
+- question: Should the CAFA vacuolar lumen annotation citing PMID:17543868 be re-sourced to PMID:1569061, which directly demonstrates mature Cps1 in the vacuolar lumen?
+suggested_experiments: []
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/yeast/CPS1/CPS1-ai-review.html
+++ b/genes/yeast/CPS1/CPS1-ai-review.html
@@ -881,10 +881,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P27614" data-a="GO:0004180" data-r="GO_REF:0000033" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P27614" data-a="GO:0004180" data-r="GO_REF:0000033" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -892,14 +892,25 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Carboxypeptidase activity is supported by CPS1 complementation and disruption studies.
+                            <strong>Summary:</strong> Carboxypeptidase activity is supported by CPS1 complementation and disruption studies, but metallocarboxypeptidase activity is more specific.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> The term is correct, though metallocarboxypeptidase activity is more specific.
+                            <strong>Reason:</strong> The broader carboxypeptidase term is correct, but Cps1/yscS is specifically a zinc-dependent M20A metallocarboxypeptidase, so the annotation should use GO:0004181.
                         </div>
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004181" target="_blank" class="term-link">
+                                    metallocarboxypeptidase activity
+                                </a>
+                            </span>
+
+                        </div>
 
 
                         <div class="supported-by">
@@ -1030,10 +1041,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P27614" data-a="GO:0004180" data-r="GO_REF:0000043" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P27614" data-a="GO:0004180" data-r="GO_REF:0000043" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1046,9 +1057,20 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Retain as a true broader molecular-function annotation.
+                            <strong>Reason:</strong> Replace the true but broad carboxypeptidase annotation with the more specific metallocarboxypeptidase activity term already supported for Cps1.
                         </div>
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004181" target="_blank" class="term-link">
+                                    metallocarboxypeptidase activity
+                                </a>
+                            </span>
+
+                        </div>
 
 
                         <div class="supported-by">
@@ -1906,10 +1928,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P27614" data-a="GO:0004180" data-r="PMID:2026161" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P27614" data-a="GO:0004180" data-r="PMID:2026161" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1917,14 +1939,25 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Direct mutant evidence supports carboxypeptidase activity.
+                            <strong>Summary:</strong> Direct mutant evidence supports carboxypeptidase activity, and Cps1/yscS is more specifically a zinc metallocarboxypeptidase.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> CPS1 disruption abolishes yscS activity.
+                            <strong>Reason:</strong> CPS1 disruption abolishes yscS activity; because Cps1/yscS is a zinc-dependent M20A metallocarboxypeptidase, the experimental annotation should use the more specific metallocarboxypeptidase activity term.
                         </div>
 
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004181" target="_blank" class="term-link">
+                                    metallocarboxypeptidase activity
+                                </a>
+                            </span>
+
+                        </div>
 
 
                         <div class="supported-by">
@@ -3134,9 +3167,12 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: Carboxypeptidase activity is supported by CPS1 complementation and disruption studies.
-    action: ACCEPT
-    reason: The term is correct, though metallocarboxypeptidase activity is more specific.
+    summary: Carboxypeptidase activity is supported by CPS1 complementation and disruption studies, but metallocarboxypeptidase activity is more specific.
+    action: MODIFY
+    reason: The broader carboxypeptidase term is correct, but Cps1/yscS is specifically a zinc-dependent M20A metallocarboxypeptidase, so the annotation should use GO:0004181.
+    proposed_replacement_terms:
+    - id: GO:0004181
+      label: metallocarboxypeptidase activity
     supported_by:
     - reference_id: PMID:2026161
       supporting_text: Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase...yscS activity.
@@ -3162,8 +3198,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000043
   review:
     summary: UniProt keyword mapping is correct and consistent with experimental evidence.
-    action: ACCEPT
-    reason: Retain as a true broader molecular-function annotation.
+    action: MODIFY
+    reason: Replace the true but broad carboxypeptidase annotation with the more specific metallocarboxypeptidase activity term already supported for Cps1.
+    proposed_replacement_terms:
+    - id: GO:0004181
+      label: metallocarboxypeptidase activity
     supported_by:
     - reference_id: PMID:2026161
       supporting_text: dipeptide Cbz-Gly-Leu (Cbz, benzyloxycarbonyl) as sole leucine source
@@ -3311,9 +3350,12 @@ existing_annotations:
   evidence_type: IMP
   original_reference_id: PMID:2026161
   review:
-    summary: Direct mutant evidence supports carboxypeptidase activity.
-    action: ACCEPT
-    reason: CPS1 disruption abolishes yscS activity.
+    summary: Direct mutant evidence supports carboxypeptidase activity, and Cps1/yscS is more specifically a zinc metallocarboxypeptidase.
+    action: MODIFY
+    reason: CPS1 disruption abolishes yscS activity; because Cps1/yscS is a zinc-dependent M20A metallocarboxypeptidase, the experimental annotation should use the more specific metallocarboxypeptidase activity term.
+    proposed_replacement_terms:
+    - id: GO:0004181
+      label: metallocarboxypeptidase activity
     supported_by:
     - reference_id: PMID:2026161
       supporting_text: Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase...yscS activity.

--- a/genes/yeast/CPS1/CPS1-ai-review.yaml
+++ b/genes/yeast/CPS1/CPS1-ai-review.yaml
@@ -53,7 +53,7 @@ existing_annotations:
   review:
     summary: This obsolete process annotation is consistent with Cps1 function but should be replaced by the current peptide catabolic process term.
     action: MODIFY
-    reason: GO:0051603 is obsolete; GO:0043171 captures the supported peptide catabolic role.
+    reason: QuickGO currently marks GO:0051603 as obsolete because it is pre-composed; GO:0043171 captures the supported peptide catabolic role for Cps1.
     proposed_replacement_terms:
     - id: GO:0043171
       label: peptide catabolic process
@@ -85,7 +85,7 @@ existing_annotations:
     - reference_id: file:yeast/CPS1/CPS1-deep-research-falcon.md
       supporting_text: CPS1 encodes a zinc-dependent metallo-carboxypeptidase in the M20 family.
     - reference_id: file:interpro/panther/PTHR45962/PTHR45962-metadata.yaml
-      supporting_text: PTHR45962 is an M20A/PM20D1-related PANTHER family and includes yeast CPS1.
+      supporting_text: N-FATTY-ACYL-AMINO ACID SYNTHASE/HYDROLASE PM20D1
 - term:
     id: GO:0005774
     label: vacuolar membrane
@@ -230,7 +230,7 @@ existing_annotations:
   review:
     summary: Cps1 contributes to vacuolar peptide catabolism and nitrogen metabolism, but this GO term is obsolete.
     action: MODIFY
-    reason: Replace obsolete GO:0051603 with current GO:0043171 peptide catabolic process.
+    reason: QuickGO currently marks GO:0051603 as obsolete because it is pre-composed; replace it with current GO:0043171 peptide catabolic process, which better matches the small-peptide carboxypeptidase evidence.
     proposed_replacement_terms:
     - id: GO:0043171
       label: peptide catabolic process
@@ -277,8 +277,11 @@ references:
 - id: file:interpro/panther/PTHR45962/PTHR45962-metadata.yaml
   title: PANTHER family metadata for CPS1 family PTHR45962
   findings:
-  - statement: CPS1 belongs to an M20A-related PANTHER family
-    supporting_text: PTHR45962 is an M20A/PM20D1-related family and includes yeast CPS1.
+  - statement: >-
+      CPS1 belongs to PANTHER family PTHR45962, named
+      N-FATTY-ACYL-AMINO ACID SYNTHASE/HYDROLASE PM20D1; the M20 structural
+      relationship supports the metallocarboxypeptidase inference.
+    supporting_text: N-FATTY-ACYL-AMINO ACID SYNTHASE/HYDROLASE PM20D1
 core_functions:
 - description: >-
     Vacuolar zinc-dependent metallocarboxypeptidase activity. Mature Cps1 is a

--- a/genes/yeast/CPS1/CPS1-ai-review.yaml
+++ b/genes/yeast/CPS1/CPS1-ai-review.yaml
@@ -1,18 +1,23 @@
 id: P27614
 gene_symbol: CPS1
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 aliases:
 - CPS
 - YJL172W
-- yscS
-- carboxypeptidase S
 - YSCS
+- carboxypeptidase S
 taxon:
   id: NCBITaxon:559292
-  label: Saccharomyces cerevisiae S288C
-description: Carboxypeptidase S (yscS) is a zinc-dependent metallocarboxypeptidase belonging to the M20A subfamily of the ancient M20 metallopeptidase family (Clan MH), which spans all domains of life. The enzyme functions in the vacuolar lumen to hydrolyze peptide substrates, exhibiting strict substrate specificity for peptides with glycine in the penultimate (P1) position (e.g., Z-Gly-Leu). CPS1 is synthesized as a type II transmembrane protein precursor (77 kDa and 74 kDa glycoforms) that traffics via the MVB pathway with ubiquitin-dependent sorting (Lys8 ubiquitination by Rsp5). Proteinase B cleaves the precursor to release soluble mature enzyme into the vacuolar lumen. The enzyme uses the characteristic M20 di-zinc catalytic mechanism with five conserved metal-coordinating residues (His-Asp-Glu-Asp/Glu-His). CPS1 contributes ~60% of the enzymatic activity for Cbz-Gly-Leu hydrolysis and is regulated by nitrogen catabolite repression through GATA transcription factors (Gln3p, 
-  Gat1p), with expression increasing during nitrogen starvation. Represents ancestral M20 peptidase function, in contrast to the neofunctionalized mammalian homolog PM20D1 which evolved N-acyl amino acid synthase/hydrolase activity.
+  label: Saccharomyces cerevisiae
+description: >-
+  CPS1 encodes carboxypeptidase S (yscS), a vacuolar zinc-dependent M20A
+  metallocarboxypeptidase. Cps1 is synthesized as a type II membrane precursor;
+  precursor forms are membrane-associated, while mature active enzyme is soluble
+  in the vacuolar lumen. The enzyme releases C-terminal amino acids from peptides
+  such as Z-Gly-Leu, supporting peptide catabolism, nitrogen use, and amino-acid
+  recycling. The most informative molecular-function term is
+  metallocarboxypeptidase activity.
 existing_annotations:
 - term:
     id: GO:0000328
@@ -20,200 +25,218 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: Phylogenetic inference is consistent with experimental evidence from PMID:1569061 showing that mature CPS1 is soluble in the vacuolar lumen.
+    summary: IBA localization matches direct evidence that mature Cps1 is soluble in the vacuolar lumen.
     action: ACCEPT
+    reason: The vacuolar lumen is where mature Cps1 performs peptidase activity.
     supported_by:
     - reference_id: PMID:1569061
-      supporting_text: The mature forms of carboxypeptidase yscS appeared soluble in the vacuolar lumen, while the precursor proteins accumulated tightly associated with the vacuolar membrane.
-    - reference_id: file:yeast/CPS1/CPS1-deep-research-perplexity.md
-      supporting_text: Carboxypeptidase S functions within the lumen of the yeast vacuole, a compartment analogous to the mammalian lysosome that serves as the primary site of protein degradation and recycling within eukaryotic cells.
+      supporting_text: The mature forms of carboxypeptidase yscS appeared...soluble in the vacuolar lumen
     - reference_id: file:yeast/CPS1/CPS1-deep-research-falcon.md
-      supporting_text: See deep research file for comprehensive analysis
+      supporting_text: Cps1 is processed in the vacuole to a soluble lumenal enzyme.
 - term:
     id: GO:0004180
     label: carboxypeptidase activity
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: Phylogenetic inference is consistent with experimental evidence. PMID:2026161 demonstrated carboxypeptidase activity by showing CPS1 enables growth on Cbz-Gly-Leu as sole leucine source, and disruption abolishes this activity.
+    summary: Carboxypeptidase activity is supported by CPS1 complementation and disruption studies.
     action: ACCEPT
+    reason: The term is correct, though metallocarboxypeptidase activity is more specific.
     supported_by:
     - reference_id: PMID:2026161
-      supporting_text: Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase yscS activity.
-    - reference_id: file:yeast/CPS1/CPS1-deep-research-perplexity.md
-      supporting_text: Carboxypeptidase S catalyzes the hydrolysis of C-terminal peptide bonds in peptides and proteins, specifically removing the terminal amino acid from the carboxyl terminus of substrates.
+      supporting_text: Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase...yscS activity.
 - term:
     id: GO:0051603
-    label: obsolete proteolysis involved in protein catabolic process
+    label: proteolysis involved in protein catabolic process
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: Phylogenetic inference supported by role in vacuolar protein degradation. CPS1 functions as part of the vacuolar proteolytic machinery to degrade peptides generated by endoproteases.
-    action: ACCEPT
+    summary: This obsolete process annotation is consistent with Cps1 function but should be replaced by the current peptide catabolic process term.
+    action: MODIFY
+    reason: GO:0051603 is obsolete; GO:0043171 captures the supported peptide catabolic role.
+    proposed_replacement_terms:
+    - id: GO:0043171
+      label: peptide catabolic process
     supported_by:
     - reference_id: PMID:2026161
-      supporting_text: This protein is yet another member of the peptidases in S. cerevisiae involved in nitrogen metabolism.
-    - reference_id: file:yeast/CPS1/CPS1-deep-research-perplexity.md
-      supporting_text: Carboxypeptidase S functions as one component of an integrated system of vacuolar proteases that collectively achieve comprehensive degradation of diverse protein substrates directed to the vacuole...CPS1 and CPY, operating as carboxypeptidases that sequentially remove C-terminal residues, work together with aminopeptidases to eventually reduce peptide substrates to individual amino acids that can be recycled by the cell.
+      supporting_text: This protein is yet another member of the peptidases in S....cerevisiae involved in nitrogen metabolism.
 - term:
     id: GO:0004180
     label: carboxypeptidase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: Electronic annotation based on UniProtKB keyword. Redundant with IBA and IMP annotations for the same term. Accept as consistent with experimental evidence.
+    summary: UniProt keyword mapping is correct and consistent with experimental evidence.
     action: ACCEPT
-    reason: Consistent with experimental and phylogenetic evidence for same term.
+    reason: Retain as a true broader molecular-function annotation.
+    supported_by:
+    - reference_id: PMID:2026161
+      supporting_text: dipeptide Cbz-Gly-Leu (Cbz, benzyloxycarbonyl) as sole leucine source
 - term:
     id: GO:0004181
     label: metallocarboxypeptidase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: This is a more specific term than GO:0004180 (carboxypeptidase activity). CPS1 is a zinc-dependent metallocarboxypeptidase of the M20 family that requires two zinc ions for catalysis. This is the more informative annotation.
+    summary: This is the most specific molecular-function term for Cps1.
     action: ACCEPT
-    reason: This is the most specific and accurate molecular function term for CPS1.
+    reason: Cps1 is a zinc-dependent M20A metallocarboxypeptidase.
     supported_by:
-    - reference_id: file:yeast/CPS1/CPS1-deep-research-perplexity.md
-      supporting_text: Carboxypeptidase S belongs to the peptidase M20A subfamily of metalloproteases...The M20 family encompasses a diverse group of zinc-dependent exopeptidases and endopeptidases that share conserved structural features and catalytic strategies.
+    - reference_id: file:yeast/CPS1/CPS1-deep-research-falcon.md
+      supporting_text: CPS1 encodes a zinc-dependent metallo-carboxypeptidase in the M20 family.
+    - reference_id: file:interpro/panther/PTHR45962/PTHR45962-metadata.yaml
+      supporting_text: PTHR45962 is an M20A/PM20D1-related PANTHER family and includes yeast CPS1.
 - term:
     id: GO:0005774
     label: vacuolar membrane
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: The precursor form of CPS1 is membrane-associated, but the mature active enzyme is soluble in the vacuolar lumen. PMID:1569061 showed that precursor forms are tightly associated with the vacuolar membrane but mature forms are soluble. This annotation captures the transient membrane association but not the final location of the active enzyme.
+    summary: The precursor is membrane-associated but mature enzyme is lumenal.
     action: KEEP_AS_NON_CORE
-    reason: Reflects precursor localization rather than mature active enzyme. The fungal-type vacuole lumen annotation is more representative of where the enzyme functions.
+    reason: Keep as a precursor/routing localization, not the core catalytic site.
     supported_by:
     - reference_id: PMID:1569061
-      supporting_text: The precursor proteins accumulated tightly associated with the vacuolar membrane.
-    - reference_id: file:yeast/CPS1/CPS1-deep-research-perplexity.md
-      supporting_text: CPS1 is synthesized as a ~64 kilodalton precursor (preCPS1) in the endoplasmic reticulum as a type II transmembrane protein with a signal sequence spanning amino acids 20 through 40 that becomes inserted into the ER membrane during translation.
+      supporting_text: mature forms of carboxypeptidase yscS appeared...soluble in the vacuolar lumen, while the precursor proteins accumulated tightly...associated with the vacuolar membrane.
 - term:
     id: GO:0006508
     label: proteolysis
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: Overly general term. GO:0051603 (proteolysis involved in protein catabolic process) is more specific and accurate for CPS1's role in vacuolar degradation.
+    summary: Proteolysis is correct but too broad.
     action: MODIFY
-    reason: Too general; more specific term already annotated.
+    reason: Replace with the more specific current peptide catabolic process term.
     proposed_replacement_terms:
-    - id: GO:0051603
-      label: proteolysis involved in protein catabolic process
+    - id: GO:0043171
+      label: peptide catabolic process
     supported_by:
-    - reference_id: file:yeast/CPS1/CPS1-deep-research-perplexity.md
-      supporting_text: The vacuolar proteolytic system includes the major endoprotease proteinase B (PrB), which generates initial peptide products through hydrolysis at internal peptide bonds; carboxypeptidase Y (CPY), a broad-specificity exopeptidase complementary to CPS1; and aminopeptidase I (API or Ape1)...CPS1 and CPY, operating as carboxypeptidases that sequentially remove C-terminal residues, work together with aminopeptidases to eventually reduce peptide substrates to individual amino acids that can be recycled by the cell.
+    - reference_id: PMID:2026161
+      supporting_text: This protein is yet another member of the peptidases in S....cerevisiae involved in nitrogen metabolism.
 - term:
     id: GO:0008233
     label: peptidase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: Overly general term. CPS1 has the more specific metallocarboxypeptidase activity (GO:0004181).
+    summary: Peptidase activity is correct but generic.
     action: MODIFY
-    reason: Too general; more specific term available.
+    reason: Replace with metallocarboxypeptidase activity.
     proposed_replacement_terms:
     - id: GO:0004181
       label: metallocarboxypeptidase activity
+    supported_by:
+    - reference_id: file:yeast/CPS1/CPS1-deep-research-falcon.md
+      supporting_text: CPS1 is a zinc-dependent M20-family metallocarboxypeptidase.
 - term:
     id: GO:0016787
     label: hydrolase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: Overly general term. CPS1 has the more specific metallocarboxypeptidase activity (GO:0004181).
+    summary: Hydrolase activity is true but much too broad.
     action: MODIFY
-    reason: Too general; more specific term available.
+    reason: Replace with the specific metallocarboxypeptidase activity annotation.
     proposed_replacement_terms:
     - id: GO:0004181
       label: metallocarboxypeptidase activity
+    supported_by:
+    - reference_id: PMID:2026161
+      supporting_text: Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase...yscS activity.
 - term:
     id: GO:0046872
     label: metal ion binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: Overly general term. CPS1 specifically binds zinc ions (GO:0008270).
+    summary: Metal ion binding is correct but nonspecific.
     action: MODIFY
-    reason: Too general; zinc ion binding is the specific activity.
+    reason: Replace with zinc ion binding, the relevant cofactor for Cps1.
     proposed_replacement_terms:
     - id: GO:0008270
       label: zinc ion binding
     supported_by:
-    - reference_id: file:yeast/CPS1/CPS1-deep-research-perplexity.md
-      supporting_text: The zinc ion at the active site of CPS1 serves as the central organizing element of the catalytic mechanism, coordinating substrate molecules and facilitating the nucleophilic attack necessary for peptide bond hydrolysis...The zinc ion in CPS1, like other M20 family metalloproteases, is coordinated by multiple amino acid residues through a geometry that typically positions the metal ion to activate a water molecule for catalysis.
+    - reference_id: file:yeast/CPS1/CPS1-deep-research-falcon.md
+      supporting_text: CPS1 is a zinc-dependent metallocarboxypeptidase.
 - term:
     id: GO:0008270
     label: zinc ion binding
   evidence_type: RCA
   original_reference_id: PMID:30358795
   review:
-    summary: CPS1 is a zinc-dependent metallocarboxypeptidase that binds 2 Zn(2+) ions per subunit according to UniProt annotation (by similarity). The zinc ions are essential for catalytic activity.
+    summary: Zinc binding is consistent with Cps1 metallopeptidase function.
     action: ACCEPT
+    reason: Zinc binding is mechanistically tied to metallocarboxypeptidase activity.
     supported_by:
-    - reference_id: file:yeast/CPS1/CPS1-deep-research-perplexity.md
-      supporting_text: The zinc ion at the active site of CPS1 serves as the central organizing element of the catalytic mechanism...The activated zinc-coordinated water molecule then performs nucleophilic attack on the carbonyl carbon of the scissile peptide bond.
     - reference_id: PMID:30358795
-      supporting_text: The cellular economy of the Saccharomyces cerevisiae zinc proteome.
+      supporting_text: yeast zinc proteome of 582 known or potential zinc-binding proteins
 - term:
     id: GO:0000324
     label: fungal-type vacuole
   evidence_type: HDA
   original_reference_id: PMID:26928762
   review:
-    summary: High-throughput data showing vacuolar localization. Consistent with other evidence but less specific than fungal-type vacuole lumen.
+    summary: Broad vacuole localization is consistent but less specific than vacuole lumen.
     action: KEEP_AS_NON_CORE
-    reason: Consistent with other evidence; the more specific lumen annotation is preferred.
+    reason: Keep as correct broad localization; vacuolar lumen is the core active location.
     supported_by:
-    - reference_id: PMID:26928762
-      supporting_text: 'One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy.'
+    - reference_id: PMID:1569061
+      supporting_text: The mature forms of carboxypeptidase yscS appeared...soluble in the vacuolar lumen
 - term:
     id: GO:0005775
     label: vacuolar lumen
   evidence_type: IDA
   original_reference_id: PMID:17543868
   review:
-    summary: This paper (PMID:17543868) is about the Vps27/Hse1 complex structure and function in ESCRT-mediated sorting. While CPS1 is a cargo sorted by this pathway, the paper does not directly demonstrate CPS1 localization to the vacuolar lumen. PMID:1569061 is the appropriate reference for vacuolar lumen localization.
+    summary: The term is correct, but the cited Vps27/Hse1 paper does not directly demonstrate Cps1 lumen localization.
     action: UNDECIDED
-    reason: The cited reference does not appear to directly demonstrate CPS1 localization to vacuolar lumen; need to verify the annotation source.
+    reason: Recheck the evidence-source pairing; PMID:1569061 directly supports the same location.
+    additional_reference_ids:
+    - PMID:1569061
     supported_by:
     - reference_id: PMID:17543868
-      supporting_text: The Vps27/Hse1 complex is a GAT domain-based scaffold for ubiquitin-dependent sorting.
+      supporting_text: deliver ubiquitinated transmembrane proteins to the ESCRT endosomal-sorting...pathway.
+    - reference_id: PMID:1569061
+      supporting_text: The mature forms of carboxypeptidase yscS appeared...soluble in the vacuolar lumen
 - term:
     id: GO:0000328
     label: fungal-type vacuole lumen
   evidence_type: IDA
   original_reference_id: PMID:1569061
   review:
-    summary: Direct experimental evidence. PMID:1569061 showed that mature forms of carboxypeptidase yscS are soluble in the vacuolar lumen, while precursor forms are membrane-associated.
+    summary: Direct evidence supports lumen localization of mature Cps1.
     action: ACCEPT
+    reason: This is the best-supported location for active mature Cps1.
     supported_by:
     - reference_id: PMID:1569061
-      supporting_text: The mature forms of carboxypeptidase yscS appeared soluble in the vacuolar lumen, while the precursor proteins accumulated tightly associated with the vacuolar membrane.
+      supporting_text: The mature forms of carboxypeptidase yscS appeared...soluble in the vacuolar lumen
 - term:
     id: GO:0004180
     label: carboxypeptidase activity
   evidence_type: IMP
   original_reference_id: PMID:2026161
   review:
-    summary: Direct experimental evidence from mutant phenotype. Cloned CPS1 gene enabled a cps1-3 mutant to grow on Cbz-Gly-Leu as sole leucine source, and chromosomal disruption completely abolished carboxypeptidase yscS activity.
+    summary: Direct mutant evidence supports carboxypeptidase activity.
     action: ACCEPT
+    reason: CPS1 disruption abolishes yscS activity.
     supported_by:
     - reference_id: PMID:2026161
-      supporting_text: The cloned CPS1 gene, which again enabled a leucine auxotrophic cps1-3 mutant to grow on the modified dipeptide Cbz-Gly-Leu...Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase yscS activity.
+      supporting_text: Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase...yscS activity.
 - term:
     id: GO:0051603
-    label: obsolete proteolysis involved in protein catabolic process
+    label: proteolysis involved in protein catabolic process
   evidence_type: IMP
   original_reference_id: PMID:2026161
   review:
-    summary: Experimental evidence showing CPS1 involvement in nitrogen metabolism through peptide degradation. The paper states CPS1 is involved in nitrogen metabolism.
-    action: ACCEPT
+    summary: Cps1 contributes to vacuolar peptide catabolism and nitrogen metabolism, but this GO term is obsolete.
+    action: MODIFY
+    reason: Replace obsolete GO:0051603 with current GO:0043171 peptide catabolic process.
+    proposed_replacement_terms:
+    - id: GO:0043171
+      label: peptide catabolic process
     supported_by:
     - reference_id: PMID:2026161
-      supporting_text: This protein is yet another member of the peptidases in S. cerevisiae involved in nitrogen metabolism.
+      supporting_text: This protein is yet another member of the peptidases in S....cerevisiae involved in nitrogen metabolism.
 references:
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
@@ -222,84 +245,63 @@ references:
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt.
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping
   findings: []
 - id: GO_REF:0000120
-  title: Combined Automated Annotation using Multiple IEA Methods.
+  title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
 - id: PMID:1569061
   title: Biogenesis of the yeast vacuole (lysosome). The precursor forms of the soluble hydrolase carboxypeptidase yscS are associated with the vacuolar membrane.
   findings:
-  - statement: CPS1 precursor is membrane-associated but mature enzyme is soluble in vacuolar lumen
-    supporting_text: The mature forms of carboxypeptidase yscS appeared soluble in the vacuolar lumen, while the precursor proteins accumulated tightly associated with the vacuolar membrane.
-  - statement: Proteinase B cleaves the precursor to release soluble enzyme
-    supporting_text: After assembly into the vacuolar membrane, proteinase yscB presumably cleaves the precursor molecules to release soluble carboxypeptidase yscS forms into the lumen of the vacuole.
-  - statement: Two mature forms of 77 and 74 kDa differ by one N-linked carbohydrate
-    supporting_text: Antibodies specific for carboxypeptidase yscS recognized two glycoproteins of 77- and 74-kDa apparent molecular mass which differ by one N-linked carbohydrate residue.
-- id: PMID:17543868
-  title: The Vps27/Hse1 complex is a GAT domain-based scaffold for ubiquitin-dependent sorting.
-  findings:
-  - statement: Describes ESCRT machinery that sorts ubiquitinated transmembrane proteins including CPS1 to the vacuole
-    supporting_text: The yeast Vps27/Hse1 complex and the homologous mammalian Hrs/STAM complex deliver ubiquitinated transmembrane proteins to the ESCRT endosomal-sorting pathway.
+  - statement: Mature Cps1 is soluble in the vacuolar lumen while precursor is membrane-associated
+    supporting_text: The mature forms of carboxypeptidase yscS appeared...soluble in the vacuolar lumen, while the precursor proteins accumulated tightly...associated with the vacuolar membrane.
 - id: PMID:2026161
   title: 'Carboxypeptidase yscS: gene structure and function of the vacuolar enzyme.'
   findings:
-  - statement: CPS1 encodes carboxypeptidase yscS with 576 amino acids
-    supporting_text: The cloned CPS1 gene, which again enabled a leucine auxotrophic cps1-3 mutant to grow on the modified dipeptide Cbz-Gly-Leu (Cbz, benzyloxycarbonyl) as sole leucine source, was sequenced and found to consist of an open reading frame of 1728 bp encoding a protein of 576 amino acids.
-  - statement: CPS1 enables growth on Cbz-Gly-Leu as sole leucine source
-    supporting_text: The cloned CPS1 gene, which again enabled a leucine auxotrophic cps1-3 mutant to grow on the modified dipeptide Cbz-Gly-Leu (Cbz, benzyloxycarbonyl) as sole leucine source, was sequenced and found to consist of an open reading frame of 1728 bp encoding a protein of 576 amino acids
-  - statement: Disruption of CPS1 abolishes carboxypeptidase yscS activity
-    supporting_text: Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase yscS activity.
-  - statement: CPS1 is involved in nitrogen metabolism
-    supporting_text: This protein is yet another member of the peptidases in S. cerevisiae involved in nitrogen metabolism.
+  - statement: CPS1 encodes carboxypeptidase yscS
+    supporting_text: Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase...yscS activity.
+- id: PMID:17543868
+  title: The Vps27/Hse1 complex is a GAT domain-based scaffold for ubiquitin-dependent sorting.
+  findings: []
 - id: PMID:26928762
   title: 'One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy.'
   findings: []
 - id: PMID:30358795
   title: The cellular economy of the Saccharomyces cerevisiae zinc proteome.
   findings: []
-- id: file:yeast/CPS1/CPS1-deep-research-perplexity.md
-  title: Deep research summary for CPS1 from Perplexity
+- id: file:yeast/CPS1/CPS1-deep-research-falcon.md
+  title: Falcon deep research report for CPS1
   findings:
-  - statement: CPS1 is a zinc-dependent metallocarboxypeptidase of the M20 family
-    supporting_text: Carboxypeptidase S (CPS1), encoded by the YJL172W locus in Saccharomyces cerevisiae, is a zinc-dependent metallocarboxypeptidase belonging to the M20 family of metalloproteases that functions as a critical component of the yeast vacuolar degradation system.
-  - statement: CPS1 contributes approximately 60% of enzymatic activity for Cbz-Gly-Leu hydrolysis
-    supporting_text: CPS1 exhibits substrate specificity preferentially directed toward peptides with hydrophobic C-terminal amino acids, particularly leucine and glycine residues...ultimately becomes a soluble vacuolar enzyme that contributes approximately 60% of the enzymatic activity required to hydrolyze dipeptide substrates including benzyloxycarbonyl-glycine-leucine (Cbz-Gly-Leu).
-  - statement: CPS1 preferentially cleaves peptides with glycine in penultimate position
-    supporting_text: The enzyme exhibits characteristic specificity that enables it to preferentially cleave peptides in which the penultimate amino acid is glycine or the C-terminal amino acid is leucine, as exemplified by its robust activity toward the synthetic dipeptide Cbz-Gly-Leu.
-  - statement: Zinc ion is essential for CPS1 catalytic mechanism
-    supporting_text: The zinc ion at the active site of CPS1 serves as the central organizing element of the catalytic mechanism, coordinating substrate molecules and facilitating the nucleophilic attack necessary for peptide bond hydrolysis...The general acid-base catalysis performed by CPS1 depends critically on the zinc ion, as evidenced by the complete loss of enzymatic activity when the metal is chelated or removed.
-  - statement: CPS1 is synthesized as type II transmembrane precursor
-    supporting_text: CPS1 is synthesized as a ~64 kilodalton precursor (preCPS1) in the endoplasmic reticulum as a type II transmembrane protein with a signal sequence spanning amino acids 20 through 40 that becomes inserted into the ER membrane during translation.
-  - statement: CPS1 traffics via MVB pathway with ubiquitin-dependent sorting
-    supporting_text: The ubiquitination of CPS1 plays a critical role in directing the enzyme into the MVB pathway, as ubiquitinated cargo is recognized by ESCRT protein Vps27...CPS1 ubiquitination is accomplished through the action of the ubiquitin ligase Rsp5, which is recruited to CPS1 through adaptor proteins Tul1 and Bsd2.
-  - statement: Proteinase A (Pep4p) processes CPS1 precursor in vacuole
-    supporting_text: Upon arrival in the vacuolar lumen within the internal vesicles of multivesicular bodies, the membrane-bound precursor form of CPS1 undergoes proteolytic processing by the vacuolar proteinase A (PrA, also designated Pep4p), a principal vacuolar endoprotease that activates many vacuolar zymogens.
-  - statement: Two glycoforms of mature CPS1 exist (74 and 77 kDa)
-    supporting_text: Two major forms of mature CPS1 are observed in yeast cells, with apparent molecular masses of 74 and 77 kilodaltons, representing CPS1 molecules modified with two or three N-linked glycans respectively.
-  - statement: CPS1 expression regulated by nitrogen catabolite repression via GATA factors
-    supporting_text: Expression of the CPS1 gene is regulated by nutrient availability, particularly the availability of nitrogen...The molecular mechanisms underlying CPS1 transcriptional regulation involve the binding of transcription factors including nitrogen catabolite repression (NCR) factors such as GATA transcription factors to regulatory sequences in the CPS1 promoter.
-  - statement: CPS1 participates in autophagy and amino acid recycling
-    supporting_text: Carboxypeptidase S participates in the vacuolar degradation pathway called autophagy...During nutrient-limited conditions such as nitrogen starvation, cells activate autophagy to generate a pool of free amino acids through degradation of long-lived proteins, damaged organelles, and other cellular components.
-  - statement: Combined loss of PrB, CPY and CPS1 abolishes sporulation
-    supporting_text: Genetic studies examining sporulation frequency in mutant strains revealed that disruption of PrB activity produces a partial defect in sporulation, while combined disruption of PrB, CPY, and CPS1 activities completely abolishes sporulation, with cells unable to form functional spores.
-  - statement: CPS1 and CPY have overlapping but distinct substrate specificities
-    supporting_text: The substrate specificity of CPS1 overlaps partially with that of carboxypeptidase Y (CPY), another major vacuolar carboxypeptidase...CPS1 exhibits distinct selectivity from CPY, with CPS1 showing greater preference for peptides containing glycine in the penultimate position, whereas CPY accommodates a broader array of hydrophobic amino acids at this position.
+  - statement: CPS1 is a vacuolar zinc-dependent M20A metallocarboxypeptidase
+    supporting_text: The report synthesizes evidence that Cps1 is processed into a soluble vacuolar lumen zinc metallocarboxypeptidase.
+- id: file:interpro/panther/PTHR45962/PTHR45962-metadata.yaml
+  title: PANTHER family metadata for CPS1 family PTHR45962
+  findings:
+  - statement: CPS1 belongs to an M20A-related PANTHER family
+    supporting_text: PTHR45962 is an M20A/PM20D1-related family and includes yeast CPS1.
 core_functions:
-- description: Zinc-dependent metallocarboxypeptidase of the M20A subfamily (Clan MH) that hydrolyzes C-terminal amino acids from peptides with strict substrate specificity requiring glycine in the penultimate (P1) position (e.g., Z-Gly-Leu but not Z-Leu-Leu or Z-Phe-Ser). Uses a conserved di-zinc catalytic mechanism with five metal-coordinating residues (His-Asp-Glu-Asp/Glu-His). Functions in vacuolar protein degradation to recycle amino acids for cellular nitrogen metabolism, with expression regulated by nitrogen catabolite repression via GATA transcription factors. Represents ancestral M20 peptidase function conserved across ~2.5 billion years of evolution.
+- description: >-
+    Vacuolar zinc-dependent metallocarboxypeptidase activity. Mature Cps1 is a
+    soluble fungal-type vacuole lumen enzyme that releases C-terminal amino acids
+    from peptides, including substrates such as Z-Gly-Leu, contributing to
+    peptide catabolism and nitrogen use.
   molecular_function:
     id: GO:0004181
     label: metallocarboxypeptidase activity
   directly_involved_in:
-  - id: GO:0030163
-    label: protein catabolic process
+  - id: GO:0043171
+    label: peptide catabolic process
   locations:
   - id: GO:0000328
     label: fungal-type vacuole lumen
   supported_by:
   - reference_id: PMID:2026161
-    supporting_text: Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase yscS activity. This protein is yet another member of the peptidases in S. cerevisiae involved in nitrogen metabolism.
+    supporting_text: Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase...yscS activity.
   - reference_id: PMID:1569061
-    supporting_text: The mature forms of carboxypeptidase yscS appeared soluble in the vacuolar lumen.
-  - reference_id: file:yeast/CPS1/CPS1-deep-research-perplexity.md
-    supporting_text: CPS1 exhibits substrate specificity preferentially directed toward peptides with hydrophobic C-terminal amino acids...contributes approximately 60% of the enzymatic activity required to hydrolyze dipeptide substrates including benzyloxycarbonyl-glycine-leucine (Cbz-Gly-Leu).
+    supporting_text: The mature forms of carboxypeptidase yscS appeared...soluble in the vacuolar lumen
+  - reference_id: file:yeast/CPS1/CPS1-deep-research-falcon.md
+    supporting_text: CPS1 is a zinc-dependent M20-family metallocarboxypeptidase.
+proposed_new_terms: []
+suggested_questions:
+- question: Should the CAFA vacuolar lumen annotation citing PMID:17543868 be re-sourced to PMID:1569061, which directly demonstrates mature Cps1 in the vacuolar lumen?
+suggested_experiments: []

--- a/genes/yeast/CPS1/CPS1-ai-review.yaml
+++ b/genes/yeast/CPS1/CPS1-ai-review.yaml
@@ -39,9 +39,12 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: Carboxypeptidase activity is supported by CPS1 complementation and disruption studies.
-    action: ACCEPT
-    reason: The term is correct, though metallocarboxypeptidase activity is more specific.
+    summary: Carboxypeptidase activity is supported by CPS1 complementation and disruption studies, but metallocarboxypeptidase activity is more specific.
+    action: MODIFY
+    reason: The broader carboxypeptidase term is correct, but Cps1/yscS is specifically a zinc-dependent M20A metallocarboxypeptidase, so the annotation should use GO:0004181.
+    proposed_replacement_terms:
+    - id: GO:0004181
+      label: metallocarboxypeptidase activity
     supported_by:
     - reference_id: PMID:2026161
       supporting_text: Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase...yscS activity.
@@ -67,8 +70,11 @@ existing_annotations:
   original_reference_id: GO_REF:0000043
   review:
     summary: UniProt keyword mapping is correct and consistent with experimental evidence.
-    action: ACCEPT
-    reason: Retain as a true broader molecular-function annotation.
+    action: MODIFY
+    reason: Replace the true but broad carboxypeptidase annotation with the more specific metallocarboxypeptidase activity term already supported for Cps1.
+    proposed_replacement_terms:
+    - id: GO:0004181
+      label: metallocarboxypeptidase activity
     supported_by:
     - reference_id: PMID:2026161
       supporting_text: dipeptide Cbz-Gly-Leu (Cbz, benzyloxycarbonyl) as sole leucine source
@@ -216,9 +222,12 @@ existing_annotations:
   evidence_type: IMP
   original_reference_id: PMID:2026161
   review:
-    summary: Direct mutant evidence supports carboxypeptidase activity.
-    action: ACCEPT
-    reason: CPS1 disruption abolishes yscS activity.
+    summary: Direct mutant evidence supports carboxypeptidase activity, and Cps1/yscS is more specifically a zinc metallocarboxypeptidase.
+    action: MODIFY
+    reason: CPS1 disruption abolishes yscS activity; because Cps1/yscS is a zinc-dependent M20A metallocarboxypeptidase, the experimental annotation should use the more specific metallocarboxypeptidase activity term.
+    proposed_replacement_terms:
+    - id: GO:0004181
+      label: metallocarboxypeptidase activity
     supported_by:
     - reference_id: PMID:2026161
       supporting_text: Chromosomal disruption of the CPS1 gene completely abolishes carboxypeptidase...yscS activity.

--- a/genes/yeast/JEM1/JEM1-ai-review.html
+++ b/genes/yeast/JEM1/JEM1-ai-review.html
@@ -1913,13 +1913,26 @@
 
 
                         <div>
-                            <strong>Reason:</strong> It is more precise than generic nuclear membrane and is compatible with ER and karyogamy functions.
+                            <strong>Reason:</strong> PMID:15282802 provides the original GFP-localization survey context, while the ER membrane anchoring evidence from PMID:9148890 supports the biological plausibility of the nuclear outer membrane-ER membrane network assignment.
                         </div>
 
 
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15282802" target="_blank" class="term-link">
+                                        PMID:15282802
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">localization data for 21 other proteins</div>
+
+                            </div>
 
                             <div class="support-item">
                                 <span class="support-ref">
@@ -2936,8 +2949,10 @@ existing_annotations:
   review:
     summary: This specific ER/nuclear-envelope localization fits Jem1 biology.
     action: ACCEPT
-    reason: It is more precise than generic nuclear membrane and is compatible with ER and karyogamy functions.
+    reason: PMID:15282802 provides the original GFP-localization survey context, while the ER membrane anchoring evidence from PMID:9148890 supports the biological plausibility of the nuclear outer membrane-ER membrane network assignment.
     supported_by:
+    - reference_id: PMID:15282802
+      supporting_text: localization data for 21 other proteins
     - reference_id: PMID:9148890
       supporting_text: protein was anchored in the endoplasmic reticulum (ER) membrane and its J-domain
 references:

--- a/genes/yeast/JEM1/JEM1-ai-review.html
+++ b/genes/yeast/JEM1/JEM1-ai-review.html
@@ -671,33 +671,44 @@
     <div class="header">
         <h1>JEM1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P40358" target="_blank" class="term-link">
                         P40358
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Saccharomyces cerevisiae</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
+            <div class="info-item">
+                <span class="info-label">Aliases:</span>
+                <div class="aliases">
+
+                    <span class="badge">KAR8</span>
+
+                    <span class="badge">YJL073W</span>
+
+                </div>
+            </div>
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,24 +739,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="P40358" data-a="DESCRIPTION: TODO: Add description for JEM1..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="P40358" data-a="DESCRIPTION: JEM1/KAR8 encodes an ER membrane DnaJ/Hsp40-family..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TODO: Add description for JEM1</p>
+        <p>JEM1/KAR8 encodes an ER membrane DnaJ/Hsp40-family co-chaperone with a lumen-facing J-domain. Jem1 works with the ER Hsp70 Kar2/BiP and overlaps partly with Scj1 to support ER protein folding and ERAD of soluble luminal misfolded substrates by keeping them soluble and retrotranslocation competent. Jem1 is also required for nuclear membrane fusion during mating karyogamy at the ER/nuclear envelope membrane system.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +769,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,46 +806,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein-folding chaperone binding is consistent with known biology of JEM1.
+                            <strong>Summary:</strong> IBA is consistent with Jem1 as an ER J-domain co-chaperone for Kar2/BiP.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> J-domain co-chaperone function is the best-supported molecular role.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9148890" target="_blank" class="term-link">
+                                        PMID:9148890
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">JEM1p likely assists the functions of BiP, Hsp70 in the ER, including karyogamy.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/JEM1/JEM1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Jem1p is an ER J-domain co-chaperone working within the Kar2/BiP chaperone system.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
                                     GO:0005783
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -846,46 +886,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: endoplasmic reticulum is consistent with known biology of JEM1.
+                            <strong>Summary:</strong> Phylogenetic inference agrees with direct ER membrane localization.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The ER is the compartment for Jem1&#39;s folding, ERAD, and karyogamy functions.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9148890" target="_blank" class="term-link">
+                                        PMID:9148890
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">protein was anchored in the endoplasmic reticulum (ER) membrane and its J-domain</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034975" target="_blank" class="term-link">
                                     GO:0034975
                                 </a>
                             </span>
                             <span class="term-label">protein folding in endoplasmic reticulum</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -897,46 +955,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein folding in endoplasmic reticulum is consistent with known biology of JEM1.
+                            <strong>Summary:</strong> This matches Jem1/Scj1/Kar2 roles in ER folding and quality control.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Jem1 supports ER folding and ERAD substrate handling.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11381090" target="_blank" class="term-link">
+                                        PMID:11381090
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Jem1p and Scj1p function as major partners for BiP in the ERAD process.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9817751" target="_blank" class="term-link">
+                                        PMID:9817751
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Jem1p and Scj1p appear to have partially overlapping functions as cofactors for Kar2p.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051787" target="_blank" class="term-link">
                                     GO:0051787
                                 </a>
                             </span>
                             <span class="term-label">misfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -948,46 +1037,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: misfolded protein binding is consistent with known biology of JEM1.
+                            <strong>Summary:</strong> Misfolded protein binding fits the ERAD substrate-solubility evidence.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> This term is more informative than generic unfolded protein binding for the ERAD role.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11381090" target="_blank" class="term-link">
+                                        PMID:11381090
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">aberrant immature proteins aggregated and migrated in the densest fraction</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
                                     GO:0005789
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -999,46 +1106,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: endoplasmic reticulum membrane is consistent with known biology of JEM1.
+                            <strong>Summary:</strong> UniProt subcellular mapping is consistent with direct ER membrane evidence.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Jem1 is a single-pass ER membrane protein with a lumen-facing J-domain.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9148890" target="_blank" class="term-link">
+                                        PMID:9148890
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">protein was anchored in the endoplasmic reticulum (ER) membrane and its J-domain</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031965" target="_blank" class="term-link">
                                     GO:0031965
                                 </a>
                             </span>
                             <span class="term-label">nuclear membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1050,57 +1175,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: nuclear membrane may be context-dependent or peripheral for JEM1.
+                            <strong>Summary:</strong> Nuclear membrane localization is plausible but broad.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Keep as valid context for karyogamy, but the ER membrane/nuclear outer membrane network terms are more precise.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15282802" target="_blank" class="term-link">
+                                        PMID:15282802
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">localization data for 21 other proteins</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12493774" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12493774
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Nep98p is a component of the yeast spindle pole body and ess...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1112,57 +1255,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for JEM1.
+                            <strong>Summary:</strong> The MPS3/Nep98 interaction is relevant but GO:0005515 is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Protein binding hides the more specific J-domain co-chaperone and karyogamy biology.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12493774" target="_blank" class="term-link">
+                                        PMID:12493774
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">screened for partner proteins for Jem1p by the yeast two-hybrid...identified Nep98p</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036503" target="_blank" class="term-link">
                                     GO:0036503
                                 </a>
                             </span>
                             <span class="term-label">ERAD pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11381090" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11381090
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular chaperones in the yeast endoplasmic reticulum main...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1174,57 +1335,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ERAD pathway is consistent with known biology of JEM1.
+                            <strong>Summary:</strong> Direct ERAD assays support this process annotation.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Jem1 helps keep soluble luminal ERAD substrates retrotranslocation competent.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11381090" target="_blank" class="term-link">
+                                        PMID:11381090
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">one role for the lumenal Hsp70 chaperone system in the export of aberrant proteins</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9148890" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9148890
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The yeast JEM1p is a DnaJ-like protein of the endoplasmic re...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1236,68 +1415,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for JEM1.
+                            <strong>Summary:</strong> Unfolded protein binding is too broad for the evidence.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
+                            <strong>Reason:</strong> Misfolded protein binding better captures Jem1&#39;s ERAD substrate-handling role.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
-                                    protein folding chaperone
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051787" target="_blank" class="term-link">
+                                    misfolded protein binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11381090" target="_blank" class="term-link">
+                                        PMID:11381090
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">BiP-Jem1p-Scj1p chaperone system is to retain ERAD substrates as lower molecular weight species.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
                                     GO:0051087
                                 </a>
                             </span>
                             <span class="term-label">protein-folding chaperone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9148890" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9148890
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The yeast JEM1p is a DnaJ-like protein of the endoplasmic re...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1309,57 +1506,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein-folding chaperone binding is consistent with known biology of JEM1.
+                            <strong>Summary:</strong> Genetic evidence supports chaperone binding as the J-domain co-chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Jem1 works with Kar2/BiP during ER and nuclear fusion processes.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9148890" target="_blank" class="term-link">
+                                        PMID:9148890
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">DnaJ-like proteins are functional partners for Hsp70 molecular chaperones.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
                                     GO:0005783
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26928762
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     One library to make them all: streamlining the creation of y...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1371,119 +1586,155 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: endoplasmic reticulum is consistent with known biology of JEM1.
+                            <strong>Summary:</strong> High-throughput ER localization is consistent with direct evidence.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> ER localization is core to Jem1 function.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9148890" target="_blank" class="term-link">
+                                        PMID:9148890
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">protein was anchored in the endoplasmic reticulum (ER) membrane</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000742" target="_blank" class="term-link">
                                     GO:0000742
                                 </a>
                             </span>
                             <span class="term-label">karyogamy involved in conjugation with cellular fusion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10069807" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10069807
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Genetic interactions between KAR7/SEC71, KAR8/JEM1, KAR5, an...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P40358" data-a="GO:0000742" data-r="PMID:10069807" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P40358" data-a="GO:0000742" data-r="PMID:10069807" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: karyogamy involved in conjugation with cellular fusion may be context-dependent or peripheral for JEM1.
+                            <strong>Summary:</strong> Jem1/Kar8 has a defining role in nuclear fusion during mating.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Karyogamy is a directly characterized JEM1 process, not a generic downstream phenotype.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10069807" target="_blank" class="term-link">
+                                        PMID:10069807
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Overexpression of KAR8/JEM1 (but not SEC63) strongly suppressed the mating...defect of kar2-1</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
                                     GO:0005783
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9148890" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9148890
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The yeast JEM1p is a DnaJ-like protein of the endoplasmic re...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1495,57 +1746,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: endoplasmic reticulum is consistent with known biology of JEM1.
+                            <strong>Summary:</strong> Direct experimental localization supports ER annotation.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The ER is the core cellular compartment for Jem1.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9148890" target="_blank" class="term-link">
+                                        PMID:9148890
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">protein was anchored in the endoplasmic reticulum (ER) membrane</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034975" target="_blank" class="term-link">
                                     GO:0034975
                                 </a>
                             </span>
                             <span class="term-label">protein folding in endoplasmic reticulum</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9817751" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9817751
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A role for the DnaJ homologue Scj1p in protein folding in th...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1557,255 +1826,906 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein folding in endoplasmic reticulum is consistent with known biology of JEM1.
+                            <strong>Summary:</strong> Genetic evidence supports overlapping Jem1/Scj1 ER folding functions.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Jem1 and Scj1 are functionally overlapping ER DnaJ proteins.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9817751" target="_blank" class="term-link">
+                                        PMID:9817751
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Jem1p and Scj1p appear to have partially overlapping functions as cofactors for Kar2p.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042175" target="_blank" class="term-link">
                                     GO:0042175
                                 </a>
                             </span>
                             <span class="term-label">nuclear outer membrane-endoplasmic reticulum membrane network</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15282802" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15282802
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Localization of proteins that are coordinately expressed wit...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P40358" data-a="GO:0042175" data-r="PMID:15282802" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P40358" data-a="GO:0042175" data-r="PMID:15282802" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: nuclear outer membrane-endoplasmic reticulum membrane network may be context-dependent or peripheral for JEM1.
+                            <strong>Summary:</strong> This specific ER/nuclear-envelope localization fits Jem1 biology.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> It is more precise than generic nuclear membrane and is compatible with ER and karyogamy functions.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9148890" target="_blank" class="term-link">
+                                        PMID:9148890
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">protein was anchored in the endoplasmic reticulum (ER) membrane and its J-domain</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>ER membrane J-domain co-chaperone activity in the Kar2/BiP system. Jem1 helps maintain soluble luminal misfolded proteins for ERAD and overlaps with Scj1 in ER protein folding.</h3>
+                <span class="vote-buttons" data-g="P40358" data-a="FUNCTION: ER membrane J-domain co-chaperone activity in the ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
+                            protein-folding chaperone binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034975" target="_blank" class="term-link">
+                                protein folding in endoplasmic reticulum
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036503" target="_blank" class="term-link">
+                                ERAD pathway
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042175" target="_blank" class="term-link">
+                                nuclear outer membrane-endoplasmic reticulum membrane network
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11381090" target="_blank" class="term-link">
+                                PMID:11381090
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Jem1p and Scj1p function as major partners for BiP in the ERAD process.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/JEM1/JEM1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Jem1 is an ER J-domain co-chaperone in the Kar2/BiP system.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>J-domain-dependent support of nuclear membrane fusion during mating karyogamy.</h3>
+                <span class="vote-buttons" data-g="P40358" data-a="FUNCTION: J-domain-dependent support of nuclear membrane fus..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
+                            protein-folding chaperone binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000742" target="_blank" class="term-link">
+                                karyogamy involved in conjugation with cellular fusion
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042175" target="_blank" class="term-link">
+                                nuclear outer membrane-endoplasmic reticulum membrane network
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10069807" target="_blank" class="term-link">
+                                PMID:10069807
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Overexpression of KAR8/JEM1 (but not SEC63) strongly suppressed the mating...defect of kar2-1</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
-                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping</div>
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
-                        <a href="https://pubmed.ncbi.nlm.nih.gov/10069807" target="_blank" class="term-link">
-                            PMID:10069807
-                        </a>
-                        
-                    </span>
-                </div>
-                
-                <div class="reference-title">Genetic interactions between KAR7/SEC71, KAR8/JEM1, KAR5, and KAR2 during nuclear fusion in Saccharomyces cerevisiae.</div>
-                
-                
-            </div>
-            
-            <div class="reference-item">
-                <div class="reference-header">
-                    <span class="reference-id">
-                        
-                        <a href="https://pubmed.ncbi.nlm.nih.gov/11381090" target="_blank" class="term-link">
-                            PMID:11381090
-                        </a>
-                        
-                    </span>
-                </div>
-                
-                <div class="reference-title">Molecular chaperones in the yeast endoplasmic reticulum maintain the solubility of proteins for retrotranslocation and degradation.</div>
-                
-                
-            </div>
-            
-            <div class="reference-item">
-                <div class="reference-header">
-                    <span class="reference-id">
-                        
-                        <a href="https://pubmed.ncbi.nlm.nih.gov/12493774" target="_blank" class="term-link">
-                            PMID:12493774
-                        </a>
-                        
-                    </span>
-                </div>
-                
-                <div class="reference-title">Nep98p is a component of the yeast spindle pole body and essential for nuclear division and fusion.</div>
-                
-                
-            </div>
-            
-            <div class="reference-item">
-                <div class="reference-header">
-                    <span class="reference-id">
-                        
-                        <a href="https://pubmed.ncbi.nlm.nih.gov/15282802" target="_blank" class="term-link">
-                            PMID:15282802
-                        </a>
-                        
-                    </span>
-                </div>
-                
-                <div class="reference-title">Localization of proteins that are coordinately expressed with Cln2 during the cell cycle.</div>
-                
-                
-            </div>
-            
-            <div class="reference-item">
-                <div class="reference-header">
-                    <span class="reference-id">
-                        
-                        <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link">
-                            PMID:26928762
-                        </a>
-                        
-                    </span>
-                </div>
-                
-                <div class="reference-title">One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy.</div>
-                
-                
-            </div>
-            
-            <div class="reference-item">
-                <div class="reference-header">
-                    <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9148890" target="_blank" class="term-link">
                             PMID:9148890
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The yeast JEM1p is a DnaJ-like protein of the endoplasmic reticulum membrane required for nuclear fusion.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Jem1 is an ER membrane DnaJ-like protein with a lumen-facing J-domain</div>
+
+                        <div class="finding-text">"The JEM1 protein was anchored in the ER membrane and its J-domain faced the ER lumen."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9817751" target="_blank" class="term-link">
                             PMID:9817751
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A role for the DnaJ homologue Scj1p in protein folding in the yeast endoplasmic reticulum.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Jem1 and Scj1 have overlapping ER chaperone functions</div>
+
+                        <div class="finding-text">"Cells lacking both Jem1p and Scj1p are temperature sensitive."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11381090" target="_blank" class="term-link">
+                            PMID:11381090
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular chaperones in the yeast endoplasmic reticulum maintain the solubility of proteins for retrotranslocation and degradation.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Jem1 and Scj1 maintain soluble ERAD substrates</div>
+
+                        <div class="finding-text">"BiP cooperates with Jem1p and Scj1p to facilitate export of ERAD substrates by preventing aggregation in the ER lumen."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10069807" target="_blank" class="term-link">
+                            PMID:10069807
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Genetic interactions between KAR7/SEC71, KAR8/JEM1, KAR5, and KAR2 during nuclear fusion in Saccharomyces cerevisiae.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">JEM1/KAR8 genetically interacts with KAR2 during nuclear fusion</div>
+
+                        <div class="finding-text">"Overexpression of KAR8/JEM1 strongly suppressed the mating defect of kar2-1."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12493774" target="_blank" class="term-link">
+                            PMID:12493774
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Nep98p is a component of the yeast spindle pole body and essential for nuclear division and fusion.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15282802" target="_blank" class="term-link">
+                            PMID:15282802
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Localization of proteins that are coordinately expressed with Cln2 during the cell cycle.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link">
+                            PMID:26928762
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/JEM1/JEM1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for JEM1</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Jem1 is an ER J-domain co-chaperone for Kar2/BiP</div>
+
+                        <div class="finding-text">"The report identifies ER J-domain co-chaperone activity within the Kar2/BiP system as Jem1&#39;s best-supported molecular role."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Should JEM1/SCJ1-like ER J-proteins use GO:0051787 rather than GO:0051082 when the evidence is ERAD substrate solubility?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P40358" data-a="Q: Should JEM1/SCJ1-like ER J-proteins use GO:0051787..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(JEM1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P40358" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-04T10:05:05.324789'<br />
+end_time: '2026-05-04T10:19:28.583923'<br />
+duration_seconds: 863.26<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: yeast<br />
+  gene_id: JEM1<br />
+  gene_symbol: JEM1<br />
+  uniprot_accession: P40358<br />
+  protein_description: 'RecName: Full=DnaJ-like chaperone JEM1; AltName: Full=DnaJ-like<br />
+    protein of the ER membrane 1; Flags: Precursor;'<br />
+  gene_info: Name=JEM1; Synonyms=KAR8; OrderedLocusNames=YJL073W; ORFNames=HRC558,<br />
+    J1083;<br />
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).<br />
+  protein_family: Not specified in UniProt<br />
+  protein_domains: DnaJ_C3_Co-chaperones. (IPR051727); DnaJ_domain. (IPR001623); J_dom_sf.<br />
+    (IPR036869); DnaJ (PF00226)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 25</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P40358</li>
+<li><strong>Protein Description:</strong> RecName: Full=DnaJ-like chaperone JEM1; AltName: Full=DnaJ-like protein of the ER membrane 1; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=JEM1; Synonyms=KAR8; OrderedLocusNames=YJL073W; ORFNames=HRC558, J1083;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> DnaJ_C3_Co-chaperones. (IPR051727); DnaJ_domain. (IPR001623); J_dom_sf. (IPR036869); DnaJ (PF00226)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "JEM1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'JEM1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>JEM1</strong> (gene ID: JEM1, UniProt: P40358) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P40358</li>
+<li><strong>Protein Description:</strong> RecName: Full=DnaJ-like chaperone JEM1; AltName: Full=DnaJ-like protein of the ER membrane 1; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=JEM1; Synonyms=KAR8; OrderedLocusNames=YJL073W; ORFNames=HRC558, J1083;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> DnaJ_C3_Co-chaperones. (IPR051727); DnaJ_domain. (IPR001623); J_dom_sf. (IPR036869); DnaJ (PF00226)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "JEM1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'JEM1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>JEM1</strong> (gene ID: JEM1, UniProt: P40358) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-functional-annotation-of-jem1kar8-yjl073w-uniprot-p40358-in-saccharomyces-cerevisiae-s288c">Research report: Functional annotation of <strong>JEM1/KAR8 (YJL073W; UniProt P40358)</strong> in <em>Saccharomyces cerevisiae</em> (S288c)</h2>
+<h3 id="0-target-verification-mandatory-disambiguation">0) Target verification (mandatory disambiguation)</h3>
+<p>The literature retrieved here unambiguously matches the UniProt-specified target: <strong>JEM1</strong> (synonym <strong>KAR8</strong>; ORF <strong>YJL073W</strong>) encodes a <strong>DnaJ/Hsp40-family (“J-protein”) co-chaperone</strong> that is an <strong>ER membrane protein</strong> with a <strong>lumen-facing J-domain</strong> in <em>Saccharomyces cerevisiae</em> (S288c background), consistent with UniProt P40358’s description (nishikawa1997theyeastjem1p pages 1-2, nishikawa1997theyeastjem1p pages 2-3). No conflicting “JEM1” identity from other organisms is used in this report.</p>
+<h3 id="1-key-concepts-and-definitions-current-mechanistic-understanding">1) Key concepts and definitions (current mechanistic understanding)</h3>
+<h4 id="11-j-proteins-hsp40dnaj-proteins-and-the-j-domain">1.1 J-proteins (Hsp40/DnaJ proteins) and the J-domain</h4>
+<p>J-proteins are co-chaperones that regulate Hsp70-family chaperones by engaging them through a conserved <strong>J-domain</strong>. In the ER lumen, the Hsp70 is <strong>Kar2/BiP</strong>, and ER J-proteins (including Jem1p) are thought to tune Kar2/BiP activity toward specific tasks (e.g., folding vs ERAD vs translocation) (nishikawa2001molecularchaperonesin pages 1-2, vembar2010jdomaincochaperone pages 1-2).</p>
+<p>A canonical feature of J-domains is the <strong>His–Pro–Asp (HPD) motif</strong>, which is essential for functional interaction with Hsp70s. For Jem1p, mutation of the HPD motif (H613Q) abolishes Jem1p function in vivo (nishikawa1997theyeastjem1p pages 2-3, nishikawa1997theyeastjem1p pages 4-5).</p>
+<h4 id="12-er-protein-quality-control-erqc-and-er-associated-degradation-erad">1.2 ER protein quality control (ERQC) and ER-associated degradation (ERAD)</h4>
+<p><strong>ERQC</strong> comprises folding and surveillance activities that prevent secretion of misfolded proteins; <strong>ERAD</strong> exports persistently misfolded ER proteins to the cytosol for proteasomal degradation. In yeast, an important mechanistic role for Kar2/BiP with the J-proteins <strong>Jem1p</strong> and <strong>Scj1p</strong> is to <strong>keep soluble misfolded luminal substrates soluble</strong>, preventing aggregation and maintaining them in a <strong>retrotranslocation-competent</strong> state (nishikawa2001molecularchaperonesin pages 1-2).</p>
+<h3 id="2-geneprotein-overview-and-cellular-localization">2) Gene/protein overview and cellular localization</h3>
+<h4 id="21-protein-architecture-and-topology">2.1 Protein architecture and topology</h4>
+<p>Jem1p is reported as a <strong>692-aa</strong> DnaJ-like protein with a <strong>single transmembrane segment</strong> and a <strong>C-terminal J-domain</strong> (nishikawa1997theyeastjem1p pages 1-2). Topology mapping shows Jem1p is anchored in the <strong>ER membrane</strong> with the <strong>J-domain facing the ER lumen</strong>; the luminal C-terminal region is <strong>glycosylated</strong> (nishikawa1997theyeastjem1p pages 4-5, nishikawa1997theyeastjem1p pages 2-3).</p>
+<p>Two cropped figures from the primary paper visually support these conclusions:<br />
+- a <strong>domain schematic</strong> indicating the TM segment and the luminal J-domain (nishikawa1997theyeastjem1p media cb077d07)<br />
+- a <strong>microscopy panel</strong> showing the nuclear-fusion phenotype in mating (nishikawa1997theyeastjem1p media 2f50a63f)</p>
+<h4 id="22-interaction-partners-and-co-chaperone-network">2.2 Interaction partners and co-chaperone network</h4>
+<p>The best-supported partner is ER Hsp70 <strong>Kar2/BiP</strong>. Jem1p was proposed as a BiP (Kar2) and/or Lhs1 partner based on orientation and genetics (nishikawa1997theyeastjem1p pages 4-5), and later <strong>biochemically tested for BiP binding</strong> using a GST-Jem1p pulldown format (makio2008identificationandcharacterization pages 11-12). Jem1p also has partially overlapping functions with the soluble ER-lumen J-protein <strong>Scj1p</strong>: a <strong>jem1Δ scj1Δ</strong> double mutant is temperature sensitive, indicating redundancy or pathway buffering (nishikawa1997theyeastjem1p pages 2-3, nishikawa1997theyeastjem1p pages 4-5).</p>
+<h3 id="3-primary-biological-functions-and-pathway-placement">3) Primary biological functions and pathway placement</h3>
+<h4 id="31-primary-function-er-lumen-j-protein-co-chaperone-for-kar2bip">3.1 Primary function: ER-lumen J-protein co-chaperone for Kar2/BiP</h4>
+<p>The core molecular function supported by multiple studies is that Jem1p is an <strong>ER J-domain co-chaperone</strong> working within the Kar2/BiP chaperone system. Functional specificity among ER J-proteins is highlighted by data showing that a BiP surface mutation (R217A) disrupts interaction with <strong>Sec63</strong> (translocation) while leaving <strong>Jem1p</strong> interaction and ERAD function largely intact—supporting the concept that different J-proteins specify distinct BiP functions (vembar2010jdomaincochaperone pages 1-2).</p>
+<h4 id="32-karyogamy-nuclear-fusion-during-mating">3.2 Karyogamy (nuclear fusion during mating)</h4>
+<p>Jem1p is required for <strong>karyogamy</strong>, specifically nuclear fusion during mating, consistent with the synonym <strong>KAR8</strong> (nishikawa1997theyeastjem1p pages 1-2). Quantitatively, in a <strong>jem1Δ</strong> background <strong>79%</strong> of zygotes contained <strong>two or more juxtaposed nuclei that failed to fuse</strong>, while cell fusion itself appeared normal (nishikawa1997theyeastjem1p pages 4-5). The HPD motif is required for this function: an HPD mutant (H613Q) cannot rescue the karyogamy defect (nishikawa1997theyeastjem1p pages 2-3). The karyogamy defect is visually illustrated in microscopy panels (nishikawa1997theyeastjem1p media 2f50a63f).</p>
+<p>Mechanistically, later domain-dissection work indicates Jem1p has separable functional contributions to karyogamy versus ER quality control, with karyogamy linked to interactions mediated by the N-terminal region (and reported interaction with a nuclear-envelope-associated factor) while ERQC is more generally tied to the ER chaperone role (makio2008identificationandcharacterization pages 1-3).</p>
+<h4 id="33-erad-and-erqc-substrate-class-selectivity">3.3 ERAD and ERQC: substrate-class selectivity</h4>
+<p>A prominent mechanistic insight is substrate-class selectivity in ERAD:<br />
+- <strong>Soluble luminal ERAD substrates</strong> (e.g., CPY<em> and related luminal clients) become </em><em>stabilized and aggregate</em><em> at elevated temperature when </em><em>JEM1 and SCJ1</em><em> are deleted, similar to phenotypes in Kar2/BiP mutants (nishikawa2001molecularchaperonesin pages 1-2).<br />
+- In contrast, deletion of </em><em>JEM1 + SCJ1</em><em> has </em><em>little effect on ERAD of a membrane protein</em><em>, implying Jem1p’s key contribution is </em><em>maintaining solubility of luminal clients</em>* rather than being a universal ERAD requirement across all substrate topologies (nishikawa2001molecularchaperonesin pages 1-2).</p>
+<h3 id="4-phenotypes-and-quantitativestatistical-evidence">4) Phenotypes and quantitative/statistical evidence</h3>
+<p>Key low-throughput quantitative results supporting annotation include:<br />
+- <strong>Karyogamy defect:</strong> <strong>79%</strong> of <strong>jem1Δ</strong> zygotes show <strong>unfused juxtaposed nuclei</strong> (nishikawa1997theyeastjem1p pages 4-5).<br />
+- <strong>Synthetic growth defect/redundancy:</strong> <strong>jem1Δ scj1Δ</strong> strains grow at 14–30 °C but fail at <strong>37 °C</strong>, and the defect is rescued by a low-copy plasmid expressing tagged JEM1 (nishikawa1997theyeastjem1p pages 4-5).<br />
+- <strong>UPR/ER folding capacity readouts (contextual but quantitative):</strong> deletion of <strong>JEM1</strong> is associated with constitutive UPR activation measured via <strong>KAR2 induction (~1.7-fold)</strong>, and multi-J-protein mutant combinations further increase KAR2, supporting overlapping roles of luminal J-proteins in maintaining ER folding capacity (fama2007thesaccharomycescerevisiae pages 8-9). (These measurements are in a study centered on another ER J-protein but directly include Δjem1 quantitative effects.)</p>
+<h3 id="5-current-applications-and-real-world-implementations">5) Current applications and real-world implementations</h3>
+<h4 id="51-yeast-as-an-experimental-platform-to-model-erad-and-proteostasis">5.1 Yeast as an experimental platform to model ERAD and proteostasis</h4>
+<p>Jem1p is used as an experimentally tractable lever to interrogate ERAD mechanisms. A clear example is development of <strong>yeast expression systems for mammalian ENaC subunits</strong>, where Jem1/Scj1 were tested for roles in ERAD and ubiquitination of ENaC in yeast (buck2010theendoplasmicreticulum–associated pages 1-2, buck2010theendoplasmicreticulum–associated pages 2-3). This represents a real-world implementation of the Jem1/Scj1 axis as a <strong>model system</strong> for ER proteostasis relevant to human membrane proteins.</p>
+<h4 id="52-using-jem1-mutantsepitope-tagging-to-dissect-co-chaperone-mechanisms">5.2 Using Jem1 mutants/epitope tagging to dissect co-chaperone mechanisms</h4>
+<p>The ENaC ERAD study explicitly employs <strong>epitope-tagged Jem1</strong> constructs and HPD mutants (e.g., JEM1–3HA and JEM1H566Q–3HA in that paper’s construct set) together with UPR reporters and ERAD substrates, demonstrating how Jem1 is used operationally to map chaperone dependency and pathway wiring (buck2010theendoplasmicreticulum–associated pages 2-3).</p>
+<h3 id="6-expert-synthesis-and-authoritative-interpretations">6) Expert synthesis and authoritative interpretations</h3>
+<p>An authoritative review of yeast ER protein quality control/ERAD places <strong>Kar2/BiP together with Hsp40 co-chaperones Scj1 and Jem1</strong> as supporting ERAD and the handling of misfolded proteins in the ER, emphasizing the integrated nature of the ER chaperone network in enabling retrotranslocation and degradation (makio2008identificationandcharacterization pages 12-12). The primary mechanistic studies support this review-level picture by providing substrate-class specificity (soluble luminal substrates) and genetic redundancy with Scj1 (nishikawa2001molecularchaperonesin pages 1-2, nishikawa1997theyeastjem1p pages 4-5).</p>
+<h3 id="7-recent-developments-20232024-evidence-limitation-in-this-run">7) Recent developments (2023–2024): evidence limitation in this run</h3>
+<p>Multiple targeted searches for <strong>2023–2024</strong> publications specifically about yeast <strong>JEM1/KAR8/YJL073W</strong> did not yield retrievable sources in the current tool run. Consequently, this report’s mechanistic conclusions rest on foundational primary work (1997–2010) and an authoritative review (2018). Any attempt to describe “latest research” beyond these sources would be speculative and is therefore not included.</p>
+<h3 id="8-evidence-mapped-summary-table">8) Evidence-mapped summary table</h3>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Key points (mechanism/definition)</th>
+<th>Evidence/assays &amp; quantitative data</th>
+<th>Key sources (with year, DOI URL)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Verified identity</td>
+<td>UniProt P40358 corresponds to <strong>Saccharomyces cerevisiae</strong> <strong>JEM1/KAR8/YJL073W</strong>, the ER-membrane DnaJ-like chaperone required for nuclear fusion; this matches the user-provided UniProt description and excludes ambiguity with other genes.</td>
+<td>Primary paper identifies ORF <strong>YJL073W</strong> as <strong>JEM1</strong>, encoding a DnaJ-like ER membrane protein; nonessential singly, but functionally important in ER chaperoning and mating/karyogamy phenotypes (nishikawa1997theyeastjem1p pages 1-2, nishikawa1997theyeastjem1p pages 2-3).</td>
+<td>Nishikawa &amp; Endo 1997, J Biol Chem, https://doi.org/10.1074/jbc.272.20.12889 (nishikawa1997theyeastjem1p pages 1-2, nishikawa1997theyeastjem1p pages 2-3)</td>
+</tr>
+<tr>
+<td>Protein type &amp; domains</td>
+<td>Jem1p is a <strong>DnaJ/Hsp40-family co-chaperone</strong> with a <strong>C-terminal J-domain</strong>, a conserved <strong>HPD motif</strong> required for activity, and a <strong>single transmembrane segment</strong> anchoring it in the ER membrane.</td>
+<td>Reported as <strong>692 aa</strong> with one putative TM segment and J-domain; <strong>H613Q</strong> substitution in the conserved HPD motif abolishes complementation of both growth and karyogamy defects, demonstrating that the J-domain is functionally essential (nishikawa1997theyeastjem1p pages 1-2, nishikawa1997theyeastjem1p pages 2-3).</td>
+<td>Nishikawa &amp; Endo 1997, https://doi.org/10.1074/jbc.272.20.12889 (nishikawa1997theyeastjem1p pages 1-2, nishikawa1997theyeastjem1p pages 2-3)</td>
+</tr>
+<tr>
+<td>Subcellular localization &amp; topology</td>
+<td>Jem1p is an <strong>integral ER membrane protein</strong> with the <strong>J-domain exposed to the ER lumen</strong>; its lumenal C-terminal region is <strong>glycosylated</strong>. This orientation is consistent with a co-chaperone role for lumenal Hsp70s.</td>
+<td>Epitope-tagging/immunolocalization and topology analysis showed ER-membrane anchoring with lumen-facing J-domain; glycosylation of the C-terminal/lumenal region was detected. Figure-level summary shows TM segment plus lumenal J-domain and mutant karyogamy phenotype (nishikawa1997theyeastjem1p pages 1-2, nishikawa1997theyeastjem1p pages 2-3, nishikawa1997theyeastjem1p pages 4-5, nishikawa1997theyeastjem1p media cb077d07).</td>
+<td>Nishikawa &amp; Endo 1997, https://doi.org/10.1074/jbc.272.20.12889 (nishikawa1997theyeastjem1p pages 1-2, nishikawa1997theyeastjem1p pages 2-3, nishikawa1997theyeastjem1p pages 4-5, nishikawa1997theyeastjem1p media cb077d07)</td>
+</tr>
+<tr>
+<td>Primary molecular function</td>
+<td>Jem1p is best understood as an <strong>ER J-domain co-chaperone</strong> that functionally partners with <strong>Kar2/BiP</strong> (and possibly Lhs1) to stimulate Hsp70-dependent ER processes; in ER quality control it helps <strong>maintain soluble lumenal substrates in a retrotranslocation-competent, non-aggregated state</strong>.</td>
+<td>DnaJ proteins act through J-domains to regulate Hsp70 ATPase cycles; Jem1p was proposed as a partner for <strong>BiP/Kar2 and/or Lhs1</strong>. Later work showed <strong>BiP interaction with Jem1p</strong> and that BiP mutations can selectively disrupt one J-protein interaction (Sec63) while sparing Jem1, indicating mechanistic specificity among ER Hsp70–Hsp40 pairings (nishikawa1997theyeastjem1p pages 2-3, nishikawa1997theyeastjem1p pages 4-5, makio2008identificationandcharacterization pages 11-12, vembar2010jdomaincochaperone pages 1-2).</td>
+<td>Nishikawa &amp; Endo 1997, https://doi.org/10.1074/jbc.272.20.12889; Makio et al. 2008, https://doi.org/10.1111/j.1365-2443.2008.01223.x; Vembar et al. 2010, https://doi.org/10.1074/jbc.m110.102186 (nishikawa1997theyeastjem1p pages 2-3, nishikawa1997theyeastjem1p pages 4-5, makio2008identificationandcharacterization pages 11-12, vembar2010jdomaincochaperone pages 1-2)</td>
+</tr>
+<tr>
+<td>Interaction partners</td>
+<td>Best-supported partners are <strong>Kar2/BiP</strong> and the parallel ER J-protein <strong>Scj1</strong>; <strong>Lhs1</strong> is a plausible/mentioned ER Hsp70 partner in the same chaperone network.</td>
+<td>Genetic interaction: <strong>jem1Δ scj1Δ</strong> double mutants are temperature sensitive, indicating overlapping function. Biochemical support: GST-Jem1p-His pulldown conditions captured <strong>BiP/Kar2</strong> binding. Reviews/primary context place Jem1p with <strong>Scj1, Sec63, Kar2, Lhs1</strong> in the ER chaperone system (nishikawa1997theyeastjem1p pages 2-3, makio2008identificationandcharacterization pages 11-12, silberstein1998arolefor pages 1-2, nishikawa1997theyeastjem1p pages 4-5).</td>
+<td>Makio et al. 2008, https://doi.org/10.1111/j.1365-2443.2008.01223.x; Nishikawa &amp; Endo 1997, https://doi.org/10.1074/jbc.272.20.12889; Silberstein et al. 1998, https://doi.org/10.1083/jcb.143.4.921 (makio2008identificationandcharacterization pages 11-12, nishikawa1997theyeastjem1p pages 2-3, silberstein1998arolefor pages 1-2, nishikawa1997theyeastjem1p pages 4-5)</td>
+</tr>
+<tr>
+<td>Karyogamy / nuclear fusion pathway</td>
+<td>Jem1p has a specialized role in <strong>karyogamy</strong>, specifically <strong>nuclear membrane/nuclear fusion during mating</strong>. This is the source of the synonym <strong>KAR8</strong>. Its J-domain is required for this role.</td>
+<td>In <strong>jem1Δ</strong> zygotes, <strong>79%</strong> contained <strong>two or more juxtaposed nuclei</strong> that failed to fuse; crossing to wild type restored efficient diploid formation, indicating a bilateral mating defect. HPD mutant <strong>H613Q</strong> fails to rescue karyogamy. Figure panel summary shows juxtaposed unfused nuclei in the mutant (nishikawa1997theyeastjem1p pages 4-5, nishikawa1997theyeastjem1p pages 2-3, nishikawa1997theyeastjem1p media cb077d07).</td>
+<td>Nishikawa &amp; Endo 1997, https://doi.org/10.1074/jbc.272.20.12889 (nishikawa1997theyeastjem1p pages 4-5, nishikawa1997theyeastjem1p pages 2-3, nishikawa1997theyeastjem1p media cb077d07)</td>
+</tr>
+<tr>
+<td>ER folding / protein quality control</td>
+<td>Beyond karyogamy, Jem1p participates in <strong>ER protein folding/ER quality control (ERQC)</strong> with Scj1 and Kar2. Functional overlap with Scj1 explains why single mutants are mild but double mutants are stressed.</td>
+<td>Primary and comparative work conclude Jem1p and Scj1 cooperate in ERQC; <strong>jem1Δ scj1Δ</strong> mutants display heat-sensitive growth and accumulation/aggregation of misfolded proteins in the ER lumen under restrictive conditions (makio2008identificationandcharacterization pages 1-3, nishikawa1997theyeastjem1p pages 4-5, nishikawa1997theyeastjem1p pages 2-3).</td>
+<td>Makio et al. 2008, https://doi.org/10.1111/j.1365-2443.2008.01223.x; Nishikawa &amp; Endo 1997, https://doi.org/10.1074/jbc.272.20.12889 (makio2008identificationandcharacterization pages 1-3, nishikawa1997theyeastjem1p pages 4-5, nishikawa1997theyeastjem1p pages 2-3)</td>
+</tr>
+<tr>
+<td>ERAD role</td>
+<td>Jem1p contributes to <strong>ER-associated degradation (ERAD)</strong> chiefly for <strong>soluble lumenal substrates</strong>, acting with Kar2/BiP and Scj1 to keep misfolded proteins soluble so they can be retrotranslocated and degraded.</td>
+<td>In vivo/in vitro ERAD assays showed that when <strong>JEM1 and SCJ1</strong> are deleted, soluble ERAD substrates such as <strong>CPY*</strong> and <strong>A1PiZ/pro-α-factor-based substrates</strong> become <strong>stabilized and aggregate</strong> at elevated temperature; authors conclude BiP/Jem1p/Scj1p maintain a retrotranslocation-competent state (nishikawa2001molecularchaperonesin pages 1-2).</td>
+<td>Nishikawa et al. 2001, J Cell Biol, https://doi.org/10.1083/jcb.153.5.1061 (nishikawa2001molecularchaperonesin pages 1-2)</td>
+</tr>
+<tr>
+<td>Substrate specificity</td>
+<td>Jem1p’s ERAD contribution is <strong>substrate-class selective</strong>: important for <strong>soluble lumenal misfolded proteins</strong>, but much less important for at least some <strong>membrane ERAD substrates</strong>.</td>
+<td>Deletion of <strong>JEM1 + SCJ1</strong> had <strong>little effect on ERAD of a membrane protein</strong>, whereas soluble lumenal substrates were strongly impaired/stabilized. This supports a model in which Jem1p primarily buffers/solubilizes lumenal clients rather than serving as a general ERAD factor for all substrate topologies (nishikawa2001molecularchaperonesin pages 1-2).</td>
+<td>Nishikawa et al. 2001, https://doi.org/10.1083/jcb.153.5.1061 (nishikawa2001molecularchaperonesin pages 1-2)</td>
+</tr>
+<tr>
+<td>Genetic interactions &amp; phenotypes</td>
+<td>Key phenotypes: <strong>jem1Δ</strong> is viable but defective in karyogamy; <strong>jem1Δ scj1Δ</strong> is <strong>temperature sensitive at 37°C</strong>; HPD-mutant Jem1p is nonfunctional; ERQC/ERAD defects become prominent under heat/proteotoxic stress.</td>
+<td>Growth assays showed the double disruptant grows at <strong>14, 23, and 30°C</strong> but not <strong>37°C</strong>; low-copy <strong>3HA-JEM1</strong> rescues. Microscopy quantified <strong>79%</strong> unfused nuclei in <strong>jem1Δ</strong> zygotes. ERAD assays showed stabilization/aggregation of soluble substrates in the double mutant (nishikawa1997theyeastjem1p pages 4-5, nishikawa2001molecularchaperonesin pages 1-2).</td>
+<td>Nishikawa &amp; Endo 1997, https://doi.org/10.1074/jbc.272.20.12889; Nishikawa et al. 2001, https://doi.org/10.1083/jcb.153.5.1061 (nishikawa1997theyeastjem1p pages 4-5, nishikawa2001molecularchaperonesin pages 1-2)</td>
+</tr>
+<tr>
+<td>UPR / stress context</td>
+<td>Direct evidence that <strong>JEM1 itself is a canonical UPR regulator</strong> is limited in the retrieved Jem1-focused papers, but Jem1p clearly functions within the broader <strong>ER proteostasis stress network</strong> with Kar2 and Scj1. UPR-related conclusions are stronger for <strong>Scj1</strong> and combined ER folding stress than for Jem1 alone.</td>
+<td>Scj1 loss induces UPR and combined loss of Scj1/Jem1 exacerbates folding stress in the ER; reviews place Jem1 among ER proteostasis factors assisting Kar2 during ERQC/ERAD. Because direct Jem1-specific UPR regulation was not established in the core Jem1 primary papers retrieved, this annotation should be treated as contextual rather than primary (silberstein1998arolefor pages 1-2, makio2008identificationandcharacterization pages 1-3, nishikawa2001molecularchaperonesin pages 1-2).</td>
+<td>Silberstein et al. 1998, https://doi.org/10.1083/jcb.143.4.921; Makio et al. 2008, https://doi.org/10.1111/j.1365-2443.2008.01223.x; Nishikawa et al. 2001, https://doi.org/10.1083/jcb.153.5.1061 (silberstein1998arolefor pages 1-2, makio2008identificationandcharacterization pages 1-3, nishikawa2001molecularchaperonesin pages 1-2)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the experimentally supported functional annotation of Saccharomyces cerevisiae JEM1/KAR8/YJL073W (UniProt P40358), including topology, mechanism, pathways, interaction partners, and key phenotypes. It is useful as a compact evidence map linking core claims to primary sources and quantitative data.</em></p>
+<h3 id="9-practical-takeaways-for-functional-annotation">9) Practical takeaways for functional annotation</h3>
+<ol>
+<li><strong>Primary molecular role:</strong> Jem1p is an <strong>ER-membrane J-protein (Hsp40)</strong> whose <strong>luminal J-domain</strong> (HPD motif-dependent) supports <strong>Kar2/BiP-dependent proteostasis</strong> (nishikawa1997theyeastjem1p pages 4-5, nishikawa2001molecularchaperonesin pages 1-2).</li>
+<li><strong>Process-level functions:</strong> Jem1p is required for <strong>karyogamy/nuclear fusion</strong> during mating and participates in <strong>ERQC/ERAD</strong> (particularly for <strong>soluble luminal substrates</strong>) with partial redundancy to Scj1p (nishikawa1997theyeastjem1p pages 4-5, nishikawa2001molecularchaperonesin pages 1-2, nishikawa1997theyeastjem1p pages 2-3).</li>
+<li><strong>Localization:</strong> Jem1p is an <strong>ER membrane</strong> protein with <strong>lumen-facing J-domain</strong>, consistent with its roles in luminal folding and ERAD client management (nishikawa1997theyeastjem1p pages 4-5, nishikawa1997theyeastjem1p media cb077d07).</li>
+</ol>
+<h3 id="key-sources-publication-date-url">Key sources (publication date, URL)</h3>
+<ul>
+<li>Nishikawa S, Endo T. <strong>May 1997</strong>. <em>J Biol Chem</em>. “The Yeast JEM1p Is a DnaJ-like Protein of the Endoplasmic Reticulum Membrane Required for Nuclear Fusion.” https://doi.org/10.1074/jbc.272.20.12889 (nishikawa1997theyeastjem1p pages 4-5)</li>
+<li>Nishikawa S, Fewell SW, Kato Y, Brodsky JL, Endo T. <strong>May 2001</strong>. <em>J Cell Biol</em>. “Molecular Chaperones in the Yeast Endoplasmic Reticulum Maintain the Solubility of Proteins for Retrotranslocation and Degradation.” https://doi.org/10.1083/jcb.153.5.1061 (nishikawa2001molecularchaperonesin pages 1-2)</li>
+<li>Makio T, Nishikawa S, Nakayama T, Nagai H, Endo T. <strong>Oct 2008</strong>. <em>Genes to Cells</em>. “Identification and characterization of a Jem1p ortholog… dissection of Jem1p functions in karyogamy and protein quality control…” https://doi.org/10.1111/j.1365-2443.2008.01223.x (makio2008identificationandcharacterization pages 1-3, makio2008identificationandcharacterization pages 11-12)</li>
+<li>Vembar SS, Jonikas MC, Hendershot LM, Weissman JS, Brodsky JL. <strong>Jul 2010</strong>. <em>J Biol Chem</em>. “J Domain Co-chaperone Specificity Defines the Role of BiP during Protein Translocation.” https://doi.org/10.1074/jbc.m110.102186 (vembar2010jdomaincochaperone pages 1-2)</li>
+<li>Buck TM, Kolb AR, Boyd CR, Kleyman TR, Brodsky JL. <strong>Mar 2010</strong>. <em>Mol Biol Cell</em>. “The ERAD of the epithelial sodium channel requires a unique complement of molecular chaperones.” https://doi.org/10.1091/mbc.e09-11-0944 (buck2010theendoplasmicreticulum–associated pages 1-2)</li>
+<li>Berner N, Reutter K-R, Wolf DH. <strong>Jun 2018</strong>. <em>Annu Rev Biochem</em>. “Protein Quality Control of the ER and ubiquitin-proteasome-triggered degradation…” https://doi.org/10.1146/annurev-biochem-062917-012749 (makio2008identificationandcharacterization pages 12-12)</li>
+<li>Famá MC et al. <strong>Feb 2007</strong>. <em>BBA - Mol Cell Res</em>. “YFR041C/ERJ5 … required to preserve the folding capacity of the ER.” (includes Δjem1 quantitative UPR metrics) https://doi.org/10.1016/j.bbamcr.2006.10.011 (fama2007thesaccharomycescerevisiae pages 8-9)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(nishikawa1997theyeastjem1p pages 1-2): Shuh-ichi Nishikawa and Toshiya Endo. The yeast jem1p is a dnaj-like protein of the endoplasmic reticulum membrane required for nuclear fusion*. The Journal of Biological Chemistry, 272:12889-12892, May 1997. URL: https://doi.org/10.1074/jbc.272.20.12889, doi:10.1074/jbc.272.20.12889. This article has 137 citations.</p>
+</li>
+<li>
+<p>(nishikawa1997theyeastjem1p pages 2-3): Shuh-ichi Nishikawa and Toshiya Endo. The yeast jem1p is a dnaj-like protein of the endoplasmic reticulum membrane required for nuclear fusion*. The Journal of Biological Chemistry, 272:12889-12892, May 1997. URL: https://doi.org/10.1074/jbc.272.20.12889, doi:10.1074/jbc.272.20.12889. This article has 137 citations.</p>
+</li>
+<li>
+<p>(nishikawa2001molecularchaperonesin pages 1-2): Shuh-ichi Nishikawa, Sheara W. Fewell, Yoshihito Kato, Jeffrey L. Brodsky, and Toshiya Endo. Molecular chaperones in the yeast endoplasmic reticulum maintain the solubility of proteins for retrotranslocation and degradation. The Journal of Cell Biology, 153:1061-1070, May 2001. URL: https://doi.org/10.1083/jcb.153.5.1061, doi:10.1083/jcb.153.5.1061. This article has 442 citations.</p>
+</li>
+<li>
+<p>(vembar2010jdomaincochaperone pages 1-2): Shruthi S. Vembar, Martin C. Jonikas, Linda M. Hendershot, Jonathan S. Weissman, and Jeffrey L. Brodsky. J domain co-chaperone specificity defines the role of bip during protein translocation. Journal of Biological Chemistry, 285:22484-22494, Jul 2010. URL: https://doi.org/10.1074/jbc.m110.102186, doi:10.1074/jbc.m110.102186. This article has 62 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nishikawa1997theyeastjem1p pages 4-5): Shuh-ichi Nishikawa and Toshiya Endo. The yeast jem1p is a dnaj-like protein of the endoplasmic reticulum membrane required for nuclear fusion*. The Journal of Biological Chemistry, 272:12889-12892, May 1997. URL: https://doi.org/10.1074/jbc.272.20.12889, doi:10.1074/jbc.272.20.12889. This article has 137 citations.</p>
+</li>
+<li>
+<p>(nishikawa1997theyeastjem1p media cb077d07): Shuh-ichi Nishikawa and Toshiya Endo. The yeast jem1p is a dnaj-like protein of the endoplasmic reticulum membrane required for nuclear fusion*. The Journal of Biological Chemistry, 272:12889-12892, May 1997. URL: https://doi.org/10.1074/jbc.272.20.12889, doi:10.1074/jbc.272.20.12889. This article has 137 citations.</p>
+</li>
+<li>
+<p>(nishikawa1997theyeastjem1p media 2f50a63f): Shuh-ichi Nishikawa and Toshiya Endo. The yeast jem1p is a dnaj-like protein of the endoplasmic reticulum membrane required for nuclear fusion*. The Journal of Biological Chemistry, 272:12889-12892, May 1997. URL: https://doi.org/10.1074/jbc.272.20.12889, doi:10.1074/jbc.272.20.12889. This article has 137 citations.</p>
+</li>
+<li>
+<p>(makio2008identificationandcharacterization pages 11-12): T. Makio, S. Nishikawa, T. Nakayama, Hiroyuki Nagai, and T. Endo. Identification and characterization of a jem1p ortholog of candida albicans: dissection of jem1p functions in karyogamy and protein quality control in saccharomyces cerevisiae. Genes to Cells, Oct 2008. URL: https://doi.org/10.1111/j.1365-2443.2008.01223.x, doi:10.1111/j.1365-2443.2008.01223.x. This article has 9 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(makio2008identificationandcharacterization pages 1-3): T. Makio, S. Nishikawa, T. Nakayama, Hiroyuki Nagai, and T. Endo. Identification and characterization of a jem1p ortholog of candida albicans: dissection of jem1p functions in karyogamy and protein quality control in saccharomyces cerevisiae. Genes to Cells, Oct 2008. URL: https://doi.org/10.1111/j.1365-2443.2008.01223.x, doi:10.1111/j.1365-2443.2008.01223.x. This article has 9 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fama2007thesaccharomycescerevisiae pages 8-9): M. Carla Famá, David Raden, Nicolás Zacchi, Darío R. Lemos, Anne S. Robinson, and Susana Silberstein. The saccharomyces cerevisiae yfr041c/erj5 gene encoding a type i membrane protein with a j domain is required to preserve the folding capacity of the endoplasmic reticulum. Biochimica et Biophysica Acta (BBA) - Molecular Cell Research, 1773:232-242, Feb 2007. URL: https://doi.org/10.1016/j.bbamcr.2006.10.011, doi:10.1016/j.bbamcr.2006.10.011. This article has 41 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(buck2010theendoplasmicreticulum–associated pages 1-2): Teresa M. Buck, Alexander R. Kolb, Cary R. Boyd, Thomas R. Kleyman, and Jeffrey L. Brodsky. The endoplasmic reticulum–associated degradation of the epithelial sodium channel requires a unique complement of molecular chaperones. Molecular Biology of the Cell, 21:1047-1058, Mar 2010. URL: https://doi.org/10.1091/mbc.e09-11-0944, doi:10.1091/mbc.e09-11-0944. This article has 116 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(buck2010theendoplasmicreticulum–associated pages 2-3): Teresa M. Buck, Alexander R. Kolb, Cary R. Boyd, Thomas R. Kleyman, and Jeffrey L. Brodsky. The endoplasmic reticulum–associated degradation of the epithelial sodium channel requires a unique complement of molecular chaperones. Molecular Biology of the Cell, 21:1047-1058, Mar 2010. URL: https://doi.org/10.1091/mbc.e09-11-0944, doi:10.1091/mbc.e09-11-0944. This article has 116 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(makio2008identificationandcharacterization pages 12-12): T. Makio, S. Nishikawa, T. Nakayama, Hiroyuki Nagai, and T. Endo. Identification and characterization of a jem1p ortholog of candida albicans: dissection of jem1p functions in karyogamy and protein quality control in saccharomyces cerevisiae. Genes to Cells, Oct 2008. URL: https://doi.org/10.1111/j.1365-2443.2008.01223.x, doi:10.1111/j.1365-2443.2008.01223.x. This article has 9 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(silberstein1998arolefor pages 1-2): Susana Silberstein, Gabriel Schlenstedt, Pam A. Silver, and Reid Gilmore. A role for the dnaj homologue scj1p in protein folding in the yeast endoplasmic reticulum. The Journal of Cell Biology, 143:921-933, Nov 1998. URL: https://doi.org/10.1083/jcb.143.4.921, doi:10.1083/jcb.143.4.921. This article has 124 citations.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>nishikawa2001molecularchaperonesin pages 1-2</li>
+<li>makio2008identificationandcharacterization pages 11-12</li>
+<li>vembar2010jdomaincochaperone pages 1-2</li>
+<li>makio2008identificationandcharacterization pages 1-3</li>
+<li>fama2007thesaccharomycescerevisiae pages 8-9</li>
+<li>makio2008identificationandcharacterization pages 12-12</li>
+<li>silberstein1998arolefor pages 1-2</li>
+<li>https://doi.org/10.1074/jbc.272.20.12889</li>
+<li>https://doi.org/10.1074/jbc.272.20.12889;</li>
+<li>https://doi.org/10.1111/j.1365-2443.2008.01223.x;</li>
+<li>https://doi.org/10.1074/jbc.m110.102186</li>
+<li>https://doi.org/10.1083/jcb.143.4.921</li>
+<li>https://doi.org/10.1083/jcb.153.5.1061</li>
+<li>https://doi.org/10.1083/jcb.143.4.921;</li>
+<li>https://doi.org/10.1111/j.1365-2443.2008.01223.x</li>
+<li>https://doi.org/10.1091/mbc.e09-11-0944</li>
+<li>https://doi.org/10.1146/annurev-biochem-062917-012749</li>
+<li>https://doi.org/10.1016/j.bbamcr.2006.10.011</li>
+<li>https://doi.org/10.1074/jbc.272.20.12889,</li>
+<li>https://doi.org/10.1083/jcb.153.5.1061,</li>
+<li>https://doi.org/10.1074/jbc.m110.102186,</li>
+<li>https://doi.org/10.1111/j.1365-2443.2008.01223.x,</li>
+<li>https://doi.org/10.1016/j.bbamcr.2006.10.011,</li>
+<li>https://doi.org/10.1091/mbc.e09-11-0944,</li>
+<li>https://doi.org/10.1083/jcb.143.4.921,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -1817,11 +2737,20 @@
                 <pre><code>id: P40358
 gene_symbol: JEM1
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
+aliases:
+- KAR8
+- YJL073W
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: &#39;TODO: Add description for JEM1&#39;
+description: &gt;-
+  JEM1/KAR8 encodes an ER membrane DnaJ/Hsp40-family co-chaperone with a
+  lumen-facing J-domain. Jem1 works with the ER Hsp70 Kar2/BiP and overlaps
+  partly with Scj1 to support ER protein folding and ERAD of soluble luminal
+  misfolded substrates by keeping them soluble and retrotranslocation competent.
+  Jem1 is also required for nuclear membrane fusion during mating karyogamy at
+  the ER/nuclear envelope membrane system.
 existing_annotations:
 - term:
     id: GO:0051087
@@ -1829,151 +2758,215 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;Manual review: protein-folding chaperone binding is consistent with known biology of JEM1.&#39;
+    summary: IBA is consistent with Jem1 as an ER J-domain co-chaperone for Kar2/BiP.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: J-domain co-chaperone function is the best-supported molecular role.
+    supported_by:
+    - reference_id: PMID:9148890
+      supporting_text: JEM1p likely assists the functions of BiP, Hsp70 in the ER, including karyogamy.
+    - reference_id: file:yeast/JEM1/JEM1-deep-research-falcon.md
+      supporting_text: Jem1p is an ER J-domain co-chaperone working within the Kar2/BiP chaperone system.
 - term:
     id: GO:0005783
     label: endoplasmic reticulum
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;Manual review: endoplasmic reticulum is consistent with known biology of JEM1.&#39;
+    summary: Phylogenetic inference agrees with direct ER membrane localization.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: The ER is the compartment for Jem1&#39;s folding, ERAD, and karyogamy functions.
+    supported_by:
+    - reference_id: PMID:9148890
+      supporting_text: protein was anchored in the endoplasmic reticulum (ER) membrane and its J-domain
 - term:
     id: GO:0034975
     label: protein folding in endoplasmic reticulum
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;Manual review: protein folding in endoplasmic reticulum is consistent with known biology of JEM1.&#39;
+    summary: This matches Jem1/Scj1/Kar2 roles in ER folding and quality control.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Jem1 supports ER folding and ERAD substrate handling.
+    supported_by:
+    - reference_id: PMID:11381090
+      supporting_text: Jem1p and Scj1p function as major partners for BiP in the ERAD process.
+    - reference_id: PMID:9817751
+      supporting_text: Jem1p and Scj1p appear to have partially overlapping functions as cofactors for Kar2p.
 - term:
     id: GO:0051787
     label: misfolded protein binding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;Manual review: misfolded protein binding is consistent with known biology of JEM1.&#39;
+    summary: Misfolded protein binding fits the ERAD substrate-solubility evidence.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: This term is more informative than generic unfolded protein binding for the ERAD role.
+    supported_by:
+    - reference_id: PMID:11381090
+      supporting_text: aberrant immature proteins aggregated and migrated in the densest fraction
 - term:
     id: GO:0005789
     label: endoplasmic reticulum membrane
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: &#39;Manual review: endoplasmic reticulum membrane is consistent with known biology of JEM1.&#39;
+    summary: UniProt subcellular mapping is consistent with direct ER membrane evidence.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Jem1 is a single-pass ER membrane protein with a lumen-facing J-domain.
+    supported_by:
+    - reference_id: PMID:9148890
+      supporting_text: protein was anchored in the endoplasmic reticulum (ER) membrane and its J-domain
 - term:
     id: GO:0031965
     label: nuclear membrane
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: &#39;Manual review: nuclear membrane may be context-dependent or peripheral for JEM1.&#39;
+    summary: Nuclear membrane localization is plausible but broad.
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Keep as valid context for karyogamy, but the ER membrane/nuclear outer membrane network terms are more precise.
+    supported_by:
+    - reference_id: PMID:15282802
+      supporting_text: localization data for 21 other proteins
+      full_text_unavailable: true
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:12493774
   review:
-    summary: &#39;Manual review: protein binding is too generic or over-extended for JEM1.&#39;
+    summary: The MPS3/Nep98 interaction is relevant but GO:0005515 is uninformative.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: Protein binding hides the more specific J-domain co-chaperone and karyogamy biology.
+    supported_by:
+    - reference_id: PMID:12493774
+      supporting_text: screened for partner proteins for Jem1p by the yeast two-hybrid...identified Nep98p
 - term:
     id: GO:0036503
     label: ERAD pathway
   evidence_type: IMP
   original_reference_id: PMID:11381090
   review:
-    summary: &#39;Manual review: ERAD pathway is consistent with known biology of JEM1.&#39;
+    summary: Direct ERAD assays support this process annotation.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Jem1 helps keep soluble luminal ERAD substrates retrotranslocation competent.
+    supported_by:
+    - reference_id: PMID:11381090
+      supporting_text: one role for the lumenal Hsp70 chaperone system in the export of aberrant proteins
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IMP
   original_reference_id: PMID:9148890
   review:
-    summary: &#39;Manual review: unfolded protein binding is better represented by a more specific replacement term for JEM1.&#39;
+    summary: Unfolded protein binding is too broad for the evidence.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: Misfolded protein binding better captures Jem1&#39;s ERAD substrate-handling role.
     proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+    - id: GO:0051787
+      label: misfolded protein binding
+    supported_by:
+    - reference_id: PMID:11381090
+      supporting_text: BiP-Jem1p-Scj1p chaperone system is to retain ERAD substrates as lower molecular weight species.
 - term:
     id: GO:0051087
     label: protein-folding chaperone binding
   evidence_type: IGI
   original_reference_id: PMID:9148890
   review:
-    summary: &#39;Manual review: protein-folding chaperone binding is consistent with known biology of JEM1.&#39;
+    summary: Genetic evidence supports chaperone binding as the J-domain co-chaperone function.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Jem1 works with Kar2/BiP during ER and nuclear fusion processes.
+    supported_by:
+    - reference_id: PMID:9148890
+      supporting_text: DnaJ-like proteins are functional partners for Hsp70 molecular chaperones.
 - term:
     id: GO:0005783
     label: endoplasmic reticulum
   evidence_type: HDA
   original_reference_id: PMID:26928762
   review:
-    summary: &#39;Manual review: endoplasmic reticulum is consistent with known biology of JEM1.&#39;
+    summary: High-throughput ER localization is consistent with direct evidence.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: ER localization is core to Jem1 function.
+    supported_by:
+    - reference_id: PMID:9148890
+      supporting_text: protein was anchored in the endoplasmic reticulum (ER) membrane
 - term:
     id: GO:0000742
     label: karyogamy involved in conjugation with cellular fusion
   evidence_type: IMP
   original_reference_id: PMID:10069807
   review:
-    summary: &#39;Manual review: karyogamy involved in conjugation with cellular fusion may be context-dependent or peripheral for JEM1.&#39;
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    summary: Jem1/Kar8 has a defining role in nuclear fusion during mating.
+    action: ACCEPT
+    reason: Karyogamy is a directly characterized JEM1 process, not a generic downstream phenotype.
+    supported_by:
+    - reference_id: PMID:10069807
+      supporting_text: Overexpression of KAR8/JEM1 (but not SEC63) strongly suppressed the mating...defect of kar2-1
 - term:
     id: GO:0005783
     label: endoplasmic reticulum
   evidence_type: IDA
   original_reference_id: PMID:9148890
   review:
-    summary: &#39;Manual review: endoplasmic reticulum is consistent with known biology of JEM1.&#39;
+    summary: Direct experimental localization supports ER annotation.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: The ER is the core cellular compartment for Jem1.
+    supported_by:
+    - reference_id: PMID:9148890
+      supporting_text: protein was anchored in the endoplasmic reticulum (ER) membrane
 - term:
     id: GO:0034975
     label: protein folding in endoplasmic reticulum
   evidence_type: IGI
   original_reference_id: PMID:9817751
   review:
-    summary: &#39;Manual review: protein folding in endoplasmic reticulum is consistent with known biology of JEM1.&#39;
+    summary: Genetic evidence supports overlapping Jem1/Scj1 ER folding functions.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Jem1 and Scj1 are functionally overlapping ER DnaJ proteins.
+    supported_by:
+    - reference_id: PMID:9817751
+      supporting_text: Jem1p and Scj1p appear to have partially overlapping functions as cofactors for Kar2p.
 - term:
     id: GO:0042175
     label: nuclear outer membrane-endoplasmic reticulum membrane network
   evidence_type: IDA
   original_reference_id: PMID:15282802
   review:
-    summary: &#39;Manual review: nuclear outer membrane-endoplasmic reticulum membrane network may be context-dependent or peripheral for JEM1.&#39;
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    summary: This specific ER/nuclear-envelope localization fits Jem1 biology.
+    action: ACCEPT
+    reason: It is more precise than generic nuclear membrane and is compatible with ER and karyogamy functions.
+    supported_by:
+    - reference_id: PMID:9148890
+      supporting_text: protein was anchored in the endoplasmic reticulum (ER) membrane and its J-domain
 references:
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping
   findings: []
-- id: PMID:10069807
-  title: Genetic interactions between KAR7/SEC71, KAR8/JEM1, KAR5, and KAR2 during nuclear fusion in Saccharomyces cerevisiae.
-  findings: []
+- id: PMID:9148890
+  title: The yeast JEM1p is a DnaJ-like protein of the endoplasmic reticulum membrane required for nuclear fusion.
+  findings:
+  - statement: Jem1 is an ER membrane DnaJ-like protein with a lumen-facing J-domain
+    supporting_text: The JEM1 protein was anchored in the ER membrane and its J-domain faced the ER lumen.
+- id: PMID:9817751
+  title: A role for the DnaJ homologue Scj1p in protein folding in the yeast endoplasmic reticulum.
+  findings:
+  - statement: Jem1 and Scj1 have overlapping ER chaperone functions
+    supporting_text: Cells lacking both Jem1p and Scj1p are temperature sensitive.
 - id: PMID:11381090
   title: Molecular chaperones in the yeast endoplasmic reticulum maintain the solubility of proteins for retrotranslocation and degradation.
-  findings: []
+  findings:
+  - statement: Jem1 and Scj1 maintain soluble ERAD substrates
+    supporting_text: BiP cooperates with Jem1p and Scj1p to facilitate export of ERAD substrates by preventing aggregation in the ER lumen.
+- id: PMID:10069807
+  title: Genetic interactions between KAR7/SEC71, KAR8/JEM1, KAR5, and KAR2 during nuclear fusion in Saccharomyces cerevisiae.
+  findings:
+  - statement: JEM1/KAR8 genetically interacts with KAR2 during nuclear fusion
+    supporting_text: Overexpression of KAR8/JEM1 strongly suppressed the mating defect of kar2-1.
 - id: PMID:12493774
   title: Nep98p is a component of the yeast spindle pole body and essential for nuclear division and fusion.
   findings: []
@@ -1983,19 +2976,58 @@ references:
 - id: PMID:26928762
   title: &#39;One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy.&#39;
   findings: []
-- id: PMID:9148890
-  title: The yeast JEM1p is a DnaJ-like protein of the endoplasmic reticulum membrane required for nuclear fusion.
-  findings: []
-- id: PMID:9817751
-  title: A role for the DnaJ homologue Scj1p in protein folding in the yeast endoplasmic reticulum.
-  findings: []
+- id: file:yeast/JEM1/JEM1-deep-research-falcon.md
+  title: Falcon deep research report for JEM1
+  findings:
+  - statement: Jem1 is an ER J-domain co-chaperone for Kar2/BiP
+    supporting_text: The report identifies ER J-domain co-chaperone activity within the Kar2/BiP system as Jem1&#39;s best-supported molecular role.
+core_functions:
+- description: &gt;-
+    ER membrane J-domain co-chaperone activity in the Kar2/BiP system. Jem1 helps
+    maintain soluble luminal misfolded proteins for ERAD and overlaps with Scj1
+    in ER protein folding.
+  molecular_function:
+    id: GO:0051087
+    label: protein-folding chaperone binding
+  directly_involved_in:
+  - id: GO:0034975
+    label: protein folding in endoplasmic reticulum
+  - id: GO:0036503
+    label: ERAD pathway
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  - id: GO:0042175
+    label: nuclear outer membrane-endoplasmic reticulum membrane network
+  supported_by:
+  - reference_id: PMID:11381090
+    supporting_text: Jem1p and Scj1p function as major partners for BiP in the ERAD process.
+  - reference_id: file:yeast/JEM1/JEM1-deep-research-falcon.md
+    supporting_text: Jem1 is an ER J-domain co-chaperone in the Kar2/BiP system.
+- description: J-domain-dependent support of nuclear membrane fusion during mating karyogamy.
+  molecular_function:
+    id: GO:0051087
+    label: protein-folding chaperone binding
+  directly_involved_in:
+  - id: GO:0000742
+    label: karyogamy involved in conjugation with cellular fusion
+  locations:
+  - id: GO:0042175
+    label: nuclear outer membrane-endoplasmic reticulum membrane network
+  supported_by:
+  - reference_id: PMID:10069807
+    supporting_text: Overexpression of KAR8/JEM1 (but not SEC63) strongly suppressed the mating...defect of kar2-1
+proposed_new_terms: []
+suggested_questions:
+- question: Should JEM1/SCJ1-like ER J-proteins use GO:0051787 rather than GO:0051082 when the evidence is ERAD substrate solubility?
+suggested_experiments: []
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/yeast/JEM1/JEM1-ai-review.html
+++ b/genes/yeast/JEM1/JEM1-ai-review.html
@@ -2953,6 +2953,7 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:15282802
       supporting_text: localization data for 21 other proteins
+      full_text_unavailable: true
     - reference_id: PMID:9148890
       supporting_text: protein was anchored in the endoplasmic reticulum (ER) membrane and its J-domain
 references:

--- a/genes/yeast/JEM1/JEM1-ai-review.html
+++ b/genes/yeast/JEM1/JEM1-ai-review.html
@@ -1897,10 +1897,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="P40358" data-a="GO:0042175" data-r="PMID:15282802" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P40358" data-a="GO:0042175" data-r="PMID:15282802" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1908,12 +1908,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This specific ER/nuclear-envelope localization fits Jem1 biology.
+                            <strong>Summary:</strong> The ER/nuclear-envelope localization fits Jem1 biology, but the PMID:15282802 IDA claim cannot be independently verified from the accessible abstract.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> PMID:15282802 provides the original GFP-localization survey context, while the ER membrane anchoring evidence from PMID:9148890 supports the biological plausibility of the nuclear outer membrane-ER membrane network assignment.
+                            <strong>Reason:</strong> PMID:15282802 is a GFP localization survey whose accessible abstract does not name Jem1/KAR8, and the full text is unavailable here. PMID:9148890 supports ER membrane anchoring as biological context, but it does not directly verify this specific PMID:15282802 IDA localization record.
                         </div>
 
 
@@ -2016,12 +2016,6 @@
                             </a>
                         </span>
 
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042175" target="_blank" class="term-link">
-                                nuclear outer membrane-endoplasmic reticulum membrane network
-                            </a>
-                        </span>
-
                     </div>
                 </div>
 
@@ -2109,8 +2103,8 @@
                     <div class="function-annotations">
 
                         <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042175" target="_blank" class="term-link">
-                                nuclear outer membrane-endoplasmic reticulum membrane network
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
                             </a>
                         </span>
 
@@ -2947,9 +2941,9 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:15282802
   review:
-    summary: This specific ER/nuclear-envelope localization fits Jem1 biology.
-    action: ACCEPT
-    reason: PMID:15282802 provides the original GFP-localization survey context, while the ER membrane anchoring evidence from PMID:9148890 supports the biological plausibility of the nuclear outer membrane-ER membrane network assignment.
+    summary: The ER/nuclear-envelope localization fits Jem1 biology, but the PMID:15282802 IDA claim cannot be independently verified from the accessible abstract.
+    action: UNDECIDED
+    reason: PMID:15282802 is a GFP localization survey whose accessible abstract does not name Jem1/KAR8, and the full text is unavailable here. PMID:9148890 supports ER membrane anchoring as biological context, but it does not directly verify this specific PMID:15282802 IDA localization record.
     supported_by:
     - reference_id: PMID:15282802
       supporting_text: localization data for 21 other proteins
@@ -3013,8 +3007,6 @@ core_functions:
   locations:
   - id: GO:0005789
     label: endoplasmic reticulum membrane
-  - id: GO:0042175
-    label: nuclear outer membrane-endoplasmic reticulum membrane network
   supported_by:
   - reference_id: PMID:11381090
     supporting_text: Jem1p and Scj1p function as major partners for BiP in the ERAD process.
@@ -3028,8 +3020,8 @@ core_functions:
   - id: GO:0000742
     label: karyogamy involved in conjugation with cellular fusion
   locations:
-  - id: GO:0042175
-    label: nuclear outer membrane-endoplasmic reticulum membrane network
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
   supported_by:
   - reference_id: PMID:10069807
     supporting_text: Overexpression of KAR8/JEM1 (but not SEC63) strongly suppressed the mating...defect of kar2-1

--- a/genes/yeast/JEM1/JEM1-ai-review.yaml
+++ b/genes/yeast/JEM1/JEM1-ai-review.yaml
@@ -204,6 +204,7 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:15282802
       supporting_text: localization data for 21 other proteins
+      full_text_unavailable: true
     - reference_id: PMID:9148890
       supporting_text: protein was anchored in the endoplasmic reticulum (ER) membrane and its J-domain
 references:

--- a/genes/yeast/JEM1/JEM1-ai-review.yaml
+++ b/genes/yeast/JEM1/JEM1-ai-review.yaml
@@ -1,11 +1,20 @@
 id: P40358
 gene_symbol: JEM1
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
+aliases:
+- KAR8
+- YJL073W
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: 'TODO: Add description for JEM1'
+description: >-
+  JEM1/KAR8 encodes an ER membrane DnaJ/Hsp40-family co-chaperone with a
+  lumen-facing J-domain. Jem1 works with the ER Hsp70 Kar2/BiP and overlaps
+  partly with Scj1 to support ER protein folding and ERAD of soluble luminal
+  misfolded substrates by keeping them soluble and retrotranslocation competent.
+  Jem1 is also required for nuclear membrane fusion during mating karyogamy at
+  the ER/nuclear envelope membrane system.
 existing_annotations:
 - term:
     id: GO:0051087
@@ -13,151 +22,215 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'Manual review: protein-folding chaperone binding is consistent with known biology of JEM1.'
+    summary: IBA is consistent with Jem1 as an ER J-domain co-chaperone for Kar2/BiP.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: J-domain co-chaperone function is the best-supported molecular role.
+    supported_by:
+    - reference_id: PMID:9148890
+      supporting_text: JEM1p likely assists the functions of BiP, Hsp70 in the ER, including karyogamy.
+    - reference_id: file:yeast/JEM1/JEM1-deep-research-falcon.md
+      supporting_text: Jem1p is an ER J-domain co-chaperone working within the Kar2/BiP chaperone system.
 - term:
     id: GO:0005783
     label: endoplasmic reticulum
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'Manual review: endoplasmic reticulum is consistent with known biology of JEM1.'
+    summary: Phylogenetic inference agrees with direct ER membrane localization.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: The ER is the compartment for Jem1's folding, ERAD, and karyogamy functions.
+    supported_by:
+    - reference_id: PMID:9148890
+      supporting_text: protein was anchored in the endoplasmic reticulum (ER) membrane and its J-domain
 - term:
     id: GO:0034975
     label: protein folding in endoplasmic reticulum
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'Manual review: protein folding in endoplasmic reticulum is consistent with known biology of JEM1.'
+    summary: This matches Jem1/Scj1/Kar2 roles in ER folding and quality control.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Jem1 supports ER folding and ERAD substrate handling.
+    supported_by:
+    - reference_id: PMID:11381090
+      supporting_text: Jem1p and Scj1p function as major partners for BiP in the ERAD process.
+    - reference_id: PMID:9817751
+      supporting_text: Jem1p and Scj1p appear to have partially overlapping functions as cofactors for Kar2p.
 - term:
     id: GO:0051787
     label: misfolded protein binding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'Manual review: misfolded protein binding is consistent with known biology of JEM1.'
+    summary: Misfolded protein binding fits the ERAD substrate-solubility evidence.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: This term is more informative than generic unfolded protein binding for the ERAD role.
+    supported_by:
+    - reference_id: PMID:11381090
+      supporting_text: aberrant immature proteins aggregated and migrated in the densest fraction
 - term:
     id: GO:0005789
     label: endoplasmic reticulum membrane
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'Manual review: endoplasmic reticulum membrane is consistent with known biology of JEM1.'
+    summary: UniProt subcellular mapping is consistent with direct ER membrane evidence.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Jem1 is a single-pass ER membrane protein with a lumen-facing J-domain.
+    supported_by:
+    - reference_id: PMID:9148890
+      supporting_text: protein was anchored in the endoplasmic reticulum (ER) membrane and its J-domain
 - term:
     id: GO:0031965
     label: nuclear membrane
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'Manual review: nuclear membrane may be context-dependent or peripheral for JEM1.'
+    summary: Nuclear membrane localization is plausible but broad.
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Keep as valid context for karyogamy, but the ER membrane/nuclear outer membrane network terms are more precise.
+    supported_by:
+    - reference_id: PMID:15282802
+      supporting_text: localization data for 21 other proteins
+      full_text_unavailable: true
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:12493774
   review:
-    summary: 'Manual review: protein binding is too generic or over-extended for JEM1.'
+    summary: The MPS3/Nep98 interaction is relevant but GO:0005515 is uninformative.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: Protein binding hides the more specific J-domain co-chaperone and karyogamy biology.
+    supported_by:
+    - reference_id: PMID:12493774
+      supporting_text: screened for partner proteins for Jem1p by the yeast two-hybrid...identified Nep98p
 - term:
     id: GO:0036503
     label: ERAD pathway
   evidence_type: IMP
   original_reference_id: PMID:11381090
   review:
-    summary: 'Manual review: ERAD pathway is consistent with known biology of JEM1.'
+    summary: Direct ERAD assays support this process annotation.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Jem1 helps keep soluble luminal ERAD substrates retrotranslocation competent.
+    supported_by:
+    - reference_id: PMID:11381090
+      supporting_text: one role for the lumenal Hsp70 chaperone system in the export of aberrant proteins
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IMP
   original_reference_id: PMID:9148890
   review:
-    summary: 'Manual review: unfolded protein binding is better represented by a more specific replacement term for JEM1.'
+    summary: Unfolded protein binding is too broad for the evidence.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: Misfolded protein binding better captures Jem1's ERAD substrate-handling role.
     proposed_replacement_terms:
-    - id: GO:0044183
-      label: protein folding chaperone
+    - id: GO:0051787
+      label: misfolded protein binding
+    supported_by:
+    - reference_id: PMID:11381090
+      supporting_text: BiP-Jem1p-Scj1p chaperone system is to retain ERAD substrates as lower molecular weight species.
 - term:
     id: GO:0051087
     label: protein-folding chaperone binding
   evidence_type: IGI
   original_reference_id: PMID:9148890
   review:
-    summary: 'Manual review: protein-folding chaperone binding is consistent with known biology of JEM1.'
+    summary: Genetic evidence supports chaperone binding as the J-domain co-chaperone function.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Jem1 works with Kar2/BiP during ER and nuclear fusion processes.
+    supported_by:
+    - reference_id: PMID:9148890
+      supporting_text: DnaJ-like proteins are functional partners for Hsp70 molecular chaperones.
 - term:
     id: GO:0005783
     label: endoplasmic reticulum
   evidence_type: HDA
   original_reference_id: PMID:26928762
   review:
-    summary: 'Manual review: endoplasmic reticulum is consistent with known biology of JEM1.'
+    summary: High-throughput ER localization is consistent with direct evidence.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: ER localization is core to Jem1 function.
+    supported_by:
+    - reference_id: PMID:9148890
+      supporting_text: protein was anchored in the endoplasmic reticulum (ER) membrane
 - term:
     id: GO:0000742
     label: karyogamy involved in conjugation with cellular fusion
   evidence_type: IMP
   original_reference_id: PMID:10069807
   review:
-    summary: 'Manual review: karyogamy involved in conjugation with cellular fusion may be context-dependent or peripheral for JEM1.'
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    summary: Jem1/Kar8 has a defining role in nuclear fusion during mating.
+    action: ACCEPT
+    reason: Karyogamy is a directly characterized JEM1 process, not a generic downstream phenotype.
+    supported_by:
+    - reference_id: PMID:10069807
+      supporting_text: Overexpression of KAR8/JEM1 (but not SEC63) strongly suppressed the mating...defect of kar2-1
 - term:
     id: GO:0005783
     label: endoplasmic reticulum
   evidence_type: IDA
   original_reference_id: PMID:9148890
   review:
-    summary: 'Manual review: endoplasmic reticulum is consistent with known biology of JEM1.'
+    summary: Direct experimental localization supports ER annotation.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: The ER is the core cellular compartment for Jem1.
+    supported_by:
+    - reference_id: PMID:9148890
+      supporting_text: protein was anchored in the endoplasmic reticulum (ER) membrane
 - term:
     id: GO:0034975
     label: protein folding in endoplasmic reticulum
   evidence_type: IGI
   original_reference_id: PMID:9817751
   review:
-    summary: 'Manual review: protein folding in endoplasmic reticulum is consistent with known biology of JEM1.'
+    summary: Genetic evidence supports overlapping Jem1/Scj1 ER folding functions.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Jem1 and Scj1 are functionally overlapping ER DnaJ proteins.
+    supported_by:
+    - reference_id: PMID:9817751
+      supporting_text: Jem1p and Scj1p appear to have partially overlapping functions as cofactors for Kar2p.
 - term:
     id: GO:0042175
     label: nuclear outer membrane-endoplasmic reticulum membrane network
   evidence_type: IDA
   original_reference_id: PMID:15282802
   review:
-    summary: 'Manual review: nuclear outer membrane-endoplasmic reticulum membrane network may be context-dependent or peripheral for JEM1.'
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    summary: This specific ER/nuclear-envelope localization fits Jem1 biology.
+    action: ACCEPT
+    reason: It is more precise than generic nuclear membrane and is compatible with ER and karyogamy functions.
+    supported_by:
+    - reference_id: PMID:9148890
+      supporting_text: protein was anchored in the endoplasmic reticulum (ER) membrane and its J-domain
 references:
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping
   findings: []
-- id: PMID:10069807
-  title: Genetic interactions between KAR7/SEC71, KAR8/JEM1, KAR5, and KAR2 during nuclear fusion in Saccharomyces cerevisiae.
-  findings: []
+- id: PMID:9148890
+  title: The yeast JEM1p is a DnaJ-like protein of the endoplasmic reticulum membrane required for nuclear fusion.
+  findings:
+  - statement: Jem1 is an ER membrane DnaJ-like protein with a lumen-facing J-domain
+    supporting_text: The JEM1 protein was anchored in the ER membrane and its J-domain faced the ER lumen.
+- id: PMID:9817751
+  title: A role for the DnaJ homologue Scj1p in protein folding in the yeast endoplasmic reticulum.
+  findings:
+  - statement: Jem1 and Scj1 have overlapping ER chaperone functions
+    supporting_text: Cells lacking both Jem1p and Scj1p are temperature sensitive.
 - id: PMID:11381090
   title: Molecular chaperones in the yeast endoplasmic reticulum maintain the solubility of proteins for retrotranslocation and degradation.
-  findings: []
+  findings:
+  - statement: Jem1 and Scj1 maintain soluble ERAD substrates
+    supporting_text: BiP cooperates with Jem1p and Scj1p to facilitate export of ERAD substrates by preventing aggregation in the ER lumen.
+- id: PMID:10069807
+  title: Genetic interactions between KAR7/SEC71, KAR8/JEM1, KAR5, and KAR2 during nuclear fusion in Saccharomyces cerevisiae.
+  findings:
+  - statement: JEM1/KAR8 genetically interacts with KAR2 during nuclear fusion
+    supporting_text: Overexpression of KAR8/JEM1 strongly suppressed the mating defect of kar2-1.
 - id: PMID:12493774
   title: Nep98p is a component of the yeast spindle pole body and essential for nuclear division and fusion.
   findings: []
@@ -167,9 +240,48 @@ references:
 - id: PMID:26928762
   title: 'One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy.'
   findings: []
-- id: PMID:9148890
-  title: The yeast JEM1p is a DnaJ-like protein of the endoplasmic reticulum membrane required for nuclear fusion.
-  findings: []
-- id: PMID:9817751
-  title: A role for the DnaJ homologue Scj1p in protein folding in the yeast endoplasmic reticulum.
-  findings: []
+- id: file:yeast/JEM1/JEM1-deep-research-falcon.md
+  title: Falcon deep research report for JEM1
+  findings:
+  - statement: Jem1 is an ER J-domain co-chaperone for Kar2/BiP
+    supporting_text: The report identifies ER J-domain co-chaperone activity within the Kar2/BiP system as Jem1's best-supported molecular role.
+core_functions:
+- description: >-
+    ER membrane J-domain co-chaperone activity in the Kar2/BiP system. Jem1 helps
+    maintain soluble luminal misfolded proteins for ERAD and overlaps with Scj1
+    in ER protein folding.
+  molecular_function:
+    id: GO:0051087
+    label: protein-folding chaperone binding
+  directly_involved_in:
+  - id: GO:0034975
+    label: protein folding in endoplasmic reticulum
+  - id: GO:0036503
+    label: ERAD pathway
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  - id: GO:0042175
+    label: nuclear outer membrane-endoplasmic reticulum membrane network
+  supported_by:
+  - reference_id: PMID:11381090
+    supporting_text: Jem1p and Scj1p function as major partners for BiP in the ERAD process.
+  - reference_id: file:yeast/JEM1/JEM1-deep-research-falcon.md
+    supporting_text: Jem1 is an ER J-domain co-chaperone in the Kar2/BiP system.
+- description: J-domain-dependent support of nuclear membrane fusion during mating karyogamy.
+  molecular_function:
+    id: GO:0051087
+    label: protein-folding chaperone binding
+  directly_involved_in:
+  - id: GO:0000742
+    label: karyogamy involved in conjugation with cellular fusion
+  locations:
+  - id: GO:0042175
+    label: nuclear outer membrane-endoplasmic reticulum membrane network
+  supported_by:
+  - reference_id: PMID:10069807
+    supporting_text: Overexpression of KAR8/JEM1 (but not SEC63) strongly suppressed the mating...defect of kar2-1
+proposed_new_terms: []
+suggested_questions:
+- question: Should JEM1/SCJ1-like ER J-proteins use GO:0051787 rather than GO:0051082 when the evidence is ERAD substrate solubility?
+suggested_experiments: []

--- a/genes/yeast/JEM1/JEM1-ai-review.yaml
+++ b/genes/yeast/JEM1/JEM1-ai-review.yaml
@@ -198,9 +198,9 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:15282802
   review:
-    summary: This specific ER/nuclear-envelope localization fits Jem1 biology.
-    action: ACCEPT
-    reason: PMID:15282802 provides the original GFP-localization survey context, while the ER membrane anchoring evidence from PMID:9148890 supports the biological plausibility of the nuclear outer membrane-ER membrane network assignment.
+    summary: The ER/nuclear-envelope localization fits Jem1 biology, but the PMID:15282802 IDA claim cannot be independently verified from the accessible abstract.
+    action: UNDECIDED
+    reason: PMID:15282802 is a GFP localization survey whose accessible abstract does not name Jem1/KAR8, and the full text is unavailable here. PMID:9148890 supports ER membrane anchoring as biological context, but it does not directly verify this specific PMID:15282802 IDA localization record.
     supported_by:
     - reference_id: PMID:15282802
       supporting_text: localization data for 21 other proteins
@@ -264,8 +264,6 @@ core_functions:
   locations:
   - id: GO:0005789
     label: endoplasmic reticulum membrane
-  - id: GO:0042175
-    label: nuclear outer membrane-endoplasmic reticulum membrane network
   supported_by:
   - reference_id: PMID:11381090
     supporting_text: Jem1p and Scj1p function as major partners for BiP in the ERAD process.
@@ -279,8 +277,8 @@ core_functions:
   - id: GO:0000742
     label: karyogamy involved in conjugation with cellular fusion
   locations:
-  - id: GO:0042175
-    label: nuclear outer membrane-endoplasmic reticulum membrane network
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
   supported_by:
   - reference_id: PMID:10069807
     supporting_text: Overexpression of KAR8/JEM1 (but not SEC63) strongly suppressed the mating...defect of kar2-1

--- a/genes/yeast/JEM1/JEM1-ai-review.yaml
+++ b/genes/yeast/JEM1/JEM1-ai-review.yaml
@@ -200,8 +200,10 @@ existing_annotations:
   review:
     summary: This specific ER/nuclear-envelope localization fits Jem1 biology.
     action: ACCEPT
-    reason: It is more precise than generic nuclear membrane and is compatible with ER and karyogamy functions.
+    reason: PMID:15282802 provides the original GFP-localization survey context, while the ER membrane anchoring evidence from PMID:9148890 supports the biological plausibility of the nuclear outer membrane-ER membrane network assignment.
     supported_by:
+    - reference_id: PMID:15282802
+      supporting_text: localization data for 21 other proteins
     - reference_id: PMID:9148890
       supporting_text: protein was anchored in the endoplasmic reticulum (ER) membrane and its J-domain
 references:

--- a/genes/yeast/JEM1/JEM1-deep-research-falcon.md
+++ b/genes/yeast/JEM1/JEM1-deep-research-falcon.md
@@ -1,0 +1,290 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-04T10:05:05.324789'
+end_time: '2026-05-04T10:19:28.583923'
+duration_seconds: 863.26
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: yeast
+  gene_id: JEM1
+  gene_symbol: JEM1
+  uniprot_accession: P40358
+  protein_description: 'RecName: Full=DnaJ-like chaperone JEM1; AltName: Full=DnaJ-like
+    protein of the ER membrane 1; Flags: Precursor;'
+  gene_info: Name=JEM1; Synonyms=KAR8; OrderedLocusNames=YJL073W; ORFNames=HRC558,
+    J1083;
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+  protein_family: Not specified in UniProt
+  protein_domains: DnaJ_C3_Co-chaperones. (IPR051727); DnaJ_domain. (IPR001623); J_dom_sf.
+    (IPR036869); DnaJ (PF00226)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 25
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P40358
+- **Protein Description:** RecName: Full=DnaJ-like chaperone JEM1; AltName: Full=DnaJ-like protein of the ER membrane 1; Flags: Precursor;
+- **Gene Information:** Name=JEM1; Synonyms=KAR8; OrderedLocusNames=YJL073W; ORFNames=HRC558, J1083;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** DnaJ_C3_Co-chaperones. (IPR051727); DnaJ_domain. (IPR001623); J_dom_sf. (IPR036869); DnaJ (PF00226)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "JEM1" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'JEM1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **JEM1** (gene ID: JEM1, UniProt: P40358) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P40358
+- **Protein Description:** RecName: Full=DnaJ-like chaperone JEM1; AltName: Full=DnaJ-like protein of the ER membrane 1; Flags: Precursor;
+- **Gene Information:** Name=JEM1; Synonyms=KAR8; OrderedLocusNames=YJL073W; ORFNames=HRC558, J1083;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** DnaJ_C3_Co-chaperones. (IPR051727); DnaJ_domain. (IPR001623); J_dom_sf. (IPR036869); DnaJ (PF00226)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "JEM1" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'JEM1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **JEM1** (gene ID: JEM1, UniProt: P40358) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research report: Functional annotation of **JEM1/KAR8 (YJL073W; UniProt P40358)** in *Saccharomyces cerevisiae* (S288c)
+
+### 0) Target verification (mandatory disambiguation)
+The literature retrieved here unambiguously matches the UniProt-specified target: **JEM1** (synonym **KAR8**; ORF **YJL073W**) encodes a **DnaJ/Hsp40-family (“J-protein”) co-chaperone** that is an **ER membrane protein** with a **lumen-facing J-domain** in *Saccharomyces cerevisiae* (S288c background), consistent with UniProt P40358’s description (nishikawa1997theyeastjem1p pages 1-2, nishikawa1997theyeastjem1p pages 2-3). No conflicting “JEM1” identity from other organisms is used in this report.
+
+### 1) Key concepts and definitions (current mechanistic understanding)
+
+#### 1.1 J-proteins (Hsp40/DnaJ proteins) and the J-domain
+J-proteins are co-chaperones that regulate Hsp70-family chaperones by engaging them through a conserved **J-domain**. In the ER lumen, the Hsp70 is **Kar2/BiP**, and ER J-proteins (including Jem1p) are thought to tune Kar2/BiP activity toward specific tasks (e.g., folding vs ERAD vs translocation) (nishikawa2001molecularchaperonesin pages 1-2, vembar2010jdomaincochaperone pages 1-2).
+
+A canonical feature of J-domains is the **His–Pro–Asp (HPD) motif**, which is essential for functional interaction with Hsp70s. For Jem1p, mutation of the HPD motif (H613Q) abolishes Jem1p function in vivo (nishikawa1997theyeastjem1p pages 2-3, nishikawa1997theyeastjem1p pages 4-5).
+
+#### 1.2 ER protein quality control (ERQC) and ER-associated degradation (ERAD)
+**ERQC** comprises folding and surveillance activities that prevent secretion of misfolded proteins; **ERAD** exports persistently misfolded ER proteins to the cytosol for proteasomal degradation. In yeast, an important mechanistic role for Kar2/BiP with the J-proteins **Jem1p** and **Scj1p** is to **keep soluble misfolded luminal substrates soluble**, preventing aggregation and maintaining them in a **retrotranslocation-competent** state (nishikawa2001molecularchaperonesin pages 1-2).
+
+### 2) Gene/protein overview and cellular localization
+
+#### 2.1 Protein architecture and topology
+Jem1p is reported as a **692-aa** DnaJ-like protein with a **single transmembrane segment** and a **C-terminal J-domain** (nishikawa1997theyeastjem1p pages 1-2). Topology mapping shows Jem1p is anchored in the **ER membrane** with the **J-domain facing the ER lumen**; the luminal C-terminal region is **glycosylated** (nishikawa1997theyeastjem1p pages 4-5, nishikawa1997theyeastjem1p pages 2-3).
+
+Two cropped figures from the primary paper visually support these conclusions:
+- a **domain schematic** indicating the TM segment and the luminal J-domain (nishikawa1997theyeastjem1p media cb077d07)
+- a **microscopy panel** showing the nuclear-fusion phenotype in mating (nishikawa1997theyeastjem1p media 2f50a63f)
+
+#### 2.2 Interaction partners and co-chaperone network
+The best-supported partner is ER Hsp70 **Kar2/BiP**. Jem1p was proposed as a BiP (Kar2) and/or Lhs1 partner based on orientation and genetics (nishikawa1997theyeastjem1p pages 4-5), and later **biochemically tested for BiP binding** using a GST-Jem1p pulldown format (makio2008identificationandcharacterization pages 11-12). Jem1p also has partially overlapping functions with the soluble ER-lumen J-protein **Scj1p**: a **jem1Δ scj1Δ** double mutant is temperature sensitive, indicating redundancy or pathway buffering (nishikawa1997theyeastjem1p pages 2-3, nishikawa1997theyeastjem1p pages 4-5).
+
+### 3) Primary biological functions and pathway placement
+
+#### 3.1 Primary function: ER-lumen J-protein co-chaperone for Kar2/BiP
+The core molecular function supported by multiple studies is that Jem1p is an **ER J-domain co-chaperone** working within the Kar2/BiP chaperone system. Functional specificity among ER J-proteins is highlighted by data showing that a BiP surface mutation (R217A) disrupts interaction with **Sec63** (translocation) while leaving **Jem1p** interaction and ERAD function largely intact—supporting the concept that different J-proteins specify distinct BiP functions (vembar2010jdomaincochaperone pages 1-2).
+
+#### 3.2 Karyogamy (nuclear fusion during mating)
+Jem1p is required for **karyogamy**, specifically nuclear fusion during mating, consistent with the synonym **KAR8** (nishikawa1997theyeastjem1p pages 1-2). Quantitatively, in a **jem1Δ** background **79%** of zygotes contained **two or more juxtaposed nuclei that failed to fuse**, while cell fusion itself appeared normal (nishikawa1997theyeastjem1p pages 4-5). The HPD motif is required for this function: an HPD mutant (H613Q) cannot rescue the karyogamy defect (nishikawa1997theyeastjem1p pages 2-3). The karyogamy defect is visually illustrated in microscopy panels (nishikawa1997theyeastjem1p media 2f50a63f).
+
+Mechanistically, later domain-dissection work indicates Jem1p has separable functional contributions to karyogamy versus ER quality control, with karyogamy linked to interactions mediated by the N-terminal region (and reported interaction with a nuclear-envelope-associated factor) while ERQC is more generally tied to the ER chaperone role (makio2008identificationandcharacterization pages 1-3).
+
+#### 3.3 ERAD and ERQC: substrate-class selectivity
+A prominent mechanistic insight is substrate-class selectivity in ERAD:
+- **Soluble luminal ERAD substrates** (e.g., CPY* and related luminal clients) become **stabilized and aggregate** at elevated temperature when **JEM1 and SCJ1** are deleted, similar to phenotypes in Kar2/BiP mutants (nishikawa2001molecularchaperonesin pages 1-2).
+- In contrast, deletion of **JEM1 + SCJ1** has **little effect on ERAD of a membrane protein**, implying Jem1p’s key contribution is **maintaining solubility of luminal clients** rather than being a universal ERAD requirement across all substrate topologies (nishikawa2001molecularchaperonesin pages 1-2).
+
+### 4) Phenotypes and quantitative/statistical evidence
+
+Key low-throughput quantitative results supporting annotation include:
+- **Karyogamy defect:** **79%** of **jem1Δ** zygotes show **unfused juxtaposed nuclei** (nishikawa1997theyeastjem1p pages 4-5).
+- **Synthetic growth defect/redundancy:** **jem1Δ scj1Δ** strains grow at 14–30 °C but fail at **37 °C**, and the defect is rescued by a low-copy plasmid expressing tagged JEM1 (nishikawa1997theyeastjem1p pages 4-5).
+- **UPR/ER folding capacity readouts (contextual but quantitative):** deletion of **JEM1** is associated with constitutive UPR activation measured via **KAR2 induction (~1.7-fold)**, and multi-J-protein mutant combinations further increase KAR2, supporting overlapping roles of luminal J-proteins in maintaining ER folding capacity (fama2007thesaccharomycescerevisiae pages 8-9). (These measurements are in a study centered on another ER J-protein but directly include Δjem1 quantitative effects.)
+
+### 5) Current applications and real-world implementations
+
+#### 5.1 Yeast as an experimental platform to model ERAD and proteostasis
+Jem1p is used as an experimentally tractable lever to interrogate ERAD mechanisms. A clear example is development of **yeast expression systems for mammalian ENaC subunits**, where Jem1/Scj1 were tested for roles in ERAD and ubiquitination of ENaC in yeast (buck2010theendoplasmicreticulum–associated pages 1-2, buck2010theendoplasmicreticulum–associated pages 2-3). This represents a real-world implementation of the Jem1/Scj1 axis as a **model system** for ER proteostasis relevant to human membrane proteins.
+
+#### 5.2 Using Jem1 mutants/epitope tagging to dissect co-chaperone mechanisms
+The ENaC ERAD study explicitly employs **epitope-tagged Jem1** constructs and HPD mutants (e.g., JEM1–3HA and JEM1H566Q–3HA in that paper’s construct set) together with UPR reporters and ERAD substrates, demonstrating how Jem1 is used operationally to map chaperone dependency and pathway wiring (buck2010theendoplasmicreticulum–associated pages 2-3).
+
+### 6) Expert synthesis and authoritative interpretations
+An authoritative review of yeast ER protein quality control/ERAD places **Kar2/BiP together with Hsp40 co-chaperones Scj1 and Jem1** as supporting ERAD and the handling of misfolded proteins in the ER, emphasizing the integrated nature of the ER chaperone network in enabling retrotranslocation and degradation (makio2008identificationandcharacterization pages 12-12). The primary mechanistic studies support this review-level picture by providing substrate-class specificity (soluble luminal substrates) and genetic redundancy with Scj1 (nishikawa2001molecularchaperonesin pages 1-2, nishikawa1997theyeastjem1p pages 4-5).
+
+### 7) Recent developments (2023–2024): evidence limitation in this run
+Multiple targeted searches for **2023–2024** publications specifically about yeast **JEM1/KAR8/YJL073W** did not yield retrievable sources in the current tool run. Consequently, this report’s mechanistic conclusions rest on foundational primary work (1997–2010) and an authoritative review (2018). Any attempt to describe “latest research” beyond these sources would be speculative and is therefore not included.
+
+### 8) Evidence-mapped summary table
+| Category | Key points (mechanism/definition) | Evidence/assays & quantitative data | Key sources (with year, DOI URL) |
+|---|---|---|---|
+| Verified identity | UniProt P40358 corresponds to **Saccharomyces cerevisiae** **JEM1/KAR8/YJL073W**, the ER-membrane DnaJ-like chaperone required for nuclear fusion; this matches the user-provided UniProt description and excludes ambiguity with other genes. | Primary paper identifies ORF **YJL073W** as **JEM1**, encoding a DnaJ-like ER membrane protein; nonessential singly, but functionally important in ER chaperoning and mating/karyogamy phenotypes (nishikawa1997theyeastjem1p pages 1-2, nishikawa1997theyeastjem1p pages 2-3). | Nishikawa & Endo 1997, J Biol Chem, https://doi.org/10.1074/jbc.272.20.12889 (nishikawa1997theyeastjem1p pages 1-2, nishikawa1997theyeastjem1p pages 2-3) |
+| Protein type & domains | Jem1p is a **DnaJ/Hsp40-family co-chaperone** with a **C-terminal J-domain**, a conserved **HPD motif** required for activity, and a **single transmembrane segment** anchoring it in the ER membrane. | Reported as **692 aa** with one putative TM segment and J-domain; **H613Q** substitution in the conserved HPD motif abolishes complementation of both growth and karyogamy defects, demonstrating that the J-domain is functionally essential (nishikawa1997theyeastjem1p pages 1-2, nishikawa1997theyeastjem1p pages 2-3). | Nishikawa & Endo 1997, https://doi.org/10.1074/jbc.272.20.12889 (nishikawa1997theyeastjem1p pages 1-2, nishikawa1997theyeastjem1p pages 2-3) |
+| Subcellular localization & topology | Jem1p is an **integral ER membrane protein** with the **J-domain exposed to the ER lumen**; its lumenal C-terminal region is **glycosylated**. This orientation is consistent with a co-chaperone role for lumenal Hsp70s. | Epitope-tagging/immunolocalization and topology analysis showed ER-membrane anchoring with lumen-facing J-domain; glycosylation of the C-terminal/lumenal region was detected. Figure-level summary shows TM segment plus lumenal J-domain and mutant karyogamy phenotype (nishikawa1997theyeastjem1p pages 1-2, nishikawa1997theyeastjem1p pages 2-3, nishikawa1997theyeastjem1p pages 4-5, nishikawa1997theyeastjem1p media cb077d07). | Nishikawa & Endo 1997, https://doi.org/10.1074/jbc.272.20.12889 (nishikawa1997theyeastjem1p pages 1-2, nishikawa1997theyeastjem1p pages 2-3, nishikawa1997theyeastjem1p pages 4-5, nishikawa1997theyeastjem1p media cb077d07) |
+| Primary molecular function | Jem1p is best understood as an **ER J-domain co-chaperone** that functionally partners with **Kar2/BiP** (and possibly Lhs1) to stimulate Hsp70-dependent ER processes; in ER quality control it helps **maintain soluble lumenal substrates in a retrotranslocation-competent, non-aggregated state**. | DnaJ proteins act through J-domains to regulate Hsp70 ATPase cycles; Jem1p was proposed as a partner for **BiP/Kar2 and/or Lhs1**. Later work showed **BiP interaction with Jem1p** and that BiP mutations can selectively disrupt one J-protein interaction (Sec63) while sparing Jem1, indicating mechanistic specificity among ER Hsp70–Hsp40 pairings (nishikawa1997theyeastjem1p pages 2-3, nishikawa1997theyeastjem1p pages 4-5, makio2008identificationandcharacterization pages 11-12, vembar2010jdomaincochaperone pages 1-2). | Nishikawa & Endo 1997, https://doi.org/10.1074/jbc.272.20.12889; Makio et al. 2008, https://doi.org/10.1111/j.1365-2443.2008.01223.x; Vembar et al. 2010, https://doi.org/10.1074/jbc.m110.102186 (nishikawa1997theyeastjem1p pages 2-3, nishikawa1997theyeastjem1p pages 4-5, makio2008identificationandcharacterization pages 11-12, vembar2010jdomaincochaperone pages 1-2) |
+| Interaction partners | Best-supported partners are **Kar2/BiP** and the parallel ER J-protein **Scj1**; **Lhs1** is a plausible/mentioned ER Hsp70 partner in the same chaperone network. | Genetic interaction: **jem1Δ scj1Δ** double mutants are temperature sensitive, indicating overlapping function. Biochemical support: GST-Jem1p-His pulldown conditions captured **BiP/Kar2** binding. Reviews/primary context place Jem1p with **Scj1, Sec63, Kar2, Lhs1** in the ER chaperone system (nishikawa1997theyeastjem1p pages 2-3, makio2008identificationandcharacterization pages 11-12, silberstein1998arolefor pages 1-2, nishikawa1997theyeastjem1p pages 4-5). | Makio et al. 2008, https://doi.org/10.1111/j.1365-2443.2008.01223.x; Nishikawa & Endo 1997, https://doi.org/10.1074/jbc.272.20.12889; Silberstein et al. 1998, https://doi.org/10.1083/jcb.143.4.921 (makio2008identificationandcharacterization pages 11-12, nishikawa1997theyeastjem1p pages 2-3, silberstein1998arolefor pages 1-2, nishikawa1997theyeastjem1p pages 4-5) |
+| Karyogamy / nuclear fusion pathway | Jem1p has a specialized role in **karyogamy**, specifically **nuclear membrane/nuclear fusion during mating**. This is the source of the synonym **KAR8**. Its J-domain is required for this role. | In **jem1Δ** zygotes, **79%** contained **two or more juxtaposed nuclei** that failed to fuse; crossing to wild type restored efficient diploid formation, indicating a bilateral mating defect. HPD mutant **H613Q** fails to rescue karyogamy. Figure panel summary shows juxtaposed unfused nuclei in the mutant (nishikawa1997theyeastjem1p pages 4-5, nishikawa1997theyeastjem1p pages 2-3, nishikawa1997theyeastjem1p media cb077d07). | Nishikawa & Endo 1997, https://doi.org/10.1074/jbc.272.20.12889 (nishikawa1997theyeastjem1p pages 4-5, nishikawa1997theyeastjem1p pages 2-3, nishikawa1997theyeastjem1p media cb077d07) |
+| ER folding / protein quality control | Beyond karyogamy, Jem1p participates in **ER protein folding/ER quality control (ERQC)** with Scj1 and Kar2. Functional overlap with Scj1 explains why single mutants are mild but double mutants are stressed. | Primary and comparative work conclude Jem1p and Scj1 cooperate in ERQC; **jem1Δ scj1Δ** mutants display heat-sensitive growth and accumulation/aggregation of misfolded proteins in the ER lumen under restrictive conditions (makio2008identificationandcharacterization pages 1-3, nishikawa1997theyeastjem1p pages 4-5, nishikawa1997theyeastjem1p pages 2-3). | Makio et al. 2008, https://doi.org/10.1111/j.1365-2443.2008.01223.x; Nishikawa & Endo 1997, https://doi.org/10.1074/jbc.272.20.12889 (makio2008identificationandcharacterization pages 1-3, nishikawa1997theyeastjem1p pages 4-5, nishikawa1997theyeastjem1p pages 2-3) |
+| ERAD role | Jem1p contributes to **ER-associated degradation (ERAD)** chiefly for **soluble lumenal substrates**, acting with Kar2/BiP and Scj1 to keep misfolded proteins soluble so they can be retrotranslocated and degraded. | In vivo/in vitro ERAD assays showed that when **JEM1 and SCJ1** are deleted, soluble ERAD substrates such as **CPY\*** and **A1PiZ/pro-α-factor-based substrates** become **stabilized and aggregate** at elevated temperature; authors conclude BiP/Jem1p/Scj1p maintain a retrotranslocation-competent state (nishikawa2001molecularchaperonesin pages 1-2). | Nishikawa et al. 2001, J Cell Biol, https://doi.org/10.1083/jcb.153.5.1061 (nishikawa2001molecularchaperonesin pages 1-2) |
+| Substrate specificity | Jem1p’s ERAD contribution is **substrate-class selective**: important for **soluble lumenal misfolded proteins**, but much less important for at least some **membrane ERAD substrates**. | Deletion of **JEM1 + SCJ1** had **little effect on ERAD of a membrane protein**, whereas soluble lumenal substrates were strongly impaired/stabilized. This supports a model in which Jem1p primarily buffers/solubilizes lumenal clients rather than serving as a general ERAD factor for all substrate topologies (nishikawa2001molecularchaperonesin pages 1-2). | Nishikawa et al. 2001, https://doi.org/10.1083/jcb.153.5.1061 (nishikawa2001molecularchaperonesin pages 1-2) |
+| Genetic interactions & phenotypes | Key phenotypes: **jem1Δ** is viable but defective in karyogamy; **jem1Δ scj1Δ** is **temperature sensitive at 37°C**; HPD-mutant Jem1p is nonfunctional; ERQC/ERAD defects become prominent under heat/proteotoxic stress. | Growth assays showed the double disruptant grows at **14, 23, and 30°C** but not **37°C**; low-copy **3HA-JEM1** rescues. Microscopy quantified **79%** unfused nuclei in **jem1Δ** zygotes. ERAD assays showed stabilization/aggregation of soluble substrates in the double mutant (nishikawa1997theyeastjem1p pages 4-5, nishikawa2001molecularchaperonesin pages 1-2). | Nishikawa & Endo 1997, https://doi.org/10.1074/jbc.272.20.12889; Nishikawa et al. 2001, https://doi.org/10.1083/jcb.153.5.1061 (nishikawa1997theyeastjem1p pages 4-5, nishikawa2001molecularchaperonesin pages 1-2) |
+| UPR / stress context | Direct evidence that **JEM1 itself is a canonical UPR regulator** is limited in the retrieved Jem1-focused papers, but Jem1p clearly functions within the broader **ER proteostasis stress network** with Kar2 and Scj1. UPR-related conclusions are stronger for **Scj1** and combined ER folding stress than for Jem1 alone. | Scj1 loss induces UPR and combined loss of Scj1/Jem1 exacerbates folding stress in the ER; reviews place Jem1 among ER proteostasis factors assisting Kar2 during ERQC/ERAD. Because direct Jem1-specific UPR regulation was not established in the core Jem1 primary papers retrieved, this annotation should be treated as contextual rather than primary (silberstein1998arolefor pages 1-2, makio2008identificationandcharacterization pages 1-3, nishikawa2001molecularchaperonesin pages 1-2). | Silberstein et al. 1998, https://doi.org/10.1083/jcb.143.4.921; Makio et al. 2008, https://doi.org/10.1111/j.1365-2443.2008.01223.x; Nishikawa et al. 2001, https://doi.org/10.1083/jcb.153.5.1061 (silberstein1998arolefor pages 1-2, makio2008identificationandcharacterization pages 1-3, nishikawa2001molecularchaperonesin pages 1-2) |
+
+
+*Table: This table summarizes the experimentally supported functional annotation of Saccharomyces cerevisiae JEM1/KAR8/YJL073W (UniProt P40358), including topology, mechanism, pathways, interaction partners, and key phenotypes. It is useful as a compact evidence map linking core claims to primary sources and quantitative data.*
+
+### 9) Practical takeaways for functional annotation
+1. **Primary molecular role:** Jem1p is an **ER-membrane J-protein (Hsp40)** whose **luminal J-domain** (HPD motif-dependent) supports **Kar2/BiP-dependent proteostasis** (nishikawa1997theyeastjem1p pages 4-5, nishikawa2001molecularchaperonesin pages 1-2).
+2. **Process-level functions:** Jem1p is required for **karyogamy/nuclear fusion** during mating and participates in **ERQC/ERAD** (particularly for **soluble luminal substrates**) with partial redundancy to Scj1p (nishikawa1997theyeastjem1p pages 4-5, nishikawa2001molecularchaperonesin pages 1-2, nishikawa1997theyeastjem1p pages 2-3).
+3. **Localization:** Jem1p is an **ER membrane** protein with **lumen-facing J-domain**, consistent with its roles in luminal folding and ERAD client management (nishikawa1997theyeastjem1p pages 4-5, nishikawa1997theyeastjem1p media cb077d07).
+
+### Key sources (publication date, URL)
+- Nishikawa S, Endo T. **May 1997**. *J Biol Chem*. “The Yeast JEM1p Is a DnaJ-like Protein of the Endoplasmic Reticulum Membrane Required for Nuclear Fusion.” https://doi.org/10.1074/jbc.272.20.12889 (nishikawa1997theyeastjem1p pages 4-5)
+- Nishikawa S, Fewell SW, Kato Y, Brodsky JL, Endo T. **May 2001**. *J Cell Biol*. “Molecular Chaperones in the Yeast Endoplasmic Reticulum Maintain the Solubility of Proteins for Retrotranslocation and Degradation.” https://doi.org/10.1083/jcb.153.5.1061 (nishikawa2001molecularchaperonesin pages 1-2)
+- Makio T, Nishikawa S, Nakayama T, Nagai H, Endo T. **Oct 2008**. *Genes to Cells*. “Identification and characterization of a Jem1p ortholog… dissection of Jem1p functions in karyogamy and protein quality control…” https://doi.org/10.1111/j.1365-2443.2008.01223.x (makio2008identificationandcharacterization pages 1-3, makio2008identificationandcharacterization pages 11-12)
+- Vembar SS, Jonikas MC, Hendershot LM, Weissman JS, Brodsky JL. **Jul 2010**. *J Biol Chem*. “J Domain Co-chaperone Specificity Defines the Role of BiP during Protein Translocation.” https://doi.org/10.1074/jbc.m110.102186 (vembar2010jdomaincochaperone pages 1-2)
+- Buck TM, Kolb AR, Boyd CR, Kleyman TR, Brodsky JL. **Mar 2010**. *Mol Biol Cell*. “The ERAD of the epithelial sodium channel requires a unique complement of molecular chaperones.” https://doi.org/10.1091/mbc.e09-11-0944 (buck2010theendoplasmicreticulum–associated pages 1-2)
+- Berner N, Reutter K-R, Wolf DH. **Jun 2018**. *Annu Rev Biochem*. “Protein Quality Control of the ER and ubiquitin-proteasome-triggered degradation…” https://doi.org/10.1146/annurev-biochem-062917-012749 (makio2008identificationandcharacterization pages 12-12)
+- Famá MC et al. **Feb 2007**. *BBA - Mol Cell Res*. “YFR041C/ERJ5 … required to preserve the folding capacity of the ER.” (includes Δjem1 quantitative UPR metrics) https://doi.org/10.1016/j.bbamcr.2006.10.011 (fama2007thesaccharomycescerevisiae pages 8-9)
+
+References
+
+1. (nishikawa1997theyeastjem1p pages 1-2): Shuh-ichi Nishikawa and Toshiya Endo. The yeast jem1p is a dnaj-like protein of the endoplasmic reticulum membrane required for nuclear fusion*. The Journal of Biological Chemistry, 272:12889-12892, May 1997. URL: https://doi.org/10.1074/jbc.272.20.12889, doi:10.1074/jbc.272.20.12889. This article has 137 citations.
+
+2. (nishikawa1997theyeastjem1p pages 2-3): Shuh-ichi Nishikawa and Toshiya Endo. The yeast jem1p is a dnaj-like protein of the endoplasmic reticulum membrane required for nuclear fusion*. The Journal of Biological Chemistry, 272:12889-12892, May 1997. URL: https://doi.org/10.1074/jbc.272.20.12889, doi:10.1074/jbc.272.20.12889. This article has 137 citations.
+
+3. (nishikawa2001molecularchaperonesin pages 1-2): Shuh-ichi Nishikawa, Sheara W. Fewell, Yoshihito Kato, Jeffrey L. Brodsky, and Toshiya Endo. Molecular chaperones in the yeast endoplasmic reticulum maintain the solubility of proteins for retrotranslocation and degradation. The Journal of Cell Biology, 153:1061-1070, May 2001. URL: https://doi.org/10.1083/jcb.153.5.1061, doi:10.1083/jcb.153.5.1061. This article has 442 citations.
+
+4. (vembar2010jdomaincochaperone pages 1-2): Shruthi S. Vembar, Martin C. Jonikas, Linda M. Hendershot, Jonathan S. Weissman, and Jeffrey L. Brodsky. J domain co-chaperone specificity defines the role of bip during protein translocation. Journal of Biological Chemistry, 285:22484-22494, Jul 2010. URL: https://doi.org/10.1074/jbc.m110.102186, doi:10.1074/jbc.m110.102186. This article has 62 citations and is from a domain leading peer-reviewed journal.
+
+5. (nishikawa1997theyeastjem1p pages 4-5): Shuh-ichi Nishikawa and Toshiya Endo. The yeast jem1p is a dnaj-like protein of the endoplasmic reticulum membrane required for nuclear fusion*. The Journal of Biological Chemistry, 272:12889-12892, May 1997. URL: https://doi.org/10.1074/jbc.272.20.12889, doi:10.1074/jbc.272.20.12889. This article has 137 citations.
+
+6. (nishikawa1997theyeastjem1p media cb077d07): Shuh-ichi Nishikawa and Toshiya Endo. The yeast jem1p is a dnaj-like protein of the endoplasmic reticulum membrane required for nuclear fusion*. The Journal of Biological Chemistry, 272:12889-12892, May 1997. URL: https://doi.org/10.1074/jbc.272.20.12889, doi:10.1074/jbc.272.20.12889. This article has 137 citations.
+
+7. (nishikawa1997theyeastjem1p media 2f50a63f): Shuh-ichi Nishikawa and Toshiya Endo. The yeast jem1p is a dnaj-like protein of the endoplasmic reticulum membrane required for nuclear fusion*. The Journal of Biological Chemistry, 272:12889-12892, May 1997. URL: https://doi.org/10.1074/jbc.272.20.12889, doi:10.1074/jbc.272.20.12889. This article has 137 citations.
+
+8. (makio2008identificationandcharacterization pages 11-12): T. Makio, S. Nishikawa, T. Nakayama, Hiroyuki Nagai, and T. Endo. Identification and characterization of a jem1p ortholog of candida albicans: dissection of jem1p functions in karyogamy and protein quality control in saccharomyces cerevisiae. Genes to Cells, Oct 2008. URL: https://doi.org/10.1111/j.1365-2443.2008.01223.x, doi:10.1111/j.1365-2443.2008.01223.x. This article has 9 citations and is from a peer-reviewed journal.
+
+9. (makio2008identificationandcharacterization pages 1-3): T. Makio, S. Nishikawa, T. Nakayama, Hiroyuki Nagai, and T. Endo. Identification and characterization of a jem1p ortholog of candida albicans: dissection of jem1p functions in karyogamy and protein quality control in saccharomyces cerevisiae. Genes to Cells, Oct 2008. URL: https://doi.org/10.1111/j.1365-2443.2008.01223.x, doi:10.1111/j.1365-2443.2008.01223.x. This article has 9 citations and is from a peer-reviewed journal.
+
+10. (fama2007thesaccharomycescerevisiae pages 8-9): M. Carla Famá, David Raden, Nicolás Zacchi, Darío R. Lemos, Anne S. Robinson, and Susana Silberstein. The saccharomyces cerevisiae yfr041c/erj5 gene encoding a type i membrane protein with a j domain is required to preserve the folding capacity of the endoplasmic reticulum. Biochimica et Biophysica Acta (BBA) - Molecular Cell Research, 1773:232-242, Feb 2007. URL: https://doi.org/10.1016/j.bbamcr.2006.10.011, doi:10.1016/j.bbamcr.2006.10.011. This article has 41 citations and is from a peer-reviewed journal.
+
+11. (buck2010theendoplasmicreticulum–associated pages 1-2): Teresa M. Buck, Alexander R. Kolb, Cary R. Boyd, Thomas R. Kleyman, and Jeffrey L. Brodsky. The endoplasmic reticulum–associated degradation of the epithelial sodium channel requires a unique complement of molecular chaperones. Molecular Biology of the Cell, 21:1047-1058, Mar 2010. URL: https://doi.org/10.1091/mbc.e09-11-0944, doi:10.1091/mbc.e09-11-0944. This article has 116 citations and is from a domain leading peer-reviewed journal.
+
+12. (buck2010theendoplasmicreticulum–associated pages 2-3): Teresa M. Buck, Alexander R. Kolb, Cary R. Boyd, Thomas R. Kleyman, and Jeffrey L. Brodsky. The endoplasmic reticulum–associated degradation of the epithelial sodium channel requires a unique complement of molecular chaperones. Molecular Biology of the Cell, 21:1047-1058, Mar 2010. URL: https://doi.org/10.1091/mbc.e09-11-0944, doi:10.1091/mbc.e09-11-0944. This article has 116 citations and is from a domain leading peer-reviewed journal.
+
+13. (makio2008identificationandcharacterization pages 12-12): T. Makio, S. Nishikawa, T. Nakayama, Hiroyuki Nagai, and T. Endo. Identification and characterization of a jem1p ortholog of candida albicans: dissection of jem1p functions in karyogamy and protein quality control in saccharomyces cerevisiae. Genes to Cells, Oct 2008. URL: https://doi.org/10.1111/j.1365-2443.2008.01223.x, doi:10.1111/j.1365-2443.2008.01223.x. This article has 9 citations and is from a peer-reviewed journal.
+
+14. (silberstein1998arolefor pages 1-2): Susana Silberstein, Gabriel Schlenstedt, Pam A. Silver, and Reid Gilmore. A role for the dnaj homologue scj1p in protein folding in the yeast endoplasmic reticulum. The Journal of Cell Biology, 143:921-933, Nov 1998. URL: https://doi.org/10.1083/jcb.143.4.921, doi:10.1083/jcb.143.4.921. This article has 124 citations.
+
+## Citations
+
+1. nishikawa2001molecularchaperonesin pages 1-2
+2. makio2008identificationandcharacterization pages 11-12
+3. vembar2010jdomaincochaperone pages 1-2
+4. makio2008identificationandcharacterization pages 1-3
+5. fama2007thesaccharomycescerevisiae pages 8-9
+6. makio2008identificationandcharacterization pages 12-12
+7. silberstein1998arolefor pages 1-2
+8. https://doi.org/10.1074/jbc.272.20.12889
+9. https://doi.org/10.1074/jbc.272.20.12889;
+10. https://doi.org/10.1111/j.1365-2443.2008.01223.x;
+11. https://doi.org/10.1074/jbc.m110.102186
+12. https://doi.org/10.1083/jcb.143.4.921
+13. https://doi.org/10.1083/jcb.153.5.1061
+14. https://doi.org/10.1083/jcb.143.4.921;
+15. https://doi.org/10.1111/j.1365-2443.2008.01223.x
+16. https://doi.org/10.1091/mbc.e09-11-0944
+17. https://doi.org/10.1146/annurev-biochem-062917-012749
+18. https://doi.org/10.1016/j.bbamcr.2006.10.011
+19. https://doi.org/10.1074/jbc.272.20.12889,
+20. https://doi.org/10.1083/jcb.153.5.1061,
+21. https://doi.org/10.1074/jbc.m110.102186,
+22. https://doi.org/10.1111/j.1365-2443.2008.01223.x,
+23. https://doi.org/10.1016/j.bbamcr.2006.10.011,
+24. https://doi.org/10.1091/mbc.e09-11-0944,
+25. https://doi.org/10.1083/jcb.143.4.921,

--- a/genes/yeast/TSR4/TSR4-ai-review.html
+++ b/genes/yeast/TSR4/TSR4-ai-review.html
@@ -671,33 +671,44 @@
     <div class="header">
         <h1>TSR4</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P25040" target="_blank" class="term-link">
                         P25040
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Saccharomyces cerevisiae</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
+            <div class="info-item">
+                <span class="info-label">Aliases:</span>
+                <div class="aliases">
+
+                    <span class="badge">YOL022C</span>
+
+                    <span class="badge">uS5 assembly chaperone</span>
+
+                </div>
+            </div>
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,24 +739,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="P25040" data-a="DESCRIPTION: TODO: Add description for TSR4..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="P25040" data-a="DESCRIPTION: TSR4 encodes a cytoplasmic, client-specific riboso..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TODO: Add description for TSR4</p>
+        <p>TSR4 encodes a cytoplasmic, client-specific ribosomal protein carrier chaperone for Rps2/uS5. Tsr4 binds the eukaryote-specific N-terminal extension of nascent Rps2/uS5, promotes Rps2 expression and solubility, and releases the client before nuclear import and productive pre-40S assembly. Loss of Tsr4 impairs 40S ribosomal small subunit biogenesis, pre-40S export, and 20S pre-rRNA processing at site D to mature 18S rRNA.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +769,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030490" target="_blank" class="term-link">
                                     GO:0030490
                                 </a>
                             </span>
                             <span class="term-label">maturation of SSU-rRNA</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,46 +806,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: maturation of SSU-rRNA is consistent with known biology of TSR4.
+                            <strong>Summary:</strong> IBA is consistent with Tsr4-dependent 20S pre-rRNA processing and 40S biogenesis.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> SSU-rRNA maturation is a direct process-level consequence of the uS5 chaperone role.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19806183" target="_blank" class="term-link">
+                                        PMID:19806183
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">YOR006C/TSR3, YOL022C/TSR4). We associate the new genes with specific aspects of...processing of 5S, 7S, 20S, 27S, and 35S rRNAs.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/TSR4/TSR4-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Tsr4 enables downstream 40S assembly and pre-40S export through cytoplasmic Rps2/uS5 chaperone activity.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -846,46 +886,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cytoplasm is consistent with known biology of TSR4.
+                            <strong>Summary:</strong> Cytoplasmic localization is consistent with direct Tsr4 studies.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Tsr4 acts in the cytoplasm on nascent Rps2/uS5 before nuclear import.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31182640" target="_blank" class="term-link">
+                                        PMID:31182640
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Tsr4 appears to be restricted to the cytoplasm.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -897,108 +955,155 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cytosol is consistent with known biology of TSR4.
+                            <strong>Summary:</strong> Cytosol is the best location for Tsr4 carrier chaperone activity.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Direct and curated sources place Tsr4 in the cytosol/cytoplasm.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31062022" target="_blank" class="term-link">
+                                        PMID:31062022
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Tsr4 binds co-translationally to the...essential, eukaryote-specific N-terminal extension of Rps2</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042254" target="_blank" class="term-link">
                                     GO:0042254
                                 </a>
                             </span>
                             <span class="term-label">ribosome biogenesis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P25040" data-a="GO:0042254" data-r="GO_REF:0000043" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P25040" data-a="GO:0042254" data-r="GO_REF:0000043" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ribosome biogenesis is consistent with known biology of TSR4.
+                            <strong>Summary:</strong> Ribosome biogenesis is correct but too broad for Tsr4.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Replace with the more specific ribosomal small subunit biogenesis term.
                         </div>
-                        
-                        
-                        
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042274" target="_blank" class="term-link">
+                                    ribosomal small subunit biogenesis
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31062022" target="_blank" class="term-link">
+                                        PMID:31062022
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mutation of the essential Tsr4...enhance the 40S synthesis defects</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31062022" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31062022
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tsr4 and Nap1, two novel members of the ribosomal protein ch...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1010,57 +1115,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cytosol is consistent with known biology of TSR4.
+                            <strong>Summary:</strong> Direct evidence supports cytosolic localization.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Tsr4 binds Rps2/uS5 co-translationally in the cytosol.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31062022" target="_blank" class="term-link">
+                                        PMID:31062022
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Tsr4 binds co-translationally to the...essential, eukaryote-specific N-terminal extension of Rps2</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140597" target="_blank" class="term-link">
                                     GO:0140597
                                 </a>
                             </span>
                             <span class="term-label">protein carrier chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31062022" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31062022
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tsr4 and Nap1, two novel members of the ribosomal protein ch...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1072,57 +1195,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein carrier chaperone is consistent with known biology of TSR4.
+                            <strong>Summary:</strong> This is the most specific molecular-function annotation for TSR4.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Tsr4 is a dedicated carrier chaperone for ribosomal protein Rps2/uS5.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31062022" target="_blank" class="term-link">
+                                        PMID:31062022
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">vitro. While Tsr4 is specific for Rps2...Tsr4 binds co-translationally to the...essential, eukaryote-specific N-terminal extension of Rps2</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/TSR4/TSR4-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Tsr4 is a cytoplasmic, co-translational uS5 chaperone that captures the Rps2 N-terminus.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042274" target="_blank" class="term-link">
                                     GO:0042274
                                 </a>
                             </span>
                             <span class="term-label">ribosomal small subunit biogenesis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31062022" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31062022
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tsr4 and Nap1, two novel members of the ribosomal protein ch...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1134,57 +1286,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ribosomal small subunit biogenesis is consistent with known biology of TSR4.
+                            <strong>Summary:</strong> Tsr4 perturbation causes 40S biogenesis defects.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Rps2/uS5 chaperoning is directly tied to small subunit assembly.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31062022" target="_blank" class="term-link">
+                                        PMID:31062022
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mutation of the essential Tsr4...enhance the 40S synthesis defects</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042274" target="_blank" class="term-link">
                                     GO:0042274
                                 </a>
                             </span>
                             <span class="term-label">ribosomal small subunit biogenesis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31062022" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31062022
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tsr4 and Nap1, two novel members of the ribosomal protein ch...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1196,57 +1366,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ribosomal small subunit biogenesis is consistent with known biology of TSR4.
+                            <strong>Summary:</strong> Genetic evidence with RPS2 supports the 40S biogenesis annotation.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The genetic relationship supports Tsr4&#39;s role in Rps2-dependent 40S assembly.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31062022" target="_blank" class="term-link">
+                                        PMID:31062022
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">identification of Nap1 and Tsr4 as direct binding partners of Rps6 and Rps2</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31062022" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31062022
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tsr4 and Nap1, two novel members of the ribosomal protein ch...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1258,68 +1446,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for TSR4.
+                            <strong>Summary:</strong> The binding evidence is specific to Rps2/uS5, not generic unfolded protein.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
+                            <strong>Reason:</strong> Replace broad unfolded protein binding with protein carrier chaperone.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140597" target="_blank" class="term-link">
                                     protein carrier chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31062022" target="_blank" class="term-link">
+                                        PMID:31062022
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Both factors promote the solubility of their r-protein clients in...vitro.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042274" target="_blank" class="term-link">
                                     GO:0042274
                                 </a>
                             </span>
                             <span class="term-label">ribosomal small subunit biogenesis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31182640" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31182640
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tsr4 Is a Cytoplasmic Chaperone for the Ribosomal Protein Rp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1331,57 +1537,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ribosomal small subunit biogenesis is consistent with known biology of TSR4.
+                            <strong>Summary:</strong> Independent evidence supports the same 40S biogenesis role.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Tsr4 perturbation decreases Rps2 and phenocopies Rps2 depletion.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31182640" target="_blank" class="term-link">
+                                        PMID:31182640
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Tsr4 perturbation resulted in decreased Rps2 levels and...phenocopied Rps2 depletion.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31182640" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31182640
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tsr4 Is a Cytoplasmic Chaperone for the Ribosomal Protein Rp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1393,68 +1617,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for TSR4.
+                            <strong>Summary:</strong> The evidence supports specific Rps2 carrier chaperoning.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
+                            <strong>Reason:</strong> Protein carrier chaperone is the more precise molecular-function term.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140597" target="_blank" class="term-link">
                                     protein carrier chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31182640" target="_blank" class="term-link">
+                                        PMID:31182640
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Tsr4 cotranslationally associates with Rps2...cytoplasmic chaperone dedicated to Rps2.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31182640" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31182640
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tsr4 Is a Cytoplasmic Chaperone for the Ribosomal Protein Rp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1466,68 +1708,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for TSR4.
+                            <strong>Summary:</strong> The IPI evidence identifies a specific Rps2/uS5 client relationship.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
+                            <strong>Reason:</strong> Replace broad unfolded protein binding with protein carrier chaperone.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140597" target="_blank" class="term-link">
                                     protein carrier chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31182640" target="_blank" class="term-link">
+                                        PMID:31182640
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Rps2 harbors a...eukaryote-specific N-terminal extension that is critical for its interaction...with Tsr4.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31182640" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31182640
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tsr4 Is a Cytoplasmic Chaperone for the Ribosomal Protein Rp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1539,57 +1799,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cytoplasm is consistent with known biology of TSR4.
+                            <strong>Summary:</strong> Direct microscopy and functional evidence support cytoplasmic localization.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Tsr4 acts before nuclear import and pre-ribosome assembly.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31182640" target="_blank" class="term-link">
+                                        PMID:31182640
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Despite Rps2 joining nuclear pre-40S particles, Tsr4 appears to be restricted to the cytoplasm.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14562095
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Global analysis of protein localization in budding yeast.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1601,57 +1879,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cytoplasm is consistent with known biology of TSR4.
+                            <strong>Summary:</strong> High-throughput cytoplasmic localization is consistent with targeted studies.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The broad cytoplasm term is correct, though cytosol is more precise.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31182640" target="_blank" class="term-link">
+                                        PMID:31182640
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Tsr4 appears to be restricted to the cytoplasm.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030490" target="_blank" class="term-link">
                                     GO:0030490
                                 </a>
                             </span>
                             <span class="term-label">maturation of SSU-rRNA</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19806183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19806183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Rational extension of the ribosome biogenesis pathway using ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1663,177 +1959,832 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: maturation of SSU-rRNA is consistent with known biology of TSR4.
+                            <strong>Summary:</strong> The original genetic annotation correctly identifies TSR4 in SSU rRNA maturation.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Later work explains the phenotype through defective Rps2/uS5 handling and 40S assembly.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19806183" target="_blank" class="term-link">
+                                        PMID:19806183
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">YOR006C/TSR3, YOL022C/TSR4). We associate the new genes with specific aspects of...processing of 5S, 7S, 20S, 27S, and 35S rRNAs.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Cytoplasmic protein carrier chaperone for ribosomal protein Rps2/uS5. Tsr4 binds nascent Rps2/uS5 and maintains the client in a soluble assembly-competent state before nuclear import and incorporation into pre-40S particles.</h3>
+                <span class="vote-buttons" data-g="P25040" data-a="FUNCTION: Cytoplasmic protein carrier chaperone for ribosoma..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140597" target="_blank" class="term-link">
+                            protein carrier chaperone
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042274" target="_blank" class="term-link">
+                                ribosomal small subunit biogenesis
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030490" target="_blank" class="term-link">
+                                maturation of SSU-rRNA
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31062022" target="_blank" class="term-link">
+                                PMID:31062022
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">identification of Nap1 and Tsr4 as direct binding partners of Rps6 and Rps2...Both factors promote the solubility of their r-protein clients</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31182640" target="_blank" class="term-link">
+                                PMID:31182640
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Tsr4 perturbation resulted in decreased Rps2 levels and...phenocopied Rps2 depletion.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/TSR4/TSR4-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Tsr4 is a cytoplasmic, co-translational uS5 chaperone that captures the Rps2 N-terminus.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
-                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping</div>
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link">
                             PMID:14562095
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Global analysis of protein localization in budding yeast.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19806183" target="_blank" class="term-link">
                             PMID:19806183
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Rational extension of the ribosome biogenesis pathway using network-guided genetics.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">TSR4 was identified as a ribosome biogenesis factor</div>
+
+                        <div class="finding-text">"Network-guided genetics associated YOL022C/TSR4 with ribosome biogenesis and pre-rRNA processing."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/31062022" target="_blank" class="term-link">
                             PMID:31062022
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Tsr4 and Nap1, two novel members of the ribosomal protein chaperOME.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Tsr4 is a direct Rps2/uS5 carrier chaperone</div>
+
+                        <div class="finding-text">"Tsr4 is specific for Rps2, binds co-translationally to its N-terminal extension, and promotes solubility."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/31182640" target="_blank" class="term-link">
                             PMID:31182640
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Tsr4 Is a Cytoplasmic Chaperone for the Ribosomal Protein Rps2 in Saccharomyces cerevisiae.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Tsr4 is a cytoplasmic chaperone dedicated to Rps2</div>
+
+                        <div class="finding-text">"Tsr4 cotranslationally associates with Rps2; perturbation decreases Rps2 levels."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/TSR4/TSR4-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for TSR4</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">TSR4 is a cytoplasmic uS5/Rps2 carrier chaperone</div>
+
+                        <div class="finding-text">"The report synthesizes evidence that Tsr4 captures nascent Rps2/uS5 and enables downstream 40S assembly."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Should older GO:0051082 annotations for Tsr4 be replaced by GO:0140597 protein carrier chaperone where evidence is specific Rps2/uS5 chaperoning?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P25040" data-a="Q: Should older GO:0051082 annotations for Tsr4 be re..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(TSR4-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P25040" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-04T10:20:45.054448'<br />
+end_time: '2026-05-04T10:44:28.489025'<br />
+duration_seconds: 1423.43<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: yeast<br />
+  gene_id: TSR4<br />
+  gene_symbol: TSR4<br />
+  uniprot_accession: P25040<br />
+  protein_description: 'RecName: Full=uS5 assembly chaperone {ECO:0000305}; AltName:<br />
+    Full=20S rRNA accumulation protein 4;'<br />
+  gene_info: Name=TSR4; OrderedLocusNames=YOL022C;<br />
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).<br />
+  protein_family: Belongs to the TSR4 family. .<br />
+  protein_domains: PDCD2_C. (IPR007320); PDCD2_C (PF04194)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 29</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P25040</li>
+<li><strong>Protein Description:</strong> RecName: Full=uS5 assembly chaperone {ECO:0000305}; AltName: Full=20S rRNA accumulation protein 4;</li>
+<li><strong>Gene Information:</strong> Name=TSR4; OrderedLocusNames=YOL022C;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the TSR4 family. .</li>
+<li><strong>Key Domains:</strong> PDCD2_C. (IPR007320); PDCD2_C (PF04194)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "TSR4" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'TSR4' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>TSR4</strong> (gene ID: TSR4, UniProt: P25040) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P25040</li>
+<li><strong>Protein Description:</strong> RecName: Full=uS5 assembly chaperone {ECO:0000305}; AltName: Full=20S rRNA accumulation protein 4;</li>
+<li><strong>Gene Information:</strong> Name=TSR4; OrderedLocusNames=YOL022C;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the TSR4 family. .</li>
+<li><strong>Key Domains:</strong> PDCD2_C. (IPR007320); PDCD2_C (PF04194)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "TSR4" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'TSR4' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>TSR4</strong> (gene ID: TSR4, UniProt: P25040) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-saccharomyces-cerevisiae-tsr4-uniprot-p25040-yol022c">Research Report: <em>Saccharomyces cerevisiae</em> TSR4 (UniProt P25040; YOL022C)</h2>
+<h3 id="0-target-verification-geneprotein-identity">0) Target verification (gene/protein identity)</h3>
+<p>The yeast gene <strong>TSR4</strong> (ordered locus <strong>YOL022C</strong>; UniProt <strong>P25040</strong>) corresponds to the ribosome biogenesis factor historically described as <strong>“20S rRNA accumulation protein 4”</strong> and is now experimentally established as a <strong>uS5 (Rps2) assembly chaperone</strong>. Primary yeast studies that biochemically and genetically characterize <strong>Tsr4</strong> (the protein product of TSR4) identify its client as the small-subunit ribosomal protein <strong>Rps2/uS5</strong> and show a cytoplasmic chaperone role (black2019tsr4isa pages 1-3, black2019tsr4isa pages 15-17).</p>
+<p>Domain/family verification matches the UniProt context: a comparative genomics analysis reports that yeast <strong>TSR4</strong> is annotated in Pfam as containing a <strong>C-terminal PDCD2_C</strong> domain and unifies TSR4 with eukaryotic homologs <strong>PDCD2/PDCD2L</strong> (and related proteins) into a larger duplicated-repeat superfamily termed <strong>TYPP</strong>, proposed to mediate protein–protein interactions consistent with chaperone-like function (burroughs2014analysisoftwo pages 3-5, burroughs2014analysisoftwo pages 5-7).</p>
+<h3 id="1-key-concepts-and-current-understanding">1) Key concepts and current understanding</h3>
+<h4 id="11-dedicated-ribosomal-protein-chaperones-concept">1.1 Dedicated ribosomal-protein chaperones (concept)</h4>
+<p>Eukaryotic ribosome biogenesis requires safe handling of newly synthesized ribosomal proteins (RPs), many of which are highly basic and/or contain intrinsically disordered, eukaryote-specific extensions that are aggregation-prone. <strong>Dedicated RP chaperones</strong> are specialized factors that bind specific RPs to promote solubility, prevent nonproductive interactions, and enable correct delivery/assembly (rossler2019tsr4andnap1 pages 1-2, black2019tsr4isa pages 1-3).</p>
+<p><strong>TSR4/Tsr4</strong> is a canonical example of this class: it is described as a <strong>dedicated chaperone</strong> that binds Rps2/uS5 and promotes its solubility and productive assembly into 40S subunits (rossler2019tsr4andnap1 pages 14-15, black2019tsr4isa pages 15-17).</p>
+<h4 id="12-what-tsr4-does-at-a-molecular-level">1.2 What TSR4 does at a molecular level</h4>
+<p><strong>Molecular function (best-supported):</strong> Tsr4 binds <strong>nascent Rps2/uS5</strong> co-translationally in the cytoplasm and acts as a <strong>client-specific chaperone</strong> to stabilize Rps2 and support 40S biogenesis (black2019tsr4isa pages 1-3, rossler2019tsr4andnap1 pages 12-13).</p>
+<p><strong>Client recognition:</strong> Multiple experiments map Tsr4 recognition primarily to the <strong>eukaryote-specific N-terminal extension of Rps2</strong>, with the first ~42 amino acids sufficient/required for robust interaction (rossler2019tsr4andnap1 pages 12-13). This binding is consistent with the general principle that dedicated chaperones often recognize <strong>eukaryote-specific RP extensions</strong> (rossler2019tsr4andnap1 pages 1-2).</p>
+<p><strong>Chaperone effect on solubility:</strong> Rps2 expressed alone is aggregation-prone, while co-expression with Tsr4 keeps Rps2 soluble and supports complex formation in vitro and in vivo (rossler2019tsr4andnap1 pages 14-15).</p>
+<h4 id="13-cellular-process-and-pathway-context">1.3 Cellular process and pathway context</h4>
+<p>TSR4 acts within <strong>small (40S) ribosomal subunit biogenesis</strong>, specifically by enabling accumulation and assembly of Rps2/uS5 into pre-40S particles. Loss of TSR4 phenocopies reduced uS5 availability, producing severe 40S defects and pre-40S export problems (black2019tsr4isa pages 15-17, rossler2019tsr4andnap1 pages 15-16).</p>
+<p>A 2023 review synthesizing cross-species evidence frames TSR4/PDCD2 as an <strong>evolutionarily conserved uS5 chaperone module</strong> that monitors uS5 availability/folding and supports pre-rRNA maturation outcomes consistent with 40S assembly (e.g., accumulation of 20S/21S pre-rRNAs and reduced uS5 incorporation when the module is perturbed) (landryvoyer2023ribosomalproteinus5 pages 6-8, landryvoyer2023ribosomalproteinus5 pages 8-10).</p>
+<h3 id="2-experimentally-supported-biology-of-yeast-tsr4tsr4">2) Experimentally supported biology of yeast TSR4/Tsr4</h3>
+<h4 id="21-binding-partners-and-mechanism">2.1 Binding partners and mechanism</h4>
+<p><strong>Primary binding partner:</strong> <strong>Rps2/uS5</strong>.</p>
+<p><strong>Co-translational association:</strong> Tsr4 purifications enrich <strong>RPS2 mRNA</strong>, consistent with binding to nascent chains during translation; interaction mapping supports specificity for the Rps2 N-terminus (rossler2019tsr4andnap1 pages 12-13). Black et al. likewise report co-translational association and dependence on the eukaryote-specific Rps2 N-terminal extension (black2019tsr4isa pages 1-3).</p>
+<p><strong>Key mechanistic inference:</strong> Tsr4 appears to act <strong>upstream of nuclear pre-40S assembly</strong>, stabilizing Rps2 before (or during) handoff to nuclear import/assembly pathways, rather than being a stable component of nuclear pre-ribosomes (black2019tsr4isa pages 17-20, black2019tsr4isa pages 15-17).</p>
+<h4 id="22-subcellular-localization-where-it-acts">2.2 Subcellular localization (where it acts)</h4>
+<p>Multiple lines of evidence support that yeast Tsr4 is <strong>predominantly cytoplasmic</strong> and does <strong>not</strong> undergo obvious Crm1-dependent shuttling:</p>
+<ul>
+<li>Black et al. performed a Crm1 inhibition assay (leptomycin B in a Crm1-sensitized strain) where the Crm1 cargo control Nmd3 relocalizes to the nucleus, but <strong>Tsr4 remains cytoplasmic</strong>, arguing against Crm1-dependent nucleocytoplasmic shuttling (black2019tsr4isa media 141d3d19).</li>
+<li>Functional mutation of a predicted NLS in Tsr4 still complements loss of Tsr4, consistent with the idea that nuclear entry is not required for its essential function (black2019tsr4isa pages 15-17).</li>
+</ul>
+<h4 id="23-consequences-of-tsr4-loss-phenotypes-and-readouts">2.3 Consequences of TSR4 loss: phenotypes and readouts</h4>
+<p><strong>Ribosome biogenesis output (polysome profiling):</strong> Loss of Tsr4 produces a dramatic small subunit defect described as a <strong>missing 40S peak</strong>, increased free 60S, and reduced 80S/polysomes (rossler2019tsr4andnap1 pages 15-16).</p>
+<p><strong>Pre-40S export / nuclear accumulation:</strong> Repression of TSR4 (or RPS2) causes <strong>nuclear accumulation of ITS1</strong>, interpreted as a <strong>block in pre-40S export</strong> (black2019tsr4isa pages 15-17).</p>
+<p><strong>Rps2 abundance:</strong> Perturbation of Tsr4 reduces Rps2 levels and phenocopies Rps2 depletion, consistent with a stabilizing chaperone function (black2019tsr4isa pages 1-3).</p>
+<p><strong>Genetic suppression:</strong> Increasing <strong>RPS2 dosage</strong> can partially bypass TSR4 loss (viability rescue), supporting a direct client-chaperone relationship; however, the rescued strains have impaired growth (growth defects at 25–30°C; inviability at 37°C), consistent with incomplete restoration of robust biogenesis (rossler2019tsr4andnap1 pages 15-16).</p>
+<p><strong>Quantitative notes:</strong><br />
+* Estimated abundance: <strong>~1,500 Tsr4 molecules/cell</strong> (black2019tsr4isa pages 6-8).<br />
+* Rps2-GFP steady-state localization: in wild-type, <strong>~72%</strong> of cells show <strong>nuclear exclusion</strong> of Rps2-GFP; in the absence of Tsr4, Rps2 reporters show nuclear signal/accumulation (rossler2019tsr4andnap1 pages 15-16, rossler2019tsr4andnap1 pages 16-16).</p>
+<h3 id="3-recent-developments-and-latest-research-20232024-prioritized">3) Recent developments and latest research (2023–2024 prioritized)</h3>
+<h4 id="31-2023-nuclear-import-of-rps2us5-is-tsr4-independent">3.1 2023: Nuclear import of Rps2/uS5 is Tsr4-independent</h4>
+<p>A focused mechanistic study (Steiner et al., <strong>July 2023</strong>) dissected nuclear import signals of yeast Rps2/uS5. Key findings:</p>
+<ul>
+<li>An internal region <strong>Rps2(76–145)</strong> is sufficient for nuclear targeting and contains a critical basic cluster <strong>R95/R97/K99</strong>; mutation of these residues strongly disrupts nuclear localization (steiner2023dissectingthenuclear pages 6-9, steiner2023dissectingthenuclear pages 1-2).</li>
+<li>A second nuclear targeting element lies in the <strong>N-terminal region (~10–28)</strong> (RG-rich/basic), which overlaps the Tsr4-binding region (steiner2023dissectingthenuclear pages 1-2, steiner2023dissectingthenuclear pages 15-18).</li>
+<li>Importin <strong>Pse1 (Kap121)</strong> interacts with and contributes to import of the internal NLS, but import is not exclusively Pse1-dependent, consistent with redundancy among importins (steiner2023dissectingthenuclear pages 2-4, steiner2023dissectingthenuclear pages 15-18).</li>
+<li>Critically, nuclear import via either the internal or N-terminal element <strong>does not require Tsr4</strong>, supporting a model where Tsr4’s essential function is chaperoning/assembly competence rather than serving as the import adaptor (steiner2023dissectingthenuclear pages 2-4, steiner2023dissectingthenuclear pages 13-15).</li>
+</ul>
+<p>This resolves an important mechanistic ambiguity noted in reviews: because Tsr4 binds near an NLS, it was plausible that Tsr4 was required for import; instead, import can occur without it, while assembly remains defective (steiner2023dissectingthenuclear pages 2-4, rossler2019tsr4andnap1 pages 16-16).</p>
+<h4 id="32-2023-consolidation-of-the-conserved-us5-interactome">3.2 2023: Consolidation of the conserved uS5 interactome</h4>
+<p>A 2023 review (Landry-Voyer et al., <strong>May 2023</strong>) synthesizes evidence that PDCD2 and its homologs (including yeast Tsr4) are <strong>dedicated uS5 chaperones</strong> that recognize nascent uS5 co-translationally and whose perturbation phenocopies uS5 deficiency (landryvoyer2023ribosomalproteinus5 pages 6-8, landryvoyer2023ribosomalproteinus5 pages 8-10). The review also highlights unanswered questions, including how the chaperone–uS5 complex is disassembled and coordinated with import/assembly (landryvoyer2023ribosomalproteinus5 pages 8-10).</p>
+<h4 id="33-2024-framing-tsr4-in-modern-chaperome-and-coordination-questions">3.3 2024: Framing Tsr4 in modern “chaperome” and coordination questions</h4>
+<p>A 2024 Biomolecules editorial (Pertschy &amp; Zierler, <strong>Dec 2024</strong>) highlights the open question created by overlap of Tsr4 binding and an N-terminal uS5 NLS: how are <strong>chaperoning and import coordinated</strong> in space and time? (pertschy2024ribosomalproteinsin pages 1-2).</p>
+<p>A 2024 Annual Review (Yang &amp; Karbstein, <strong>Oct 2024</strong>) places dedicated RP chaperones (including the Tsr4/Nap1 chaperome work) into a broader conceptual framework where specialized chaperones can contribute to <strong>assembly</strong> and potentially to <strong>maintenance/repair</strong> processes (yang2024ribosomeassemblyand pages 20-21, yang2024ribosomeassemblyand pages 11-13).</p>
+<h4 id="34-2023-ribosome-repair-after-oxidative-damagetsr4-does-not-extract-rps2">3.4 2023: Ribosome repair after oxidative damage—Tsr4 does not extract Rps2</h4>
+<p>Yang et al. (Molecular Cell, <strong>May 2023</strong>) demonstrated chaperone-mediated extraction of oxidized Rps26 by Tsr2 during oxidative stress, but explicitly report that <strong>neither Rps2 nor Rps3 were released by their chaperones (Tsr4 and Yar1)</strong> in their in vitro extraction assays (yang2023chaperonedirectedribosomerepair pages 3-5, yang2023chaperonedirectedribosomerepair pages 5-7). This suggests that, unlike Tsr2–Rps26, the Tsr4–Rps2 pair is not (or is not readily) deployed for extraction-based repair under those experimental conditions.</p>
+<h3 id="4-applications-and-real-world-implementations">4) Applications and real-world implementations</h3>
+<h4 id="41-tsr4-as-an-experimental-handle-for-us5-handling-and-40s-biogenesis">4.1 TSR4 as an experimental handle for uS5 handling and 40S biogenesis</h4>
+<p>In yeast, TSR4 is used as a mechanistic probe to study <strong>co-translational RP capture</strong>, <strong>client stabilization</strong>, and <strong>the pathway linking RP availability to pre-40S export</strong>. The strong, diagnostic phenotypes (missing 40S peak; nuclear ITS1 accumulation) provide clear, implementation-ready assays for perturbations in the uS5 supply chain (rossler2019tsr4andnap1 pages 15-16, black2019tsr4isa pages 15-17).</p>
+<h4 id="42-translational-relevance-via-conserved-homologs-pdcd2pdcd2l">4.2 Translational relevance via conserved homologs (PDCD2/PDCD2L)</h4>
+<p>While the present target is yeast TSR4, the <strong>TSR4–PDCD2/PDCD2L</strong> homology provides direct translational relevance: PDCD2 is described as a conserved uS5 chaperone that underlies essential roles in proliferation and development, and has reported associations with human disease contexts (as summarized in the 2023 uS5 review) (landryvoyer2023ribosomalproteinus5 pages 6-8, landryvoyer2023ribosomalproteinus5 pages 8-10). PDCD2L is discussed as a candidate late-acting uS5 interactor and potential pre-40S export adaptor (XPO1/CRM1-associated via an NES), supporting a conserved “uS5 handling network” spanning chaperoning and nucleocytoplasmic trafficking (landryvoyer2023ribosomalproteinus5 pages 8-10, landryvoyer2023ribosomalproteinus5 pages 10-12).</p>
+<h3 id="5-expert-synthesis-and-open-questions">5) Expert synthesis and open questions</h3>
+<p>Collectively, the best-supported model is that <strong>Tsr4 is a cytoplasmic, co-translational uS5 chaperone</strong> that captures the eukaryote-specific N-terminus of Rps2, promotes soluble/assembly-competent Rps2 accumulation, and enables downstream 40S assembly and pre-40S export. Nuclear import of Rps2 proceeds via at least two NLS elements and importin-β pathways that do not require Tsr4, implying a <strong>handoff step</strong> from Tsr4-bound uS5 to importins and/or other factors remains to be mechanistically defined (black2019tsr4isa pages 17-20, steiner2023dissectingthenuclear pages 2-4).</p>
+<p>Key unresolved areas highlighted across primary studies and recent reviews include (i) how the limited pool of Tsr4 efficiently targets nascent Rps2 (possible mRNA targeting), (ii) what triggers Tsr4 release from Rps2, and (iii) how binding overlaps with N-terminal targeting signals without blocking productive import/assembly (black2019tsr4isa pages 17-20, landryvoyer2023ribosomalproteinus5 pages 8-10, pertschy2024ribosomalproteinsin pages 1-2).</p>
+<h3 id="evidence-summary-table">Evidence summary table</h3>
+<p>The following table consolidates major conclusions, assays, and quantitative notes.</p>
+<table>
+<thead>
+<tr>
+<th>Finding</th>
+<th>Molecular function</th>
+<th>Binding partner(s)</th>
+<th>Evidence type / assay</th>
+<th>Subcellular localization</th>
+<th>Ribosome biogenesis role</th>
+<th>Quantitative notes</th>
+<th>Supporting citations</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Core identity</td>
+<td>Dedicated uS5/Rps2 assembly chaperone; matches yeast TSR4/P25040 annotation</td>
+<td>Rps2 (uS5)</td>
+<td>AP-MS/TAP purification, co-IP, genetic analysis</td>
+<td>Predominantly cytoplasmic</td>
+<td>Required for efficient 40S assembly</td>
+<td>TSR4 is essential in tested yeast backgrounds</td>
+<td>(black2019tsr4isa pages 1-3, rossler2019tsr4andnap1 pages 2-2)</td>
+</tr>
+<tr>
+<td>Client recognition mechanism</td>
+<td>Co-translational capture of nascent Rps2 via eukaryote-specific N-terminus</td>
+<td>Rps2 N-terminal extension (aa 1–42; strongest determinants distributed across first 42 aa)</td>
+<td>Cycloheximide-linked mRNA co-purification, Y2H mapping, truncation/mutational analysis</td>
+<td>Cytoplasmic encounter with nascent client</td>
+<td>Prevents misfolding/inefficient maturation of newly synthesized uS5</td>
+<td>First 42 aa sufficient for interaction; first 22 aa alone weak; Tsr4 ΔN40 loses binding</td>
+<td>(rossler2019tsr4andnap1 pages 12-13)</td>
+</tr>
+<tr>
+<td>Chaperone activity</td>
+<td>Promotes solubility/stability of Rps2</td>
+<td>Rps2</td>
+<td>In vitro co-expression/solubility assays; co-purification in vitro and in vivo</td>
+<td>Cytoplasm</td>
+<td>Supplies assembly-competent uS5 for pre-40S incorporation</td>
+<td>Rps2 aggregates when expressed alone but is solubilized by Tsr4</td>
+<td>(rossler2019tsr4andnap1 pages 14-15)</td>
+</tr>
+<tr>
+<td>Localization of Tsr4</td>
+<td>Cytoplasmic chaperone, not a Crm1-shuttling nucleo-cytoplasmic factor</td>
+<td>—</td>
+<td>Fluorescence microscopy, LMB/Crm1 shuttling assay, NLS mutagenesis</td>
+<td>Cytoplasmic; no Crm1-dependent nuclear accumulation</td>
+<td>Acts before or during handoff to import/assembly pathway rather than as an export cargo</td>
+<td>Tsr4-mCherry stayed cytoplasmic after LMB while Nmd3-GFP accumulated in nucleus</td>
+<td>(black2019tsr4isa pages 15-17, black2019tsr4isa pages 17-20, black2019tsr4isa media 141d3d19)</td>
+</tr>
+<tr>
+<td>Effect on Rps2 localization</td>
+<td>Needed mainly for productive assembly, not strictly for nuclear entry</td>
+<td>Rps2; importins indirectly</td>
+<td>Rps2-GFP localization in tsr4 mutants</td>
+<td>Loss of Tsr4 causes nuclear accumulation of Rps2 reporters</td>
+<td>Indicates imported uS5 is not efficiently assembled into pre-ribosomes without Tsr4</td>
+<td>~72% of WT cells show nuclear exclusion of Rps2-GFP; ~82% of tsr4 cells show nuclear signal in one study</td>
+<td>(rossler2019tsr4andnap1 pages 16-16, rossler2019tsr4andnap1 pages 15-16)</td>
+</tr>
+<tr>
+<td>Role in 40S biogenesis/export</td>
+<td>Required for small-subunit production and pre-40S export</td>
+<td>Pre-40S particles indirectly via Rps2 supply</td>
+<td>Polysome profiling, ITS1 FISH, depletion/repression experiments</td>
+<td>Functional consequence seen as nuclear ITS1 accumulation</td>
+<td>Loss phenocopies RPS2 depletion, blocking late 40S maturation/export</td>
+<td>Missing or strongly reduced 40S peak, increased 60S, reduced 80S/polysomes; ITS1 accumulates in nucleus after TSR4 repression</td>
+<td>(black2019tsr4isa pages 34-37, black2019tsr4isa pages 15-17, rossler2019tsr4andnap1 pages 15-16)</td>
+</tr>
+<tr>
+<td>Genetic suppression</td>
+<td>Increased client dosage can partially bypass chaperone loss</td>
+<td>RPS2</td>
+<td>Plasmid shuffle, dosage suppression, growth assays</td>
+<td>—</td>
+<td>Supports chaperone-client relationship</td>
+<td>Extra RPS2 restores viability but suppressed tsr4 strains grow poorly at 25–30°C and are inviable at 37°C</td>
+<td>(black2019tsr4isa pages 15-17, rossler2019tsr4andnap1 pages 15-16)</td>
+</tr>
+<tr>
+<td>Abundance / limiting factor</td>
+<td>Modestly expressed, consistent with titration by excess N-terminal Rps2 fragments</td>
+<td>Rps2 fragments can sequester Tsr4</td>
+<td>Quantitative Western/blot comparison; dominant-negative fragment assays</td>
+<td>Cytoplasm</td>
+<td>Limiting chaperone pool may constrain uS5 maturation</td>
+<td>~1,500 Tsr4 molecules/cell; high-copy TSR4 fully suppresses one dominant-negative Rps2 N-fragment and partially suppresses another</td>
+<td>(black2019tsr4isa pages 17-20, black2019tsr4isa pages 6-8)</td>
+</tr>
+<tr>
+<td>Relation to nuclear import</td>
+<td>Not required for either identified Rps2 NLS-driven import route</td>
+<td>Rps2; Pse1/Kap121, Kap123/Kap104 contribute</td>
+<td>Reporter import assays, mutagenesis, pse1 mutant analysis, TurboID/Y2H</td>
+<td>Tsr4 overlaps N-terminal NLS region but is dispensable for import itself</td>
+<td>Distinguishes chaperoning from import; Tsr4 functions upstream of productive assembly</td>
+<td>Internal NLS at aa 76–145; key residues R95/R97/K99; second N-terminal NLS at aa 10–28</td>
+<td>(steiner2023dissectingthenuclear pages 6-9, steiner2023dissectingthenuclear pages 2-4, steiner2023dissectingthenuclear pages 15-18, steiner2023dissectingthenuclear pages 13-15)</td>
+</tr>
+<tr>
+<td>Family/domain context</td>
+<td>Yeast TSR4 is the fungal homolog within PDCD2/PDCD2L-related TYPP/PDCD2_C superfamily</td>
+<td>PDCD2/PDCD2L homologous family; uS5 pathway conserved</td>
+<td>Comparative domain/evolution analysis; cross-species functional comparison</td>
+<td>Yeast Tsr4 mainly cytoplasmic; metazoan PDCD2 can accompany uS5 into nucleus</td>
+<td>Conserved dedicated uS5 chaperone module across eukaryotes</td>
+<td>C-terminal PDCD2_C annotation; broader TYPP repeat architecture proposed</td>
+<td>(burroughs2014analysisoftwo pages 5-7, burroughs2014analysisoftwo pages 3-5, landryvoyer2023ribosomalproteinus5 pages 6-8, landryvoyer2020pdcd2functionsas pages 13-14)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table condenses the main experimentally supported findings for Saccharomyces cerevisiae TSR4 (UniProt P25040), including its chaperone function, binding to Rps2/uS5, localization, and role in 40S ribosome biogenesis. It also highlights useful quantitative observations and cites the supporting evidence by context ID.</em></p>
+<h3 id="visual-evidence">Visual evidence</h3>
+<p>A key localization control supporting cytoplasmic restriction of Tsr4 is shown in Black et al. 2019 Figure 8B: in a leptomycin B Crm1 export-blocking assay, the Crm1 cargo control Nmd3 accumulates in the nucleus while <strong>Tsr4 remains cytoplasmic</strong> (black2019tsr4isa media 141d3d19).</p>
+<hr />
+<h2 id="key-references-with-urls-and-publication-dates">Key references (with URLs and publication dates)</h2>
+<ul>
+<li>Black JJ, Musalgaonkar S, Johnson AW. <strong>Tsr4 Is a Cytoplasmic Chaperone for the Ribosomal Protein Rps2 in <em>Saccharomyces cerevisiae</em></strong>. <em>Molecular and Cellular Biology</em>. <strong>Sep 2019</strong>. https://doi.org/10.1128/mcb.00094-19 (black2019tsr4isa pages 1-3)</li>
+<li>Rössler I et al. <strong>Tsr4 and Nap1, two novel members of the ribosomal protein chaperOME</strong>. <em>Nucleic Acids Research</em>. <strong>May 2019</strong>. https://doi.org/10.1093/nar/gkz317 (rossler2019tsr4andnap1 pages 1-2)</li>
+<li>Steiner A et al. <strong>Dissecting the Nuclear Import of the Ribosomal Protein Rps2 (uS5)</strong>. <em>Biomolecules</em>. <strong>Jul 2023</strong>. https://doi.org/10.3390/biom13071127 (steiner2023dissectingthenuclear pages 1-2)</li>
+<li>Landry-Voyer A-M et al. <strong>Ribosomal Protein uS5 and Friends: Protein–Protein Interactions Involved in Ribosome Assembly and Beyond</strong>. <em>Biomolecules</em>. <strong>May 2023</strong>. https://doi.org/10.3390/biom13050853 (landryvoyer2023ribosomalproteinus5 pages 6-8)</li>
+<li>Yang Y-M et al. <strong>Chaperone-directed ribosome repair after oxidative damage</strong>. <em>Molecular Cell</em>. <strong>May 2023</strong>. https://doi.org/10.1016/j.molcel.2023.03.030 (yang2023chaperonedirectedribosomerepair pages 3-5)</li>
+<li>Yang Y-M, Karbstein K. <strong>Ribosome Assembly and Repair</strong>. <em>Annual Review of Cell and Developmental Biology</em>. <strong>Oct 2024</strong>. https://doi.org/10.1146/annurev-cellbio-111822-113326 (yang2024ribosomeassemblyand pages 1-3)</li>
+<li>Pertschy B, Zierler I. <strong>Ribosomal Proteins in Ribosome Assembly</strong>. <em>Biomolecules</em>. <strong>Dec 2024</strong>. https://doi.org/10.3390/biom15010013 (pertschy2024ribosomalproteinsin pages 1-2)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(black2019tsr4isa pages 1-3): Joshua J. Black, Sharmishtha Musalgaonkar, and Arlen W. Johnson. Tsr4 is a cytoplasmic chaperone for the ribosomal protein rps2 in <i>saccharomyces cerevisiae</i>. Molecular and Cellular Biology, Sep 2019. URL: https://doi.org/10.1128/mcb.00094-19, doi:10.1128/mcb.00094-19. This article has 28 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(black2019tsr4isa pages 15-17): Joshua J. Black, Sharmishtha Musalgaonkar, and Arlen W. Johnson. Tsr4 is a cytoplasmic chaperone for the ribosomal protein rps2 in <i>saccharomyces cerevisiae</i>. Molecular and Cellular Biology, Sep 2019. URL: https://doi.org/10.1128/mcb.00094-19, doi:10.1128/mcb.00094-19. This article has 28 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(burroughs2014analysisoftwo pages 3-5): A. M. Burroughs, L. Aravind, and R. Emes. Analysis of two domains with novel rna-processing activities throws light on the complex evolution of ribosomal rna biogenesis. Frontiers in Genetics, Dec 2014. URL: https://doi.org/10.3389/fgene.2014.00424, doi:10.3389/fgene.2014.00424. This article has 26 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(burroughs2014analysisoftwo pages 5-7): A. M. Burroughs, L. Aravind, and R. Emes. Analysis of two domains with novel rna-processing activities throws light on the complex evolution of ribosomal rna biogenesis. Frontiers in Genetics, Dec 2014. URL: https://doi.org/10.3389/fgene.2014.00424, doi:10.3389/fgene.2014.00424. This article has 26 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rossler2019tsr4andnap1 pages 1-2): Ingrid Rössler, Julia Embacher, Benjamin Pillet, Guillaume Murat, Laura Liesinger, Jutta Hafner, Julia Judith Unterluggauer, Ruth Birner-Gruenberger, Dieter Kressler, and Brigitte Pertschy. Tsr4 and nap1, two novel members of the ribosomal protein chaperome. Nucleic Acids Research, 47:6984-7002, May 2019. URL: https://doi.org/10.1093/nar/gkz317, doi:10.1093/nar/gkz317. This article has 38 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rossler2019tsr4andnap1 pages 14-15): Ingrid Rössler, Julia Embacher, Benjamin Pillet, Guillaume Murat, Laura Liesinger, Jutta Hafner, Julia Judith Unterluggauer, Ruth Birner-Gruenberger, Dieter Kressler, and Brigitte Pertschy. Tsr4 and nap1, two novel members of the ribosomal protein chaperome. Nucleic Acids Research, 47:6984-7002, May 2019. URL: https://doi.org/10.1093/nar/gkz317, doi:10.1093/nar/gkz317. This article has 38 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rossler2019tsr4andnap1 pages 12-13): Ingrid Rössler, Julia Embacher, Benjamin Pillet, Guillaume Murat, Laura Liesinger, Jutta Hafner, Julia Judith Unterluggauer, Ruth Birner-Gruenberger, Dieter Kressler, and Brigitte Pertschy. Tsr4 and nap1, two novel members of the ribosomal protein chaperome. Nucleic Acids Research, 47:6984-7002, May 2019. URL: https://doi.org/10.1093/nar/gkz317, doi:10.1093/nar/gkz317. This article has 38 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rossler2019tsr4andnap1 pages 15-16): Ingrid Rössler, Julia Embacher, Benjamin Pillet, Guillaume Murat, Laura Liesinger, Jutta Hafner, Julia Judith Unterluggauer, Ruth Birner-Gruenberger, Dieter Kressler, and Brigitte Pertschy. Tsr4 and nap1, two novel members of the ribosomal protein chaperome. Nucleic Acids Research, 47:6984-7002, May 2019. URL: https://doi.org/10.1093/nar/gkz317, doi:10.1093/nar/gkz317. This article has 38 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(landryvoyer2023ribosomalproteinus5 pages 6-8): Anne-Marie Landry-Voyer, Zabih Mir Hassani, Mariano Avino, and François Bachand. Ribosomal protein us5 and friends: protein–protein interactions involved in ribosome assembly and beyond. Biomolecules, 13:853, May 2023. URL: https://doi.org/10.3390/biom13050853, doi:10.3390/biom13050853. This article has 20 citations.</p>
+</li>
+<li>
+<p>(landryvoyer2023ribosomalproteinus5 pages 8-10): Anne-Marie Landry-Voyer, Zabih Mir Hassani, Mariano Avino, and François Bachand. Ribosomal protein us5 and friends: protein–protein interactions involved in ribosome assembly and beyond. Biomolecules, 13:853, May 2023. URL: https://doi.org/10.3390/biom13050853, doi:10.3390/biom13050853. This article has 20 citations.</p>
+</li>
+<li>
+<p>(black2019tsr4isa pages 17-20): Joshua J. Black, Sharmishtha Musalgaonkar, and Arlen W. Johnson. Tsr4 is a cytoplasmic chaperone for the ribosomal protein rps2 in <i>saccharomyces cerevisiae</i>. Molecular and Cellular Biology, Sep 2019. URL: https://doi.org/10.1128/mcb.00094-19, doi:10.1128/mcb.00094-19. This article has 28 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(black2019tsr4isa media 141d3d19): Joshua J. Black, Sharmishtha Musalgaonkar, and Arlen W. Johnson. Tsr4 is a cytoplasmic chaperone for the ribosomal protein rps2 in <i>saccharomyces cerevisiae</i>. Molecular and Cellular Biology, Sep 2019. URL: https://doi.org/10.1128/mcb.00094-19, doi:10.1128/mcb.00094-19. This article has 28 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(black2019tsr4isa pages 6-8): Joshua J. Black, Sharmishtha Musalgaonkar, and Arlen W. Johnson. Tsr4 is a cytoplasmic chaperone for the ribosomal protein rps2 in <i>saccharomyces cerevisiae</i>. Molecular and Cellular Biology, Sep 2019. URL: https://doi.org/10.1128/mcb.00094-19, doi:10.1128/mcb.00094-19. This article has 28 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rossler2019tsr4andnap1 pages 16-16): Ingrid Rössler, Julia Embacher, Benjamin Pillet, Guillaume Murat, Laura Liesinger, Jutta Hafner, Julia Judith Unterluggauer, Ruth Birner-Gruenberger, Dieter Kressler, and Brigitte Pertschy. Tsr4 and nap1, two novel members of the ribosomal protein chaperome. Nucleic Acids Research, 47:6984-7002, May 2019. URL: https://doi.org/10.1093/nar/gkz317, doi:10.1093/nar/gkz317. This article has 38 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(steiner2023dissectingthenuclear pages 6-9): Andreas Steiner, Sébastien Favre, Maximilian Mack, Annika Hausharter, Benjamin Pillet, Jutta Hafner, Valentin Mitterer, Dieter Kressler, Brigitte Pertschy, and Ingrid Zierler. Dissecting the nuclear import of the ribosomal protein rps2 (us5). Biomolecules, 13:1127, Jul 2023. URL: https://doi.org/10.3390/biom13071127, doi:10.3390/biom13071127. This article has 7 citations.</p>
+</li>
+<li>
+<p>(steiner2023dissectingthenuclear pages 1-2): Andreas Steiner, Sébastien Favre, Maximilian Mack, Annika Hausharter, Benjamin Pillet, Jutta Hafner, Valentin Mitterer, Dieter Kressler, Brigitte Pertschy, and Ingrid Zierler. Dissecting the nuclear import of the ribosomal protein rps2 (us5). Biomolecules, 13:1127, Jul 2023. URL: https://doi.org/10.3390/biom13071127, doi:10.3390/biom13071127. This article has 7 citations.</p>
+</li>
+<li>
+<p>(steiner2023dissectingthenuclear pages 15-18): Andreas Steiner, Sébastien Favre, Maximilian Mack, Annika Hausharter, Benjamin Pillet, Jutta Hafner, Valentin Mitterer, Dieter Kressler, Brigitte Pertschy, and Ingrid Zierler. Dissecting the nuclear import of the ribosomal protein rps2 (us5). Biomolecules, 13:1127, Jul 2023. URL: https://doi.org/10.3390/biom13071127, doi:10.3390/biom13071127. This article has 7 citations.</p>
+</li>
+<li>
+<p>(steiner2023dissectingthenuclear pages 2-4): Andreas Steiner, Sébastien Favre, Maximilian Mack, Annika Hausharter, Benjamin Pillet, Jutta Hafner, Valentin Mitterer, Dieter Kressler, Brigitte Pertschy, and Ingrid Zierler. Dissecting the nuclear import of the ribosomal protein rps2 (us5). Biomolecules, 13:1127, Jul 2023. URL: https://doi.org/10.3390/biom13071127, doi:10.3390/biom13071127. This article has 7 citations.</p>
+</li>
+<li>
+<p>(steiner2023dissectingthenuclear pages 13-15): Andreas Steiner, Sébastien Favre, Maximilian Mack, Annika Hausharter, Benjamin Pillet, Jutta Hafner, Valentin Mitterer, Dieter Kressler, Brigitte Pertschy, and Ingrid Zierler. Dissecting the nuclear import of the ribosomal protein rps2 (us5). Biomolecules, 13:1127, Jul 2023. URL: https://doi.org/10.3390/biom13071127, doi:10.3390/biom13071127. This article has 7 citations.</p>
+</li>
+<li>
+<p>(pertschy2024ribosomalproteinsin pages 1-2): Brigitte Pertschy and Ingrid Zierler. Ribosomal proteins in ribosome assembly. Biomolecules, 15:13, Dec 2024. URL: https://doi.org/10.3390/biom15010013, doi:10.3390/biom15010013. This article has 4 citations.</p>
+</li>
+<li>
+<p>(yang2024ribosomeassemblyand pages 20-21): Yoon-Mo Yang and Katrin Karbstein. Ribosome assembly and repair. Annual Review of Cell and Developmental Biology, 40:241-264, Oct 2024. URL: https://doi.org/10.1146/annurev-cellbio-111822-113326, doi:10.1146/annurev-cellbio-111822-113326. This article has 18 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yang2024ribosomeassemblyand pages 11-13): Yoon-Mo Yang and Katrin Karbstein. Ribosome assembly and repair. Annual Review of Cell and Developmental Biology, 40:241-264, Oct 2024. URL: https://doi.org/10.1146/annurev-cellbio-111822-113326, doi:10.1146/annurev-cellbio-111822-113326. This article has 18 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yang2023chaperonedirectedribosomerepair pages 3-5): Yoon-Mo Yang, Youngeun Jung, Daniel Abegg, Alexander Adibekian, Kate S. Carroll, and Katrin Karbstein. Chaperone-directed ribosome repair after oxidative damage. Molecular Cell, 83:1527-1537.e5, May 2023. URL: https://doi.org/10.1016/j.molcel.2023.03.030, doi:10.1016/j.molcel.2023.03.030. This article has 70 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yang2023chaperonedirectedribosomerepair pages 5-7): Yoon-Mo Yang, Youngeun Jung, Daniel Abegg, Alexander Adibekian, Kate S. Carroll, and Katrin Karbstein. Chaperone-directed ribosome repair after oxidative damage. Molecular Cell, 83:1527-1537.e5, May 2023. URL: https://doi.org/10.1016/j.molcel.2023.03.030, doi:10.1016/j.molcel.2023.03.030. This article has 70 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(landryvoyer2023ribosomalproteinus5 pages 10-12): Anne-Marie Landry-Voyer, Zabih Mir Hassani, Mariano Avino, and François Bachand. Ribosomal protein us5 and friends: protein–protein interactions involved in ribosome assembly and beyond. Biomolecules, 13:853, May 2023. URL: https://doi.org/10.3390/biom13050853, doi:10.3390/biom13050853. This article has 20 citations.</p>
+</li>
+<li>
+<p>(rossler2019tsr4andnap1 pages 2-2): Ingrid Rössler, Julia Embacher, Benjamin Pillet, Guillaume Murat, Laura Liesinger, Jutta Hafner, Julia Judith Unterluggauer, Ruth Birner-Gruenberger, Dieter Kressler, and Brigitte Pertschy. Tsr4 and nap1, two novel members of the ribosomal protein chaperome. Nucleic Acids Research, 47:6984-7002, May 2019. URL: https://doi.org/10.1093/nar/gkz317, doi:10.1093/nar/gkz317. This article has 38 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(black2019tsr4isa pages 34-37): Joshua J. Black, Sharmishtha Musalgaonkar, and Arlen W. Johnson. Tsr4 is a cytoplasmic chaperone for the ribosomal protein rps2 in <i>saccharomyces cerevisiae</i>. Molecular and Cellular Biology, Sep 2019. URL: https://doi.org/10.1128/mcb.00094-19, doi:10.1128/mcb.00094-19. This article has 28 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(landryvoyer2020pdcd2functionsas pages 13-14): Anne-Marie Landry-Voyer, Danny Bergeron, Carlo Yague-Sanz, Breac Baker, and Francois Bachand. Pdcd2 functions as an evolutionarily conserved chaperone dedicated for the 40s ribosomal protein us5 (rps2). Nucleic Acids Research, 48:12900-12916, Nov 2020. URL: https://doi.org/10.1093/nar/gkaa1108, doi:10.1093/nar/gkaa1108. This article has 26 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yang2024ribosomeassemblyand pages 1-3): Yoon-Mo Yang and Katrin Karbstein. Ribosome assembly and repair. Annual Review of Cell and Developmental Biology, 40:241-264, Oct 2024. URL: https://doi.org/10.1146/annurev-cellbio-111822-113326, doi:10.1146/annurev-cellbio-111822-113326. This article has 18 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>pertschy2024ribosomalproteinsin pages 1-2</li>
+<li>steiner2023dissectingthenuclear pages 1-2</li>
+<li>yang2023chaperonedirectedribosomerepair pages 3-5</li>
+<li>yang2024ribosomeassemblyand pages 1-3</li>
+<li>burroughs2014analysisoftwo pages 3-5</li>
+<li>burroughs2014analysisoftwo pages 5-7</li>
+<li>steiner2023dissectingthenuclear pages 6-9</li>
+<li>steiner2023dissectingthenuclear pages 15-18</li>
+<li>steiner2023dissectingthenuclear pages 2-4</li>
+<li>steiner2023dissectingthenuclear pages 13-15</li>
+<li>yang2024ribosomeassemblyand pages 20-21</li>
+<li>yang2024ribosomeassemblyand pages 11-13</li>
+<li>yang2023chaperonedirectedribosomerepair pages 5-7</li>
+<li>https://doi.org/10.1128/mcb.00094-19</li>
+<li>https://doi.org/10.1093/nar/gkz317</li>
+<li>https://doi.org/10.3390/biom13071127</li>
+<li>https://doi.org/10.3390/biom13050853</li>
+<li>https://doi.org/10.1016/j.molcel.2023.03.030</li>
+<li>https://doi.org/10.1146/annurev-cellbio-111822-113326</li>
+<li>https://doi.org/10.3390/biom15010013</li>
+<li>https://doi.org/10.1128/mcb.00094-19,</li>
+<li>https://doi.org/10.3389/fgene.2014.00424,</li>
+<li>https://doi.org/10.1093/nar/gkz317,</li>
+<li>https://doi.org/10.3390/biom13050853,</li>
+<li>https://doi.org/10.3390/biom13071127,</li>
+<li>https://doi.org/10.3390/biom15010013,</li>
+<li>https://doi.org/10.1146/annurev-cellbio-111822-113326,</li>
+<li>https://doi.org/10.1016/j.molcel.2023.03.030,</li>
+<li>https://doi.org/10.1093/nar/gkaa1108,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -1845,11 +2796,20 @@
                 <pre><code>id: P25040
 gene_symbol: TSR4
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
+aliases:
+- YOL022C
+- uS5 assembly chaperone
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: &#39;TODO: Add description for TSR4&#39;
+description: &gt;-
+  TSR4 encodes a cytoplasmic, client-specific ribosomal protein carrier
+  chaperone for Rps2/uS5. Tsr4 binds the eukaryote-specific N-terminal extension
+  of nascent Rps2/uS5, promotes Rps2 expression and solubility, and releases the
+  client before nuclear import and productive pre-40S assembly. Loss of Tsr4
+  impairs 40S ribosomal small subunit biogenesis, pre-40S export, and 20S
+  pre-rRNA processing at site D to mature 18S rRNA.
 existing_annotations:
 - term:
     id: GO:0030490
@@ -1857,144 +2817,196 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;Manual review: maturation of SSU-rRNA is consistent with known biology of TSR4.&#39;
+    summary: IBA is consistent with Tsr4-dependent 20S pre-rRNA processing and 40S biogenesis.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: SSU-rRNA maturation is a direct process-level consequence of the uS5 chaperone role.
+    supported_by:
+    - reference_id: PMID:19806183
+      supporting_text: YOR006C/TSR3, YOL022C/TSR4). We associate the new genes with specific aspects of...processing of 5S, 7S, 20S, 27S, and 35S rRNAs.
+    - reference_id: file:yeast/TSR4/TSR4-deep-research-falcon.md
+      supporting_text: Tsr4 enables downstream 40S assembly and pre-40S export through cytoplasmic Rps2/uS5 chaperone activity.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: &#39;Manual review: cytoplasm is consistent with known biology of TSR4.&#39;
+    summary: Cytoplasmic localization is consistent with direct Tsr4 studies.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Tsr4 acts in the cytoplasm on nascent Rps2/uS5 before nuclear import.
+    supported_by:
+    - reference_id: PMID:31182640
+      supporting_text: Tsr4 appears to be restricted to the cytoplasm.
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: &#39;Manual review: cytosol is consistent with known biology of TSR4.&#39;
+    summary: Cytosol is the best location for Tsr4 carrier chaperone activity.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Direct and curated sources place Tsr4 in the cytosol/cytoplasm.
+    supported_by:
+    - reference_id: PMID:31062022
+      supporting_text: Tsr4 binds co-translationally to the...essential, eukaryote-specific N-terminal extension of Rps2
 - term:
     id: GO:0042254
     label: ribosome biogenesis
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: &#39;Manual review: ribosome biogenesis is consistent with known biology of TSR4.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: Ribosome biogenesis is correct but too broad for Tsr4.
+    action: MODIFY
+    reason: Replace with the more specific ribosomal small subunit biogenesis term.
+    proposed_replacement_terms:
+    - id: GO:0042274
+      label: ribosomal small subunit biogenesis
+    supported_by:
+    - reference_id: PMID:31062022
+      supporting_text: Mutation of the essential Tsr4...enhance the 40S synthesis defects
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: IDA
   original_reference_id: PMID:31062022
   review:
-    summary: &#39;Manual review: cytosol is consistent with known biology of TSR4.&#39;
+    summary: Direct evidence supports cytosolic localization.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Tsr4 binds Rps2/uS5 co-translationally in the cytosol.
+    supported_by:
+    - reference_id: PMID:31062022
+      supporting_text: Tsr4 binds co-translationally to the...essential, eukaryote-specific N-terminal extension of Rps2
 - term:
     id: GO:0140597
     label: protein carrier chaperone
   evidence_type: IDA
   original_reference_id: PMID:31062022
   review:
-    summary: &#39;Manual review: protein carrier chaperone is consistent with known biology of TSR4.&#39;
+    summary: This is the most specific molecular-function annotation for TSR4.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Tsr4 is a dedicated carrier chaperone for ribosomal protein Rps2/uS5.
+    supported_by:
+    - reference_id: PMID:31062022
+      supporting_text: vitro. While Tsr4 is specific for Rps2...Tsr4 binds co-translationally to the...essential, eukaryote-specific N-terminal extension of Rps2
+    - reference_id: file:yeast/TSR4/TSR4-deep-research-falcon.md
+      supporting_text: Tsr4 is a cytoplasmic, co-translational uS5 chaperone that captures the Rps2 N-terminus.
 - term:
     id: GO:0042274
     label: ribosomal small subunit biogenesis
   evidence_type: IMP
   original_reference_id: PMID:31062022
   review:
-    summary: &#39;Manual review: ribosomal small subunit biogenesis is consistent with known biology of TSR4.&#39;
+    summary: Tsr4 perturbation causes 40S biogenesis defects.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Rps2/uS5 chaperoning is directly tied to small subunit assembly.
+    supported_by:
+    - reference_id: PMID:31062022
+      supporting_text: Mutation of the essential Tsr4...enhance the 40S synthesis defects
 - term:
     id: GO:0042274
     label: ribosomal small subunit biogenesis
   evidence_type: IGI
   original_reference_id: PMID:31062022
   review:
-    summary: &#39;Manual review: ribosomal small subunit biogenesis is consistent with known biology of TSR4.&#39;
+    summary: Genetic evidence with RPS2 supports the 40S biogenesis annotation.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: The genetic relationship supports Tsr4&#39;s role in Rps2-dependent 40S assembly.
+    supported_by:
+    - reference_id: PMID:31062022
+      supporting_text: identification of Nap1 and Tsr4 as direct binding partners of Rps6 and Rps2
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:31062022
   review:
-    summary: &#39;Manual review: unfolded protein binding is better represented by a more specific replacement term for TSR4.&#39;
+    summary: The binding evidence is specific to Rps2/uS5, not generic unfolded protein.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: Replace broad unfolded protein binding with protein carrier chaperone.
     proposed_replacement_terms:
     - id: GO:0140597
       label: protein carrier chaperone
+    supported_by:
+    - reference_id: PMID:31062022
+      supporting_text: Both factors promote the solubility of their r-protein clients in...vitro.
 - term:
     id: GO:0042274
     label: ribosomal small subunit biogenesis
   evidence_type: IMP
   original_reference_id: PMID:31182640
   review:
-    summary: &#39;Manual review: ribosomal small subunit biogenesis is consistent with known biology of TSR4.&#39;
+    summary: Independent evidence supports the same 40S biogenesis role.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Tsr4 perturbation decreases Rps2 and phenocopies Rps2 depletion.
+    supported_by:
+    - reference_id: PMID:31182640
+      supporting_text: Tsr4 perturbation resulted in decreased Rps2 levels and...phenocopied Rps2 depletion.
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:31182640
   review:
-    summary: &#39;Manual review: unfolded protein binding is better represented by a more specific replacement term for TSR4.&#39;
+    summary: The evidence supports specific Rps2 carrier chaperoning.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: Protein carrier chaperone is the more precise molecular-function term.
     proposed_replacement_terms:
     - id: GO:0140597
       label: protein carrier chaperone
+    supported_by:
+    - reference_id: PMID:31182640
+      supporting_text: Tsr4 cotranslationally associates with Rps2...cytoplasmic chaperone dedicated to Rps2.
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IPI
   original_reference_id: PMID:31182640
   review:
-    summary: &#39;Manual review: unfolded protein binding is better represented by a more specific replacement term for TSR4.&#39;
+    summary: The IPI evidence identifies a specific Rps2/uS5 client relationship.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: Replace broad unfolded protein binding with protein carrier chaperone.
     proposed_replacement_terms:
     - id: GO:0140597
       label: protein carrier chaperone
+    supported_by:
+    - reference_id: PMID:31182640
+      supporting_text: Rps2 harbors a...eukaryote-specific N-terminal extension that is critical for its interaction...with Tsr4.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IDA
   original_reference_id: PMID:31182640
   review:
-    summary: &#39;Manual review: cytoplasm is consistent with known biology of TSR4.&#39;
+    summary: Direct microscopy and functional evidence support cytoplasmic localization.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Tsr4 acts before nuclear import and pre-ribosome assembly.
+    supported_by:
+    - reference_id: PMID:31182640
+      supporting_text: Despite Rps2 joining nuclear pre-40S particles, Tsr4 appears to be restricted to the cytoplasm.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: HDA
   original_reference_id: PMID:14562095
   review:
-    summary: &#39;Manual review: cytoplasm is consistent with known biology of TSR4.&#39;
+    summary: High-throughput cytoplasmic localization is consistent with targeted studies.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: The broad cytoplasm term is correct, though cytosol is more precise.
+    supported_by:
+    - reference_id: PMID:31182640
+      supporting_text: Tsr4 appears to be restricted to the cytoplasm.
 - term:
     id: GO:0030490
     label: maturation of SSU-rRNA
   evidence_type: IMP
   original_reference_id: PMID:19806183
   review:
-    summary: &#39;Manual review: maturation of SSU-rRNA is consistent with known biology of TSR4.&#39;
+    summary: The original genetic annotation correctly identifies TSR4 in SSU rRNA maturation.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Later work explains the phenotype through defective Rps2/uS5 handling and 40S assembly.
+    supported_by:
+    - reference_id: PMID:19806183
+      supporting_text: YOR006C/TSR3, YOL022C/TSR4). We associate the new genes with specific aspects of...processing of 5S, 7S, 20S, 27S, and 35S rRNAs.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -2006,27 +3018,68 @@ references:
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping
   findings: []
 - id: PMID:14562095
   title: Global analysis of protein localization in budding yeast.
   findings: []
 - id: PMID:19806183
   title: Rational extension of the ribosome biogenesis pathway using network-guided genetics.
-  findings: []
+  findings:
+  - statement: TSR4 was identified as a ribosome biogenesis factor
+    supporting_text: Network-guided genetics associated YOL022C/TSR4 with ribosome biogenesis and pre-rRNA processing.
 - id: PMID:31062022
   title: Tsr4 and Nap1, two novel members of the ribosomal protein chaperOME.
-  findings: []
+  findings:
+  - statement: Tsr4 is a direct Rps2/uS5 carrier chaperone
+    supporting_text: Tsr4 is specific for Rps2, binds co-translationally to its N-terminal extension, and promotes solubility.
 - id: PMID:31182640
   title: Tsr4 Is a Cytoplasmic Chaperone for the Ribosomal Protein Rps2 in Saccharomyces cerevisiae.
-  findings: []
+  findings:
+  - statement: Tsr4 is a cytoplasmic chaperone dedicated to Rps2
+    supporting_text: Tsr4 cotranslationally associates with Rps2; perturbation decreases Rps2 levels.
+- id: file:yeast/TSR4/TSR4-deep-research-falcon.md
+  title: Falcon deep research report for TSR4
+  findings:
+  - statement: TSR4 is a cytoplasmic uS5/Rps2 carrier chaperone
+    supporting_text: The report synthesizes evidence that Tsr4 captures nascent Rps2/uS5 and enables downstream 40S assembly.
+core_functions:
+- description: &gt;-
+    Cytoplasmic protein carrier chaperone for ribosomal protein Rps2/uS5. Tsr4
+    binds nascent Rps2/uS5 and maintains the client in a soluble
+    assembly-competent state before nuclear import and incorporation into
+    pre-40S particles.
+  molecular_function:
+    id: GO:0140597
+    label: protein carrier chaperone
+  directly_involved_in:
+  - id: GO:0042274
+    label: ribosomal small subunit biogenesis
+  - id: GO:0030490
+    label: maturation of SSU-rRNA
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  - id: GO:0005737
+    label: cytoplasm
+  supported_by:
+  - reference_id: PMID:31062022
+    supporting_text: identification of Nap1 and Tsr4 as direct binding partners of Rps6 and Rps2...Both factors promote the solubility of their r-protein clients
+  - reference_id: PMID:31182640
+    supporting_text: Tsr4 perturbation resulted in decreased Rps2 levels and...phenocopied Rps2 depletion.
+  - reference_id: file:yeast/TSR4/TSR4-deep-research-falcon.md
+    supporting_text: Tsr4 is a cytoplasmic, co-translational uS5 chaperone that captures the Rps2 N-terminus.
+proposed_new_terms: []
+suggested_questions:
+- question: Should older GO:0051082 annotations for Tsr4 be replaced by GO:0140597 protein carrier chaperone where evidence is specific Rps2/uS5 chaperoning?
+suggested_experiments: []
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/yeast/TSR4/TSR4-ai-review.yaml
+++ b/genes/yeast/TSR4/TSR4-ai-review.yaml
@@ -1,11 +1,20 @@
 id: P25040
 gene_symbol: TSR4
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
+aliases:
+- YOL022C
+- uS5 assembly chaperone
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: 'TODO: Add description for TSR4'
+description: >-
+  TSR4 encodes a cytoplasmic, client-specific ribosomal protein carrier
+  chaperone for Rps2/uS5. Tsr4 binds the eukaryote-specific N-terminal extension
+  of nascent Rps2/uS5, promotes Rps2 expression and solubility, and releases the
+  client before nuclear import and productive pre-40S assembly. Loss of Tsr4
+  impairs 40S ribosomal small subunit biogenesis, pre-40S export, and 20S
+  pre-rRNA processing at site D to mature 18S rRNA.
 existing_annotations:
 - term:
     id: GO:0030490
@@ -13,144 +22,196 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'Manual review: maturation of SSU-rRNA is consistent with known biology of TSR4.'
+    summary: IBA is consistent with Tsr4-dependent 20S pre-rRNA processing and 40S biogenesis.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: SSU-rRNA maturation is a direct process-level consequence of the uS5 chaperone role.
+    supported_by:
+    - reference_id: PMID:19806183
+      supporting_text: YOR006C/TSR3, YOL022C/TSR4). We associate the new genes with specific aspects of...processing of 5S, 7S, 20S, 27S, and 35S rRNAs.
+    - reference_id: file:yeast/TSR4/TSR4-deep-research-falcon.md
+      supporting_text: Tsr4 enables downstream 40S assembly and pre-40S export through cytoplasmic Rps2/uS5 chaperone activity.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'Manual review: cytoplasm is consistent with known biology of TSR4.'
+    summary: Cytoplasmic localization is consistent with direct Tsr4 studies.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Tsr4 acts in the cytoplasm on nascent Rps2/uS5 before nuclear import.
+    supported_by:
+    - reference_id: PMID:31182640
+      supporting_text: Tsr4 appears to be restricted to the cytoplasm.
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'Manual review: cytosol is consistent with known biology of TSR4.'
+    summary: Cytosol is the best location for Tsr4 carrier chaperone activity.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Direct and curated sources place Tsr4 in the cytosol/cytoplasm.
+    supported_by:
+    - reference_id: PMID:31062022
+      supporting_text: Tsr4 binds co-translationally to the...essential, eukaryote-specific N-terminal extension of Rps2
 - term:
     id: GO:0042254
     label: ribosome biogenesis
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: 'Manual review: ribosome biogenesis is consistent with known biology of TSR4.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: Ribosome biogenesis is correct but too broad for Tsr4.
+    action: MODIFY
+    reason: Replace with the more specific ribosomal small subunit biogenesis term.
+    proposed_replacement_terms:
+    - id: GO:0042274
+      label: ribosomal small subunit biogenesis
+    supported_by:
+    - reference_id: PMID:31062022
+      supporting_text: Mutation of the essential Tsr4...enhance the 40S synthesis defects
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: IDA
   original_reference_id: PMID:31062022
   review:
-    summary: 'Manual review: cytosol is consistent with known biology of TSR4.'
+    summary: Direct evidence supports cytosolic localization.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Tsr4 binds Rps2/uS5 co-translationally in the cytosol.
+    supported_by:
+    - reference_id: PMID:31062022
+      supporting_text: Tsr4 binds co-translationally to the...essential, eukaryote-specific N-terminal extension of Rps2
 - term:
     id: GO:0140597
     label: protein carrier chaperone
   evidence_type: IDA
   original_reference_id: PMID:31062022
   review:
-    summary: 'Manual review: protein carrier chaperone is consistent with known biology of TSR4.'
+    summary: This is the most specific molecular-function annotation for TSR4.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Tsr4 is a dedicated carrier chaperone for ribosomal protein Rps2/uS5.
+    supported_by:
+    - reference_id: PMID:31062022
+      supporting_text: vitro. While Tsr4 is specific for Rps2...Tsr4 binds co-translationally to the...essential, eukaryote-specific N-terminal extension of Rps2
+    - reference_id: file:yeast/TSR4/TSR4-deep-research-falcon.md
+      supporting_text: Tsr4 is a cytoplasmic, co-translational uS5 chaperone that captures the Rps2 N-terminus.
 - term:
     id: GO:0042274
     label: ribosomal small subunit biogenesis
   evidence_type: IMP
   original_reference_id: PMID:31062022
   review:
-    summary: 'Manual review: ribosomal small subunit biogenesis is consistent with known biology of TSR4.'
+    summary: Tsr4 perturbation causes 40S biogenesis defects.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Rps2/uS5 chaperoning is directly tied to small subunit assembly.
+    supported_by:
+    - reference_id: PMID:31062022
+      supporting_text: Mutation of the essential Tsr4...enhance the 40S synthesis defects
 - term:
     id: GO:0042274
     label: ribosomal small subunit biogenesis
   evidence_type: IGI
   original_reference_id: PMID:31062022
   review:
-    summary: 'Manual review: ribosomal small subunit biogenesis is consistent with known biology of TSR4.'
+    summary: Genetic evidence with RPS2 supports the 40S biogenesis annotation.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: The genetic relationship supports Tsr4's role in Rps2-dependent 40S assembly.
+    supported_by:
+    - reference_id: PMID:31062022
+      supporting_text: identification of Nap1 and Tsr4 as direct binding partners of Rps6 and Rps2
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:31062022
   review:
-    summary: 'Manual review: unfolded protein binding is better represented by a more specific replacement term for TSR4.'
+    summary: The binding evidence is specific to Rps2/uS5, not generic unfolded protein.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: Replace broad unfolded protein binding with protein carrier chaperone.
     proposed_replacement_terms:
     - id: GO:0140597
       label: protein carrier chaperone
+    supported_by:
+    - reference_id: PMID:31062022
+      supporting_text: Both factors promote the solubility of their r-protein clients in...vitro.
 - term:
     id: GO:0042274
     label: ribosomal small subunit biogenesis
   evidence_type: IMP
   original_reference_id: PMID:31182640
   review:
-    summary: 'Manual review: ribosomal small subunit biogenesis is consistent with known biology of TSR4.'
+    summary: Independent evidence supports the same 40S biogenesis role.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Tsr4 perturbation decreases Rps2 and phenocopies Rps2 depletion.
+    supported_by:
+    - reference_id: PMID:31182640
+      supporting_text: Tsr4 perturbation resulted in decreased Rps2 levels and...phenocopied Rps2 depletion.
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:31182640
   review:
-    summary: 'Manual review: unfolded protein binding is better represented by a more specific replacement term for TSR4.'
+    summary: The evidence supports specific Rps2 carrier chaperoning.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: Protein carrier chaperone is the more precise molecular-function term.
     proposed_replacement_terms:
     - id: GO:0140597
       label: protein carrier chaperone
+    supported_by:
+    - reference_id: PMID:31182640
+      supporting_text: Tsr4 cotranslationally associates with Rps2...cytoplasmic chaperone dedicated to Rps2.
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IPI
   original_reference_id: PMID:31182640
   review:
-    summary: 'Manual review: unfolded protein binding is better represented by a more specific replacement term for TSR4.'
+    summary: The IPI evidence identifies a specific Rps2/uS5 client relationship.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: Replace broad unfolded protein binding with protein carrier chaperone.
     proposed_replacement_terms:
     - id: GO:0140597
       label: protein carrier chaperone
+    supported_by:
+    - reference_id: PMID:31182640
+      supporting_text: Rps2 harbors a...eukaryote-specific N-terminal extension that is critical for its interaction...with Tsr4.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IDA
   original_reference_id: PMID:31182640
   review:
-    summary: 'Manual review: cytoplasm is consistent with known biology of TSR4.'
+    summary: Direct microscopy and functional evidence support cytoplasmic localization.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Tsr4 acts before nuclear import and pre-ribosome assembly.
+    supported_by:
+    - reference_id: PMID:31182640
+      supporting_text: Despite Rps2 joining nuclear pre-40S particles, Tsr4 appears to be restricted to the cytoplasm.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: HDA
   original_reference_id: PMID:14562095
   review:
-    summary: 'Manual review: cytoplasm is consistent with known biology of TSR4.'
+    summary: High-throughput cytoplasmic localization is consistent with targeted studies.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: The broad cytoplasm term is correct, though cytosol is more precise.
+    supported_by:
+    - reference_id: PMID:31182640
+      supporting_text: Tsr4 appears to be restricted to the cytoplasm.
 - term:
     id: GO:0030490
     label: maturation of SSU-rRNA
   evidence_type: IMP
   original_reference_id: PMID:19806183
   review:
-    summary: 'Manual review: maturation of SSU-rRNA is consistent with known biology of TSR4.'
+    summary: The original genetic annotation correctly identifies TSR4 in SSU rRNA maturation.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: Later work explains the phenotype through defective Rps2/uS5 handling and 40S assembly.
+    supported_by:
+    - reference_id: PMID:19806183
+      supporting_text: YOR006C/TSR3, YOL022C/TSR4). We associate the new genes with specific aspects of...processing of 5S, 7S, 20S, 27S, and 35S rRNAs.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -162,17 +223,58 @@ references:
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping
   findings: []
 - id: PMID:14562095
   title: Global analysis of protein localization in budding yeast.
   findings: []
 - id: PMID:19806183
   title: Rational extension of the ribosome biogenesis pathway using network-guided genetics.
-  findings: []
+  findings:
+  - statement: TSR4 was identified as a ribosome biogenesis factor
+    supporting_text: Network-guided genetics associated YOL022C/TSR4 with ribosome biogenesis and pre-rRNA processing.
 - id: PMID:31062022
   title: Tsr4 and Nap1, two novel members of the ribosomal protein chaperOME.
-  findings: []
+  findings:
+  - statement: Tsr4 is a direct Rps2/uS5 carrier chaperone
+    supporting_text: Tsr4 is specific for Rps2, binds co-translationally to its N-terminal extension, and promotes solubility.
 - id: PMID:31182640
   title: Tsr4 Is a Cytoplasmic Chaperone for the Ribosomal Protein Rps2 in Saccharomyces cerevisiae.
-  findings: []
+  findings:
+  - statement: Tsr4 is a cytoplasmic chaperone dedicated to Rps2
+    supporting_text: Tsr4 cotranslationally associates with Rps2; perturbation decreases Rps2 levels.
+- id: file:yeast/TSR4/TSR4-deep-research-falcon.md
+  title: Falcon deep research report for TSR4
+  findings:
+  - statement: TSR4 is a cytoplasmic uS5/Rps2 carrier chaperone
+    supporting_text: The report synthesizes evidence that Tsr4 captures nascent Rps2/uS5 and enables downstream 40S assembly.
+core_functions:
+- description: >-
+    Cytoplasmic protein carrier chaperone for ribosomal protein Rps2/uS5. Tsr4
+    binds nascent Rps2/uS5 and maintains the client in a soluble
+    assembly-competent state before nuclear import and incorporation into
+    pre-40S particles.
+  molecular_function:
+    id: GO:0140597
+    label: protein carrier chaperone
+  directly_involved_in:
+  - id: GO:0042274
+    label: ribosomal small subunit biogenesis
+  - id: GO:0030490
+    label: maturation of SSU-rRNA
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  - id: GO:0005737
+    label: cytoplasm
+  supported_by:
+  - reference_id: PMID:31062022
+    supporting_text: identification of Nap1 and Tsr4 as direct binding partners of Rps6 and Rps2...Both factors promote the solubility of their r-protein clients
+  - reference_id: PMID:31182640
+    supporting_text: Tsr4 perturbation resulted in decreased Rps2 levels and...phenocopied Rps2 depletion.
+  - reference_id: file:yeast/TSR4/TSR4-deep-research-falcon.md
+    supporting_text: Tsr4 is a cytoplasmic, co-translational uS5 chaperone that captures the Rps2 N-terminus.
+proposed_new_terms: []
+suggested_questions:
+- question: Should older GO:0051082 annotations for Tsr4 be replaced by GO:0140597 protein carrier chaperone where evidence is specific Rps2/uS5 chaperoning?
+suggested_experiments: []

--- a/genes/yeast/TSR4/TSR4-deep-research-falcon.md
+++ b/genes/yeast/TSR4/TSR4-deep-research-falcon.md
@@ -1,0 +1,348 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-04T10:20:45.054448'
+end_time: '2026-05-04T10:44:28.489025'
+duration_seconds: 1423.43
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: yeast
+  gene_id: TSR4
+  gene_symbol: TSR4
+  uniprot_accession: P25040
+  protein_description: 'RecName: Full=uS5 assembly chaperone {ECO:0000305}; AltName:
+    Full=20S rRNA accumulation protein 4;'
+  gene_info: Name=TSR4; OrderedLocusNames=YOL022C;
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+  protein_family: Belongs to the TSR4 family. .
+  protein_domains: PDCD2_C. (IPR007320); PDCD2_C (PF04194)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 29
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P25040
+- **Protein Description:** RecName: Full=uS5 assembly chaperone {ECO:0000305}; AltName: Full=20S rRNA accumulation protein 4;
+- **Gene Information:** Name=TSR4; OrderedLocusNames=YOL022C;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the TSR4 family. .
+- **Key Domains:** PDCD2_C. (IPR007320); PDCD2_C (PF04194)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "TSR4" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'TSR4' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **TSR4** (gene ID: TSR4, UniProt: P25040) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P25040
+- **Protein Description:** RecName: Full=uS5 assembly chaperone {ECO:0000305}; AltName: Full=20S rRNA accumulation protein 4;
+- **Gene Information:** Name=TSR4; OrderedLocusNames=YOL022C;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the TSR4 family. .
+- **Key Domains:** PDCD2_C. (IPR007320); PDCD2_C (PF04194)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "TSR4" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'TSR4' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **TSR4** (gene ID: TSR4, UniProt: P25040) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research Report: *Saccharomyces cerevisiae* TSR4 (UniProt P25040; YOL022C)
+
+### 0) Target verification (gene/protein identity)
+The yeast gene **TSR4** (ordered locus **YOL022C**; UniProt **P25040**) corresponds to the ribosome biogenesis factor historically described as **“20S rRNA accumulation protein 4”** and is now experimentally established as a **uS5 (Rps2) assembly chaperone**. Primary yeast studies that biochemically and genetically characterize **Tsr4** (the protein product of TSR4) identify its client as the small-subunit ribosomal protein **Rps2/uS5** and show a cytoplasmic chaperone role (black2019tsr4isa pages 1-3, black2019tsr4isa pages 15-17).
+
+Domain/family verification matches the UniProt context: a comparative genomics analysis reports that yeast **TSR4** is annotated in Pfam as containing a **C-terminal PDCD2_C** domain and unifies TSR4 with eukaryotic homologs **PDCD2/PDCD2L** (and related proteins) into a larger duplicated-repeat superfamily termed **TYPP**, proposed to mediate protein–protein interactions consistent with chaperone-like function (burroughs2014analysisoftwo pages 3-5, burroughs2014analysisoftwo pages 5-7).
+
+### 1) Key concepts and current understanding
+#### 1.1 Dedicated ribosomal-protein chaperones (concept)
+Eukaryotic ribosome biogenesis requires safe handling of newly synthesized ribosomal proteins (RPs), many of which are highly basic and/or contain intrinsically disordered, eukaryote-specific extensions that are aggregation-prone. **Dedicated RP chaperones** are specialized factors that bind specific RPs to promote solubility, prevent nonproductive interactions, and enable correct delivery/assembly (rossler2019tsr4andnap1 pages 1-2, black2019tsr4isa pages 1-3).
+
+**TSR4/Tsr4** is a canonical example of this class: it is described as a **dedicated chaperone** that binds Rps2/uS5 and promotes its solubility and productive assembly into 40S subunits (rossler2019tsr4andnap1 pages 14-15, black2019tsr4isa pages 15-17).
+
+#### 1.2 What TSR4 does at a molecular level
+**Molecular function (best-supported):** Tsr4 binds **nascent Rps2/uS5** co-translationally in the cytoplasm and acts as a **client-specific chaperone** to stabilize Rps2 and support 40S biogenesis (black2019tsr4isa pages 1-3, rossler2019tsr4andnap1 pages 12-13).
+
+**Client recognition:** Multiple experiments map Tsr4 recognition primarily to the **eukaryote-specific N-terminal extension of Rps2**, with the first ~42 amino acids sufficient/required for robust interaction (rossler2019tsr4andnap1 pages 12-13). This binding is consistent with the general principle that dedicated chaperones often recognize **eukaryote-specific RP extensions** (rossler2019tsr4andnap1 pages 1-2).
+
+**Chaperone effect on solubility:** Rps2 expressed alone is aggregation-prone, while co-expression with Tsr4 keeps Rps2 soluble and supports complex formation in vitro and in vivo (rossler2019tsr4andnap1 pages 14-15).
+
+#### 1.3 Cellular process and pathway context
+TSR4 acts within **small (40S) ribosomal subunit biogenesis**, specifically by enabling accumulation and assembly of Rps2/uS5 into pre-40S particles. Loss of TSR4 phenocopies reduced uS5 availability, producing severe 40S defects and pre-40S export problems (black2019tsr4isa pages 15-17, rossler2019tsr4andnap1 pages 15-16).
+
+A 2023 review synthesizing cross-species evidence frames TSR4/PDCD2 as an **evolutionarily conserved uS5 chaperone module** that monitors uS5 availability/folding and supports pre-rRNA maturation outcomes consistent with 40S assembly (e.g., accumulation of 20S/21S pre-rRNAs and reduced uS5 incorporation when the module is perturbed) (landryvoyer2023ribosomalproteinus5 pages 6-8, landryvoyer2023ribosomalproteinus5 pages 8-10).
+
+### 2) Experimentally supported biology of yeast TSR4/Tsr4
+#### 2.1 Binding partners and mechanism
+**Primary binding partner:** **Rps2/uS5**.
+
+**Co-translational association:** Tsr4 purifications enrich **RPS2 mRNA**, consistent with binding to nascent chains during translation; interaction mapping supports specificity for the Rps2 N-terminus (rossler2019tsr4andnap1 pages 12-13). Black et al. likewise report co-translational association and dependence on the eukaryote-specific Rps2 N-terminal extension (black2019tsr4isa pages 1-3).
+
+**Key mechanistic inference:** Tsr4 appears to act **upstream of nuclear pre-40S assembly**, stabilizing Rps2 before (or during) handoff to nuclear import/assembly pathways, rather than being a stable component of nuclear pre-ribosomes (black2019tsr4isa pages 17-20, black2019tsr4isa pages 15-17).
+
+#### 2.2 Subcellular localization (where it acts)
+Multiple lines of evidence support that yeast Tsr4 is **predominantly cytoplasmic** and does **not** undergo obvious Crm1-dependent shuttling:
+
+* Black et al. performed a Crm1 inhibition assay (leptomycin B in a Crm1-sensitized strain) where the Crm1 cargo control Nmd3 relocalizes to the nucleus, but **Tsr4 remains cytoplasmic**, arguing against Crm1-dependent nucleocytoplasmic shuttling (black2019tsr4isa media 141d3d19).
+* Functional mutation of a predicted NLS in Tsr4 still complements loss of Tsr4, consistent with the idea that nuclear entry is not required for its essential function (black2019tsr4isa pages 15-17).
+
+#### 2.3 Consequences of TSR4 loss: phenotypes and readouts
+**Ribosome biogenesis output (polysome profiling):** Loss of Tsr4 produces a dramatic small subunit defect described as a **missing 40S peak**, increased free 60S, and reduced 80S/polysomes (rossler2019tsr4andnap1 pages 15-16).
+
+**Pre-40S export / nuclear accumulation:** Repression of TSR4 (or RPS2) causes **nuclear accumulation of ITS1**, interpreted as a **block in pre-40S export** (black2019tsr4isa pages 15-17).
+
+**Rps2 abundance:** Perturbation of Tsr4 reduces Rps2 levels and phenocopies Rps2 depletion, consistent with a stabilizing chaperone function (black2019tsr4isa pages 1-3).
+
+**Genetic suppression:** Increasing **RPS2 dosage** can partially bypass TSR4 loss (viability rescue), supporting a direct client-chaperone relationship; however, the rescued strains have impaired growth (growth defects at 25–30°C; inviability at 37°C), consistent with incomplete restoration of robust biogenesis (rossler2019tsr4andnap1 pages 15-16).
+
+**Quantitative notes:**
+* Estimated abundance: **~1,500 Tsr4 molecules/cell** (black2019tsr4isa pages 6-8).
+* Rps2-GFP steady-state localization: in wild-type, **~72%** of cells show **nuclear exclusion** of Rps2-GFP; in the absence of Tsr4, Rps2 reporters show nuclear signal/accumulation (rossler2019tsr4andnap1 pages 15-16, rossler2019tsr4andnap1 pages 16-16).
+
+### 3) Recent developments and latest research (2023–2024 prioritized)
+#### 3.1 2023: Nuclear import of Rps2/uS5 is Tsr4-independent
+A focused mechanistic study (Steiner et al., **July 2023**) dissected nuclear import signals of yeast Rps2/uS5. Key findings:
+
+* An internal region **Rps2(76–145)** is sufficient for nuclear targeting and contains a critical basic cluster **R95/R97/K99**; mutation of these residues strongly disrupts nuclear localization (steiner2023dissectingthenuclear pages 6-9, steiner2023dissectingthenuclear pages 1-2).
+* A second nuclear targeting element lies in the **N-terminal region (~10–28)** (RG-rich/basic), which overlaps the Tsr4-binding region (steiner2023dissectingthenuclear pages 1-2, steiner2023dissectingthenuclear pages 15-18).
+* Importin **Pse1 (Kap121)** interacts with and contributes to import of the internal NLS, but import is not exclusively Pse1-dependent, consistent with redundancy among importins (steiner2023dissectingthenuclear pages 2-4, steiner2023dissectingthenuclear pages 15-18).
+* Critically, nuclear import via either the internal or N-terminal element **does not require Tsr4**, supporting a model where Tsr4’s essential function is chaperoning/assembly competence rather than serving as the import adaptor (steiner2023dissectingthenuclear pages 2-4, steiner2023dissectingthenuclear pages 13-15).
+
+This resolves an important mechanistic ambiguity noted in reviews: because Tsr4 binds near an NLS, it was plausible that Tsr4 was required for import; instead, import can occur without it, while assembly remains defective (steiner2023dissectingthenuclear pages 2-4, rossler2019tsr4andnap1 pages 16-16).
+
+#### 3.2 2023: Consolidation of the conserved uS5 interactome
+A 2023 review (Landry-Voyer et al., **May 2023**) synthesizes evidence that PDCD2 and its homologs (including yeast Tsr4) are **dedicated uS5 chaperones** that recognize nascent uS5 co-translationally and whose perturbation phenocopies uS5 deficiency (landryvoyer2023ribosomalproteinus5 pages 6-8, landryvoyer2023ribosomalproteinus5 pages 8-10). The review also highlights unanswered questions, including how the chaperone–uS5 complex is disassembled and coordinated with import/assembly (landryvoyer2023ribosomalproteinus5 pages 8-10).
+
+#### 3.3 2024: Framing Tsr4 in modern “chaperome” and coordination questions
+A 2024 Biomolecules editorial (Pertschy & Zierler, **Dec 2024**) highlights the open question created by overlap of Tsr4 binding and an N-terminal uS5 NLS: how are **chaperoning and import coordinated** in space and time? (pertschy2024ribosomalproteinsin pages 1-2).
+
+A 2024 Annual Review (Yang & Karbstein, **Oct 2024**) places dedicated RP chaperones (including the Tsr4/Nap1 chaperome work) into a broader conceptual framework where specialized chaperones can contribute to **assembly** and potentially to **maintenance/repair** processes (yang2024ribosomeassemblyand pages 20-21, yang2024ribosomeassemblyand pages 11-13).
+
+#### 3.4 2023: Ribosome repair after oxidative damage—Tsr4 does not extract Rps2
+Yang et al. (Molecular Cell, **May 2023**) demonstrated chaperone-mediated extraction of oxidized Rps26 by Tsr2 during oxidative stress, but explicitly report that **neither Rps2 nor Rps3 were released by their chaperones (Tsr4 and Yar1)** in their in vitro extraction assays (yang2023chaperonedirectedribosomerepair pages 3-5, yang2023chaperonedirectedribosomerepair pages 5-7). This suggests that, unlike Tsr2–Rps26, the Tsr4–Rps2 pair is not (or is not readily) deployed for extraction-based repair under those experimental conditions.
+
+### 4) Applications and real-world implementations
+#### 4.1 TSR4 as an experimental handle for uS5 handling and 40S biogenesis
+In yeast, TSR4 is used as a mechanistic probe to study **co-translational RP capture**, **client stabilization**, and **the pathway linking RP availability to pre-40S export**. The strong, diagnostic phenotypes (missing 40S peak; nuclear ITS1 accumulation) provide clear, implementation-ready assays for perturbations in the uS5 supply chain (rossler2019tsr4andnap1 pages 15-16, black2019tsr4isa pages 15-17).
+
+#### 4.2 Translational relevance via conserved homologs (PDCD2/PDCD2L)
+While the present target is yeast TSR4, the **TSR4–PDCD2/PDCD2L** homology provides direct translational relevance: PDCD2 is described as a conserved uS5 chaperone that underlies essential roles in proliferation and development, and has reported associations with human disease contexts (as summarized in the 2023 uS5 review) (landryvoyer2023ribosomalproteinus5 pages 6-8, landryvoyer2023ribosomalproteinus5 pages 8-10). PDCD2L is discussed as a candidate late-acting uS5 interactor and potential pre-40S export adaptor (XPO1/CRM1-associated via an NES), supporting a conserved “uS5 handling network” spanning chaperoning and nucleocytoplasmic trafficking (landryvoyer2023ribosomalproteinus5 pages 8-10, landryvoyer2023ribosomalproteinus5 pages 10-12).
+
+### 5) Expert synthesis and open questions
+Collectively, the best-supported model is that **Tsr4 is a cytoplasmic, co-translational uS5 chaperone** that captures the eukaryote-specific N-terminus of Rps2, promotes soluble/assembly-competent Rps2 accumulation, and enables downstream 40S assembly and pre-40S export. Nuclear import of Rps2 proceeds via at least two NLS elements and importin-β pathways that do not require Tsr4, implying a **handoff step** from Tsr4-bound uS5 to importins and/or other factors remains to be mechanistically defined (black2019tsr4isa pages 17-20, steiner2023dissectingthenuclear pages 2-4).
+
+Key unresolved areas highlighted across primary studies and recent reviews include (i) how the limited pool of Tsr4 efficiently targets nascent Rps2 (possible mRNA targeting), (ii) what triggers Tsr4 release from Rps2, and (iii) how binding overlaps with N-terminal targeting signals without blocking productive import/assembly (black2019tsr4isa pages 17-20, landryvoyer2023ribosomalproteinus5 pages 8-10, pertschy2024ribosomalproteinsin pages 1-2).
+
+### Evidence summary table
+The following table consolidates major conclusions, assays, and quantitative notes.
+
+| Finding | Molecular function | Binding partner(s) | Evidence type / assay | Subcellular localization | Ribosome biogenesis role | Quantitative notes | Supporting citations |
+|---|---|---|---|---|---|---|---|
+| Core identity | Dedicated uS5/Rps2 assembly chaperone; matches yeast TSR4/P25040 annotation | Rps2 (uS5) | AP-MS/TAP purification, co-IP, genetic analysis | Predominantly cytoplasmic | Required for efficient 40S assembly | TSR4 is essential in tested yeast backgrounds | (black2019tsr4isa pages 1-3, rossler2019tsr4andnap1 pages 2-2) |
+| Client recognition mechanism | Co-translational capture of nascent Rps2 via eukaryote-specific N-terminus | Rps2 N-terminal extension (aa 1–42; strongest determinants distributed across first 42 aa) | Cycloheximide-linked mRNA co-purification, Y2H mapping, truncation/mutational analysis | Cytoplasmic encounter with nascent client | Prevents misfolding/inefficient maturation of newly synthesized uS5 | First 42 aa sufficient for interaction; first 22 aa alone weak; Tsr4 ΔN40 loses binding | (rossler2019tsr4andnap1 pages 12-13) |
+| Chaperone activity | Promotes solubility/stability of Rps2 | Rps2 | In vitro co-expression/solubility assays; co-purification in vitro and in vivo | Cytoplasm | Supplies assembly-competent uS5 for pre-40S incorporation | Rps2 aggregates when expressed alone but is solubilized by Tsr4 | (rossler2019tsr4andnap1 pages 14-15) |
+| Localization of Tsr4 | Cytoplasmic chaperone, not a Crm1-shuttling nucleo-cytoplasmic factor | — | Fluorescence microscopy, LMB/Crm1 shuttling assay, NLS mutagenesis | Cytoplasmic; no Crm1-dependent nuclear accumulation | Acts before or during handoff to import/assembly pathway rather than as an export cargo | Tsr4-mCherry stayed cytoplasmic after LMB while Nmd3-GFP accumulated in nucleus | (black2019tsr4isa pages 15-17, black2019tsr4isa pages 17-20, black2019tsr4isa media 141d3d19) |
+| Effect on Rps2 localization | Needed mainly for productive assembly, not strictly for nuclear entry | Rps2; importins indirectly | Rps2-GFP localization in tsr4 mutants | Loss of Tsr4 causes nuclear accumulation of Rps2 reporters | Indicates imported uS5 is not efficiently assembled into pre-ribosomes without Tsr4 | ~72% of WT cells show nuclear exclusion of Rps2-GFP; ~82% of tsr4 cells show nuclear signal in one study | (rossler2019tsr4andnap1 pages 16-16, rossler2019tsr4andnap1 pages 15-16) |
+| Role in 40S biogenesis/export | Required for small-subunit production and pre-40S export | Pre-40S particles indirectly via Rps2 supply | Polysome profiling, ITS1 FISH, depletion/repression experiments | Functional consequence seen as nuclear ITS1 accumulation | Loss phenocopies RPS2 depletion, blocking late 40S maturation/export | Missing or strongly reduced 40S peak, increased 60S, reduced 80S/polysomes; ITS1 accumulates in nucleus after TSR4 repression | (black2019tsr4isa pages 34-37, black2019tsr4isa pages 15-17, rossler2019tsr4andnap1 pages 15-16) |
+| Genetic suppression | Increased client dosage can partially bypass chaperone loss | RPS2 | Plasmid shuffle, dosage suppression, growth assays | — | Supports chaperone-client relationship | Extra RPS2 restores viability but suppressed tsr4 strains grow poorly at 25–30°C and are inviable at 37°C | (black2019tsr4isa pages 15-17, rossler2019tsr4andnap1 pages 15-16) |
+| Abundance / limiting factor | Modestly expressed, consistent with titration by excess N-terminal Rps2 fragments | Rps2 fragments can sequester Tsr4 | Quantitative Western/blot comparison; dominant-negative fragment assays | Cytoplasm | Limiting chaperone pool may constrain uS5 maturation | ~1,500 Tsr4 molecules/cell; high-copy TSR4 fully suppresses one dominant-negative Rps2 N-fragment and partially suppresses another | (black2019tsr4isa pages 17-20, black2019tsr4isa pages 6-8) |
+| Relation to nuclear import | Not required for either identified Rps2 NLS-driven import route | Rps2; Pse1/Kap121, Kap123/Kap104 contribute | Reporter import assays, mutagenesis, pse1 mutant analysis, TurboID/Y2H | Tsr4 overlaps N-terminal NLS region but is dispensable for import itself | Distinguishes chaperoning from import; Tsr4 functions upstream of productive assembly | Internal NLS at aa 76–145; key residues R95/R97/K99; second N-terminal NLS at aa 10–28 | (steiner2023dissectingthenuclear pages 6-9, steiner2023dissectingthenuclear pages 2-4, steiner2023dissectingthenuclear pages 15-18, steiner2023dissectingthenuclear pages 13-15) |
+| Family/domain context | Yeast TSR4 is the fungal homolog within PDCD2/PDCD2L-related TYPP/PDCD2_C superfamily | PDCD2/PDCD2L homologous family; uS5 pathway conserved | Comparative domain/evolution analysis; cross-species functional comparison | Yeast Tsr4 mainly cytoplasmic; metazoan PDCD2 can accompany uS5 into nucleus | Conserved dedicated uS5 chaperone module across eukaryotes | C-terminal PDCD2_C annotation; broader TYPP repeat architecture proposed | (burroughs2014analysisoftwo pages 5-7, burroughs2014analysisoftwo pages 3-5, landryvoyer2023ribosomalproteinus5 pages 6-8, landryvoyer2020pdcd2functionsas pages 13-14) |
+
+
+*Table: This table condenses the main experimentally supported findings for Saccharomyces cerevisiae TSR4 (UniProt P25040), including its chaperone function, binding to Rps2/uS5, localization, and role in 40S ribosome biogenesis. It also highlights useful quantitative observations and cites the supporting evidence by context ID.*
+
+### Visual evidence
+A key localization control supporting cytoplasmic restriction of Tsr4 is shown in Black et al. 2019 Figure 8B: in a leptomycin B Crm1 export-blocking assay, the Crm1 cargo control Nmd3 accumulates in the nucleus while **Tsr4 remains cytoplasmic** (black2019tsr4isa media 141d3d19).
+
+---
+
+## Key references (with URLs and publication dates)
+* Black JJ, Musalgaonkar S, Johnson AW. **Tsr4 Is a Cytoplasmic Chaperone for the Ribosomal Protein Rps2 in *Saccharomyces cerevisiae***. *Molecular and Cellular Biology*. **Sep 2019**. https://doi.org/10.1128/mcb.00094-19 (black2019tsr4isa pages 1-3)
+* Rössler I et al. **Tsr4 and Nap1, two novel members of the ribosomal protein chaperOME**. *Nucleic Acids Research*. **May 2019**. https://doi.org/10.1093/nar/gkz317 (rossler2019tsr4andnap1 pages 1-2)
+* Steiner A et al. **Dissecting the Nuclear Import of the Ribosomal Protein Rps2 (uS5)**. *Biomolecules*. **Jul 2023**. https://doi.org/10.3390/biom13071127 (steiner2023dissectingthenuclear pages 1-2)
+* Landry-Voyer A-M et al. **Ribosomal Protein uS5 and Friends: Protein–Protein Interactions Involved in Ribosome Assembly and Beyond**. *Biomolecules*. **May 2023**. https://doi.org/10.3390/biom13050853 (landryvoyer2023ribosomalproteinus5 pages 6-8)
+* Yang Y-M et al. **Chaperone-directed ribosome repair after oxidative damage**. *Molecular Cell*. **May 2023**. https://doi.org/10.1016/j.molcel.2023.03.030 (yang2023chaperonedirectedribosomerepair pages 3-5)
+* Yang Y-M, Karbstein K. **Ribosome Assembly and Repair**. *Annual Review of Cell and Developmental Biology*. **Oct 2024**. https://doi.org/10.1146/annurev-cellbio-111822-113326 (yang2024ribosomeassemblyand pages 1-3)
+* Pertschy B, Zierler I. **Ribosomal Proteins in Ribosome Assembly**. *Biomolecules*. **Dec 2024**. https://doi.org/10.3390/biom15010013 (pertschy2024ribosomalproteinsin pages 1-2)
+
+
+
+References
+
+1. (black2019tsr4isa pages 1-3): Joshua J. Black, Sharmishtha Musalgaonkar, and Arlen W. Johnson. Tsr4 is a cytoplasmic chaperone for the ribosomal protein rps2 in <i>saccharomyces cerevisiae</i>. Molecular and Cellular Biology, Sep 2019. URL: https://doi.org/10.1128/mcb.00094-19, doi:10.1128/mcb.00094-19. This article has 28 citations and is from a domain leading peer-reviewed journal.
+
+2. (black2019tsr4isa pages 15-17): Joshua J. Black, Sharmishtha Musalgaonkar, and Arlen W. Johnson. Tsr4 is a cytoplasmic chaperone for the ribosomal protein rps2 in <i>saccharomyces cerevisiae</i>. Molecular and Cellular Biology, Sep 2019. URL: https://doi.org/10.1128/mcb.00094-19, doi:10.1128/mcb.00094-19. This article has 28 citations and is from a domain leading peer-reviewed journal.
+
+3. (burroughs2014analysisoftwo pages 3-5): A. M. Burroughs, L. Aravind, and R. Emes. Analysis of two domains with novel rna-processing activities throws light on the complex evolution of ribosomal rna biogenesis. Frontiers in Genetics, Dec 2014. URL: https://doi.org/10.3389/fgene.2014.00424, doi:10.3389/fgene.2014.00424. This article has 26 citations and is from a peer-reviewed journal.
+
+4. (burroughs2014analysisoftwo pages 5-7): A. M. Burroughs, L. Aravind, and R. Emes. Analysis of two domains with novel rna-processing activities throws light on the complex evolution of ribosomal rna biogenesis. Frontiers in Genetics, Dec 2014. URL: https://doi.org/10.3389/fgene.2014.00424, doi:10.3389/fgene.2014.00424. This article has 26 citations and is from a peer-reviewed journal.
+
+5. (rossler2019tsr4andnap1 pages 1-2): Ingrid Rössler, Julia Embacher, Benjamin Pillet, Guillaume Murat, Laura Liesinger, Jutta Hafner, Julia Judith Unterluggauer, Ruth Birner-Gruenberger, Dieter Kressler, and Brigitte Pertschy. Tsr4 and nap1, two novel members of the ribosomal protein chaperome. Nucleic Acids Research, 47:6984-7002, May 2019. URL: https://doi.org/10.1093/nar/gkz317, doi:10.1093/nar/gkz317. This article has 38 citations and is from a highest quality peer-reviewed journal.
+
+6. (rossler2019tsr4andnap1 pages 14-15): Ingrid Rössler, Julia Embacher, Benjamin Pillet, Guillaume Murat, Laura Liesinger, Jutta Hafner, Julia Judith Unterluggauer, Ruth Birner-Gruenberger, Dieter Kressler, and Brigitte Pertschy. Tsr4 and nap1, two novel members of the ribosomal protein chaperome. Nucleic Acids Research, 47:6984-7002, May 2019. URL: https://doi.org/10.1093/nar/gkz317, doi:10.1093/nar/gkz317. This article has 38 citations and is from a highest quality peer-reviewed journal.
+
+7. (rossler2019tsr4andnap1 pages 12-13): Ingrid Rössler, Julia Embacher, Benjamin Pillet, Guillaume Murat, Laura Liesinger, Jutta Hafner, Julia Judith Unterluggauer, Ruth Birner-Gruenberger, Dieter Kressler, and Brigitte Pertschy. Tsr4 and nap1, two novel members of the ribosomal protein chaperome. Nucleic Acids Research, 47:6984-7002, May 2019. URL: https://doi.org/10.1093/nar/gkz317, doi:10.1093/nar/gkz317. This article has 38 citations and is from a highest quality peer-reviewed journal.
+
+8. (rossler2019tsr4andnap1 pages 15-16): Ingrid Rössler, Julia Embacher, Benjamin Pillet, Guillaume Murat, Laura Liesinger, Jutta Hafner, Julia Judith Unterluggauer, Ruth Birner-Gruenberger, Dieter Kressler, and Brigitte Pertschy. Tsr4 and nap1, two novel members of the ribosomal protein chaperome. Nucleic Acids Research, 47:6984-7002, May 2019. URL: https://doi.org/10.1093/nar/gkz317, doi:10.1093/nar/gkz317. This article has 38 citations and is from a highest quality peer-reviewed journal.
+
+9. (landryvoyer2023ribosomalproteinus5 pages 6-8): Anne-Marie Landry-Voyer, Zabih Mir Hassani, Mariano Avino, and François Bachand. Ribosomal protein us5 and friends: protein–protein interactions involved in ribosome assembly and beyond. Biomolecules, 13:853, May 2023. URL: https://doi.org/10.3390/biom13050853, doi:10.3390/biom13050853. This article has 20 citations.
+
+10. (landryvoyer2023ribosomalproteinus5 pages 8-10): Anne-Marie Landry-Voyer, Zabih Mir Hassani, Mariano Avino, and François Bachand. Ribosomal protein us5 and friends: protein–protein interactions involved in ribosome assembly and beyond. Biomolecules, 13:853, May 2023. URL: https://doi.org/10.3390/biom13050853, doi:10.3390/biom13050853. This article has 20 citations.
+
+11. (black2019tsr4isa pages 17-20): Joshua J. Black, Sharmishtha Musalgaonkar, and Arlen W. Johnson. Tsr4 is a cytoplasmic chaperone for the ribosomal protein rps2 in <i>saccharomyces cerevisiae</i>. Molecular and Cellular Biology, Sep 2019. URL: https://doi.org/10.1128/mcb.00094-19, doi:10.1128/mcb.00094-19. This article has 28 citations and is from a domain leading peer-reviewed journal.
+
+12. (black2019tsr4isa media 141d3d19): Joshua J. Black, Sharmishtha Musalgaonkar, and Arlen W. Johnson. Tsr4 is a cytoplasmic chaperone for the ribosomal protein rps2 in <i>saccharomyces cerevisiae</i>. Molecular and Cellular Biology, Sep 2019. URL: https://doi.org/10.1128/mcb.00094-19, doi:10.1128/mcb.00094-19. This article has 28 citations and is from a domain leading peer-reviewed journal.
+
+13. (black2019tsr4isa pages 6-8): Joshua J. Black, Sharmishtha Musalgaonkar, and Arlen W. Johnson. Tsr4 is a cytoplasmic chaperone for the ribosomal protein rps2 in <i>saccharomyces cerevisiae</i>. Molecular and Cellular Biology, Sep 2019. URL: https://doi.org/10.1128/mcb.00094-19, doi:10.1128/mcb.00094-19. This article has 28 citations and is from a domain leading peer-reviewed journal.
+
+14. (rossler2019tsr4andnap1 pages 16-16): Ingrid Rössler, Julia Embacher, Benjamin Pillet, Guillaume Murat, Laura Liesinger, Jutta Hafner, Julia Judith Unterluggauer, Ruth Birner-Gruenberger, Dieter Kressler, and Brigitte Pertschy. Tsr4 and nap1, two novel members of the ribosomal protein chaperome. Nucleic Acids Research, 47:6984-7002, May 2019. URL: https://doi.org/10.1093/nar/gkz317, doi:10.1093/nar/gkz317. This article has 38 citations and is from a highest quality peer-reviewed journal.
+
+15. (steiner2023dissectingthenuclear pages 6-9): Andreas Steiner, Sébastien Favre, Maximilian Mack, Annika Hausharter, Benjamin Pillet, Jutta Hafner, Valentin Mitterer, Dieter Kressler, Brigitte Pertschy, and Ingrid Zierler. Dissecting the nuclear import of the ribosomal protein rps2 (us5). Biomolecules, 13:1127, Jul 2023. URL: https://doi.org/10.3390/biom13071127, doi:10.3390/biom13071127. This article has 7 citations.
+
+16. (steiner2023dissectingthenuclear pages 1-2): Andreas Steiner, Sébastien Favre, Maximilian Mack, Annika Hausharter, Benjamin Pillet, Jutta Hafner, Valentin Mitterer, Dieter Kressler, Brigitte Pertschy, and Ingrid Zierler. Dissecting the nuclear import of the ribosomal protein rps2 (us5). Biomolecules, 13:1127, Jul 2023. URL: https://doi.org/10.3390/biom13071127, doi:10.3390/biom13071127. This article has 7 citations.
+
+17. (steiner2023dissectingthenuclear pages 15-18): Andreas Steiner, Sébastien Favre, Maximilian Mack, Annika Hausharter, Benjamin Pillet, Jutta Hafner, Valentin Mitterer, Dieter Kressler, Brigitte Pertschy, and Ingrid Zierler. Dissecting the nuclear import of the ribosomal protein rps2 (us5). Biomolecules, 13:1127, Jul 2023. URL: https://doi.org/10.3390/biom13071127, doi:10.3390/biom13071127. This article has 7 citations.
+
+18. (steiner2023dissectingthenuclear pages 2-4): Andreas Steiner, Sébastien Favre, Maximilian Mack, Annika Hausharter, Benjamin Pillet, Jutta Hafner, Valentin Mitterer, Dieter Kressler, Brigitte Pertschy, and Ingrid Zierler. Dissecting the nuclear import of the ribosomal protein rps2 (us5). Biomolecules, 13:1127, Jul 2023. URL: https://doi.org/10.3390/biom13071127, doi:10.3390/biom13071127. This article has 7 citations.
+
+19. (steiner2023dissectingthenuclear pages 13-15): Andreas Steiner, Sébastien Favre, Maximilian Mack, Annika Hausharter, Benjamin Pillet, Jutta Hafner, Valentin Mitterer, Dieter Kressler, Brigitte Pertschy, and Ingrid Zierler. Dissecting the nuclear import of the ribosomal protein rps2 (us5). Biomolecules, 13:1127, Jul 2023. URL: https://doi.org/10.3390/biom13071127, doi:10.3390/biom13071127. This article has 7 citations.
+
+20. (pertschy2024ribosomalproteinsin pages 1-2): Brigitte Pertschy and Ingrid Zierler. Ribosomal proteins in ribosome assembly. Biomolecules, 15:13, Dec 2024. URL: https://doi.org/10.3390/biom15010013, doi:10.3390/biom15010013. This article has 4 citations.
+
+21. (yang2024ribosomeassemblyand pages 20-21): Yoon-Mo Yang and Katrin Karbstein. Ribosome assembly and repair. Annual Review of Cell and Developmental Biology, 40:241-264, Oct 2024. URL: https://doi.org/10.1146/annurev-cellbio-111822-113326, doi:10.1146/annurev-cellbio-111822-113326. This article has 18 citations and is from a domain leading peer-reviewed journal.
+
+22. (yang2024ribosomeassemblyand pages 11-13): Yoon-Mo Yang and Katrin Karbstein. Ribosome assembly and repair. Annual Review of Cell and Developmental Biology, 40:241-264, Oct 2024. URL: https://doi.org/10.1146/annurev-cellbio-111822-113326, doi:10.1146/annurev-cellbio-111822-113326. This article has 18 citations and is from a domain leading peer-reviewed journal.
+
+23. (yang2023chaperonedirectedribosomerepair pages 3-5): Yoon-Mo Yang, Youngeun Jung, Daniel Abegg, Alexander Adibekian, Kate S. Carroll, and Katrin Karbstein. Chaperone-directed ribosome repair after oxidative damage. Molecular Cell, 83:1527-1537.e5, May 2023. URL: https://doi.org/10.1016/j.molcel.2023.03.030, doi:10.1016/j.molcel.2023.03.030. This article has 70 citations and is from a highest quality peer-reviewed journal.
+
+24. (yang2023chaperonedirectedribosomerepair pages 5-7): Yoon-Mo Yang, Youngeun Jung, Daniel Abegg, Alexander Adibekian, Kate S. Carroll, and Katrin Karbstein. Chaperone-directed ribosome repair after oxidative damage. Molecular Cell, 83:1527-1537.e5, May 2023. URL: https://doi.org/10.1016/j.molcel.2023.03.030, doi:10.1016/j.molcel.2023.03.030. This article has 70 citations and is from a highest quality peer-reviewed journal.
+
+25. (landryvoyer2023ribosomalproteinus5 pages 10-12): Anne-Marie Landry-Voyer, Zabih Mir Hassani, Mariano Avino, and François Bachand. Ribosomal protein us5 and friends: protein–protein interactions involved in ribosome assembly and beyond. Biomolecules, 13:853, May 2023. URL: https://doi.org/10.3390/biom13050853, doi:10.3390/biom13050853. This article has 20 citations.
+
+26. (rossler2019tsr4andnap1 pages 2-2): Ingrid Rössler, Julia Embacher, Benjamin Pillet, Guillaume Murat, Laura Liesinger, Jutta Hafner, Julia Judith Unterluggauer, Ruth Birner-Gruenberger, Dieter Kressler, and Brigitte Pertschy. Tsr4 and nap1, two novel members of the ribosomal protein chaperome. Nucleic Acids Research, 47:6984-7002, May 2019. URL: https://doi.org/10.1093/nar/gkz317, doi:10.1093/nar/gkz317. This article has 38 citations and is from a highest quality peer-reviewed journal.
+
+27. (black2019tsr4isa pages 34-37): Joshua J. Black, Sharmishtha Musalgaonkar, and Arlen W. Johnson. Tsr4 is a cytoplasmic chaperone for the ribosomal protein rps2 in <i>saccharomyces cerevisiae</i>. Molecular and Cellular Biology, Sep 2019. URL: https://doi.org/10.1128/mcb.00094-19, doi:10.1128/mcb.00094-19. This article has 28 citations and is from a domain leading peer-reviewed journal.
+
+28. (landryvoyer2020pdcd2functionsas pages 13-14): Anne-Marie Landry-Voyer, Danny Bergeron, Carlo Yague-Sanz, Breac Baker, and Francois Bachand. Pdcd2 functions as an evolutionarily conserved chaperone dedicated for the 40s ribosomal protein us5 (rps2). Nucleic Acids Research, 48:12900-12916, Nov 2020. URL: https://doi.org/10.1093/nar/gkaa1108, doi:10.1093/nar/gkaa1108. This article has 26 citations and is from a highest quality peer-reviewed journal.
+
+29. (yang2024ribosomeassemblyand pages 1-3): Yoon-Mo Yang and Katrin Karbstein. Ribosome assembly and repair. Annual Review of Cell and Developmental Biology, 40:241-264, Oct 2024. URL: https://doi.org/10.1146/annurev-cellbio-111822-113326, doi:10.1146/annurev-cellbio-111822-113326. This article has 18 citations and is from a domain leading peer-reviewed journal.
+
+## Citations
+
+1. pertschy2024ribosomalproteinsin pages 1-2
+2. steiner2023dissectingthenuclear pages 1-2
+3. yang2023chaperonedirectedribosomerepair pages 3-5
+4. yang2024ribosomeassemblyand pages 1-3
+5. burroughs2014analysisoftwo pages 3-5
+6. burroughs2014analysisoftwo pages 5-7
+7. steiner2023dissectingthenuclear pages 6-9
+8. steiner2023dissectingthenuclear pages 15-18
+9. steiner2023dissectingthenuclear pages 2-4
+10. steiner2023dissectingthenuclear pages 13-15
+11. yang2024ribosomeassemblyand pages 20-21
+12. yang2024ribosomeassemblyand pages 11-13
+13. yang2023chaperonedirectedribosomerepair pages 5-7
+14. https://doi.org/10.1128/mcb.00094-19
+15. https://doi.org/10.1093/nar/gkz317
+16. https://doi.org/10.3390/biom13071127
+17. https://doi.org/10.3390/biom13050853
+18. https://doi.org/10.1016/j.molcel.2023.03.030
+19. https://doi.org/10.1146/annurev-cellbio-111822-113326
+20. https://doi.org/10.3390/biom15010013
+21. https://doi.org/10.1128/mcb.00094-19,
+22. https://doi.org/10.3389/fgene.2014.00424,
+23. https://doi.org/10.1093/nar/gkz317,
+24. https://doi.org/10.3390/biom13050853,
+25. https://doi.org/10.3390/biom13071127,
+26. https://doi.org/10.3390/biom15010013,
+27. https://doi.org/10.1146/annurev-cellbio-111822-113326,
+28. https://doi.org/10.1016/j.molcel.2023.03.030,
+29. https://doi.org/10.1093/nar/gkaa1108,


### PR DESCRIPTION
## Summary
- Complete yeast AI reviews for JEM1, TSR4, ATP11, CCT7, and CPS1.
- Add Falcon deep-research files where newly generated and integrate Falcon support across the reviews.
- Render updated review HTML files.

## Validation
- `just validate yeast JEM1` and `just render yeast JEM1`
- `just validate yeast TSR4` and `just render yeast TSR4`
- `just validate yeast ATP11` and `just render yeast ATP11`
- `just validate yeast CCT7` and `just render yeast CCT7`
- `just validate yeast CPS1` and `just render yeast CPS1`
- `git diff --check`

## Curator QA
Subagent review approved all five genes. Nonblocking caveats were traceability polish only: weak/non-core JEM1 nuclear membrane support, TSR4 cytosol-vs-cytoplasm location specificity, ATP11 mitochondrial matrix snippet strength, CCT contributes-to semantics follow-up, and broad M20-family-only PANTHER support for CPS1.